### PR TITLE
SOLR-15261: SortedDocValues no longer extends BinaryDocValues

### DIFF
--- a/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
@@ -312,6 +312,6 @@ class ChildDocTransformer extends DocTransformer {
     int numToAdvance = segPathDocValues.docID() == -1 ? segDocId : segDocId - (segPathDocValues.docID());
     assert numToAdvance >= 0;
     boolean advanced = segPathDocValues.advanceExact(segDocId);
-    return advanced ? segPathDocValues.binaryValue().utf8ToString(): "";
+    return advanced ? segPathDocValues.lookupOrd(segPathDocValues.ordValue()).utf8ToString(): "";//TODO: SortedDocValues quick fix
   }
 }

--- a/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
@@ -312,6 +312,6 @@ class ChildDocTransformer extends DocTransformer {
     int numToAdvance = segPathDocValues.docID() == -1 ? segDocId : segDocId - (segPathDocValues.docID());
     assert numToAdvance >= 0;
     boolean advanced = segPathDocValues.advanceExact(segDocId);
-    return advanced ? segPathDocValues.lookupOrd(segPathDocValues.ordValue()).utf8ToString(): "";//TODO: SortedDocValues quick fix
+    return advanced ? segPathDocValues.lookupOrd(segPathDocValues.ordValue()).utf8ToString(): "";
   }
 }

