### PR TITLE
SOLR-15248 Disable login autocomplete

### DIFF
--- a/solr/webapp/web/partials/login.html
+++ b/solr/webapp/web/partials/login.html
@@ -28,7 +28,7 @@ limitations under the License.
       </p>
       <br/>
       <div ng-show="error" class="alert alert-danger">{{error}}</div>
-      <form name="form" ng-submit="login()" role="form">
+      <form name="form" ng-submit="login()" role="form" autocomplete="off">
         <div class="form-group">
           <label for="username">Username</label>
           <input type="text" name="username" id="username" class="form-control" ng-model="username" required />


### PR DESCRIPTION
# Description

Remove login autocomplete, which currently allows you to see who had previously logged in. 

# Solution

Add `autocomplete=off` 

# Tests

Go to the login page and confirm that clicking in the username box doesn't show other users.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
