### PR TITLE
SOLR-15155: Let CloudHttp2SolrClient accept an external Http2SolrClient Builder

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -284,6 +284,8 @@ Improvements
 
 * SOLR-11233: Add optional JAVA8_GC_LOG_FILE_OPTS for bin/solr. (Pranav Murugappan, Christine Poerschke)
 
+* SOLR-15155: Let CloudHttp2SolrClient accept an external Http2SolrClient Builder (Tomás Fernández Löbbe)
+
 Optimizations
 ---------------------
 * SOLR-15079: Block Collapse - Faster collapse code when groups are co-located via Block Join style nested doc indexing.


### PR DESCRIPTION
This allows configuring the internal client with things like timeouts, credentials, etc
Moved from https://github.com/apache/lucene-solr/pull/2450