--- a/solr/core/src/java/org/apache/solr/schema/TrieDoubleField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieDoubleField.java
@@ -95,7 +95,7 @@ public class TrieDoubleField extends TrieField implements DoubleValueFieldType {
           @Override
           public double doubleVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.binaryValue();
+              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
               assert bytes.length > 0;
               return NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(bytes));
             } else {
@@ -122,7 +122,7 @@ public class TrieDoubleField extends TrieField implements DoubleValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(view.binaryValue()));
+                  mval.value = NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(view.lookupOrd(view.ordValue())));//TODO: SortedDocValues quick fix
                 } else {
                   mval.exists = false;
                   mval.value = 0D;

--- a/solr/core/src/java/org/apache/solr/schema/TrieDoubleField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieDoubleField.java
@@ -95,7 +95,7 @@ public class TrieDoubleField extends TrieField implements DoubleValueFieldType {
           @Override
           public double doubleVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
+              BytesRef bytes = view.lookupOrd(view.ordValue());
               assert bytes.length > 0;
               return NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(bytes));
             } else {
@@ -122,7 +122,7 @@ public class TrieDoubleField extends TrieField implements DoubleValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(view.lookupOrd(view.ordValue())));//TODO: SortedDocValues quick fix
+                  mval.value = NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(view.lookupOrd(view.ordValue())));
                 } else {
                   mval.exists = false;
                   mval.value = 0D;

--- a/solr/core/src/java/org/apache/solr/schema/TrieFloatField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieFloatField.java
@@ -94,7 +94,7 @@ public class TrieFloatField extends TrieField implements FloatValueFieldType {
           @Override
           public float floatVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.binaryValue();
+              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
               assert bytes.length > 0;
               return NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(bytes));
             } else {
@@ -121,7 +121,7 @@ public class TrieFloatField extends TrieField implements FloatValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(view.binaryValue()));
+                  mval.value = NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(view.lookupOrd(view.ordValue())));//TODO: SortedDocValues quick fix
                 } else {
                   mval.exists = false;
                   mval.value = 0F;

--- a/solr/core/src/java/org/apache/solr/schema/TrieFloatField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieFloatField.java
@@ -94,7 +94,7 @@ public class TrieFloatField extends TrieField implements FloatValueFieldType {
           @Override
           public float floatVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
+              BytesRef bytes = view.lookupOrd(view.ordValue());
               assert bytes.length > 0;
               return NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(bytes));
             } else {
@@ -121,7 +121,7 @@ public class TrieFloatField extends TrieField implements FloatValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(view.lookupOrd(view.ordValue())));//TODO: SortedDocValues quick fix
+                  mval.value = NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(view.lookupOrd(view.ordValue())));
                 } else {
                   mval.exists = false;
                   mval.value = 0F;

--- a/solr/core/src/java/org/apache/solr/schema/TrieIntField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieIntField.java
@@ -93,7 +93,7 @@ public class TrieIntField extends TrieField implements IntValueFieldType {
           @Override
           public int intVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
+              BytesRef bytes = view.lookupOrd(view.ordValue());
               assert bytes.length > 0;
               return LegacyNumericUtils.prefixCodedToInt(bytes);
             } else {
@@ -120,7 +120,7 @@ public class TrieIntField extends TrieField implements IntValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = LegacyNumericUtils.prefixCodedToInt(view.lookupOrd(view.ordValue()));//TODO: SortedDocValues quick fix
+                  mval.value = LegacyNumericUtils.prefixCodedToInt(view.lookupOrd(view.ordValue()));
                 } else {
                   mval.exists = false;
                   mval.value = 0;

--- a/solr/core/src/java/org/apache/solr/schema/TrieIntField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieIntField.java
@@ -93,7 +93,7 @@ public class TrieIntField extends TrieField implements IntValueFieldType {
           @Override
           public int intVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.binaryValue();
+              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
               assert bytes.length > 0;
               return LegacyNumericUtils.prefixCodedToInt(bytes);
             } else {
@@ -120,7 +120,7 @@ public class TrieIntField extends TrieField implements IntValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = LegacyNumericUtils.prefixCodedToInt(view.binaryValue());
+                  mval.value = LegacyNumericUtils.prefixCodedToInt(view.lookupOrd(view.ordValue()));//TODO: SortedDocValues quick fix
                 } else {
                   mval.exists = false;
                   mval.value = 0;

--- a/solr/core/src/java/org/apache/solr/schema/TrieLongField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieLongField.java
@@ -93,7 +93,7 @@ public class TrieLongField extends TrieField implements LongValueFieldType {
           @Override
           public long longVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.binaryValue();
+              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
               assert bytes.length > 0;
               return LegacyNumericUtils.prefixCodedToLong(bytes);
             } else {
@@ -120,7 +120,7 @@ public class TrieLongField extends TrieField implements LongValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = LegacyNumericUtils.prefixCodedToLong(view.binaryValue());
+                  mval.value = LegacyNumericUtils.prefixCodedToLong(view.lookupOrd(view.ordValue()));//TODO: SortedDocValues quick fix
                 } else {
                   mval.exists = false;
                   mval.value = 0L;

--- a/solr/core/src/java/org/apache/solr/schema/TrieLongField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieLongField.java
@@ -93,7 +93,7 @@ public class TrieLongField extends TrieField implements LongValueFieldType {
           @Override
           public long longVal(int doc) throws IOException {
             if (setDoc(doc)) {
-              BytesRef bytes = view.lookupOrd(view.ordValue());//TODO: SortedDocValues quick fix
+              BytesRef bytes = view.lookupOrd(view.ordValue());
               assert bytes.length > 0;
               return LegacyNumericUtils.prefixCodedToLong(bytes);
             } else {
@@ -120,7 +120,7 @@ public class TrieLongField extends TrieField implements LongValueFieldType {
               public void fillValue(int doc) throws IOException {
                 if (setDoc(doc)) {
                   mval.exists = true;
-                  mval.value = LegacyNumericUtils.prefixCodedToLong(view.lookupOrd(view.ordValue()));//TODO: SortedDocValues quick fix
+                  mval.value = LegacyNumericUtils.prefixCodedToLong(view.lookupOrd(view.ordValue()));
                 } else {
                   mval.exists = false;
                   mval.value = 0L;

--- a/solr/core/src/java/org/apache/solr/search/HashQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/HashQParserPlugin.java
@@ -112,7 +112,7 @@ public class HashQParserPlugin extends QParserPlugin {
             @Override
             public boolean advanceExact(int doc) throws IOException { atDoc = values.advanceExact(doc); return true; }
             @Override
-            public long longValue() throws IOException { return atDoc ? values.binaryValue().hashCode() : 0; }
+            public long longValue() throws IOException { return atDoc ? values.lookupOrd(values.ordValue()).hashCode() : 0; }//TODO: SortedDocValues quick fix
           };
           continue;
         }

--- a/solr/core/src/java/org/apache/solr/search/HashQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/HashQParserPlugin.java
@@ -112,7 +112,10 @@ public class HashQParserPlugin extends QParserPlugin {
             @Override
             public boolean advanceExact(int doc) throws IOException { atDoc = values.advanceExact(doc); return true; }
             @Override
-            public long longValue() throws IOException { return atDoc ? values.lookupOrd(values.ordValue()).hashCode() : 0; }//TODO: SortedDocValues quick fix
+            public long longValue() throws IOException {
+              //TODO: maybe cache hashCode if same ord as prev doc to save lookupOrd?
+              return atDoc ? values.lookupOrd(values.ordValue()).hashCode() : 0;
+            }
           };
           continue;
         }

--- a/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
@@ -561,7 +561,7 @@ public class SolrDocumentFetcher {
       case SORTED:
         SortedDocValues sdv = leafReader.getSortedDocValues(fieldName);
         if (sdv != null && sdv.advanceExact(localId)) {
-          final BytesRef bRef = sdv.binaryValue();
+          final BytesRef bRef = sdv.lookupOrd(sdv.ordValue());//TODO: SortedDocValues quick fix
           // Special handling for Boolean fields since they're stored as 'T' and 'F'.
           if (schemaField.getType() instanceof BoolField) {
             return schemaField.getType().toObject(schemaField, bRef);

--- a/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
@@ -561,7 +561,7 @@ public class SolrDocumentFetcher {
       case SORTED:
         SortedDocValues sdv = leafReader.getSortedDocValues(fieldName);
         if (sdv != null && sdv.advanceExact(localId)) {
-          final BytesRef bRef = sdv.lookupOrd(sdv.ordValue());//TODO: SortedDocValues quick fix
+          final BytesRef bRef = sdv.lookupOrd(sdv.ordValue());
           // Special handling for Boolean fields since they're stored as 'T' and 'F'.
           if (schemaField.getType() instanceof BoolField) {
             return schemaField.getType().toObject(schemaField, bRef);

--- a/solr/core/src/java/org/apache/solr/search/join/HashRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/join/HashRangeQuery.java
@@ -104,7 +104,8 @@ public class HashRangeQuery extends Query {
       }
 
       private int hash(SortedDocValues docValues) throws IOException {
-        BytesRef bytesRef = docValues.lookupOrd(docValues.ordValue());//TODO: SortedDocValues quick fix
+        //TODO maybe cache hashCode if same ord as prev doc to save lookupOrd?
+        BytesRef bytesRef = docValues.lookupOrd(docValues.ordValue());
         return Hash.murmurhash3_x86_32(bytesRef.bytes, bytesRef.offset, bytesRef.length, 0);
       }
     };

--- a/solr/core/src/java/org/apache/solr/search/join/HashRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/join/HashRangeQuery.java
@@ -104,7 +104,7 @@ public class HashRangeQuery extends Query {
       }
 
       private int hash(SortedDocValues docValues) throws IOException {
-        BytesRef bytesRef = docValues.binaryValue();
+        BytesRef bytesRef = docValues.lookupOrd(docValues.ordValue());//TODO: SortedDocValues quick fix
         return Hash.murmurhash3_x86_32(bytesRef.bytes, bytesRef.offset, bytesRef.length, 0);
       }
     };

--- a/solr/core/src/java/org/apache/solr/uninverting/FieldCacheImpl.java
+++ b/solr/core/src/java/org/apache/solr/uninverting/FieldCacheImpl.java
@@ -1076,10 +1076,6 @@ public class FieldCacheImpl implements FieldCache {
 
   public BinaryDocValues getTerms(LeafReader reader, String field, float acceptableOverheadRatio) throws IOException {
     BinaryDocValues valuesIn = reader.getBinaryDocValues(field);
-    if (valuesIn == null) {
-      valuesIn = reader.getSortedDocValues(field);
-    }
-
     if (valuesIn != null) {
       // Not cached here by FieldCacheImpl (cached instead
       // per-thread by SegmentReader):

--- a/solr/core/src/test/org/apache/solr/index/UninvertDocValuesMergePolicyTest.java
+++ b/solr/core/src/test/org/apache/solr/index/UninvertDocValuesMergePolicyTest.java
@@ -140,7 +140,7 @@ public class UninvertDocValuesMergePolicyTest extends SolrTestCaseJ4 {
           assertEquals(v, id);
           
           docvalues.nextDoc();
-          assertEquals(v, docvalues.binaryValue().utf8ToString());
+          assertEquals(v, docvalues.lookupOrd(docvalues.ordValue()).utf8ToString());
         }
       }
     });
@@ -186,7 +186,7 @@ public class UninvertDocValuesMergePolicyTest extends SolrTestCaseJ4 {
          
           if(id.equals("2")) {
             assertTrue(docvalues.advanceExact(i));
-            assertEquals(v, docvalues.binaryValue().utf8ToString());
+            assertEquals(v, docvalues.lookupOrd(docvalues.ordValue()).utf8ToString());
           } else {
             assertFalse(docvalues.advanceExact(i));
           }

--- a/solr/core/src/test/org/apache/solr/schema/DocValuesTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DocValuesTest.java
@@ -100,10 +100,10 @@ public class DocValuesTest extends SolrTestCaseJ4 {
         assertEquals(4L, dvs.longValue());
         SortedDocValues sdv = reader.getSortedDocValues("stringdv");
         assertEquals(0, sdv.nextDoc());
-        assertEquals("solr", sdv.binaryValue().utf8ToString());
+        assertEquals("solr", sdv.lookupOrd(sdv.ordValue()).utf8ToString());
         sdv = reader.getSortedDocValues("booldv");
         assertEquals(0, sdv.nextDoc());
-        assertEquals("T", sdv.binaryValue().utf8ToString());
+        assertEquals("T", sdv.lookupOrd(sdv.ordValue()).utf8ToString());
 
         final IndexSchema schema = core.getLatestSchema();
         final SchemaField floatDv = schema.getField("floatdv");

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCache.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCache.java
@@ -188,7 +188,7 @@ public class TestFieldCache extends SolrTestCase {
         termsIndex.advance(i);
       }
       if (i == termsIndex.docID()) {
-        s = termsIndex.binaryValue().utf8ToString();
+        s = termsIndex.lookupOrd(termsIndex.ordValue()).utf8ToString();
       } else {
         s = null;
       }
@@ -459,7 +459,7 @@ public class TestFieldCache extends SolrTestCase {
     assertEquals(0, sorted.nextDoc());
     assertEquals(0, sorted.ordValue());
     assertEquals(1, sorted.getValueCount());
-    scratch = sorted.binaryValue();
+    scratch = sorted.lookupOrd(sorted.ordValue());
     assertEquals("sorted value", scratch.utf8ToString());
     
     SortedSetDocValues sortedSet = FieldCache.DEFAULT.getDocTermOrds(ar, "sorted", null);

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCache.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCache.java
@@ -449,17 +449,11 @@ public class TestFieldCache extends SolrTestCase {
       new DocTermOrds(ar, null, "sorted");
     });
     
-    binary = FieldCache.DEFAULT.getTerms(ar, "sorted");
-    assertEquals(0, binary.nextDoc());
-
-    BytesRef scratch = binary.binaryValue();
-    assertEquals("sorted value", scratch.utf8ToString());
-    
     SortedDocValues sorted = FieldCache.DEFAULT.getTermsIndex(ar, "sorted");
     assertEquals(0, sorted.nextDoc());
     assertEquals(0, sorted.ordValue());
     assertEquals(1, sorted.getValueCount());
-    scratch = sorted.lookupOrd(sorted.ordValue());
+    BytesRef scratch = sorted.lookupOrd(sorted.ordValue());
     assertEquals("sorted value", scratch.utf8ToString());
     
     SortedSetDocValues sortedSet = FieldCache.DEFAULT.getDocTermOrds(ar, "sorted", null);

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheVsDocValues.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheVsDocValues.java
@@ -404,7 +404,7 @@ public class TestFieldCacheVsDocValues extends SolrTestCase {
       }
       assertEquals(docID, actual.nextDoc());
       assertEquals(expected.ordValue(), actual.ordValue());
-      assertEquals(expected.binaryValue(), actual.binaryValue());
+      assertEquals(expected.lookupOrd(expected.ordValue()), actual.lookupOrd(actual.ordValue()));
     }
     
     // compare ord dictionary

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheWithThreads.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheWithThreads.java
@@ -123,7 +123,7 @@ public class TestFieldCacheWithThreads extends SolrTestCase {
                 assertEquals(binary.get(docID), bdv.binaryValue());
                 SortedDocValues sdv = FieldCache.DEFAULT.getTermsIndex(ar, "sorted");
                 assertEquals(docID, sdv.advance(docID));
-                assertEquals(sorted.get(docID), sdv.binaryValue());
+                assertEquals(sorted.get(docID), sdv.lookupOrd(sdv.ordValue()));
               }
             } catch (Exception e) {
               throw new RuntimeException(e);
@@ -234,7 +234,7 @@ public class TestFieldCacheWithThreads extends SolrTestCase {
                 try {
                   SortedDocValues dvs = sr.getSortedDocValues("stringdv");
                   assertEquals(docID, dvs.advance(docID));
-                  assertEquals(docValues.get(docIDToIDArray[docID]), dvs.binaryValue());
+                  assertEquals(docValues.get(docIDToIDArray[docID]), dvs.lookupOrd(dvs.ordValue()));
                 } catch (IOException ioe) {
                   throw new RuntimeException(ioe);
                 }


### PR DESCRIPTION
Adapts Solr to Lucene changes where SortedDocValues no longer extends BinaryDocValues (LUCENE-9796).

I added a "//TODO: SortedDocValues quick fix" markers to allow us to adapt the algorithms to be more efficient if possible. I'll try to follow up on that quickly.