### PR TITLE
SOLR-15276: Use same pattern on GET as on DELETE and be more RESTful.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -94,11 +94,14 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-2852: SolrJ: remove Woodstox dependency.  It was never truly required there.
   Software doing lots of XML processing can choose to add it or alternatives if they wish.
   (David Smiley)
-  
+
 * SOLR-15161: Don't encourage users to hack JSON response mimetype by documenting in examples how to
   specify wt=json use mimetype of text/plain.  (Eric Pugh)
 
 * SOLR-15203: remove deprecated parameter name jwkUrl in favour of jwksUrl for the JWK Url. (Eric Pugh)
+
+* SOLR-15276: V2 API call to look up async request status restful style of "/cluster/command-status/1000" instead of "/cluster/command-status?requestid=1000". (Eric Pugh)
+
 
 Other Changes
 ----------------------

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -189,9 +189,10 @@ public class ClusterAPI {
   }
 
   @EndPoint(method = GET,
-      path = "/cluster/command-status",
+      path = "/cluster/command-status/{id}",
       permission = COLL_READ_PERM)
   public void getCommandStatus(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+    wrapParams(req, REQUESTID, req.getPathTemplateValues().get("id"));
     CollectionsHandler.CollectionOperation.REQUESTSTATUS_OP.execute(req, rsp, collectionsHandler);
   }
 

--- a/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
@@ -155,6 +155,8 @@ escaping because it's inconsistent with the rest of Solr and was limiting.  This
 
 * SOLR-15203: Remove the deprecated `jwkUrl` in favour of `jwksUrl` when configuring JWT authentication.
 
+* SOLR-15276: V2 API call to look up async request status restful style of "/cluster/command-status/1000" instead of "/cluster/command-status?requestid=1000".
+
 === Upgrade Prerequisites in Solr 9
 
 * Upgrade all collections in stateFormat=1 to stateFormat=2 *before* upgrading to Solr 9, as Solr 9 does not support the


### PR DESCRIPTION
# Description

Pass the requestid param as the `{id}` in the url, same as in the DELETE verb

# Solution

Simple change to mapper

# Tests

run tests

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [X ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)

Docs are being updated in another PR.
