### PR TITLE
SOLR-15104: add SOLR_GC_LOG_PRESTART_ARCHIVE option to bin/solr

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2004,8 +2004,11 @@ if [ "${SOLR_LOG_PRESTART_ROTATION:=false}" == "true" ]; then
   # Enable any of these if you require old remove/archive behavior
   #run_tool utils -s "$DEFAULT_SERVER_DIR" -l "$SOLR_LOGS_DIR" $q -remove_old_solr_logs 7 || echo "Failed removing old solr logs"
   #run_tool utils -s "$DEFAULT_SERVER_DIR" -l "$SOLR_LOGS_DIR" $q -archive_gc_logs $q     || echo "Failed archiving old GC logs"
-  #run_tool utils -s "$DEFAULT_SERVER_DIR" -l "$SOLR_LOGS_DIR" $q -archive_console_logs   || echo "Failed archiving old console logs"
   run_tool utils -s "$DEFAULT_SERVER_DIR" -l "$SOLR_LOGS_DIR" $q -rotate_solr_logs 10    || echo "Failed rotating old solr logs"
+fi
+
+if [ "${SOLR_GC_LOG_PRESTART_ARCHIVE:=false}" == "true" ]; then
+  run_tool utils -s "$DEFAULT_SERVER_DIR" -l "$SOLR_LOGS_DIR" $q -archive_gc_logs $q || echo "Failed archiving old GC logs"
 fi
 
 # Establish default GC logging opts if no env var set (otherwise init to sensible default)

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -127,6 +127,10 @@
 # framework that cannot do startup rotation, you may want to enable this to let Solr rotate logs on startup.
 #SOLR_LOG_PRESTART_ROTATION=false
 
+# Enables gc log rotation before starting Solr. Setting SOLR_GC_LOG_PRESTART_ARCHIVE=true will let Solr take care
+# of pre start archiving of gc logs.
+#SOLR_GC_LOG_PRESTART_ARCHIVE=false
+
 # Enables jetty request log for all requests
 #SOLR_REQUESTLOG_ENABLED=false
 


### PR DESCRIPTION
Default value of `SOLR_GC_LOG_PRESTART_ARCHIVE` to be confirmed, current value corresponds to existing behaviour.

* `solr` and `solr.in.sh` changes: done but not yet tested
* `solr.cmd` and `solr.in.cmd` changes: todo (help needed)

https://issues.apache.org/jira/browse/SOLR-15104