### PR TITLE
SOLR-15169 SolrPaths.assertPathAllowed normalization problem

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -240,6 +240,8 @@ Other Changes
 
 * SOLR-15121: Move XSLT (tr param) response writer and update request handler to scripting contrib.  (Eric Pugh, David Smiley)
 
+* SOLR-15169: SolrPaths.assertPathAllowed normalization problem (Andras Salamon via janhoy)
+
 * SOLR-15292: SignatureUpdateProcessorFactory will fail to initialize if it is used in a SolrCloud cluster in a way that is
   known to be problematic with multiple replicas.  (hossman)
 

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -373,13 +374,13 @@ public class CoreContainer {
             new SolrNamedThreadFactory("replayUpdatesExecutor")));
 
     this.allowPaths = new java.util.HashSet<>();
-    this.allowPaths.add(cfg.getSolrHome());
-    this.allowPaths.add(cfg.getCoreRootDirectory());
+    addToAllowPath(cfg.getSolrHome());
+    addToAllowPath(cfg.getCoreRootDirectory());
     if (cfg.getSolrDataHome() != null) {
-      this.allowPaths.add(cfg.getSolrDataHome());
+      addToAllowPath(cfg.getSolrDataHome());
     }
     if (!cfg.getAllowPaths().isEmpty()) {
-      this.allowPaths.addAll(cfg.getAllowPaths());
+      addAllToAllowPath(cfg.getAllowPaths());
       if (log.isInfoEnabled()) {
         log.info("Allowing use of paths: {}", cfg.getAllowPaths());
       }
@@ -391,6 +392,14 @@ public class CoreContainer {
     } catch (Exception e) {
       log.warn("Unable to create [{}].  Features requiring this directory may fail.", userFilesPath, e);
     }
+  }
+
+  private void addToAllowPath(Path path) {
+    this.allowPaths.add(path.normalize());
+  }
+
+  private void addAllToAllowPath(Set<Path> paths) {
+    this.allowPaths.addAll(paths.stream().map( path -> path.normalize()).collect(Collectors.toSet()));
   }
 
   @SuppressWarnings({"unchecked"})

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -609,6 +609,28 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
     assertPathBlocked("\\\\unc-server\\share\\path");
   }
 
+  @Test
+  public void assertAllowPathNormalization() throws Exception {
+    Assume.assumeFalse(OS.isFamilyWindows());
+    System.setProperty("solr.allowPaths", "/var/solr/../solr");
+    CoreContainer cc = init(ALLOW_PATHS_SOLR_XML);
+    cc.assertPathAllowed(Paths.get("/var/solr/foo"));
+    assertThrows("Path /tmp should not be allowed", SolrException.class, () -> { cc.assertPathAllowed(Paths.get("/tmp")); });
+    cc.shutdown();
+    System.clearProperty("solr.allowPaths");
+  }
+
+  @Test
+  public void assertAllowPathNormalizationWin() throws Exception {
+    Assume.assumeTrue(OS.isFamilyWindows());
+    System.setProperty("solr.allowPaths", "C:\\solr\\..\\solr");
+    CoreContainer cc = init(ALLOW_PATHS_SOLR_XML);
+    cc.assertPathAllowed(Paths.get("C:\\solr\\foo"));
+    assertThrows("Path C:\\tmp should not be allowed", SolrException.class, () -> { cc.assertPathAllowed(Paths.get("C:\\tmp")); });
+    cc.shutdown();
+    System.clearProperty("solr.allowPaths");
+  }
+
   private static Set<Path> ALLOWED_PATHS = Set.of(Path.of("/var/solr"));
   private static Set<Path> ALLOWED_PATHS_WIN = Set.of(Path.of("C:\\var\\solr"));
 


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->

Original lucene-solr pull request: https://github.com/apache/lucene-solr/pull/2406

# Description

In the SolrPaths.assertPathAllowed the normalize() method is only called for pathToAssert and not for the allowPaths elements

# Solution

Calling it for allowPaths elements

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
