### PR TITLE
SOLR-15278: allow the flush parameter to be passed when doing a DELETE

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -102,6 +102,14 @@ public class ClusterAPI {
   }
 
   @EndPoint(method = DELETE,
+      path = "/cluster/command-status",
+      permission = COLL_EDIT_PERM)
+  public void flushCommandStatus(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+    wrapParams(req, "flush", true);
+    CollectionsHandler.CollectionOperation.DELETESTATUS_OP.execute(req, rsp, collectionsHandler);
+  }
+
+  @EndPoint(method = DELETE,
       path =   "/cluster/configs/{name}",
       permission = CONFIG_EDIT_PERM
   )


### PR DESCRIPTION
# Description

V2 API didn't support passing the flush command.   

# Solution

Need to add support to do:

```
curl -X DELETE http://localhost:8983/api/cluster/command-status -H 'Content-Type: application/json'
```
and that is the same as passing the `flush` parameter.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
