### PR TITLE
Allow configuring maven snapshots repository mirrors

### DIFF
--- a/gradle/defaults.gradle
+++ b/gradle/defaults.gradle
@@ -20,15 +20,6 @@ allprojects {
 
   group "org.apache"
 
-  // Repositories to fetch dependencies from.
-  repositories {
-    mavenCentral()
-    maven {
-      name "ApacheSnapshots"
-      url 'https://repository.apache.org/content/repositories/snapshots/'
-    }
-  }
-
   // Artifacts will have names after full gradle project path
   // so :solr:core will have solr-core.jar, etc.
   project.archivesBaseName = project.path.replaceAll("^:", "").replace(':', '-')
@@ -75,6 +66,15 @@ allprojects {
           dummyOutput.createNewFile()
         }
       }
+    }
+  }
+
+  // Repositories to fetch dependencies from.
+  repositories {
+    mavenCentral()
+    maven {
+      name "ApacheSnapshots"
+      url propertyOrDefault('apache-snapshot-repo', 'https://repository.apache.org/content/repositories/snapshots/')
     }
   }
 }


### PR DESCRIPTION
Not sure if this is the best approach, but I need a way to be able to specify an internal repo for building against Lucene snapshots without depending on the state of the last published Apache snapshots.