### PR TITLE
SOLR-15340: Rename shardsWhitelist and extract AllowListUrlChecker to use it more broadly.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -116,6 +116,8 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 
 * SOLR-15322: Solr releases now contain everything needed to build runable docker images (Houston Putman, hossman)
 
+* SOLR-15340: Rename shardsWhitelist and extract AllowListUrlChecker to use it more broadly. (Bruno Roustant)
+
 Other Changes
 ----------------------
 * SOLR-14656: Autoscaling framework removed (Ishan Chattopadhyaya, noble, Ilan Ginzburg)

--- a/solr/bin/solr.in.cmd
+++ b/solr/bin/solr.in.cmd
@@ -185,9 +185,9 @@ REM set SOLR_OPTS=%SOLR_OPTS% %SOLR_ZK_CREDS_AND_ACLS%
 
 REM When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the
 REM list of hosts needs to be defined in an allow-list or Solr will forbid the request. The allow-list can be configured
-REM in solr.xml, or if you are using the OOTB solr.xml, can be specified using the system property "solr.urlAllowList".
-REM Alternatively host checking can be disabled by using the system property "solr.disable.urlAllowList"
-REM set SOLR_OPTS=%SOLR_OPTS% -Dsolr.urlAllowList=http://localhost:8983,http://localhost:8984
+REM in solr.xml, or if you are using the OOTB solr.xml, can be specified using the system property "solr.allowUrls".
+REM Alternatively host checking can be disabled by using the system property "solr.disable.allowUrls"
+REM set SOLR_OPTS=%SOLR_OPTS% -Dsolr.allowUrls=http://localhost:8983,http://localhost:8984
 
 REM For a visual indication in the Admin UI of what type of environment this cluster is, configure
 REM a -Dsolr.environment property below. Valid values are prod, stage, test, dev, with an optional

--- a/solr/bin/solr.in.cmd
+++ b/solr/bin/solr.in.cmd
@@ -184,10 +184,10 @@ REM  -DzkDigestReadonlyUsername=readonly-user -DzkDigestReadonlyPassword=CHANGEM
 REM set SOLR_OPTS=%SOLR_OPTS% %SOLR_ZK_CREDS_AND_ACLS%
 
 REM When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the
-REM list of hosts needs to be whitelisted or Solr will forbid the request. The whitelist can be configured in solr.xml,
-REM or if you are using the OOTB solr.xml, can be specified using the system property "solr.shardsWhitelist". Alternatively
-REM host checking can be disabled by using the system property "solr.disable.shardsWhitelist"
-REM set SOLR_OPTS=%SOLR_OPTS% -Dsolr.shardsWhitelist=http://localhost:8983,http://localhost:8984
+REM list of hosts needs to be defined in an allow-list or Solr will forbid the request. The allow-list can be configured
+REM in solr.xml, or if you are using the OOTB solr.xml, can be specified using the system property "solr.urlAllowList".
+REM Alternatively host checking can be disabled by using the system property "solr.disable.urlAllowList"
+REM set SOLR_OPTS=%SOLR_OPTS% -Dsolr.urlAllowList=http://localhost:8983,http://localhost:8984
 
 REM For a visual indication in the Admin UI of what type of environment this cluster is, configure
 REM a -Dsolr.environment property below. Valid values are prod, stage, test, dev, with an optional

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -219,10 +219,10 @@
 #SOLR_ULIMIT_CHECKS=
 
 # When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the
-# list of hosts needs to be whitelisted or Solr will forbid the request. The whitelist can be configured in solr.xml,
-# or if you are using the OOTB solr.xml, can be specified using the system property "solr.shardsWhitelist". Alternatively
-# host checking can be disabled by using the system property "solr.disable.shardsWhitelist"
-#SOLR_OPTS="$SOLR_OPTS -Dsolr.shardsWhitelist=http://localhost:8983,http://localhost:8984"
+# list of hosts needs to be defined in an allow-list or Solr will forbid the request. The allow-list can be configured
+# in solr.xml, or if you are using the OOTB solr.xml, can be specified using the system property "solr.urlAllowList".
+# Alternatively host checking can be disabled by using the system property "solr.disable.urlAllowList"
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.urlAllowList=http://localhost:8983,http://localhost:8984"
 
 # For a visual indication in the Admin UI of what type of environment this cluster is, configure
 # a -Dsolr.environment property below. Valid values are prod, stage, test, dev, with an optional

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -220,9 +220,9 @@
 
 # When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the
 # list of hosts needs to be defined in an allow-list or Solr will forbid the request. The allow-list can be configured
-# in solr.xml, or if you are using the OOTB solr.xml, can be specified using the system property "solr.urlAllowList".
-# Alternatively host checking can be disabled by using the system property "solr.disable.urlAllowList"
-#SOLR_OPTS="$SOLR_OPTS -Dsolr.urlAllowList=http://localhost:8983,http://localhost:8984"
+# in solr.xml, or if you are using the OOTB solr.xml, can be specified using the system property "solr.allowUrls".
+# Alternatively host checking can be disabled by using the system property "solr.disable.allowUrls"
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.allowUrls=http://localhost:8983,http://localhost:8984"
 
 # For a visual indication in the Admin UI of what type of environment this cluster is, configure
 # a -Dsolr.environment property below. Valid values are prod, stage, test, dev, with an optional

--- a/solr/contrib/jaegertracer-configurator/src/test-files/solr/solr.xml
+++ b/solr/contrib/jaegertracer-configurator/src/test-files/solr/solr.xml
@@ -31,7 +31,7 @@
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:90000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="shardsWhitelist">${solr.tests.shardsWhitelist:}</str>
+    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <tracerConfig name="tracerConfig" class="org.apache.solr.jaeger.JaegerTracerConfigurator">

--- a/solr/contrib/jaegertracer-configurator/src/test-files/solr/solr.xml
+++ b/solr/contrib/jaegertracer-configurator/src/test-files/solr/solr.xml
@@ -26,12 +26,12 @@
   <str name="configSetBaseDir">${configSetBaseDir:configsets}</str>
   <str name="coreRootDirectory">${coreRootDirectory:.}</str>
   <str name="collectionsHandler">${collectionsHandler:solr.CollectionsHandler}</str>
+  <str name="allowUrls">${solr.tests.allowUrls:}</str>
 
   <shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory">
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:90000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <tracerConfig name="tracerConfig" class="org.apache.solr.jaeger.JaegerTracerConfigurator">

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -221,7 +221,7 @@ public class RecoveryStrategy implements Runnable, Closeable {
   final private void replicate(String nodeName, SolrCore core, ZkNodeProps leaderprops)
       throws SolrServerException, IOException {
 
-    final String leaderUrl = getReplicateLeaderUrl(leaderprops);//TODO?
+    final String leaderUrl = getReplicateLeaderUrl(leaderprops);
 
     log.info("Attempting to replicate from [{}].", leaderUrl);
 

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -221,7 +221,7 @@ public class RecoveryStrategy implements Runnable, Closeable {
   final private void replicate(String nodeName, SolrCore core, ZkNodeProps leaderprops)
       throws SolrServerException, IOException {
 
-    final String leaderUrl = getReplicateLeaderUrl(leaderprops);
+    final String leaderUrl = getReplicateLeaderUrl(leaderprops);//TODO?
 
     log.info("Attempting to replicate from [{}].", leaderUrl);
 

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -128,6 +128,7 @@ import org.apache.solr.pkg.PackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.search.SolrFieldCacheBean;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.security.AuditLoggerPlugin;
 import org.apache.solr.security.AuthenticationPlugin;
 import org.apache.solr.security.AuthorizationPlugin;
@@ -269,6 +270,8 @@ public class CoreContainer {
 
   private Set<Path> allowPaths;
 
+  private AllowListUrlChecker allowListUrlChecker;
+
   // Bits for the state variable.
   public final static long LOAD_COMPLETE = 0x1L;
   public final static long CORE_DISCOVERY_COMPLETE = 0x2L;
@@ -393,6 +396,9 @@ public class CoreContainer {
         log.info("Allowing use of paths: {}", cfg.getAllowPaths());
       }
     }
+
+    this.allowListUrlChecker = AllowListUrlChecker.create(config);
+    log.info("URL allow-list initialized: {}", this.allowListUrlChecker);
 
     Path userFilesPath = getUserFilesPath(); // TODO make configurable on cfg?
     try {
@@ -1424,6 +1430,13 @@ public class CoreContainer {
   @VisibleForTesting
   public Set<Path> getAllowPaths() {
     return allowPaths;
+  }
+
+  /**
+   * Gets the URLs checker based on the {@code allowUrls} configuration of solr.xml.
+   */
+  public AllowListUrlChecker getAllowListUrlChecker() {
+    return allowListUrlChecker;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -398,7 +398,6 @@ public class CoreContainer {
     }
 
     this.allowListUrlChecker = AllowListUrlChecker.create(config);
-    log.info("URL allow-list initialized: {}", this.allowListUrlChecker);
 
     Path userFilesPath = getUserFilesPath(); // TODO make configurable on cfg?
     try {

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -16,17 +16,17 @@
  */
 package org.apache.solr.core;
 
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.logging.LogWatcherConfig;
+import org.apache.solr.update.UpdateShardHandlerConfig;
+
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.solr.common.SolrException;
-import org.apache.solr.logging.LogWatcherConfig;
-import org.apache.solr.update.UpdateShardHandlerConfig;
 
 
 public class NodeConfig {
@@ -43,6 +43,8 @@ public class NodeConfig {
   private final Path configSetBaseDirectory;
 
   private final Set<Path> allowPaths;
+
+  private final String allowUrls;
 
   private final String sharedLibDirectory;
 
@@ -102,7 +104,8 @@ public class NodeConfig {
                      Path solrHome, SolrResourceLoader loader,
                      Properties solrProperties, PluginInfo[] backupRepositoryPlugins,
                      MetricsConfig metricsConfig, PluginInfo transientCacheConfig, PluginInfo tracerConfig,
-                     boolean fromZookeeper, String defaultZkHost, Set<Path> allowPaths,String configSetServiceClass) {
+                     boolean fromZookeeper, String defaultZkHost, Set<Path> allowPaths, String allowUrls,
+                     String configSetServiceClass) {
     // all Path params here are absolute and normalized.
     this.nodeName = nodeName;
     this.coreRootDirectory = coreRootDirectory;
@@ -134,6 +137,7 @@ public class NodeConfig {
     this.fromZookeeper = fromZookeeper;
     this.defaultZkHost = defaultZkHost;
     this.allowPaths = allowPaths;
+    this.allowUrls = allowUrls;
     this.configSetServiceClass = configSetServiceClass;
 
     if (this.cloudConfig != null && this.getCoreLoadThreadCount(false) < 2) {
@@ -309,6 +313,13 @@ public class NodeConfig {
    */
   public Set<Path> getAllowPaths() { return allowPaths; }
 
+  /**
+   * Comma-separated allow-list of Solr nodes URLs.
+   */
+  public String getAllowUrls() {
+    return allowUrls;
+  }
+
   public static class NodeConfigBuilder {
     // all Path fields here are absolute and normalized.
     private SolrResourceLoader loader;
@@ -342,6 +353,7 @@ public class NodeConfig {
     private boolean fromZookeeper = false;
     private String defaultZkHost;
     private Set<Path> allowPaths = Collections.emptySet();
+    private String allowUrls;
 
     private final Path solrHome;
     private final String nodeName;
@@ -516,6 +528,11 @@ public class NodeConfig {
       return this;
     }
 
+    public NodeConfigBuilder setAllowUrls(String urls) {
+      this.allowUrls = urls;
+      return this;
+    }
+
     public NodeConfigBuilder setConfigSetServiceClass(String configSetServiceClass){
       this.configSetServiceClass = configSetServiceClass;
       return this;
@@ -526,12 +543,16 @@ public class NodeConfig {
       if (loader == null) {
         loader = new SolrResourceLoader(solrHome);
       }
-      return new NodeConfig(nodeName, coreRootDirectory, solrDataHome, booleanQueryMaxClauseCount,
-                            configSetBaseDirectory, sharedLibDirectory, shardHandlerFactoryConfig,
-                            updateShardHandlerConfig, coreAdminHandlerClass, collectionsAdminHandlerClass, healthCheckHandlerClass, infoHandlerClass, configSetsHandlerClass,
-                            logWatcherConfig, cloudConfig, coreLoadThreads, replayUpdatesThreads, transientCacheSize, useSchemaCache, managementPath,
-                            solrHome, loader, solrProperties,
-                            backupRepositoryPlugins, metricsConfig, transientCacheConfig, tracerConfig, fromZookeeper, defaultZkHost, allowPaths, configSetServiceClass);
+      return new NodeConfig(
+              nodeName, coreRootDirectory, solrDataHome, booleanQueryMaxClauseCount,
+              configSetBaseDirectory, sharedLibDirectory, shardHandlerFactoryConfig,
+              updateShardHandlerConfig, coreAdminHandlerClass, collectionsAdminHandlerClass,
+              healthCheckHandlerClass, infoHandlerClass, configSetsHandlerClass,
+              logWatcherConfig, cloudConfig, coreLoadThreads, replayUpdatesThreads,
+              transientCacheSize, useSchemaCache, managementPath,
+              solrHome, loader, solrProperties,
+              backupRepositoryPlugins, metricsConfig, transientCacheConfig, tracerConfig,
+              fromZookeeper, defaultZkHost, allowPaths, allowUrls, configSetServiceClass);
     }
 
     public NodeConfigBuilder setSolrResourceLoader(SolrResourceLoader resourceLoader) {

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -44,7 +45,7 @@ public class NodeConfig {
 
   private final Set<Path> allowPaths;
 
-  private final String allowUrls;
+  private final List<String> allowUrls;
 
   private final String sharedLibDirectory;
 
@@ -104,7 +105,7 @@ public class NodeConfig {
                      Path solrHome, SolrResourceLoader loader,
                      Properties solrProperties, PluginInfo[] backupRepositoryPlugins,
                      MetricsConfig metricsConfig, PluginInfo transientCacheConfig, PluginInfo tracerConfig,
-                     boolean fromZookeeper, String defaultZkHost, Set<Path> allowPaths, String allowUrls,
+                     boolean fromZookeeper, String defaultZkHost, Set<Path> allowPaths, List<String> allowUrls,
                      String configSetServiceClass) {
     // all Path params here are absolute and normalized.
     this.nodeName = nodeName;
@@ -314,9 +315,9 @@ public class NodeConfig {
   public Set<Path> getAllowPaths() { return allowPaths; }
 
   /**
-   * Comma-separated allow-list of Solr nodes URLs.
+   * Allow-list of Solr nodes URLs.
    */
-  public String getAllowUrls() {
+  public List<String> getAllowUrls() {
     return allowUrls;
   }
 
@@ -353,7 +354,7 @@ public class NodeConfig {
     private boolean fromZookeeper = false;
     private String defaultZkHost;
     private Set<Path> allowPaths = Collections.emptySet();
-    private String allowUrls;
+    private List<String> allowUrls = Collections.emptyList();
 
     private final Path solrHome;
     private final String nodeName;
@@ -528,7 +529,7 @@ public class NodeConfig {
       return this;
     }
 
-    public NodeConfigBuilder setAllowUrls(String urls) {
+    public NodeConfigBuilder setAllowUrls(List<String> urls) {
       this.allowUrls = urls;
       return this;
     }

--- a/solr/core/src/java/org/apache/solr/core/SolrPaths.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrPaths.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Set;
 
 import org.apache.commons.exec.OS;
@@ -33,6 +34,11 @@ import org.slf4j.LoggerFactory;
  */
 public final class SolrPaths {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * Special path set which accepts all paths.
+   */
+  public static final Set<Path> ALL_PATHS = Collections.singleton(Paths.get("_ALL_"));
 
   private SolrPaths() {} // don't create this
 
@@ -58,6 +64,7 @@ public final class SolrPaths {
    * @throws SolrException if path is outside allowed paths
    */
   public static void assertPathAllowed(Path pathToAssert, Set<Path> allowPaths) throws SolrException {
+    if (ALL_PATHS.equals(allowPaths)) return; // Catch-all allows all paths (*/_ALL_)
     if (pathToAssert == null) return;
     if (OS.isFamilyWindows() && pathToAssert.toString().startsWith("\\\\")) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
@@ -70,7 +77,6 @@ public final class SolrPaths {
           "Path " + pathToAssert + " disallowed due to path traversal..");
     }
     if (!path.isAbsolute()) return; // All relative paths are accepted
-    if (allowPaths.contains(Paths.get("_ALL_"))) return; // Catch-all path "*"/"_ALL_" will allow all other paths
     if (allowPaths.stream().noneMatch(p -> path.startsWith(Path.of(p.toString())))) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
           "Path " + path + " must be relative to SOLR_HOME, SOLR_DATA_HOME coreRootDirectory. Set system property 'solr.allowPaths' to add other allowed paths.");

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
@@ -73,6 +74,8 @@ public class SolrXmlConfig {
   public final static String SOLR_DATA_HOME = "solr.data.home";
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final Pattern COMMA_SEPARATED_PATTERN = Pattern.compile(",\\s*");
 
   /**
    * Given some node Properties, checks if non-null and a 'zkHost' is alread included.  If so, the Properties are
@@ -327,7 +330,7 @@ public class SolrXmlConfig {
           builder.setSharedLibDirectory(value);
           break;
         case "allowPaths":
-          builder.setAllowPaths(stringToPaths(value));
+          builder.setAllowPaths(separatePaths(value));
           break;
         case "configSetBaseDir":
           builder.setConfigSetBaseDirectory(value);
@@ -345,7 +348,7 @@ public class SolrXmlConfig {
           builder.setTransientCacheSize(parseInt(name, value));
           break;
         case "allowUrls":
-          builder.setAllowUrls(value);
+          builder.setAllowUrls(separateStrings(value));
           break;
         default:
           throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Unknown configuration value in solr.xml: " + name);
@@ -355,12 +358,19 @@ public class SolrXmlConfig {
     return builder.build();
   }
 
-  private static Set<Path> stringToPaths(String commaSeparatedString) {
+  private static List<String> separateStrings(String commaSeparatedString) {
+    if (Strings.isNullOrEmpty(commaSeparatedString)) {
+      return Collections.emptyList();
+    }
+    return Arrays.asList(COMMA_SEPARATED_PATTERN.split(commaSeparatedString));
+  }
+
+  private static Set<Path> separatePaths(String commaSeparatedString) {
     if (Strings.isNullOrEmpty(commaSeparatedString)) {
       return Collections.emptySet();
     }
     // Parse list of paths. The special value '*' is mapped to _ALL_ to mean all paths
-    return Arrays.stream(commaSeparatedString.split(",\\s?"))
+    return Arrays.stream(COMMA_SEPARATED_PATTERN.split(commaSeparatedString))
         .map(p -> Paths.get("*".equals(p) ? "_ALL_" : p)).collect(Collectors.toSet());
   }
 

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -344,6 +344,9 @@ public class SolrXmlConfig {
         case "transientCacheSize":
           builder.setTransientCacheSize(parseInt(name, value));
           break;
+        case "allowUrls":
+          builder.setAllowUrls(value);
+          break;
         default:
           throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Unknown configuration value in solr.xml: " + name);
       }

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
@@ -79,6 +80,7 @@ import org.apache.solr.cloud.CloudDescriptor;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -94,6 +96,7 @@ import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.SolrIndexSearcher;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.update.CommitUpdateCommand;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.util.FileUtils;
@@ -242,7 +245,7 @@ public class IndexFetcher {
       leaderUrl = leaderUrl.substring(0, leaderUrl.length()-12);
       log.warn("'leaderUrl' must be specified without the {} suffix", ReplicationHandler.PATH);
     }
-    this.leaderUrl = leaderUrl;//TODO each time leaderUrl is set, check the allowUrls?
+    setLeaderUrl(leaderUrl);
 
     this.replicationHandler = handler;
     String compress = (String) initArgs.get(COMPRESSION);
@@ -261,7 +264,29 @@ public class IndexFetcher {
     String httpBasicAuthPassword = (String) initArgs.get(HttpClientUtil.PROP_BASIC_AUTH_PASS);
     myHttpClient = createHttpClient(solrCore, httpBasicAuthUser, httpBasicAuthPassword, useExternalCompression);
   }
-  
+
+  private void setLeaderUrl(String leaderUrl) {
+    if (leaderUrl != null) {
+      ClusterState clusterState = solrCore.getCoreContainer().getZkController() == null ?
+              null : solrCore.getCoreContainer().getZkController().getClusterState();
+      try {
+        solrCore.getCoreContainer().getAllowListUrlChecker()
+                .checkAllowList(Collections.singletonList(leaderUrl), clusterState);
+      } catch (MalformedURLException e) {
+        throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Malformed 'leaderUrl' " + leaderUrl, e);
+      } catch (SolrException e) {
+        log.warn("The '{}' parameter value '{}' is not allowed: {}.",
+                LEADER_URL, leaderUrl, e.getMessage());
+        throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
+                "The '" + LEADER_URL + "' parameter value '" + leaderUrl
+                        + "' is not allowed: "
+                        + e.getMessage() + ". "
+                        + AllowListUrlChecker.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
+      }
+    }
+    this.leaderUrl = leaderUrl;
+  }
+
   @SuppressWarnings({"unchecked"})
   protected <T> T getParameter(@SuppressWarnings({"rawtypes"})NamedList initArgs, String configKey, T defaultValue, StringBuilder sb) {
     T toReturn = defaultValue;
@@ -389,7 +414,7 @@ public class IndexFetcher {
           return IndexFetchResult.LEADER_IS_NOT_ACTIVE;
         }
         if (!replica.getCoreUrl().equals(leaderUrl)) {
-          leaderUrl = replica.getCoreUrl();
+          setLeaderUrl(replica.getCoreUrl());
           log.info("Updated leaderUrl to {}", leaderUrl);
           // TODO: Do we need to set forceReplication = true?
         } else {

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -242,7 +242,7 @@ public class IndexFetcher {
       leaderUrl = leaderUrl.substring(0, leaderUrl.length()-12);
       log.warn("'leaderUrl' must be specified without the {} suffix", ReplicationHandler.PATH);
     }
-    this.leaderUrl = leaderUrl;
+    this.leaderUrl = leaderUrl;//TODO each time leaderUrl is set, check the allowUrls?
 
     this.replicationHandler = handler;
     String compress = (String) initArgs.get(COMPRESSION);

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -275,8 +275,6 @@ public class IndexFetcher {
       } catch (MalformedURLException e) {
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Malformed 'leaderUrl' " + leaderUrl, e);
       } catch (SolrException e) {
-        log.warn("The '{}' parameter value '{}' is not allowed: {}.",
-                LEADER_URL, leaderUrl, e.getMessage());
         throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
                 "The '" + LEADER_URL + "' parameter value '" + leaderUrl
                         + "' is not allowed: "

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1230,9 +1230,6 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
   @Override
   @SuppressWarnings({"resource"})
   public void inform(SolrCore core) {
-
-    //TODO core.getCoreContainer().getAllowListUrlChecker()
-
     this.core = core;
     registerCloseHook();
     Object nbtk = initArgs.get(NUMBER_BACKUPS_TO_KEEP_INIT_PARAM);

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1230,6 +1230,9 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
   @Override
   @SuppressWarnings({"resource"})
   public void inform(SolrCore core) {
+
+    //TODO core.getCoreContainer().getAllowListUrlChecker()
+
     this.core = core;
     registerCloseHook();
     Object nbtk = initArgs.get(NUMBER_BACKUPS_TO_KEEP_INIT_PARAM);

--- a/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
@@ -18,6 +18,7 @@
 package org.apache.solr.handler.component;
 
 import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,6 +39,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,8 +119,24 @@ class CloudReplicaSource implements ReplicaSource {
         // this has urls
         this.replicas[i] = StrUtils.splitSmart(sliceOrUrl, "|", true);
         builder.replicaListTransformer.transform(replicas[i]);
-        builder.hostChecker.checkWhitelist(clusterState, shardsParam, replicas[i]);
+        checkUrlsAllowList(builder.urlChecker, clusterState, shardsParam, replicas[i]);
       }
+    }
+  }
+
+  static void checkUrlsAllowList(AllowListUrlChecker urlChecker, ClusterState clusterState, String shardsParam, List<String> urls) {
+    try {
+      urlChecker.checkAllowList(urls, clusterState);
+    } catch (MalformedURLException e) {
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid URL syntax in 'shards' parameter: " + shardsParam, e);
+    } catch (SolrException e) {
+      log.warn("The '{}' parameter value '{}' contained value(s) not on the shards allow-list: {}.",
+              ShardParams.SHARDS, shardsParam, e.getMessage());
+      throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
+              "The '" + ShardParams.SHARDS + "' parameter value '" + shardsParam
+                      + "' contained value(s) not on the shards allow-list: "
+                      + e.getMessage() + ". "
+                      + HttpShardHandlerFactory.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
     }
   }
 
@@ -135,9 +153,9 @@ class CloudReplicaSource implements ReplicaSource {
           .filter(replica -> !builder.onlyNrt || (replica.getType() == Replica.Type.NRT || (replica.getType() == Replica.Type.TLOG && isShardLeader.test(replica))))
           .collect(Collectors.toList());
       builder.replicaListTransformer.transform(list);
-      List<String> collect = list.stream().map(Replica::getCoreUrl).collect(Collectors.toList());
-      builder.hostChecker.checkWhitelist(clusterState, shardsParam, collect);
-      return collect;
+      List<String> coreUrls = list.stream().map(Replica::getCoreUrl).collect(Collectors.toList());
+      checkUrlsAllowList(builder.urlChecker, clusterState, shardsParam, coreUrls);
+      return coreUrls;
     }
   }
 
@@ -209,7 +227,7 @@ class CloudReplicaSource implements ReplicaSource {
     private SolrParams params;
     private boolean onlyNrt;
     private ReplicaListTransformer replicaListTransformer;
-    private HttpShardHandlerFactory.WhitelistHostChecker hostChecker;
+    private AllowListUrlChecker urlChecker;
 
     public Builder collection(String collection) {
       this.collection = collection;
@@ -236,8 +254,8 @@ class CloudReplicaSource implements ReplicaSource {
       return this;
     }
 
-    public Builder whitelistHostChecker(HttpShardHandlerFactory.WhitelistHostChecker hostChecker) {
-      this.hostChecker = hostChecker;
+    public Builder allowListUrlChecker(AllowListUrlChecker urlChecker) {
+      this.urlChecker = urlChecker;
       return this;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
@@ -130,8 +130,6 @@ class CloudReplicaSource implements ReplicaSource {
     } catch (MalformedURLException e) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid URL syntax in '" + ShardParams.SHARDS + "' parameter: " + shardsParam, e);
     } catch (SolrException e) {
-      log.warn("The '{}' parameter value '{}' contained value(s) not allowed: {}.",
-              ShardParams.SHARDS, shardsParam, e.getMessage());
       throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
               "The '" + ShardParams.SHARDS + "' parameter value '" + shardsParam
                       + "' contained value(s) not allowed: "

--- a/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
@@ -130,12 +130,11 @@ class CloudReplicaSource implements ReplicaSource {
     } catch (MalformedURLException e) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid URL syntax in '" + ShardParams.SHARDS + "' parameter: " + shardsParam, e);
     } catch (SolrException e) {
-      log.warn("The '{}' parameter value '{}' contained value(s) not on the configured '{}': {}.",
-              ShardParams.SHARDS, shardsParam, AllowListUrlChecker.URL_ALLOW_LIST, e.getMessage());
+      log.warn("The '{}' parameter value '{}' contained value(s) not allowed: {}.",
+              ShardParams.SHARDS, shardsParam, e.getMessage());
       throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
               "The '" + ShardParams.SHARDS + "' parameter value '" + shardsParam
-                      + "' contained value(s) not on the configured '" +
-                      AllowListUrlChecker.URL_ALLOW_LIST + "': "
+                      + "' contained value(s) not allowed: "
                       + e.getMessage() + ". "
                       + AllowListUrlChecker.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
     }

--- a/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
@@ -128,15 +128,16 @@ class CloudReplicaSource implements ReplicaSource {
     try {
       urlChecker.checkAllowList(urls, clusterState);
     } catch (MalformedURLException e) {
-      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid URL syntax in 'shards' parameter: " + shardsParam, e);
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid URL syntax in '" + ShardParams.SHARDS + "' parameter: " + shardsParam, e);
     } catch (SolrException e) {
-      log.warn("The '{}' parameter value '{}' contained value(s) not on the shards allow-list: {}.",
-              ShardParams.SHARDS, shardsParam, e.getMessage());
+      log.warn("The '{}' parameter value '{}' contained value(s) not on the configured '{}': {}.",
+              ShardParams.SHARDS, shardsParam, AllowListUrlChecker.URL_ALLOW_LIST, e.getMessage());
       throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
               "The '" + ShardParams.SHARDS + "' parameter value '" + shardsParam
-                      + "' contained value(s) not on the shards allow-list: "
+                      + "' contained value(s) not on the configured '" +
+                      AllowListUrlChecker.URL_ALLOW_LIST + "': "
                       + e.getMessage() + ". "
-                      + HttpShardHandlerFactory.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
+                      + AllowListUrlChecker.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -268,13 +268,13 @@ public class HttpShardHandler extends ShardHandler {
 
     final ReplicaListTransformer replicaListTransformer = httpShardHandlerFactory.getReplicaListTransformer(req);
 
-    AllowListUrlChecker urlChecker = httpShardHandlerFactory.getAllowListUrlChecker();
+    AllowListUrlChecker urlChecker = req.getCore().getCoreContainer().getAllowListUrlChecker();
     if (shards != null && zkController == null && urlChecker.isEnabled() && !urlChecker.hasExplicitAllowList()) {
       throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
-              "HttpShardHandlerFactory " + HttpShardHandlerFactory.URL_ALLOW_LIST
-                      + " not configured but required (in lieu of ZkController and ClusterState) when using the '"
+              "solr.xml property '" + AllowListUrlChecker.URL_ALLOW_LIST
+                      + "' not configured but required (in lieu of ZkController and ClusterState) when using the '"
                       + ShardParams.SHARDS + "' parameter. "
-                      + HttpShardHandlerFactory.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
+                      + AllowListUrlChecker.SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE);
     }
 
     ReplicaSource replicaSource;

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -225,8 +225,8 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
         sb);
     this.accessPolicy = getParameter(args, INIT_FAIRNESS_POLICY, accessPolicy,sb);
 
-    if (args.get("shardsWhitelist") != null) {
-      log.warn("Property 'shardsWhitelist' is deprecated, please use '" + AllowListUrlChecker.URL_ALLOW_LIST + "' instead.");
+    if (args != null && args.get("shardsWhitelist") != null) {
+      log.warn("Property 'shardsWhitelist' is deprecated, please use '{}' instead.", AllowListUrlChecker.URL_ALLOW_LIST);
     }
 
     // magic sysprop to make tests reproducible: set by SolrTestCaseJ4.

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -18,21 +18,16 @@ package org.apache.solr.handler.component;
 
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
@@ -46,7 +41,6 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
-import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
@@ -62,6 +56,7 @@ import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.security.HttpClientBuilderPlugin;
 import org.apache.solr.update.UpdateShardHandlerConfig;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
@@ -97,7 +92,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
   int   permittedLoadBalancerRequestsMinimumAbsolute = 0;
   float permittedLoadBalancerRequestsMaximumFraction = 1.0f;
   boolean accessPolicy = false;
-  private WhitelistHostChecker whitelistHostChecker = null;
+  private AllowListUrlChecker allowListUrlChecker = null;
   private SolrMetricsContext solrMetricsContext;
 
   private String scheme = null;
@@ -132,11 +127,11 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
   // Configure if the threadpool favours fairness over throughput
   static final String INIT_FAIRNESS_POLICY = "fairnessPolicy";
 
-  public static final String INIT_SHARDS_WHITELIST = "shardsWhitelist";
+  static final String URL_ALLOW_LIST = "urlAllowList";
 
-  static final String INIT_SOLR_DISABLE_SHARDS_WHITELIST = "solr.disable." + INIT_SHARDS_WHITELIST;
+  static final String DISABLE_URL_ALLOW_LIST = "solr.disable." + URL_ALLOW_LIST;
 
-  static final String SET_SOLR_DISABLE_SHARDS_WHITELIST_CLUE = " set -D"+INIT_SOLR_DISABLE_SHARDS_WHITELIST+"=true to disable shards whitelist checks";
+  static final String SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE = "Set -D" + DISABLE_URL_ALLOW_LIST + "=true to disable URL allow-list checks.";
 
   /**
    * Get {@link ShardHandler} that uses the default http client.
@@ -147,21 +142,11 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
   }
 
   /**
-   * Returns this Factory's {@link WhitelistHostChecker}.
+   * Returns this Factory's {@link AllowListUrlChecker}.
    * This method can be overridden to change the checker implementation.
    */
-  public WhitelistHostChecker getWhitelistHostChecker() {
-    return this.whitelistHostChecker;
-  }
-
-  @Deprecated // For temporary use by the TermsComponent only.
-  static boolean doGetDisableShardsWhitelist() {
-    return getDisableShardsWhitelist();
-  }
-
-
-  private static boolean getDisableShardsWhitelist() {
-    return Boolean.getBoolean(INIT_SOLR_DISABLE_SHARDS_WHITELIST);
+  public AllowListUrlChecker getAllowListUrlChecker() {
+    return this.allowListUrlChecker;
   }
 
   private static NamedList<?> getNamedList(Object val) {
@@ -255,8 +240,8 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
         permittedLoadBalancerRequestsMaximumFraction,
         sb);
     this.accessPolicy = getParameter(args, INIT_FAIRNESS_POLICY, accessPolicy,sb);
-    this.whitelistHostChecker = new WhitelistHostChecker(args == null? null: (String) args.get(INIT_SHARDS_WHITELIST), !getDisableShardsWhitelist());
-    log.info("Host whitelist initialized: {}", this.whitelistHostChecker);
+    this.allowListUrlChecker = createAllowListUrlChecker(args);
+    log.info("Host allow list initialized: {}", this.allowListUrlChecker);
 
     // magic sysprop to make tests reproducible: set by SolrTestCaseJ4.
     String v = System.getProperty("tests.shardhandler.randomSeed");
@@ -298,6 +283,28 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
     initReplicaListTransformers(getParameter(args, "replicaRouting", null, sb));
 
     log.debug("created with {}",sb);
+  }
+
+  private AllowListUrlChecker createAllowListUrlChecker(@SuppressWarnings({"rawtypes"}) NamedList args) {
+    if (Boolean.getBoolean(DISABLE_URL_ALLOW_LIST)) {
+      return AllowListUrlChecker.ALLOW_ALL;
+    } else if (System.getProperty("solr.disable.shardsWhitelist") != null) {
+      log.warn("Property 'solr.disable.shardsWhitelist' is deprecated, please use '" + DISABLE_URL_ALLOW_LIST + "' instead.");
+    }
+    String urlAllowList;
+    if (args == null) {
+      urlAllowList = null;
+    } else {
+      urlAllowList = (String) args.get(URL_ALLOW_LIST);
+      if (urlAllowList == null && args.get("shardsWhitelist") != null) {
+        log.warn("Property 'shardsWhitelist' is deprecated, please use '" + URL_ALLOW_LIST + "' instead.");
+      }
+    }
+    try {
+      return new AllowListUrlChecker(urlAllowList);
+    } catch (MalformedURLException e) {
+      throw new SolrException(ErrorCode.SERVER_ERROR, "Invalid URL syntax in '" + URL_ALLOW_LIST + "': " + urlAllowList, e);
+    }
   }
 
   @Override
@@ -413,139 +420,4 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
         solrMetricsContext.getMetricRegistry(),
         SolrMetricManager.mkName("httpShardExecutor", expandedScope, "threadPool"));
   }
-
-  /**
-   * Class used to validate the hosts in the "shards" parameter when doing a distributed
-   * request
-   */
-  public static class WhitelistHostChecker {
-
-    /**
-     * List of the whitelisted hosts. Elements in the list will be host:port (no protocol or context)
-     */
-    private final Set<String> whitelistHosts;
-
-    /**
-     * Indicates whether host checking is enabled
-     */
-    private final boolean whitelistHostCheckingEnabled;
-
-    public WhitelistHostChecker(String whitelistStr, boolean enabled) {
-      this.whitelistHosts = implGetShardsWhitelist(whitelistStr);
-      this.whitelistHostCheckingEnabled = enabled;
-    }
-
-    final static Set<String> implGetShardsWhitelist(final String shardsWhitelist) {
-      if (shardsWhitelist != null && !shardsWhitelist.isEmpty()) {
-        return StrUtils.splitSmart(shardsWhitelist, ',')
-            .stream()
-            .map(String::trim)
-            .map((hostUrl) -> {
-              URL url;
-              try {
-                if (!hostUrl.startsWith("http://") && !hostUrl.startsWith("https://")) {
-                  // It doesn't really matter which protocol we set here because we are not going to use it. We just need a full URL.
-                  url = new URL("http://" + hostUrl);
-                } else {
-                  url = new URL(hostUrl);
-                }
-              } catch (MalformedURLException e) {
-                throw new SolrException(ErrorCode.SERVER_ERROR, "Invalid URL syntax in \"" + INIT_SHARDS_WHITELIST + "\": " + shardsWhitelist, e);
-              }
-              if (url.getHost() == null || url.getPort() < 0) {
-                throw new SolrException(ErrorCode.SERVER_ERROR, "Invalid URL syntax in \"" + INIT_SHARDS_WHITELIST + "\": " + shardsWhitelist);
-              }
-              return url.getHost() + ":" + url.getPort();
-            }).collect(Collectors.toSet());
-      }
-      return null;
-    }
-
-
-    /**
-     * @see #checkWhitelist(ClusterState, String, List)
-     */
-    protected void checkWhitelist(String shardsParamValue, List<String> shardUrls) {
-      checkWhitelist(null, shardsParamValue, shardUrls);
-    }
-
-    /**
-     * Checks that all the hosts for all the shards requested in shards parameter exist in the configured whitelist
-     * or in the ClusterState (in case of cloud mode)
-     *
-     * @param clusterState The up to date ClusterState, can be null in case of non-cloud mode
-     * @param shardsParamValue The original shards parameter
-     * @param shardUrls The list of cores generated from the shards parameter.
-     */
-    protected void checkWhitelist(ClusterState clusterState, String shardsParamValue, List<String> shardUrls) {
-      if (!whitelistHostCheckingEnabled) {
-        return;
-      }
-      Set<String> localWhitelistHosts;
-      if (whitelistHosts == null && clusterState != null) {
-        // TODO: We could implement caching, based on the version of the live_nodes znode
-        localWhitelistHosts = generateWhitelistFromLiveNodes(clusterState);
-      } else if (whitelistHosts != null) {
-        localWhitelistHosts = whitelistHosts;
-      } else {
-        localWhitelistHosts = Collections.emptySet();
-      }
-
-      shardUrls.stream().map(String::trim).forEach((shardUrl) -> {
-        URL url;
-        try {
-          if (!shardUrl.startsWith("http://") && !shardUrl.startsWith("https://")) {
-            // It doesn't really matter which protocol we set here because we are not going to use it. We just need a full URL.
-            url = new URL("http://" + shardUrl);
-          } else {
-            url = new URL(shardUrl);
-          }
-        } catch (MalformedURLException e) {
-          throw new SolrException(ErrorCode.BAD_REQUEST, "Invalid URL syntax in \"shards\" parameter: " + shardsParamValue, e);
-        }
-        if (url.getHost() == null || url.getPort() < 0) {
-          throw new SolrException(ErrorCode.BAD_REQUEST, "Invalid URL syntax in \"shards\" parameter: " + shardsParamValue);
-        }
-        if (!localWhitelistHosts.contains(url.getHost() + ":" + url.getPort())) {
-          log.warn("The '{}' parameter value '{}' contained value(s) not on the shards whitelist ({}), shardUrl: '{}'"
-              , ShardParams.SHARDS, shardsParamValue, localWhitelistHosts, shardUrl);
-          throw new SolrException(ErrorCode.FORBIDDEN,
-              "The '"+ShardParams.SHARDS+"' parameter value '"+shardsParamValue+"' contained value(s) not on the shards whitelist. shardUrl:" + shardUrl + "." +
-                  HttpShardHandlerFactory.SET_SOLR_DISABLE_SHARDS_WHITELIST_CLUE);
-        }
-      });
-    }
-    
-    Set<String> generateWhitelistFromLiveNodes(ClusterState clusterState) {
-      return clusterState
-          .getLiveNodes()
-          .stream()
-          .map((liveNode) -> liveNode.substring(0, liveNode.indexOf('_')))
-          .collect(Collectors.toSet());
-    }
-    
-    public boolean hasExplicitWhitelist() {
-      return this.whitelistHosts != null;
-    }
-    
-    public boolean isWhitelistHostCheckingEnabled() {
-      return whitelistHostCheckingEnabled;
-    }
-    
-    /**
-     * Only to be used by tests
-     */
-    @VisibleForTesting
-    Set<String> getWhitelistHosts() {
-      return this.whitelistHosts;
-    }
-
-    @Override
-    public String toString() {
-      return "WhitelistHostChecker [whitelistHosts=" + whitelistHosts + ", whitelistHostCheckingEnabled="
-          + whitelistHostCheckingEnabled + "]";
-    }
-    
-  }
-  
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/StandaloneReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/StandaloneReplicaSource.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.security.AllowListUrlChecker;
 
 /**
  * A replica source for solr stand alone mode
@@ -36,7 +37,7 @@ class StandaloneReplicaSource implements ReplicaSource {
       replicas[i] = StrUtils.splitSmart(list.get(i), "|", true);
       // todo do we really not need to transform in non-cloud mode?!
       // builder.replicaListTransformer.transform(replicas[i]);
-      builder.hostChecker.checkWhitelist(builder.shardsParam, replicas[i]);
+      CloudReplicaSource.checkUrlsAllowList(builder.urlChecker, null, builder.shardsParam, replicas[i]);
     }
   }
 
@@ -59,15 +60,15 @@ class StandaloneReplicaSource implements ReplicaSource {
 
   static class Builder {
     private String shardsParam;
-    private HttpShardHandlerFactory.WhitelistHostChecker hostChecker;
+    private AllowListUrlChecker urlChecker;
 
     public Builder shards(String shardsParam) {
       this.shardsParam = shardsParam;
       return this;
     }
 
-    public Builder whitelistHostChecker(HttpShardHandlerFactory.WhitelistHostChecker hostChecker) {
-      this.hostChecker = hostChecker;
+    public Builder allowListUrlChecker(AllowListUrlChecker urlChecker) {
+      this.urlChecker = urlChecker;
       return this;
     }
 

--- a/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
+++ b/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
@@ -107,7 +107,7 @@ public class AllowListUrlChecker {
         if (Boolean.getBoolean(DISABLE_URL_ALLOW_LIST)) {
             return AllowListUrlChecker.ALLOW_ALL;
         } else if (System.getProperty("solr.disable.shardsWhitelist") != null) {
-            log.warn("Property 'solr.disable.shardsWhitelist' is deprecated, please use '" + DISABLE_URL_ALLOW_LIST + "' instead.");
+            log.warn("Property 'solr.disable.shardsWhitelist' is deprecated, please use '{}' instead.", DISABLE_URL_ALLOW_LIST);
         }
         try {
             return new AllowListUrlChecker(config.getAllowUrls());

--- a/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
+++ b/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
@@ -35,181 +35,175 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Validates URLs based on an allow list or a {@link ClusterState} in SolrCloud.
- */
+/** Validates URLs based on an allow list or a {@link ClusterState} in SolrCloud. */
 public class AllowListUrlChecker {
 
-    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    /**
-     * {@link org.apache.solr.core.SolrXmlConfig} property to configure the allowed URLs.
-     */
-    public static final String URL_ALLOW_LIST = "allowUrls";
+  /** {@link org.apache.solr.core.SolrXmlConfig} property to configure the allowed URLs. */
+  public static final String URL_ALLOW_LIST = "allowUrls";
 
-    /**
-     * System property to disable URL checking and {@link #ALLOW_ALL} instead.
-     */
-    public static final String DISABLE_URL_ALLOW_LIST = "solr.disable." + URL_ALLOW_LIST;
+  /** System property to disable URL checking and {@link #ALLOW_ALL} instead. */
+  public static final String DISABLE_URL_ALLOW_LIST = "solr.disable." + URL_ALLOW_LIST;
 
-    /**
-     * Clue given in URL-forbidden exceptions messages.
-     */
-    public static final String SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE = "Set -D" + DISABLE_URL_ALLOW_LIST + "=true to disable URL allow-list checks.";
+  /** Clue given in URL-forbidden exceptions messages. */
+  public static final String SET_SOLR_DISABLE_URL_ALLOW_LIST_CLUE =
+      "Set -D" + DISABLE_URL_ALLOW_LIST + "=true to disable URL allow-list checks.";
 
-    /**
-     * Singleton checker which allows all URLs. {@link #isEnabled()} returns false.
-     */
-    public static final AllowListUrlChecker ALLOW_ALL;
+  /** Singleton checker which allows all URLs. {@link #isEnabled()} returns false. */
+  public static final AllowListUrlChecker ALLOW_ALL;
 
-    static {
-        try {
-            ALLOW_ALL = new AllowListUrlChecker(Collections.emptyList()) {
-                @Override
-                public void checkAllowList(List<String> urls, ClusterState clusterState) {
-                    // Allow.
-                }
-
-                @Override
-                public boolean isEnabled() {
-                    return false;
-                }
-
-                @Override
-                public String toString() {
-                    return getClass().getSimpleName() + " [allow all]";
-                }
-            };
-        } catch (MalformedURLException e) {
-            // Never thrown.
-            throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
-        }
-    }
-
-    /**
-     * Regex pattern to match any protocol, e.g. http:// https:// s3://.
-     * After a match, regex group 1 contains the protocol and group 2 the rest.
-     */
-    private static final Pattern PROTOCOL_PATTERN = Pattern.compile("(\\w+)(://.*)");
-
-    /**
-     * Allow list of hosts. Elements in the list will be host:port (no protocol or context).
-     */
-    private final Set<String> hostAllowList;
-
-    /**
-     * @param urlAllowList List of allowed URLs. URLs must be well-formed, missing protocol is tolerated.
-     *                    An empty list means there is no explicit allow-list of URLs, in this case no
-     *                    URL is allowed unless a {@link ClusterState} is provided in
-     *                    {@link #checkAllowList(List, ClusterState)}.
-     * @throws MalformedURLException If an URL is invalid.
-     */
-    public AllowListUrlChecker(List<String> urlAllowList) throws MalformedURLException {
-        hostAllowList = parseHostPorts(urlAllowList);
-    }
-
-    /**
-     * Creates a URL checker based on the {@link NodeConfig} property to configure the allowed URLs.
-     */
-    public static AllowListUrlChecker create(NodeConfig config) {
-        if (Boolean.getBoolean(DISABLE_URL_ALLOW_LIST)) {
-            return AllowListUrlChecker.ALLOW_ALL;
-        } else if (System.getProperty("solr.disable.shardsWhitelist") != null) {
-            log.warn("Property 'solr.disable.shardsWhitelist' is deprecated, please use '{}' instead.", DISABLE_URL_ALLOW_LIST);
-        }
-        try {
-            return new AllowListUrlChecker(config.getAllowUrls());
-        } catch (MalformedURLException e) {
-            throw new SolrException(SolrException.ErrorCode.SERVER_ERROR,
-                    "Invalid URL syntax in '" + URL_ALLOW_LIST + "' configuration: " + config.getAllowUrls(), e);
-        }
-    }
-
-    /**
-     * @see #checkAllowList(List, ClusterState)
-     */
-    public void checkAllowList(List<String> urls) throws MalformedURLException {
-        checkAllowList(urls, null);
-    }
-
-    /**
-     * Checks that the given URLs are present in the configured allow-list or in the provided {@link ClusterState}
-     * (in case of cloud mode).
-     *
-     * @param urls         The list of urls to check.
-     * @param clusterState The up to date {@link ClusterState}, can be null in case of non-cloud mode.
-     * @throws MalformedURLException If an URL is invalid.
-     * @throws SolrException         If an URL is not present in the allow-list or in the provided {@link ClusterState}.
-     */
-    public void checkAllowList(List<String> urls, @Nullable ClusterState clusterState) throws MalformedURLException {
-        Set<String> clusterHostAllowList = clusterState == null ? Collections.emptySet() : clusterState.getHostAllowList();
-        for (String url : urls) {
-            String hostPort = parseHostPort(url);
-            if (!clusterHostAllowList.contains(hostPort) && !hostAllowList.contains(hostPort)) {
-                throw new SolrException(SolrException.ErrorCode.FORBIDDEN, "URL " + url +
-                        " is neither a live node of the cluster nor in the configured '" +
-                        URL_ALLOW_LIST + "' " + hostAllowList);
+  static {
+    try {
+      ALLOW_ALL =
+          new AllowListUrlChecker(Collections.emptyList()) {
+            @Override
+            public void checkAllowList(List<String> urls, ClusterState clusterState) {
+              // Allow.
             }
-        }
-    }
 
-    /**
-     * Whether this checker has been created with a non-empty allow-list of URLs.
-     */
-    public boolean hasExplicitAllowList() {
-        return !hostAllowList.isEmpty();
-    }
-
-    /**
-     * Whether the URL checking is enabled. Only {@link #ALLOW_ALL} returns false.
-     */
-    public boolean isEnabled() {
-        return true;
-    }
-
-    /**
-     * Only for testing.
-     */
-    @VisibleForTesting
-    public Set<String> getHostAllowList() {
-        return hostAllowList == null ? null : Collections.unmodifiableSet(hostAllowList);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + " [allowList=" + hostAllowList + "]";
-    }
-
-    @VisibleForTesting
-    static Set<String> parseHostPorts(List<String> urls) throws MalformedURLException {
-        if (urls == null || urls.isEmpty()) {
-            return Collections.emptySet();
-        }
-        Set<String> hostPorts = new HashSet<>();
-        for (String urlString : urls) {
-            hostPorts.add(parseHostPort(urlString));
-        }
-        return hostPorts;
-    }
-
-    private static String parseHostPort(String url) throws MalformedURLException {
-        // Parse the host and port.
-        // It doesn't really matter which protocol we set here because we are not going to use it.
-        url = url.trim();
-        URL u;
-        Matcher protocolMatcher = PROTOCOL_PATTERN.matcher(url);
-        if (protocolMatcher.matches()) {
-            // Replace any protocol unsupported by URL.
-            if (!protocolMatcher.group(1).startsWith("http")) {
-                url = "http" + protocolMatcher.group(2);
+            @Override
+            public boolean isEnabled() {
+              return false;
             }
-            u = new URL(url);
-        } else {
-            u = new URL("http://" + url);
-        }
-        if (u.getHost() == null || u.getPort() < 0) {
-            throw new MalformedURLException("Invalid host or port in '" + url + "'");
-        }
-        return u.getHost() + ":" + u.getPort();
+
+            @Override
+            public String toString() {
+              return getClass().getSimpleName() + " [allow all]";
+            }
+          };
+    } catch (MalformedURLException e) {
+      // Never thrown.
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
     }
+  }
+
+  /**
+   * Regex pattern to match any protocol, e.g. http:// https:// s3://. After a match, regex group 1
+   * contains the protocol and group 2 the rest.
+   */
+  private static final Pattern PROTOCOL_PATTERN = Pattern.compile("(\\w+)(://.*)");
+
+  /** Allow list of hosts. Elements in the list will be host:port (no protocol or context). */
+  private final Set<String> hostAllowList;
+
+  /**
+   * @param urlAllowList List of allowed URLs. URLs must be well-formed, missing protocol is
+   *     tolerated. An empty list means there is no explicit allow-list of URLs, in this case no URL
+   *     is allowed unless a {@link ClusterState} is provided in {@link #checkAllowList(List,
+   *     ClusterState)}.
+   * @throws MalformedURLException If an URL is invalid.
+   */
+  public AllowListUrlChecker(List<String> urlAllowList) throws MalformedURLException {
+    hostAllowList = parseHostPorts(urlAllowList);
+  }
+
+  /**
+   * Creates a URL checker based on the {@link NodeConfig} property to configure the allowed URLs.
+   */
+  public static AllowListUrlChecker create(NodeConfig config) {
+    if (Boolean.getBoolean(DISABLE_URL_ALLOW_LIST)) {
+      return AllowListUrlChecker.ALLOW_ALL;
+    } else if (System.getProperty("solr.disable.shardsWhitelist") != null) {
+      log.warn(
+          "Property 'solr.disable.shardsWhitelist' is deprecated, please use '{}' instead.",
+          DISABLE_URL_ALLOW_LIST);
+    }
+    try {
+      return new AllowListUrlChecker(config.getAllowUrls());
+    } catch (MalformedURLException e) {
+      throw new SolrException(
+          SolrException.ErrorCode.SERVER_ERROR,
+          "Invalid URL syntax in '" + URL_ALLOW_LIST + "' configuration: " + config.getAllowUrls(),
+          e);
+    }
+  }
+
+  /** @see #checkAllowList(List, ClusterState) */
+  public void checkAllowList(List<String> urls) throws MalformedURLException {
+    checkAllowList(urls, null);
+  }
+
+  /**
+   * Checks that the given URLs are present in the configured allow-list or in the provided {@link
+   * ClusterState} (in case of cloud mode).
+   *
+   * @param urls The list of urls to check.
+   * @param clusterState The up to date {@link ClusterState}, can be null in case of non-cloud mode.
+   * @throws MalformedURLException If an URL is invalid.
+   * @throws SolrException If an URL is not present in the allow-list or in the provided {@link
+   *     ClusterState}.
+   */
+  public void checkAllowList(List<String> urls, @Nullable ClusterState clusterState)
+      throws MalformedURLException {
+    Set<String> clusterHostAllowList =
+        clusterState == null ? Collections.emptySet() : clusterState.getHostAllowList();
+    for (String url : urls) {
+      String hostPort = parseHostPort(url);
+      if (!clusterHostAllowList.contains(hostPort) && !hostAllowList.contains(hostPort)) {
+        throw new SolrException(
+            SolrException.ErrorCode.FORBIDDEN,
+            "URL "
+                + url
+                + " is neither a live node of the cluster nor in the configured '"
+                + URL_ALLOW_LIST
+                + "' "
+                + hostAllowList);
+      }
+    }
+  }
+
+  /** Whether this checker has been created with a non-empty allow-list of URLs. */
+  public boolean hasExplicitAllowList() {
+    return !hostAllowList.isEmpty();
+  }
+
+  /** Whether the URL checking is enabled. Only {@link #ALLOW_ALL} returns false. */
+  public boolean isEnabled() {
+    return true;
+  }
+
+  /** Only for testing. */
+  @VisibleForTesting
+  public Set<String> getHostAllowList() {
+    return hostAllowList == null ? null : Collections.unmodifiableSet(hostAllowList);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + " [allowList=" + hostAllowList + "]";
+  }
+
+  @VisibleForTesting
+  static Set<String> parseHostPorts(List<String> urls) throws MalformedURLException {
+    if (urls == null || urls.isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<String> hostPorts = new HashSet<>();
+    for (String urlString : urls) {
+      hostPorts.add(parseHostPort(urlString));
+    }
+    return hostPorts;
+  }
+
+  private static String parseHostPort(String url) throws MalformedURLException {
+    // Parse the host and port.
+    // It doesn't really matter which protocol we set here because we are not going to use it.
+    url = url.trim();
+    URL u;
+    Matcher protocolMatcher = PROTOCOL_PATTERN.matcher(url);
+    if (protocolMatcher.matches()) {
+      // Replace any protocol unsupported by URL.
+      if (!protocolMatcher.group(1).startsWith("http")) {
+        url = "http" + protocolMatcher.group(2);
+      }
+      u = new URL(url);
+    } else {
+      u = new URL("http://" + url);
+    }
+    if (u.getHost() == null || u.getPort() < 0) {
+      throw new MalformedURLException("Invalid host or port in '" + url + "'");
+    }
+    return u.getHost() + ":" + u.getPort();
+  }
 }

--- a/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
+++ b/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
@@ -25,6 +25,7 @@ import org.apache.solr.core.NodeConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -96,7 +97,7 @@ public class AllowListUrlChecker {
      *                    {@link #checkAllowList(List, ClusterState)}.
      * @throws MalformedURLException If an URL is invalid.
      */
-    public AllowListUrlChecker(String urlAllowList) throws MalformedURLException {
+    public AllowListUrlChecker(@Nullable String urlAllowList) throws MalformedURLException {
         hostAllowList = parseHostPorts(urlAllowList);
     }
 
@@ -133,7 +134,7 @@ public class AllowListUrlChecker {
      * @throws MalformedURLException If an URL is invalid.
      * @throws SolrException         If an URL is not present in the allow-list or in the provided {@link ClusterState}.
      */
-    public void checkAllowList(List<String> urls, ClusterState clusterState) throws MalformedURLException {
+    public void checkAllowList(List<String> urls, @Nullable ClusterState clusterState) throws MalformedURLException {
         Set<String> localHostAllowList;
         if (hostAllowList != null) {
             localHostAllowList = hostAllowList;
@@ -144,7 +145,8 @@ public class AllowListUrlChecker {
         }
         for (String url : urls) {
             if (!localHostAllowList.contains(parseHostPort(url))) {
-                throw new SolrException(SolrException.ErrorCode.FORBIDDEN, "URL " + url + " is not in allow-list " + localHostAllowList);
+                throw new SolrException(SolrException.ErrorCode.FORBIDDEN,
+                        "URL " + url + " is not in configured '" + URL_ALLOW_LIST + "' " + localHostAllowList);
             }
         }
     }

--- a/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
+++ b/solr/core/src/java/org/apache/solr/security/AllowListUrlChecker.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.security;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.ClusterState;
+import org.apache.solr.common.util.StrUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates URLs based on an allow list or a {@link ClusterState} in SolrCloud.
+ */
+public class AllowListUrlChecker {
+
+    /**
+     * Singleton checker which allows all URLs. {@link #isEnabled()} returns false.
+     */
+    public static final AllowListUrlChecker ALLOW_ALL;
+
+    static {
+        try {
+            ALLOW_ALL = new AllowListUrlChecker(null) {
+                @Override
+                public void checkAllowList(List<String> urls, ClusterState clusterState) {
+                    // Allow.
+                }
+
+                @Override
+                public boolean isEnabled() {
+                    return false;
+                }
+
+                @Override
+                public String toString() {
+                    return getClass().getSimpleName() + " [allow all]";
+                }
+            };
+        } catch (MalformedURLException e) {
+            // Never thrown.
+            throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
+        }
+    }
+
+    /**
+     * Allow list of hosts. Elements in the list will be host:port (no protocol or context).
+     */
+    private final Set<String> hostAllowList;
+
+    /**
+     * @param urlAllowList Comma-separated list of allowed URLs. URLs must be well-formed, missing protocol is tolerated.
+     *                    Empty or null is supported and means there is no explicit allow-list of URLs. In this case no
+     *                    URL is allowed unless a {@link ClusterState} is provided in
+     *                    {@link #checkAllowList(List, ClusterState)}.
+     * @throws MalformedURLException If an URL is invalid.
+     */
+    public AllowListUrlChecker(String urlAllowList) throws MalformedURLException {
+        hostAllowList = parseHostPorts(urlAllowList);
+    }
+
+    /**
+     * @see #checkAllowList(List, ClusterState)
+     */
+    public void checkAllowList(List<String> urls) throws MalformedURLException {
+        checkAllowList(urls, null);
+    }
+
+    /**
+     * Checks that the given URLs are present in the configured allow-list or in the provided {@link ClusterState}
+     * (in case of cloud mode).
+     *
+     * @param urls         The list of urls to check.
+     * @param clusterState The up to date {@link ClusterState}, can be null in case of non-cloud mode.
+     * @throws MalformedURLException If an URL is invalid.
+     * @throws SolrException         If an URL is not present in the allow-list or in the provided {@link ClusterState}.
+     */
+    public void checkAllowList(List<String> urls, ClusterState clusterState) throws MalformedURLException {
+        Set<String> localHostAllowList;
+        if (hostAllowList != null) {
+            localHostAllowList = hostAllowList;
+        } else if (clusterState != null) {
+            localHostAllowList = clusterState.getHostAllowList();
+        } else {
+            localHostAllowList = Collections.emptySet();
+        }
+        for (String url : urls) {
+            if (!localHostAllowList.contains(parseHostPort(url))) {
+                throw new SolrException(SolrException.ErrorCode.FORBIDDEN, "URL " + url + " is not in allow-list " + localHostAllowList);
+            }
+        }
+    }
+
+    /**
+     * Whether this checker has been created with a non-empty allow-list of URLs.
+     */
+    public boolean hasExplicitAllowList() {
+        return hostAllowList != null;
+    }
+
+    /**
+     * Whether the URL checking is enabled. Only {@link #ALLOW_ALL} returns false.
+     */
+    public boolean isEnabled() {
+        return true;
+    }
+
+    /**
+     * Only for testing.
+     */
+    @VisibleForTesting
+    public Set<String> getHostAllowList() {
+        return hostAllowList == null ? null : Collections.unmodifiableSet(hostAllowList);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [allowList=" + hostAllowList + "]";
+    }
+
+    @VisibleForTesting
+    static Set<String> parseHostPorts(String commaSeparatedUrls) throws MalformedURLException {
+        if (commaSeparatedUrls == null || commaSeparatedUrls.isEmpty()) {
+            return null;
+        }
+        List<String> urlStrings = StrUtils.splitSmart(commaSeparatedUrls, ',');
+        Set<String> hostPorts = new HashSet<>((int) (urlStrings.size() / 0.7f) + 1);
+        for (String urlString : urlStrings) {
+            hostPorts.add(parseHostPort(urlString));
+        }
+        return hostPorts;
+    }
+
+    private static String parseHostPort(String url) throws MalformedURLException {
+        url = url.trim();
+        URL u;
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            // It doesn't really matter which protocol we set here because we are not going to use it. We just need a full URL.
+            u = new URL("http://" + url);
+        } else {
+            u = new URL(url);
+        }
+        if (u.getHost() == null || u.getPort() < 0) {
+            throw new MalformedURLException("Invalid host or port in '" + url + "'");
+        }
+        return u.getHost() + ":" + u.getPort();
+    }
+}

--- a/solr/core/src/test-files/solr/solr-tracing.xml
+++ b/solr/core/src/test-files/solr/solr-tracing.xml
@@ -25,12 +25,12 @@
   <str name="configSetBaseDir">${configSetBaseDir:configsets}</str>
   <str name="coreRootDirectory">${coreRootDirectory:.}</str>
   <str name="collectionsHandler">${collectionsHandler:solr.CollectionsHandler}</str>
+  <str name="allowUrls">${solr.tests.allowUrls:}</str>
 
   <shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory">
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:90000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <tracerConfig name="tracerConfig" class="MockTracerConfigurator">

--- a/solr/core/src/test-files/solr/solr-tracing.xml
+++ b/solr/core/src/test-files/solr/solr-tracing.xml
@@ -30,7 +30,7 @@
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:90000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="shardsWhitelist">${solr.tests.shardsWhitelist:}</str>
+    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <tracerConfig name="tracerConfig" class="MockTracerConfigurator">

--- a/solr/core/src/test-files/solr/solr.xml
+++ b/solr/core/src/test-files/solr/solr.xml
@@ -32,7 +32,7 @@
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:15000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="shardsWhitelist">${solr.tests.shardsWhitelist:}</str>
+    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <transientCoreCacheFactory name="transientCoreCacheFactory" class="TransientSolrCoreCacheFactoryDefault">

--- a/solr/core/src/test-files/solr/solr.xml
+++ b/solr/core/src/test-files/solr/solr.xml
@@ -27,12 +27,12 @@
   <str name="configSetBaseDir">${configSetBaseDir:configsets}</str>
   <str name="coreRootDirectory">${coreRootDirectory:.}</str>
   <str name="allowPaths">${solr.allowPaths:}</str>
+  <str name="allowUrls">${solr.tests.allowUrls:}</str>
 
   <shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory">
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:15000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <transientCoreCacheFactory name="transientCoreCacheFactory" class="TransientSolrCoreCacheFactoryDefault">

--- a/solr/core/src/test/org/apache/solr/TestTolerantSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestTolerantSearch.java
@@ -56,7 +56,7 @@ public class TestTolerantSearch extends SolrJettyTestBase {
   
   @BeforeClass
   public static void createThings() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     solrHome = createSolrHome();
     createAndStartJetty(solrHome.getAbsolutePath());
     String url = jetty.getBaseUrl().toString();
@@ -112,7 +112,7 @@ public class TestTolerantSearch extends SolrJettyTestBase {
       jetty=null;
     }
     resetExceptionIgnores();
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
   }
   
   @SuppressWarnings("unchecked")

--- a/solr/core/src/test/org/apache/solr/cloud/UnloadDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/UnloadDistributedZkTest.java
@@ -35,6 +35,7 @@ import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
+import org.apache.solr.core.SolrPaths;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.TimeOut;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +67,11 @@ public class UnloadDistributedZkTest extends BasicDistributedZkTest {
 
   @Test
   public void test() throws Exception {
-    jettys.forEach(j -> j.getCoreContainer().getAllowPaths().add(Path.of("_ALL_"))); // Allow non-standard core instance path
+    jettys.forEach(j -> {
+      Set<Path> allowPath = j.getCoreContainer().getAllowPaths();
+      allowPath.clear();
+      allowPath.addAll(SolrPaths.ALL_PATHS); // Allow non-standard core instance path
+    });
     testCoreUnloadAndLeaders(); // long
     testUnloadLotsOfCores(); // long
 

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -311,12 +311,11 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     // Expect an exception because the leader URL is not allowed.
     systemClearPropertySolrDisableUrlAllowList();
     SolrException e = expectThrows(SolrException.class, this::doTestDetails);
-    assertTrue(e.getMessage().contains("is not in the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'"));
+    assertTrue(e.getMessage().contains("nor in the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'"));
 
     // Set the allow-list to allow the leader URL.
     // Expect the same test to pass now.
-    System.setProperty(TEST_URL_ALLOW_LIST, "127.0.0.1:" + leaderJetty.getLocalPort()
-            + ",127.0.0.1:" + followerJetty.getLocalPort());
+    System.setProperty(TEST_URL_ALLOW_LIST, leaderJetty.getBaseUrl() + "," + followerJetty.getBaseUrl());
     try {
       doTestDetails();
     } finally {

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -311,7 +311,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     // Expect an exception because the leader URL is not allowed.
     systemClearPropertySolrDisableUrlAllowList();
     SolrException e = expectThrows(SolrException.class, this::doTestDetails);
-    assertTrue(e.getMessage().contains("is not in configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'"));
+    assertTrue(e.getMessage().contains("is not in the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'"));
 
     // Set the allow-list to allow the leader URL.
     // Expect the same test to pass now.

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -79,6 +79,7 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.StandardDirectoryFactory;
 import org.apache.solr.core.snapshots.SolrSnapshotMetaDataManager;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.util.FileUtils;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.TimeOut;
@@ -131,6 +132,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    systemSetPropertySolrDisableUrlAllowList("true");
 //    System.setProperty("solr.directoryFactory", "solr.StandardDirectoryFactory");
     // For manual testing only
     // useFactory(null); // force an FS factory.
@@ -160,6 +162,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   @After
   public void tearDown() throws Exception {
     super.tearDown();
+    systemClearPropertySolrDisableUrlAllowList();
     if (null != leaderJetty) {
       leaderJetty.stop();
       leaderJetty = null;
@@ -300,6 +303,25 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   @Test
   public void doTestHandlerPathUnchanged() throws Exception {
     assertEquals("/replication", ReplicationHandler.PATH);
+  }
+
+  @Test
+  public void testUrlAllowList() throws Exception {
+    // Run another test with URL allow-list enabled and allow-list is empty.
+    // Expect an exception because the leader URL is not allowed.
+    systemClearPropertySolrDisableUrlAllowList();
+    SolrException e = expectThrows(SolrException.class, this::doTestDetails);
+    assertTrue(e.getMessage().contains("is not in configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'"));
+
+    // Set the allow-list to allow the leader URL.
+    // Expect the same test to pass now.
+    System.setProperty(TEST_URL_ALLOW_LIST, "127.0.0.1:" + leaderJetty.getLocalPort()
+            + ",127.0.0.1:" + followerJetty.getLocalPort());
+    try {
+      doTestDetails();
+    } finally {
+      System.clearProperty(TEST_URL_ALLOW_LIST);
+    }
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerDiskOverFlow.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerDiskOverFlow.java
@@ -71,7 +71,6 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
     originalTestWait = IndexFetcher.testWait;
     
     super.setUp();
-    systemSetPropertySolrDisableUrlAllowList("true");
     System.setProperty("solr.directoryFactory", "solr.StandardDirectoryFactory");
     String factory = random().nextInt(100) < 75 ? "solr.NRTCachingDirectoryFactory" : "solr.StandardDirectoryFactory"; // test the default most of the time
     System.setProperty("solr.directoryFactory", factory);
@@ -79,6 +78,7 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
     leader.setUp();
     leaderJetty = createAndStartJetty(leader);
     leaderClient = createNewSolrClient(leaderJetty.getLocalPort());
+    System.setProperty(TEST_URL_ALLOW_LIST, leaderJetty.getBaseUrl().toString());
 
     follower = new TestReplicationHandler.SolrInstance(createTempDir("solr-instance").toFile(), "follower", leaderJetty.getLocalPort());
     follower.setUp();
@@ -92,7 +92,6 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
   @After
   public void tearDown() throws Exception {
     super.tearDown();
-    systemClearPropertySolrDisableUrlAllowList();
     if (null != leaderJetty) {
       leaderJetty.stop();
       leaderJetty = null;
@@ -110,6 +109,7 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
       followerClient.close();
       followerClient = null;
     }
+    System.clearProperty(TEST_URL_ALLOW_LIST);
     System.clearProperty("solr.indexfetcher.sotimeout");
     
     IndexFetcher.usableDiskSpaceProvider = originalDiskSpaceprovider;

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerDiskOverFlow.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerDiskOverFlow.java
@@ -71,6 +71,7 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
     originalTestWait = IndexFetcher.testWait;
     
     super.setUp();
+    systemSetPropertySolrDisableUrlAllowList("true");
     System.setProperty("solr.directoryFactory", "solr.StandardDirectoryFactory");
     String factory = random().nextInt(100) < 75 ? "solr.NRTCachingDirectoryFactory" : "solr.StandardDirectoryFactory"; // test the default most of the time
     System.setProperty("solr.directoryFactory", factory);
@@ -91,6 +92,7 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
   @After
   public void tearDown() throws Exception {
     super.tearDown();
+    systemClearPropertySolrDisableUrlAllowList();
     if (null != leaderJetty) {
       leaderJetty.stop();
       leaderJetty = null;

--- a/solr/core/src/test/org/apache/solr/handler/component/CloudReplicaSourceTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/CloudReplicaSourceTest.java
@@ -24,6 +24,7 @@ import org.apache.solr.client.solrj.routing.ReplicaListTransformer;
 import org.apache.solr.cloud.ClusterStateMockUtil;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -42,7 +43,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testSimple_ShardsParam() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("shards", "slice1,slice2");
     try (ZkStateReader zkStateReader = ClusterStateMockUtil.buildClusterState("csr*sr2", "baseUrl1:8983_", "baseUrl2:8984_")) {
@@ -51,7 +52,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(false)
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(2, cloudReplicaSource.getSliceCount());
@@ -66,7 +67,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testShardsParam_DeadNode() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("shards", "slice1,slice2");
     // here node2 is not live so there should be no replicas found for slice2
@@ -76,7 +77,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(false)
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(2, cloudReplicaSource.getSliceCount());
@@ -90,7 +91,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testShardsParam_DownReplica() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("shards", "slice1,slice2");
     // here replica3 is in DOWN state so only 1 replica should be returned for slice2
@@ -100,7 +101,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(false)
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(2, cloudReplicaSource.getSliceCount());
@@ -116,7 +117,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testMultipleCollections() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("collection", "collection1,collection2");
     try (ZkStateReader zkStateReader = ClusterStateMockUtil.buildClusterState("csr*sr2csr*", "baseUrl1:8983_", "baseUrl2:8984_")) {
@@ -125,7 +126,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(false)
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(3, cloudReplicaSource.getSliceCount());
@@ -155,7 +156,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testSimple_UsingClusterState() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     try (ZkStateReader zkStateReader = ClusterStateMockUtil.buildClusterState("csr*sr2", "baseUrl1:8983_", "baseUrl2:8984_")) {
       CloudReplicaSource cloudReplicaSource = new CloudReplicaSource.Builder()
@@ -163,7 +164,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(false)
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(2, cloudReplicaSource.getSliceCount());
@@ -189,7 +190,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testSimple_OnlyNrt() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     // the cluster state will have slice2 with two tlog replicas out of which the first one will be the leader
     try (ZkStateReader zkStateReader = ClusterStateMockUtil.buildClusterState("csrr*st2t2", "baseUrl1:8983_", "baseUrl2:8984_")) {
@@ -198,7 +199,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(true) // enable only nrt mode
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(2, cloudReplicaSource.getSliceCount());
@@ -224,7 +225,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
   @Test
   public void testMultipleCollections_OnlyNrt() {
     ReplicaListTransformer replicaListTransformer = Mockito.mock(ReplicaListTransformer.class);
-    HttpShardHandlerFactory.WhitelistHostChecker whitelistHostChecker = Mockito.mock(HttpShardHandlerFactory.WhitelistHostChecker.class);
+    AllowListUrlChecker checker = Mockito.mock(AllowListUrlChecker.class);
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("collection", "collection1,collection2");
     // the cluster state will have collection1 with slice2 with two tlog replicas out of which the first one will be the leader
@@ -235,7 +236,7 @@ public class CloudReplicaSourceTest extends SolrTestCaseJ4 {
           .onlyNrt(true) // enable only nrt mode
           .zkStateReader(zkStateReader)
           .replicaListTransformer(replicaListTransformer)
-          .whitelistHostChecker(whitelistHostChecker)
+          .allowListUrlChecker(checker)
           .params(params)
           .build();
       assertEquals(3, cloudReplicaSource.getSliceCount());

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
@@ -62,7 +62,7 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
   
   @BeforeClass
   public static void createThings() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     solrHome = createSolrHome();
     createAndStartJetty(solrHome.getAbsolutePath());
     String url = jetty.getBaseUrl().toString();
@@ -111,7 +111,7 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
       jetty=null;
     }
     resetExceptionIgnores();
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
   }
   
   @Test

--- a/solr/core/src/test/org/apache/solr/handler/component/ShardsAllowListTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ShardsAllowListTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 
 import java.io.IOException;
 import java.net.URI;
@@ -125,7 +124,7 @@ public class ShardsAllowListTest extends MultiSolrCloudTestCase {
   @Test
   public void test() throws Exception {
     assertThat(getAllowListUrlChecker(EXPLICIT_CLUSTER_KEY).getHostAllowList(), notNullValue());
-    assertThat(getAllowListUrlChecker(IMPLICIT_CLUSTER_KEY).getHostAllowList(), nullValue());
+    assertThat(getAllowListUrlChecker(IMPLICIT_CLUSTER_KEY).getHostAllowList().isEmpty(), is(true));
 
     assertThat(getAllowListUrlChecker(EXPLICIT_CLUSTER_KEY).hasExplicitAllowList(), is(true));
     assertThat(getAllowListUrlChecker(IMPLICIT_CLUSTER_KEY).hasExplicitAllowList(), is(false));
@@ -224,7 +223,7 @@ public class ShardsAllowListTest extends MultiSolrCloudTestCase {
   }
 
   private void assertForbidden(String query, String shards, MiniSolrCloudCluster cluster) throws IOException {
-    String expectedExceptionMessage = "is not in the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'";
+    String expectedExceptionMessage = "nor in the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'";
     ignoreException(expectedExceptionMessage);
     try {
       numDocs(

--- a/solr/core/src/test/org/apache/solr/handler/component/ShardsAllowListTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ShardsAllowListTest.java
@@ -236,8 +236,9 @@ public class ShardsAllowListTest extends MultiSolrCloudTestCase {
       assertThat(e.getCause(), instanceOf(SolrException.class));
       assertThat(((SolrException) e.getCause()).code(), is(SolrException.ErrorCode.FORBIDDEN.code));
       assertThat(e.getCause().getMessage(), containsString(expectedExceptionMessage));
+    } finally {
+      unIgnoreException(expectedExceptionMessage);
     }
-    unIgnoreException(expectedExceptionMessage);
   }
 
   private String getShardUrl(String shardName, MiniSolrCloudCluster cluster) {

--- a/solr/core/src/test/org/apache/solr/handler/component/ShardsAllowListTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ShardsAllowListTest.java
@@ -224,7 +224,7 @@ public class ShardsAllowListTest extends MultiSolrCloudTestCase {
   }
 
   private void assertForbidden(String query, String shards, MiniSolrCloudCluster cluster) throws IOException {
-    String expectedExceptionMessage = "not on the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'";
+    String expectedExceptionMessage = "is not in the configured '" + AllowListUrlChecker.URL_ALLOW_LIST + "'";
     ignoreException(expectedExceptionMessage);
     try {
       numDocs(

--- a/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
@@ -28,19 +28,15 @@ import java.util.Set;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.impl.LBSolrClient;
 import org.apache.solr.client.solrj.request.QueryRequest;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.core.CoreContainer;
-import org.apache.solr.handler.component.HttpShardHandlerFactory.WhitelistHostChecker;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 
 /**
  * Tests specifying a custom ShardHandlerFactory
@@ -49,7 +45,7 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
 
   private static final String LOAD_BALANCER_REQUESTS_MIN_ABSOLUTE = "solr.tests.loadBalancerRequestsMinimumAbsolute";
   private static final String LOAD_BALANCER_REQUESTS_MAX_FRACTION = "solr.tests.loadBalancerRequestsMaximumFraction";
-  private static final String SHARDS_WHITELIST = "solr.tests.shardsWhitelist";
+  private static final String TEST_URL_ALLOW_LIST = "solr.tests." + HttpShardHandlerFactory.URL_ALLOW_LIST;
 
   private static int   expectedLoadBalancerRequestsMinimumAbsolute = 0;
   private static float expectedLoadBalancerRequestsMaximumFraction = 1.0f;
@@ -95,7 +91,7 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
       final LBSolrClient.Req req = httpShardHandlerFactory.newLBHttpSolrClientReq(queryRequest, urls);
 
       // actual vs. expected test
-      final int actualNumServersToTry = req.getNumServersToTry().intValue();
+      final int actualNumServersToTry = req.getNumServersToTry();
       int expectedNumServersToTry = (int)Math.floor(urls.size() * expectedLoadBalancerRequestsMaximumFraction);
       if (expectedNumServersToTry < expectedLoadBalancerRequestsMinimumAbsolute) {
         expectedNumServersToTry = expectedLoadBalancerRequestsMinimumAbsolute;
@@ -114,177 +110,37 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void getShardsWhitelist() throws Exception {
-    System.setProperty(SHARDS_WHITELIST, "http://abc:8983/,http://def:8984/,");
-    final Path home = Paths.get(TEST_HOME());
+  public void getShardsAllowList() throws Exception {
+    System.setProperty(TEST_URL_ALLOW_LIST, "http://abc:8983/,http://def:8984/,");
     CoreContainer cc = null;
     ShardHandlerFactory factory = null;
     try {
+      final Path home = Paths.get(TEST_HOME());
       cc = CoreContainer.createAndLoad(home, home.resolve("solr.xml"));
       factory = cc.getShardHandlerFactory();
       assertTrue(factory instanceof HttpShardHandlerFactory);
       @SuppressWarnings("resource")
-      final HttpShardHandlerFactory httpShardHandlerFactory = ((HttpShardHandlerFactory)factory);
-      assertThat(httpShardHandlerFactory.getWhitelistHostChecker().getWhitelistHosts().size(), is(2));
-      assertThat(httpShardHandlerFactory.getWhitelistHostChecker().getWhitelistHosts(), hasItem("abc:8983"));
-      assertThat(httpShardHandlerFactory.getWhitelistHostChecker().getWhitelistHosts(), hasItem("def:8984"));
+      final HttpShardHandlerFactory httpShardHandlerFactory = (HttpShardHandlerFactory) factory;
+      assertThat(httpShardHandlerFactory.getAllowListUrlChecker().getHostAllowList(),
+              equalTo(new HashSet<>(Arrays.asList("abc:8983", "def:8984"))));
     } finally {
       if (factory != null) factory.close();
       if (cc != null) cc.shutdown();
-      System.clearProperty(SHARDS_WHITELIST);
+      System.clearProperty(TEST_URL_ALLOW_LIST);
     }
   }
   
   @Test
   public void testLiveNodesToHostUrl() throws Exception {
-    Set<String> liveNodes = new HashSet<>(Arrays.asList(new String[]{
-        "1.2.3.4:8983_solr",
-        "1.2.3.4:9000_",
-        "1.2.3.4:9001_solr-2",
-    }));
+    Set<String> liveNodes = new HashSet<>(Arrays.asList(
+            "1.2.3.4:8983_solr",
+            "1.2.3.4:9000_",
+            "1.2.3.4:9001_solr-2"));
     ClusterState cs = new ClusterState(liveNodes, new HashMap<>());
-    WhitelistHostChecker checker = new WhitelistHostChecker(null, true);
-    Set<String> hostSet = checker.generateWhitelistFromLiveNodes(cs);
+    Set<String> hostSet = cs.getHostAllowList();
     assertThat(hostSet.size(), is(3));
     assertThat(hostSet, hasItem("1.2.3.4:8983"));
     assertThat(hostSet, hasItem("1.2.3.4:9000"));
     assertThat(hostSet, hasItem("1.2.3.4:9001"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerDisabled() throws Exception {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://cde:8983", false);
-    checker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList(new String[]{"abc-1.com:8983/solr"}));
-
-    WhitelistHostChecker whitelistHostChecker = new WhitelistHostChecker("http://cde:8983", true);
-    SolrException e = expectThrows(SolrException.class, () -> {
-      whitelistHostChecker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList("http://abc-1.com:8983/solr"));
-    });
-    assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerNoInput() throws Exception {
-    assertNull("Whitelist hosts should be null with null input",
-        new WhitelistHostChecker(null, true).getWhitelistHosts());
-    assertNull("Whitelist hosts should be null with empty input",
-        new WhitelistHostChecker("", true).getWhitelistHosts());
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerSingleHost() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983/solr", true);
-    checker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList("http://abc-1.com:8983/solr"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerMultipleHost() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    checker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList("http://abc-1.com:8983/solr"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerMultipleHost2() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    checker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList("http://abc-1.com:8983/solr", "http://abc-2.com:8983/solr"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerNoProtocolInParameter() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    checker.checkWhitelist("abc-1.com:8983/solr", Arrays.asList("abc-1.com:8983/solr"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerNonWhitelistedHost1() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    SolrException e = expectThrows(SolrException.class, () -> {
-      checker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList("http://abc-4.com:8983/solr"));
-    });
-    assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
-    assertThat(e.getMessage(), containsString("not on the shards whitelist"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerNonWhitelistedHost2() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    SolrException e = expectThrows(SolrException.class, () -> {
-      checker.checkWhitelist("http://abc-1.com:8983/solr", Arrays.asList("http://abc-1.com:8983/solr", "http://abc-4.com:8983/solr"));
-    });
-    assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
-    assertThat(e.getMessage(), containsString("not on the shards whitelist"));
-
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerNonWhitelistedHostHttps() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    checker.checkWhitelist("https://abc-1.com:8983/solr", Arrays.asList("https://abc-1.com:8983/solr"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerInvalidUrl() {
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983", true);
-    SolrException e = expectThrows(SolrException.class, () -> checker.checkWhitelist("abc_1", Arrays.asList("abc_1")));
-    assertThat(e.code(), is(SolrException.ErrorCode.BAD_REQUEST.code));
-    assertThat(e.getMessage(), containsString("Invalid URL syntax"));
-  }
-  
-  @Test
-  public void testWhitelistHostCheckerCoreSpecific() {
-    // cores are removed completely so it doesn't really matter if they were set in config
-    WhitelistHostChecker checker = new WhitelistHostChecker("http://abc-1.com:8983/solr/core1, http://abc-2.com:8983/solr2/core2", true);
-    checker.checkWhitelist("http://abc-1.com:8983/solr/core2", Arrays.asList(new String[]{"http://abc-1.com:8983/solr/core2"}));
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsUnset() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist(null), nullValue());
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsEmpty() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist(""), nullValue());
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsSingle() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://abc-1.com:8983/solr/core1").size(), is(1));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://abc-1.com:8983/solr/core1").iterator().next(), equalTo("abc-1.com:8983"));
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsMulti() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://abc-1.com:8983/solr/core1,http://abc-1.com:8984/solr").size(), is(2));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://abc-1.com:8983/solr/core1,http://abc-1.com:8984/solr"), hasItem("abc-1.com:8983"));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://abc-1.com:8983/solr/core1,http://abc-1.com:8984/solr"), hasItem("abc-1.com:8984"));
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsIpv4() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://10.0.0.1:8983/solr/core1,http://127.0.0.1:8984/solr").size(), is(2));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://10.0.0.1:8983/solr/core1,http://127.0.0.1:8984/solr"), hasItem("10.0.0.1:8983"));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://10.0.0.1:8983/solr/core1,http://127.0.0.1:8984/solr"), hasItem("127.0.0.1:8984"));
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsIpv6() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1,http://[::1]:8984/solr").size(), is(2));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1,http://[::1]:8984/solr"), hasItem("[2001:abc:abc:0:0:123:456:1234]:8983"));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1,http://[::1]:8984/solr"), hasItem("[::1]:8984"));
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsHttps() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("https://abc-1.com:8983/solr/core1").size(), is(1));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("https://abc-1.com:8983/solr/core1"), hasItem("abc-1.com:8983"));
-  }
-  
-  @Test
-  public void testGetShardsOfWhitelistedHostsNoProtocol() {
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("abc-1.com:8983/solr"),
-        equalTo(WhitelistHostChecker.implGetShardsWhitelist("http://abc-1.com:8983/solr")));
-    assertThat(WhitelistHostChecker.implGetShardsWhitelist("abc-1.com:8983/solr"),
-        equalTo(WhitelistHostChecker.implGetShardsWhitelist("https://abc-1.com:8983/solr")));
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
@@ -45,7 +45,6 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
 
   private static final String LOAD_BALANCER_REQUESTS_MIN_ABSOLUTE = "solr.tests.loadBalancerRequestsMinimumAbsolute";
   private static final String LOAD_BALANCER_REQUESTS_MAX_FRACTION = "solr.tests.loadBalancerRequestsMaximumFraction";
-  private static final String TEST_URL_ALLOW_LIST = "solr.tests." + HttpShardHandlerFactory.URL_ALLOW_LIST;
 
   private static int   expectedLoadBalancerRequestsMinimumAbsolute = 0;
   private static float expectedLoadBalancerRequestsMaximumFraction = 1.0f;
@@ -119,9 +118,7 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
       cc = CoreContainer.createAndLoad(home, home.resolve("solr.xml"));
       factory = cc.getShardHandlerFactory();
       assertTrue(factory instanceof HttpShardHandlerFactory);
-      @SuppressWarnings("resource")
-      final HttpShardHandlerFactory httpShardHandlerFactory = (HttpShardHandlerFactory) factory;
-      assertThat(httpShardHandlerFactory.getAllowListUrlChecker().getHostAllowList(),
+      assertThat(cc.getAllowListUrlChecker().getHostAllowList(),
               equalTo(new HashSet<>(Arrays.asList("abc:8983", "def:8984"))));
     } finally {
       if (factory != null) factory.close();

--- a/solr/core/src/test/org/apache/solr/search/TestSmileRequest.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSmileRequest.java
@@ -42,7 +42,7 @@ public class TestSmileRequest extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void beforeTests() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     JSONTestUtil.failRepeatedKeys = true;
     initCore("solrconfig-tlog.xml", "schema_latest.xml");
   }
@@ -60,7 +60,7 @@ public class TestSmileRequest extends SolrTestCaseJ4 {
       servers.stop();
       servers = null;
     }
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetErrors.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetErrors.java
@@ -35,7 +35,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @BeforeClass
   public static void beforeTests() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     JSONTestUtil.failRepeatedKeys = true;
 
     // we need DVs on point fields to compute stats & facets
@@ -56,7 +56,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @AfterClass
   public static void afterTests() throws Exception {
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
     JSONTestUtil.failRepeatedKeys = false;
     if (servers != null) {
       servers.stop();

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetRefinement.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetRefinement.java
@@ -42,7 +42,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
 
   @BeforeClass
   public static void beforeTests() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     // we need DVs on point fields to compute stats & facets
     if (Boolean.getBoolean(NUMERIC_POINTS_SYSPROP)) System.setProperty(NUMERIC_DOCVALUES_SYSPROP,"true");
     
@@ -63,7 +63,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
       servers.stop();
       servers = null;
     }
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
   }
 
 

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -60,7 +60,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @BeforeClass
   public static void beforeTests() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     JSONTestUtil.failRepeatedKeys = true;
 
     origTableSize = FacetFieldProcessorByHashDV.MAXIMUM_STARTING_TABLE_SIZE;
@@ -88,7 +88,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @AfterClass
   public static void afterTests() throws Exception {
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
     JSONTestUtil.failRepeatedKeys = false;
     FacetFieldProcessorByHashDV.MAXIMUM_STARTING_TABLE_SIZE=origTableSize;
     FacetField.FacetMethod.DEFAULT_METHOD = origDefaultFacetMethod;

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonRangeFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonRangeFacets.java
@@ -35,7 +35,7 @@ public class TestJsonRangeFacets extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @BeforeClass
   public static void beforeTests() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     JSONTestUtil.failRepeatedKeys = true;
 
     // we need DVs on point fields to compute stats & facets
@@ -57,7 +57,7 @@ public class TestJsonRangeFacets extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @AfterClass
   public static void afterTests() throws Exception {
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
     JSONTestUtil.failRepeatedKeys = false;
     if (servers != null) {
       servers.stop();

--- a/solr/core/src/test/org/apache/solr/search/json/TestJsonRequest.java
+++ b/solr/core/src/test/org/apache/solr/search/json/TestJsonRequest.java
@@ -43,7 +43,7 @@ public class TestJsonRequest extends SolrTestCaseHS {
   @SuppressWarnings("deprecation")
   @BeforeClass
   public static void beforeTests() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
     JSONTestUtil.failRepeatedKeys = true;
     initCore("solrconfig-tlog.xml","schema_latest.xml");
   }
@@ -62,7 +62,7 @@ public class TestJsonRequest extends SolrTestCaseHS {
       servers.stop();
       servers = null;
     }
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
@@ -87,15 +87,16 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
     }
 
     @Test
-    public void testProtocolHttps() throws Exception {
+    public void testProtocols() throws Exception {
         AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
         checker.checkAllowList(urls("https://abc-1.com:8983/solr", "https://abc-2.com:8983/solr"));
+        checker.checkAllowList(urls("s3://abc-1.com:8983/solr"));
     }
 
     @Test
     public void testInvalidUrlInConstructor() {
-        MalformedURLException e = expectThrows(MalformedURLException.class, () -> new AllowListUrlChecker(urls("h://abc-1.com:8983")));
-        assertThat(e.getMessage(), containsString("h://abc-1.com:8983"));
+        MalformedURLException e = expectThrows(MalformedURLException.class, () -> new AllowListUrlChecker(urls("http/abc-1.com:8983")));
+        assertThat(e.getMessage(), containsString("http/abc-1.com:8983"));
     }
 
     @Test

--- a/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.net.MalformedURLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,7 +23,7 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
     @Test
     public void testAllowAll() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://cde:8983");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://cde:8983"));
         SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr")));
         assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
 
@@ -31,39 +32,30 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
     @Test
     public void testNoInput() throws Exception {
-        assertNull(new AllowListUrlChecker(null).getHostAllowList());
-        assertNull(new AllowListUrlChecker("").getHostAllowList());
+        assertNull(new AllowListUrlChecker(Collections.emptyList()).getHostAllowList());
     }
 
     @Test
     public void testSingleHost() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983/solr");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983/solr"));
         checker.checkAllowList(urls("http://abc-1.com:8983/solr"));
     }
 
     @Test
-    public void testMultipleHostsInConstructor() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983,http://abc-3.com:8983,");
-        checker.checkAllowList(urls("http://abc-1.com:8983/solr"));
-        checker.checkAllowList(urls("http://abc-2.com:8983/solr"));
-        checker.checkAllowList(urls("http://abc-3.com:8983/solr"));
-    }
-
-    @Test
-    public void testMultipleHostsInCheck() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+    public void testMultipleHosts() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
         checker.checkAllowList(urls("http://abc-3.com:8983/solr", "http://abc-1.com:8983/solr", "http://abc-2.com:8983/solr"));
     }
 
     @Test
     public void testNoProtocol() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, abc-3.com:8983");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "abc-3.com:8983"));
         checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-3.com:8983/solr"));
     }
 
     @Test
     public void testDisallowedHost() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
         SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("http://abc-4.com:8983/solr")));
         assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
         assertThat(e.getMessage(), containsString("http://abc-4.com:8983/solr"));
@@ -71,7 +63,7 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
     @Test
     public void testDisallowedHostNoProtocol() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
         SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-4.com:8983/solr")));
         assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
         assertThat(e.getMessage(), containsString("abc-4.com:8983/solr"));
@@ -80,19 +72,19 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
     @Test
     public void testProtocolHttps() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
         checker.checkAllowList(urls("https://abc-1.com:8983/solr", "https://abc-2.com:8983/solr"));
     }
 
     @Test
     public void testInvalidUrlInConstructor() {
-        MalformedURLException e = expectThrows(MalformedURLException.class, () -> new AllowListUrlChecker("h://abc-1.com:8983"));
+        MalformedURLException e = expectThrows(MalformedURLException.class, () -> new AllowListUrlChecker(urls("h://abc-1.com:8983")));
         assertThat(e.getMessage(), containsString("h://abc-1.com:8983"));
     }
 
     @Test
     public void testInvalidUrlInCheck() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
         MalformedURLException e = expectThrows(MalformedURLException.class, () -> checker.checkAllowList(urls("http://abc-1.com:8983", "abc-2")));
         assertThat(e.getMessage(), containsString("abc-2"));
     }
@@ -100,52 +92,52 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
     @Test
     public void testCoreSpecific() throws Exception {
         // Cores are removed completely so it doesn't really matter if they were set in config.
-        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983/solr/core1, http://abc-2.com:8983/solr2/core2");
+        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983/solr/core1", "http://abc-2.com:8983/solr2/core2"));
         checker.checkAllowList(urls("abc-1.com:8983/solr/core3", "http://abc-2.com:8983/solr"));
     }
 
     @Test
     public void testHostParsingUnsetEmpty() throws Exception {
         assertThat(AllowListUrlChecker.parseHostPorts(null), nullValue());
-        assertThat(AllowListUrlChecker.parseHostPorts(""), nullValue());
+        assertThat(AllowListUrlChecker.parseHostPorts(Collections.emptyList()), nullValue());
     }
 
     @Test
     public void testHostParsingSingle() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts("http://abc-1.com:8983/solr/core1"),
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr/core1")),
                 equalTo(hosts("abc-1.com:8983")));
     }
 
     @Test
     public void testHostParsingMulti() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts("http://abc-1.com:8983/solr/core1,http://abc-1.com:8984/solr"),
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr/core1", "http://abc-1.com:8984/solr")),
         equalTo(hosts("abc-1.com:8983", "abc-1.com:8984")));
     }
 
     @Test
     public void testHostParsingIpv4() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts("http://10.0.0.1:8983/solr/core1,http://127.0.0.1:8984/solr"),
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://10.0.0.1:8983/solr/core1", "http://127.0.0.1:8984/solr")),
                 equalTo(hosts("10.0.0.1:8983", "127.0.0.1:8984")));
     }
 
     @Test
     public void testHostParsingIpv6() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1,http://[::1]:8984/solr"),
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1", "http://[::1]:8984/solr")),
                 equalTo(hosts("[2001:abc:abc:0:0:123:456:1234]:8983", "[::1]:8984")));
     }
 
     @Test
     public void testHostParsingHttps() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts("https://abc-1.com:8983/solr/core1"),
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("https://abc-1.com:8983/solr/core1")),
                 equalTo(hosts("abc-1.com:8983")));
     }
 
     @Test
     public void testHostParsingNoProtocol() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts("abc-1.com:8983/solr"),
-                equalTo(AllowListUrlChecker.parseHostPorts("http://abc-1.com:8983/solr")));
-        assertThat(AllowListUrlChecker.parseHostPorts("abc-1.com:8983/solr"),
-                equalTo(AllowListUrlChecker.parseHostPorts("https://abc-1.com:8983/solr")));
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("abc-1.com:8983/solr")),
+                equalTo(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr"))));
+        assertThat(AllowListUrlChecker.parseHostPorts(urls("abc-1.com:8983/solr")),
+                equalTo(AllowListUrlChecker.parseHostPorts(urls("https://abc-1.com:8983/solr"))));
     }
 
     private static List<String> urls(String... urls) {

--- a/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.security;
 
 import org.apache.solr.SolrTestCaseJ4;

--- a/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 
 /**
  * Tests {@link AllowListUrlChecker}.
@@ -32,7 +31,7 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
     @Test
     public void testNoInput() throws Exception {
-        assertNull(new AllowListUrlChecker(Collections.emptyList()).getHostAllowList());
+        assertThat(new AllowListUrlChecker(Collections.emptyList()).getHostAllowList().isEmpty(), is(true));
     }
 
     @Test
@@ -98,8 +97,7 @@ public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
     @Test
     public void testHostParsingUnsetEmpty() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(null), nullValue());
-        assertThat(AllowListUrlChecker.parseHostPorts(Collections.emptyList()), nullValue());
+        assertThat(AllowListUrlChecker.parseHostPorts(Collections.emptyList()).isEmpty(), is(true));
     }
 
     @Test

--- a/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
@@ -1,0 +1,158 @@
+package org.apache.solr.security;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+/**
+ * Tests {@link AllowListUrlChecker}.
+ */
+public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
+
+    @Test
+    public void testAllowAll() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://cde:8983");
+        SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr")));
+        assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
+
+        AllowListUrlChecker.ALLOW_ALL.checkAllowList(urls("abc-1.com:8983/solr"));
+    }
+
+    @Test
+    public void testNoInput() throws Exception {
+        assertNull(new AllowListUrlChecker(null).getHostAllowList());
+        assertNull(new AllowListUrlChecker("").getHostAllowList());
+    }
+
+    @Test
+    public void testSingleHost() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983/solr");
+        checker.checkAllowList(urls("http://abc-1.com:8983/solr"));
+    }
+
+    @Test
+    public void testMultipleHostsInConstructor() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983,http://abc-3.com:8983,");
+        checker.checkAllowList(urls("http://abc-1.com:8983/solr"));
+        checker.checkAllowList(urls("http://abc-2.com:8983/solr"));
+        checker.checkAllowList(urls("http://abc-3.com:8983/solr"));
+    }
+
+    @Test
+    public void testMultipleHostsInCheck() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        checker.checkAllowList(urls("http://abc-3.com:8983/solr", "http://abc-1.com:8983/solr", "http://abc-2.com:8983/solr"));
+    }
+
+    @Test
+    public void testNoProtocol() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, abc-3.com:8983");
+        checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-3.com:8983/solr"));
+    }
+
+    @Test
+    public void testDisallowedHost() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("http://abc-4.com:8983/solr")));
+        assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
+        assertThat(e.getMessage(), containsString("http://abc-4.com:8983/solr"));
+    }
+
+    @Test
+    public void testDisallowedHostNoProtocol() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-4.com:8983/solr")));
+        assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
+        assertThat(e.getMessage(), containsString("abc-4.com:8983/solr"));
+
+    }
+
+    @Test
+    public void testProtocolHttps() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        checker.checkAllowList(urls("https://abc-1.com:8983/solr", "https://abc-2.com:8983/solr"));
+    }
+
+    @Test
+    public void testInvalidUrlInConstructor() {
+        MalformedURLException e = expectThrows(MalformedURLException.class, () -> new AllowListUrlChecker("h://abc-1.com:8983"));
+        assertThat(e.getMessage(), containsString("h://abc-1.com:8983"));
+    }
+
+    @Test
+    public void testInvalidUrlInCheck() throws Exception {
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983, http://abc-2.com:8983, http://abc-3.com:8983");
+        MalformedURLException e = expectThrows(MalformedURLException.class, () -> checker.checkAllowList(urls("http://abc-1.com:8983", "abc-2")));
+        assertThat(e.getMessage(), containsString("abc-2"));
+    }
+
+    @Test
+    public void testCoreSpecific() throws Exception {
+        // Cores are removed completely so it doesn't really matter if they were set in config.
+        AllowListUrlChecker checker = new AllowListUrlChecker("http://abc-1.com:8983/solr/core1, http://abc-2.com:8983/solr2/core2");
+        checker.checkAllowList(urls("abc-1.com:8983/solr/core3", "http://abc-2.com:8983/solr"));
+    }
+
+    @Test
+    public void testHostParsingUnsetEmpty() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts(null), nullValue());
+        assertThat(AllowListUrlChecker.parseHostPorts(""), nullValue());
+    }
+
+    @Test
+    public void testHostParsingSingle() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts("http://abc-1.com:8983/solr/core1"),
+                equalTo(hosts("abc-1.com:8983")));
+    }
+
+    @Test
+    public void testHostParsingMulti() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts("http://abc-1.com:8983/solr/core1,http://abc-1.com:8984/solr"),
+        equalTo(hosts("abc-1.com:8983", "abc-1.com:8984")));
+    }
+
+    @Test
+    public void testHostParsingIpv4() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts("http://10.0.0.1:8983/solr/core1,http://127.0.0.1:8984/solr"),
+                equalTo(hosts("10.0.0.1:8983", "127.0.0.1:8984")));
+    }
+
+    @Test
+    public void testHostParsingIpv6() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1,http://[::1]:8984/solr"),
+                equalTo(hosts("[2001:abc:abc:0:0:123:456:1234]:8983", "[::1]:8984")));
+    }
+
+    @Test
+    public void testHostParsingHttps() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts("https://abc-1.com:8983/solr/core1"),
+                equalTo(hosts("abc-1.com:8983")));
+    }
+
+    @Test
+    public void testHostParsingNoProtocol() throws Exception {
+        assertThat(AllowListUrlChecker.parseHostPorts("abc-1.com:8983/solr"),
+                equalTo(AllowListUrlChecker.parseHostPorts("http://abc-1.com:8983/solr")));
+        assertThat(AllowListUrlChecker.parseHostPorts("abc-1.com:8983/solr"),
+                equalTo(AllowListUrlChecker.parseHostPorts("https://abc-1.com:8983/solr")));
+    }
+
+    private static List<String> urls(String... urls) {
+        return Arrays.asList(urls);
+    }
+
+    private static Set<String> hosts(String... hosts) {
+        return new HashSet<>(Arrays.asList(hosts));
+    }
+}

--- a/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AllowListUrlCheckerTest.java
@@ -32,135 +32,176 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
-/**
- * Tests {@link AllowListUrlChecker}.
- */
+/** Tests {@link AllowListUrlChecker}. */
 public class AllowListUrlCheckerTest extends SolrTestCaseJ4 {
 
-    @Test
-    public void testAllowAll() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://cde:8983"));
-        SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr")));
-        assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
+  @Test
+  public void testAllowAll() throws Exception {
+    AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://cde:8983"));
+    SolrException e =
+        expectThrows(
+            SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr")));
+    assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
 
-        AllowListUrlChecker.ALLOW_ALL.checkAllowList(urls("abc-1.com:8983/solr"));
-    }
+    AllowListUrlChecker.ALLOW_ALL.checkAllowList(urls("abc-1.com:8983/solr"));
+  }
 
-    @Test
-    public void testNoInput() throws Exception {
-        assertThat(new AllowListUrlChecker(Collections.emptyList()).getHostAllowList().isEmpty(), is(true));
-    }
+  @Test
+  public void testNoInput() throws Exception {
+    assertThat(
+        new AllowListUrlChecker(Collections.emptyList()).getHostAllowList().isEmpty(), is(true));
+  }
 
-    @Test
-    public void testSingleHost() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983/solr"));
-        checker.checkAllowList(urls("http://abc-1.com:8983/solr"));
-    }
+  @Test
+  public void testSingleHost() throws Exception {
+    AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983/solr"));
+    checker.checkAllowList(urls("http://abc-1.com:8983/solr"));
+  }
 
-    @Test
-    public void testMultipleHosts() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
-        checker.checkAllowList(urls("http://abc-3.com:8983/solr", "http://abc-1.com:8983/solr", "http://abc-2.com:8983/solr"));
-    }
+  @Test
+  public void testMultipleHosts() throws Exception {
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
+    checker.checkAllowList(
+        urls(
+            "http://abc-3.com:8983/solr",
+            "http://abc-1.com:8983/solr",
+            "http://abc-2.com:8983/solr"));
+  }
 
-    @Test
-    public void testNoProtocol() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "abc-3.com:8983"));
-        checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-3.com:8983/solr"));
-    }
+  @Test
+  public void testNoProtocol() throws Exception {
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983", "http://abc-2.com:8983", "abc-3.com:8983"));
+    checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-3.com:8983/solr"));
+  }
 
-    @Test
-    public void testDisallowedHost() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
-        SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("http://abc-4.com:8983/solr")));
-        assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
-        assertThat(e.getMessage(), containsString("http://abc-4.com:8983/solr"));
-    }
+  @Test
+  public void testDisallowedHost() throws Exception {
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
+    SolrException e =
+        expectThrows(
+            SolrException.class, () -> checker.checkAllowList(urls("http://abc-4.com:8983/solr")));
+    assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
+    assertThat(e.getMessage(), containsString("http://abc-4.com:8983/solr"));
+  }
 
-    @Test
-    public void testDisallowedHostNoProtocol() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
-        SolrException e = expectThrows(SolrException.class, () -> checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-4.com:8983/solr")));
-        assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
-        assertThat(e.getMessage(), containsString("abc-4.com:8983/solr"));
+  @Test
+  public void testDisallowedHostNoProtocol() throws Exception {
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
+    SolrException e =
+        expectThrows(
+            SolrException.class,
+            () -> checker.checkAllowList(urls("abc-1.com:8983/solr", "abc-4.com:8983/solr")));
+    assertThat(e.code(), is(SolrException.ErrorCode.FORBIDDEN.code));
+    assertThat(e.getMessage(), containsString("abc-4.com:8983/solr"));
+  }
 
-    }
+  @Test
+  public void testProtocols() throws Exception {
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
+    checker.checkAllowList(urls("https://abc-1.com:8983/solr", "https://abc-2.com:8983/solr"));
+    checker.checkAllowList(urls("s3://abc-1.com:8983/solr"));
+  }
 
-    @Test
-    public void testProtocols() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
-        checker.checkAllowList(urls("https://abc-1.com:8983/solr", "https://abc-2.com:8983/solr"));
-        checker.checkAllowList(urls("s3://abc-1.com:8983/solr"));
-    }
+  @Test
+  public void testInvalidUrlInConstructor() {
+    MalformedURLException e =
+        expectThrows(
+            MalformedURLException.class,
+            () -> new AllowListUrlChecker(urls("http/abc-1.com:8983")));
+    assertThat(e.getMessage(), containsString("http/abc-1.com:8983"));
+  }
 
-    @Test
-    public void testInvalidUrlInConstructor() {
-        MalformedURLException e = expectThrows(MalformedURLException.class, () -> new AllowListUrlChecker(urls("http/abc-1.com:8983")));
-        assertThat(e.getMessage(), containsString("http/abc-1.com:8983"));
-    }
+  @Test
+  public void testInvalidUrlInCheck() throws Exception {
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
+    MalformedURLException e =
+        expectThrows(
+            MalformedURLException.class,
+            () -> checker.checkAllowList(urls("http://abc-1.com:8983", "abc-2")));
+    assertThat(e.getMessage(), containsString("abc-2"));
+  }
 
-    @Test
-    public void testInvalidUrlInCheck() throws Exception {
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983", "http://abc-2.com:8983", "http://abc-3.com:8983"));
-        MalformedURLException e = expectThrows(MalformedURLException.class, () -> checker.checkAllowList(urls("http://abc-1.com:8983", "abc-2")));
-        assertThat(e.getMessage(), containsString("abc-2"));
-    }
+  @Test
+  public void testCoreSpecific() throws Exception {
+    // Cores are removed completely so it doesn't really matter if they were set in config.
+    AllowListUrlChecker checker =
+        new AllowListUrlChecker(
+            urls("http://abc-1.com:8983/solr/core1", "http://abc-2.com:8983/solr2/core2"));
+    checker.checkAllowList(urls("abc-1.com:8983/solr/core3", "http://abc-2.com:8983/solr"));
+  }
 
-    @Test
-    public void testCoreSpecific() throws Exception {
-        // Cores are removed completely so it doesn't really matter if they were set in config.
-        AllowListUrlChecker checker = new AllowListUrlChecker(urls("http://abc-1.com:8983/solr/core1", "http://abc-2.com:8983/solr2/core2"));
-        checker.checkAllowList(urls("abc-1.com:8983/solr/core3", "http://abc-2.com:8983/solr"));
-    }
+  @Test
+  public void testHostParsingUnsetEmpty() throws Exception {
+    assertThat(AllowListUrlChecker.parseHostPorts(Collections.emptyList()).isEmpty(), is(true));
+  }
 
-    @Test
-    public void testHostParsingUnsetEmpty() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(Collections.emptyList()).isEmpty(), is(true));
-    }
+  @Test
+  public void testHostParsingSingle() throws Exception {
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr/core1")),
+        equalTo(hosts("abc-1.com:8983")));
+  }
 
-    @Test
-    public void testHostParsingSingle() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr/core1")),
-                equalTo(hosts("abc-1.com:8983")));
-    }
-
-    @Test
-    public void testHostParsingMulti() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr/core1", "http://abc-1.com:8984/solr")),
+  @Test
+  public void testHostParsingMulti() throws Exception {
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(
+            urls("http://abc-1.com:8983/solr/core1", "http://abc-1.com:8984/solr")),
         equalTo(hosts("abc-1.com:8983", "abc-1.com:8984")));
-    }
+  }
 
-    @Test
-    public void testHostParsingIpv4() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://10.0.0.1:8983/solr/core1", "http://127.0.0.1:8984/solr")),
-                equalTo(hosts("10.0.0.1:8983", "127.0.0.1:8984")));
-    }
+  @Test
+  public void testHostParsingIpv4() throws Exception {
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(
+            urls("http://10.0.0.1:8983/solr/core1", "http://127.0.0.1:8984/solr")),
+        equalTo(hosts("10.0.0.1:8983", "127.0.0.1:8984")));
+  }
 
-    @Test
-    public void testHostParsingIpv6() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1", "http://[::1]:8984/solr")),
-                equalTo(hosts("[2001:abc:abc:0:0:123:456:1234]:8983", "[::1]:8984")));
-    }
+  @Test
+  public void testHostParsingIpv6() throws Exception {
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(
+            urls(
+                "http://[2001:abc:abc:0:0:123:456:1234]:8983/solr/core1",
+                "http://[::1]:8984/solr")),
+        equalTo(hosts("[2001:abc:abc:0:0:123:456:1234]:8983", "[::1]:8984")));
+  }
 
-    @Test
-    public void testHostParsingHttps() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("https://abc-1.com:8983/solr/core1")),
-                equalTo(hosts("abc-1.com:8983")));
-    }
+  @Test
+  public void testHostParsingHttps() throws Exception {
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(urls("https://abc-1.com:8983/solr/core1")),
+        equalTo(hosts("abc-1.com:8983")));
+  }
 
-    @Test
-    public void testHostParsingNoProtocol() throws Exception {
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("abc-1.com:8983/solr")),
-                equalTo(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr"))));
-        assertThat(AllowListUrlChecker.parseHostPorts(urls("abc-1.com:8983/solr")),
-                equalTo(AllowListUrlChecker.parseHostPorts(urls("https://abc-1.com:8983/solr"))));
-    }
+  @Test
+  public void testHostParsingNoProtocol() throws Exception {
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(urls("abc-1.com:8983/solr")),
+        equalTo(AllowListUrlChecker.parseHostPorts(urls("http://abc-1.com:8983/solr"))));
+    assertThat(
+        AllowListUrlChecker.parseHostPorts(urls("abc-1.com:8983/solr")),
+        equalTo(AllowListUrlChecker.parseHostPorts(urls("https://abc-1.com:8983/solr"))));
+  }
 
-    private static List<String> urls(String... urls) {
-        return Arrays.asList(urls);
-    }
+  private static List<String> urls(String... urls) {
+    return Arrays.asList(urls);
+  }
 
-    private static Set<String> hosts(String... hosts) {
-        return new HashSet<>(Arrays.asList(hosts));
-    }
+  private static Set<String> hosts(String... hosts) {
+    return new HashSet<>(Arrays.asList(hosts));
+  }
 }

--- a/solr/server/etc/security.properties
+++ b/solr/server/etc/security.properties
@@ -20,5 +20,5 @@
 # as protection against DNS spoofing.  We set this back to the default (non-security-manager)
 # value of 30 seconds, to prevent surprising behavior (e.g. nodes in cloud environments without
 # static IP addresses). Users concerned about DNS spoofing should instead follow best practices:
-# populating solr.shardsWhitelist, enabling TLS, etc.
+# populating solr.urlAllowList, enabling TLS, etc.
 networkaddress.cache.ttl=30

--- a/solr/server/etc/security.properties
+++ b/solr/server/etc/security.properties
@@ -20,5 +20,5 @@
 # as protection against DNS spoofing.  We set this back to the default (non-security-manager)
 # value of 30 seconds, to prevent surprising behavior (e.g. nodes in cloud environments without
 # static IP addresses). Users concerned about DNS spoofing should instead follow best practices:
-# populating solr.urlAllowList, enabling TLS, etc.
+# populating solr.allowUrls, enabling TLS, etc.
 networkaddress.cache.ttl=30

--- a/solr/server/solr/solr.xml
+++ b/solr/server/solr/solr.xml
@@ -31,6 +31,7 @@
   <int name="maxBooleanClauses">${solr.max.booleanClauses:1024}</int>
   <str name="sharedLib">${solr.sharedLib:}</str>
   <str name="allowPaths">${solr.allowPaths:}</str>
+  <str name="allowUrls">${solr.allowUrls:}</str>
 
   <solrcloud>
 
@@ -54,7 +55,6 @@
     class="HttpShardHandlerFactory">
     <int name="socketTimeout">${socketTimeout:600000}</int>
     <int name="connTimeout">${connTimeout:60000}</int>
-    <str name="urlAllowList">${solr.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <metrics enabled="${metricsEnabled:true}"/>

--- a/solr/server/solr/solr.xml
+++ b/solr/server/solr/solr.xml
@@ -54,7 +54,7 @@
     class="HttpShardHandlerFactory">
     <int name="socketTimeout">${socketTimeout:600000}</int>
     <int name="connTimeout">${connTimeout:60000}</int>
-    <str name="shardsWhitelist">${solr.shardsWhitelist:}</str>
+    <str name="urlAllowList">${solr.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <metrics enabled="${metricsEnabled:true}"/>

--- a/solr/solr-ref-guide/src/distributed-requests.adoc
+++ b/solr/solr-ref-guide/src/distributed-requests.adoc
@@ -115,17 +115,17 @@ If specified, the thread pool will use a backing queue instead of a direct hando
 `fairnessPolicy`::
 Chooses the JVM specifics dealing with fair policy queuing, if enabled distributed searches will be handled in a First in First out fashion at a cost to throughput. If disabled throughput will be favored over latency. The default is `false`.
 
-`shardsWhitelist`::
+`urlAllowList`::
 If specified, this lists limits what nodes can be requested in the `shards` request parameter.
 +
-In SolrCloud mode this whitelist is automatically configured to include all live nodes in the cluster.
+In SolrCloud mode this allow-list is automatically configured to include all live nodes in the cluster.
 +
-In standalone mode the whitelist defaults to empty (sharding not allowed).
+In standalone mode the allow-list defaults to empty (sharding not allowed).
 +
-If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.shardsWhitelist=true`. The value of this parameter is a comma separated list of the nodes that will be whitelisted, i.e.,
+If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.urlAllowList=true`. The value of this parameter is a comma separated list of the nodes that will be allowed, i.e.,
 `10.0.0.1:8983/solr,10.0.0.1:8984/solr`.
 +
-NOTE: In SolrCloud mode, if at least one node is included in the whitelist, then the `live_nodes` will no longer be used as source for the list. This means that if you need to do a cross-cluster request using the `shards` parameter in SolrCloud mode (in addition to regular within-cluster requests), you'll need to add all nodes (local cluster + remote nodes) to the whitelist.
+NOTE: In SolrCloud mode, if at least one node is included in the allow-list, then the `live_nodes` will no longer be used as source for the list. This means that if you need to do a cross-cluster request using the `shards` parameter in SolrCloud mode (in addition to regular within-cluster requests), you'll need to add all nodes (local cluster + remote nodes) to the allow-list.
 
 [[distributedidf]]
 == Configuring statsCache (Distributed IDF)

--- a/solr/solr-ref-guide/src/distributed-requests.adoc
+++ b/solr/solr-ref-guide/src/distributed-requests.adoc
@@ -118,16 +118,7 @@ Chooses the JVM specifics dealing with fair policy queuing, if enabled distribut
 In addition, `HttpShardHandlerFactory` also depends on the following top-level property:
 
 `allowUrls`::
-If specified, this lists limits what nodes can be requested in the `shards` request parameter.
-+
-In SolrCloud mode this allow-list is automatically configured to include all live nodes in the cluster.
-+
-In standalone mode the allow-list defaults to empty (sharding not allowed).
-+
-If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.allowUrls=true`. The value of this parameter is a comma separated list of the nodes that will be allowed, i.e.,
-`10.0.0.1:8983/solr,10.0.0.1:8984/solr`.
-+
-NOTE: In SolrCloud mode, if at least one node is included in the allow-list, then the `live_nodes` will no longer be used as source for the list. This means that if you need to do a cross-cluster request using the `shards` parameter in SolrCloud mode (in addition to regular within-cluster requests), you'll need to add all nodes (local cluster + remote nodes) to the allow-list.
+See <<format-of-solr-xml.adoc#_allow_urls, Format of solr.allowUrls>>
 
 [[distributedidf]]
 == Configuring statsCache (Distributed IDF)

--- a/solr/solr-ref-guide/src/distributed-requests.adoc
+++ b/solr/solr-ref-guide/src/distributed-requests.adoc
@@ -115,14 +115,16 @@ If specified, the thread pool will use a backing queue instead of a direct hando
 `fairnessPolicy`::
 Chooses the JVM specifics dealing with fair policy queuing, if enabled distributed searches will be handled in a First in First out fashion at a cost to throughput. If disabled throughput will be favored over latency. The default is `false`.
 
-`urlAllowList`::
+In addition, `HttpShardHandlerFactory` also depends on the following top-level property:
+
+`allowUrls`::
 If specified, this lists limits what nodes can be requested in the `shards` request parameter.
 +
 In SolrCloud mode this allow-list is automatically configured to include all live nodes in the cluster.
 +
 In standalone mode the allow-list defaults to empty (sharding not allowed).
 +
-If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.urlAllowList=true`. The value of this parameter is a comma separated list of the nodes that will be allowed, i.e.,
+If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.allowUrls=true`. The value of this parameter is a comma separated list of the nodes that will be allowed, i.e.,
 `10.0.0.1:8983/solr,10.0.0.1:8984/solr`.
 +
 NOTE: In SolrCloud mode, if at least one node is included in the allow-list, then the `live_nodes` will no longer be used as source for the list. This means that if you need to do a cross-cluster request using the `shards` parameter in SolrCloud mode (in addition to regular within-cluster requests), you'll need to add all nodes (local cluster + remote nodes) to the allow-list.

--- a/solr/solr-ref-guide/src/distributed-search-with-index-sharding.adoc
+++ b/solr/solr-ref-guide/src/distributed-search-with-index-sharding.adoc
@@ -59,9 +59,9 @@ The following components support distributed search:
 * The *Stats* component, which returns simple statistics for numeric fields within the DocSet.
 * The *Debug* component, which helps with debugging.
 
-=== Shards Allow List
+=== URL Allow List
 
-The nodes allowed in the `shards` parameter is configurable through the `urlAllowList` property in `solr.xml`. This allow-list is automatically configured for SolrCloud but needs explicit configuration for leader/follower mode. Read more details in the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>>.
+The nodes allowed in the `shards` parameter is configurable through the `allowUrls` property in `solr.xml`. This allow-list is automatically configured for SolrCloud but needs explicit configuration for leader/follower mode. Read more details in the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>>.
 
 == Limitations to Distributed Search
 

--- a/solr/solr-ref-guide/src/distributed-search-with-index-sharding.adoc
+++ b/solr/solr-ref-guide/src/distributed-search-with-index-sharding.adoc
@@ -59,9 +59,9 @@ The following components support distributed search:
 * The *Stats* component, which returns simple statistics for numeric fields within the DocSet.
 * The *Debug* component, which helps with debugging.
 
-=== Shards Whitelist
+=== Shards Allow List
 
-The nodes allowed in the `shards` parameter is configurable through the `shardsWhitelist` property in `solr.xml`. This whitelist is automatically configured for SolrCloud but needs explicit configuration for leader/follower mode. Read more details in the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>>.
+The nodes allowed in the `shards` parameter is configurable through the `urlAllowList` property in `solr.xml`. This allow-list is automatically configured for SolrCloud but needs explicit configuration for leader/follower mode. Read more details in the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>>.
 
 == Limitations to Distributed Search
 

--- a/solr/solr-ref-guide/src/format-of-solr-xml.adoc
+++ b/solr/solr-ref-guide/src/format-of-solr-xml.adoc
@@ -103,8 +103,11 @@ Specifies the path to a common library directory that will be shared across all 
 `allowPaths`::
 Solr will normally only access folders relative to `$SOLR_HOME`, `$SOLR_DATA_HOME` or `coreRootDir`. If you need to e.g., create a core outside of these paths, you can explicitly allow the path with `allowPaths`. It is a comma separated string of file system paths to allow. The special value of `*` will allow any path on the system.
 
-`allowUrls``:
-When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the list of hosts needs to be allowed or Solr will forbid the request. The allow-list can also be configured in `solr.in.sh`.
+[#_allow_urls]
+`allowUrls`::
+Comma-separated list of Solr hosts to allow. The http/https protocol may be omitted, and only the host and port are checked, i.e. `10.0.0.1:8983/solr,10.0.0.1:8984/solr`.
+When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the list of hosts needs to be allowed or Solr will forbid the request. In Solr cloud mode, this allow-list is added to the cluster's live nodes to determine which hosts are allowed. The allow-list can also be configured with the `solr.allowUrls` system property (see its use in `solr.in.sh`).
+If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.allowUrls=true`.
 
 `shareSchema`::
 This attribute, when set to `true`, ensures that the multiple cores pointing to the same Schema resource file will be referring to the same IndexSchema Object. Sharing the IndexSchema Object makes loading the core faster. If you use this feature, make sure that no core-specific property is used in your Schema file.

--- a/solr/solr-ref-guide/src/format-of-solr-xml.adoc
+++ b/solr/solr-ref-guide/src/format-of-solr-xml.adoc
@@ -49,7 +49,7 @@ You can find `solr.xml` in your `$SOLR_HOME` directory (usually `server/solr` or
     class="HttpShardHandlerFactory">
     <int name="socketTimeout">${socketTimeout:600000}</int>
     <int name="connTimeout">${connTimeout:60000}</int>
-    <str name="shardsWhitelist">${solr.shardsWhitelist:}</str>
+    <str name="urlAllowList">${solr.urlAllowList:}</str>
   </shardHandlerFactory>
 
 </solr>
@@ -228,8 +228,8 @@ If the threadpool uses a backing queue, what is its maximum size to use direct h
 `fairnessPolicy`::
 A boolean to configure if the threadpool favors fairness over throughput. Default is false to favor throughput.
 
-`shardsWhitelist`::
-When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the list of hosts needs to be whitelisted or Solr will forbid the request. The whitelist can also be configured in `solr.in.sh`.
+`urlAllowList`::
+When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the list of hosts needs to be allowed or Solr will forbid the request. The allow-list can also be configured in `solr.in.sh`.
 
 `replicaRouting`::
 A NamedList specifying replica routing preference configuration. This may be used to select and configure replica routing preferences. `default=true` may be used to set the default base replica routing preference. Only positive default status assertions are respected; i.e., `default=false` has no effect. If no explicit default base replica routing preference is configured, the implicit default will be `random`.

--- a/solr/solr-ref-guide/src/format-of-solr-xml.adoc
+++ b/solr/solr-ref-guide/src/format-of-solr-xml.adoc
@@ -31,6 +31,7 @@ You can find `solr.xml` in your `$SOLR_HOME` directory (usually `server/solr` or
   <int name="maxBooleanClauses">${solr.max.booleanClauses:1024}</int>
   <str name="sharedLib">${solr.sharedLib:}</str>
   <str name="allowPaths">${solr.allowPaths:}</str>
+  <str name="allowUrls">${solr.allowUrls:}</str>
 
   <solrcloud>
     <str name="host">${host:}</str>
@@ -49,7 +50,6 @@ You can find `solr.xml` in your `$SOLR_HOME` directory (usually `server/solr` or
     class="HttpShardHandlerFactory">
     <int name="socketTimeout">${socketTimeout:600000}</int>
     <int name="connTimeout">${connTimeout:60000}</int>
-    <str name="urlAllowList">${solr.urlAllowList:}</str>
   </shardHandlerFactory>
 
 </solr>
@@ -102,6 +102,9 @@ Specifies the path to a common library directory that will be shared across all 
 
 `allowPaths`::
 Solr will normally only access folders relative to `$SOLR_HOME`, `$SOLR_DATA_HOME` or `coreRootDir`. If you need to e.g., create a core outside of these paths, you can explicitly allow the path with `allowPaths`. It is a comma separated string of file system paths to allow. The special value of `*` will allow any path on the system.
+
+`allowUrls``:
+When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the list of hosts needs to be allowed or Solr will forbid the request. The allow-list can also be configured in `solr.in.sh`.
 
 `shareSchema`::
 This attribute, when set to `true`, ensures that the multiple cores pointing to the same Schema resource file will be referring to the same IndexSchema Object. Sharing the IndexSchema Object makes loading the core faster. If you use this feature, make sure that no core-specific property is used in your Schema file.
@@ -227,9 +230,6 @@ If the threadpool uses a backing queue, what is its maximum size to use direct h
 
 `fairnessPolicy`::
 A boolean to configure if the threadpool favors fairness over throughput. Default is false to favor throughput.
-
-`urlAllowList`::
-When running Solr in non-cloud mode and if planning to do distributed search (using the "shards" parameter), the list of hosts needs to be allowed or Solr will forbid the request. The allow-list can also be configured in `solr.in.sh`.
 
 `replicaRouting`::
 A NamedList specifying replica routing preference configuration. This may be used to select and configure replica routing preferences. `default=true` may be used to set the default base replica routing preference. Only positive default status assertions are respected; i.e., `default=false` has no effect. If no explicit default base replica routing preference is configured, the implicit default will be `random`.

--- a/solr/solr-ref-guide/src/major-changes-in-solr-8.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-8.adoc
@@ -283,9 +283,9 @@ The login screen's purpose is cosmetic only - Admin UI-triggered Solr requests w
 
 *Distributed Requests*
 
-* The `shards` parameter, used to manually select the shards and replicas that receive distributed requests, now checks nodes against a whitelist of acceptable values for security reasons.
+* The `shards` parameter, used to manually select the shards and replicas that receive distributed requests, now checks nodes against an allow-list of acceptable values for security reasons.
 +
-In SolrCloud mode this whitelist is automatically configured to contain all live nodes.  In standalone mode the whitelist is empty by default.  Upgrading users who use the `shards` parameter in standalone mode can correct this value by setting the `shardsWhitelist` property in any `shardHandler` configurations in their `solrconfig.xml` file.
+In SolrCloud mode this allow-list is automatically configured to contain all live nodes.  In standalone mode the allow-list is empty by default.  Upgrading users who use the `shards` parameter in standalone mode can correct this value by setting the `urlAllowList` property in any `shardHandler` configurations in their `solrconfig.xml` file.
 +
 For more information, see the <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Distributed Request>> documentation.
 

--- a/solr/solr-ref-guide/src/major-changes-in-solr-8.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-8.adoc
@@ -285,7 +285,7 @@ The login screen's purpose is cosmetic only - Admin UI-triggered Solr requests w
 
 * The `shards` parameter, used to manually select the shards and replicas that receive distributed requests, now checks nodes against an allow-list of acceptable values for security reasons.
 +
-In SolrCloud mode this allow-list is automatically configured to contain all live nodes.  In standalone mode the allow-list is empty by default.  Upgrading users who use the `shards` parameter in standalone mode can correct this value by setting the `allowUrls` property in their `solrconfig.xml` file.
+In SolrCloud mode this allow-list is automatically configured to contain all live nodes.  In standalone mode the allow-list is empty by default.  Upgrading users who use the `shards` parameter in standalone mode can correct this value by setting the `shardsWhitelist` property in any `shardHandler` configurations in their `solrconfig.xml` file.
 +
 For more information, see the <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Distributed Request>> documentation.
 

--- a/solr/solr-ref-guide/src/major-changes-in-solr-8.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-8.adoc
@@ -285,7 +285,7 @@ The login screen's purpose is cosmetic only - Admin UI-triggered Solr requests w
 
 * The `shards` parameter, used to manually select the shards and replicas that receive distributed requests, now checks nodes against an allow-list of acceptable values for security reasons.
 +
-In SolrCloud mode this allow-list is automatically configured to contain all live nodes.  In standalone mode the allow-list is empty by default.  Upgrading users who use the `shards` parameter in standalone mode can correct this value by setting the `urlAllowList` property in any `shardHandler` configurations in their `solrconfig.xml` file.
+In SolrCloud mode this allow-list is automatically configured to contain all live nodes.  In standalone mode the allow-list is empty by default.  Upgrading users who use the `shards` parameter in standalone mode can correct this value by setting the `allowUrls` property in their `solrconfig.xml` file.
 +
 For more information, see the <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Distributed Request>> documentation.
 

--- a/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
@@ -193,3 +193,5 @@ Support for the `solr.storeBaseUrl` system property will be removed in Solr 10.x
 === Authentication & Security Changes in Solr 9
 
 * BasicAuthPlugin property 'blockUnknown' now defaults to 'true'. This change is backward incompatible. If you need the pre-9.0 default behavior, you need to explicitly set 'blockUnknown':'false' in security.json.
+
+* The allow-list defining allowed URLs for the `shards` parameter is not in the `shardHandler` configuration anymore. It is defined by the `allowUrls` top-level property of the `solrconfig.xml` file. For more information, see <<format-of-solr-xml.adoc#_allow_urls, Format of solr.allowUrls>> documentation.

--- a/solr/solr-ref-guide/src/the-terms-component.adoc
+++ b/solr/solr-ref-guide/src/the-terms-component.adoc
@@ -341,7 +341,3 @@ Result:
   }
 }
 ----
-
-== Distributed Search Support
-
-The TermsComponent also supports distributed indexes.

--- a/solr/solr-ref-guide/src/the-terms-component.adoc
+++ b/solr/solr-ref-guide/src/the-terms-component.adoc
@@ -344,16 +344,4 @@ Result:
 
 == Distributed Search Support
 
-The TermsComponent also supports distributed indexes. For the `/terms` request handler, you must provide the following two parameters:
-
-`shards`::
-Specifies the shards in your distributed indexing configuration. For more information about distributed indexing, see <<distributed-search-with-index-sharding.adoc#,Distributed Search with Index Sharding>>.
-+
-The `shards` parameter is subject to a host allow-list that has to be configured in the component's parameters using the configuration key `allowUrls` and the list of hosts as values.
-+
-By default the allow-list will be populated with all live nodes when running in SolrCloud mode. If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.allowUrls=true`.
-+
-See the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>> for more information about how the allow-list works.
-
-`shards.qt`::
-Specifies the request handler Solr uses for requests to shards.
+The TermsComponent also supports distributed indexes.

--- a/solr/solr-ref-guide/src/the-terms-component.adoc
+++ b/solr/solr-ref-guide/src/the-terms-component.adoc
@@ -349,11 +349,11 @@ The TermsComponent also supports distributed indexes. For the `/terms` request h
 `shards`::
 Specifies the shards in your distributed indexing configuration. For more information about distributed indexing, see <<distributed-search-with-index-sharding.adoc#,Distributed Search with Index Sharding>>.
 +
-The `shards` parameter is subject to a host whitelist that has to be configured in the component's parameters using the configuration key `shardsWhitelist` and the list of hosts as values.
+The `shards` parameter is subject to a host allow-list that has to be configured in the component's parameters using the configuration key `urlAllowList` and the list of hosts as values.
 +
-By default the whitelist will be populated with all live nodes when running in SolrCloud mode. If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.shardsWhitelist=true`.
+By default the allow-list will be populated with all live nodes when running in SolrCloud mode. If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.urlAllowList=true`.
 +
-See the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>> for more information about how the whitelist works.
+See the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>> for more information about how the allow-list works.
 
 `shards.qt`::
 Specifies the request handler Solr uses for requests to shards.

--- a/solr/solr-ref-guide/src/the-terms-component.adoc
+++ b/solr/solr-ref-guide/src/the-terms-component.adoc
@@ -349,9 +349,9 @@ The TermsComponent also supports distributed indexes. For the `/terms` request h
 `shards`::
 Specifies the shards in your distributed indexing configuration. For more information about distributed indexing, see <<distributed-search-with-index-sharding.adoc#,Distributed Search with Index Sharding>>.
 +
-The `shards` parameter is subject to a host allow-list that has to be configured in the component's parameters using the configuration key `urlAllowList` and the list of hosts as values.
+The `shards` parameter is subject to a host allow-list that has to be configured in the component's parameters using the configuration key `allowUrls` and the list of hosts as values.
 +
-By default the allow-list will be populated with all live nodes when running in SolrCloud mode. If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.urlAllowList=true`.
+By default the allow-list will be populated with all live nodes when running in SolrCloud mode. If you need to disable this feature for backwards compatibility, you can set the system property `solr.disable.allowUrls=true`.
 +
 See the section <<distributed-requests.adoc#configuring-the-shardhandlerfactory,Configuring the ShardHandlerFactory>> for more information about how the allow-list works.
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -16,20 +16,6 @@
  */
 package org.apache.solr.common.cloud;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.Utils;
@@ -37,6 +23,14 @@ import org.apache.zookeeper.KeeperException;
 import org.noggit.JSONWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Immutable state of the cloud. Normally you can get the state by using
@@ -49,6 +43,7 @@ public class ClusterState implements JSONWriter.Writable {
 
   private final Map<String, CollectionRef> collectionStates, immutableCollectionStates;
   private Set<String> liveNodes;
+  private Set<String> hostAllowList;
 
   /**
    * Use this constr when ClusterState is meant for consumption.
@@ -330,6 +325,19 @@ public class ClusterState implements JSONWriter.Writable {
    */
   public Map<String, CollectionRef> getCollectionStates() {
     return immutableCollectionStates;
+  }
+
+  /**
+   * Gets the set of allowed hosts (host:port) built from the set of live nodes.
+   * The set is cached to be reused.
+   */
+  public Set<String> getHostAllowList() {
+    if (hostAllowList == null) {
+      hostAllowList = getLiveNodes().stream()
+              .map((liveNode) -> liveNode.substring(0, liveNode.indexOf('_')))
+              .collect(Collectors.toSet());
+    }
+    return hostAllowList;
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -25,8 +25,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/solr/solrj/src/test-files/solrj/solr/solr.xml
+++ b/solr/solrj/src/test-files/solrj/solr/solr.xml
@@ -30,7 +30,7 @@
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:90000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="shardsWhitelist">${solr.tests.shardsWhitelist:}</str>
+    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <solrcloud>

--- a/solr/solrj/src/test-files/solrj/solr/solr.xml
+++ b/solr/solrj/src/test-files/solrj/solr/solr.xml
@@ -25,12 +25,12 @@
   <str name="shareSchema">${shareSchema:false}</str>
   <str name="configSetBaseDir">${configSetBaseDir:configsets}</str>
   <str name="coreRootDirectory">${coreRootDirectory:.}</str>
+  <str name="allowUrls">${solr.tests.allowUrls:}</str>
 
   <shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory">
     <str name="urlScheme">${urlScheme:}</str>
     <int name="socketTimeout">${socketTimeout:90000}</int>
     <int name="connTimeout">${connTimeout:15000}</int>
-    <str name="urlAllowList">${solr.tests.urlAllowList:}</str>
   </shardHandlerFactory>
 
   <solrcloud>

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -176,13 +176,13 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
   @SuppressWarnings("deprecation")
   @BeforeClass
   public static void setSolrDisableShardsWhitelist() throws Exception {
-    systemSetPropertySolrDisableShardsWhitelist("true");
+    systemSetPropertySolrDisableUrlAllowList("true");
   }
 
   @SuppressWarnings("deprecation")
   @AfterClass
   public static void clearSolrDisableShardsWhitelist() throws Exception {
-    systemClearPropertySolrDisableShardsWhitelist();
+    systemClearPropertySolrDisableUrlAllowList();
   }
 
   private static String getHostContextSuitableForServletContext() {

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
 //@LuceneTestCase.SuppressCodecs({"Lucene3x","Lucene40","Lucene41","Lucene42","Lucene45","Appending","Asserting"})
 public class SolrTestCaseHS extends SolrTestCaseJ4 {
   
-  public static final String SOLR_TESTS_SHARDS_WHITELIST = "solr.tests.shardsWhitelist";
+  public static final String TEST_URL_ALLOW_LIST = "solr.tests.urlAllowList";
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   @SafeVarargs
@@ -524,7 +524,7 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
       
       // If we want to run with whitelist list, this must be explicitly set to true for the test
       // otherwise we disable the check
-      if (System.getProperty(SYSTEM_PROPERTY_SOLR_DISABLE_SHARDS_WHITELIST) == null) {
+      if (System.getProperty(SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST) == null) {
         systemSetPropertySolrDisableShardsWhitelist("true");
       }
 

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
@@ -57,6 +57,7 @@ import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.servlet.DirectSolrConnection;
 import org.apache.solr.util.TestHarness;
 import org.noggit.JSONUtil;
@@ -69,8 +70,6 @@ import org.slf4j.LoggerFactory;
 //@LuceneTestCase.SuppressCodecs({"Lucene3x","Lucene40","Lucene41","Lucene42","Lucene45","Appending","Asserting"})
 public class SolrTestCaseHS extends SolrTestCaseJ4 {
   
-  public static final String TEST_URL_ALLOW_LIST = "solr.tests.urlAllowList";
-
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   @SafeVarargs
   public static <T> Set<T> set(T... a) {
@@ -524,8 +523,8 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
       
       // If we want to run with whitelist list, this must be explicitly set to true for the test
       // otherwise we disable the check
-      if (System.getProperty(SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST) == null) {
-        systemSetPropertySolrDisableShardsWhitelist("true");
+      if (System.getProperty(AllowListUrlChecker.DISABLE_URL_ALLOW_LIST) == null) {
+        systemSetPropertySolrDisableUrlAllowList("true");
       }
 
       jetty.start();

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -193,7 +193,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   public static final String SYSTEM_PROPERTY_SOLR_TESTS_MERGEPOLICYFACTORY = "solr.tests.mergePolicyFactory";
 
   @Deprecated // For backwards compatibility only. Please do not use in new tests.
-  public static final String SYSTEM_PROPERTY_SOLR_DISABLE_SHARDS_WHITELIST = "solr.disable.shardsWhitelist";
+  public static final String SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST = "solr.disable.urlAllowList";
 
   protected static String coreName = DEFAULT_TEST_CORENAME;
 
@@ -2942,12 +2942,12 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   
   @Deprecated // For backwards compatibility only. Please do not use in new tests.
   protected static void systemSetPropertySolrDisableShardsWhitelist(String value) {
-    System.setProperty(SYSTEM_PROPERTY_SOLR_DISABLE_SHARDS_WHITELIST, value);
+    System.setProperty(SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST, value);
   }
 
   @Deprecated // For backwards compatibility only. Please do not use in new tests.
   protected static void systemClearPropertySolrDisableShardsWhitelist() {
-    System.clearProperty(SYSTEM_PROPERTY_SOLR_DISABLE_SHARDS_WHITELIST);
+    System.clearProperty(SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST);
   }
 
   @SuppressWarnings({"unchecked"})

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -130,6 +130,7 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.SolrIndexSearcher;
+import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.servlet.DirectSolrConnection;
 import org.apache.solr.update.processor.DistributedUpdateProcessor;
 import org.apache.solr.update.processor.DistributedZkUpdateProcessor;
@@ -192,8 +193,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   public static final String SYSTEM_PROPERTY_SOLR_TESTS_MERGEPOLICYFACTORY = "solr.tests.mergePolicyFactory";
 
-  @Deprecated // For backwards compatibility only. Please do not use in new tests.
-  public static final String SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST = "solr.disable.urlAllowList";
+  public static final String TEST_URL_ALLOW_LIST = "solr.tests." + AllowListUrlChecker.URL_ALLOW_LIST;
 
   protected static String coreName = DEFAULT_TEST_CORENAME;
 
@@ -2941,13 +2941,13 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
   
   @Deprecated // For backwards compatibility only. Please do not use in new tests.
-  protected static void systemSetPropertySolrDisableShardsWhitelist(String value) {
-    System.setProperty(SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST, value);
+  protected static void systemSetPropertySolrDisableUrlAllowList(String value) {
+    System.setProperty(AllowListUrlChecker.DISABLE_URL_ALLOW_LIST, value);
   }
 
   @Deprecated // For backwards compatibility only. Please do not use in new tests.
-  protected static void systemClearPropertySolrDisableShardsWhitelist() {
-    System.clearProperty(SYSTEM_PROPERTY_SOLR_DISABLE_URL_ALLOW_LIST);
+  protected static void systemClearPropertySolrDisableUrlAllowList() {
+    System.clearProperty(AllowListUrlChecker.DISABLE_URL_ALLOW_LIST);
   }
 
   @SuppressWarnings({"unchecked"})

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -88,7 +88,7 @@ public class MiniSolrCloudCluster {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   
-  public static final String SOLR_TESTS_SHARDS_WHITELIST = "solr.tests.shardsWhitelist";
+  public static final String TEST_URL_ALLOW_LIST = "solr.tests.urlAllowList";
 
   public static final int DEFAULT_TIMEOUT = 30;
 
@@ -104,7 +104,7 @@ public class MiniSolrCloudCluster {
       "    <str name=\"urlScheme\">${urlScheme:}</str>\n" +
       "    <int name=\"socketTimeout\">${socketTimeout:90000}</int>\n" +
       "    <int name=\"connTimeout\">${connTimeout:15000}</int>\n" +
-      "    <str name=\"shardsWhitelist\">${"+SOLR_TESTS_SHARDS_WHITELIST+":}</str>\n" +
+      "    <str name=\"urlAllowList\">${"+ TEST_URL_ALLOW_LIST +":}</str>\n" +
       "  </shardHandlerFactory>\n" +
       "\n" +
       "  <solrcloud>\n" +

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.Filter;
 
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.embedded.JettyConfig;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.embedded.SSLConfig;
@@ -88,7 +89,7 @@ public class MiniSolrCloudCluster {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   
-  public static final String TEST_URL_ALLOW_LIST = "solr.tests.urlAllowList";
+  public static final String TEST_URL_ALLOW_LIST = SolrTestCaseJ4.TEST_URL_ALLOW_LIST;
 
   public static final int DEFAULT_TIMEOUT = 30;
 
@@ -99,12 +100,12 @@ public class MiniSolrCloudCluster {
       "  <str name=\"configSetBaseDir\">${configSetBaseDir:configsets}</str>\n" +
       "  <str name=\"coreRootDirectory\">${coreRootDirectory:.}</str>\n" +
       "  <str name=\"collectionsHandler\">${collectionsHandler:solr.CollectionsHandler}</str>\n" +
+      "  <str name=\"allowUrls\">${"+ TEST_URL_ALLOW_LIST +":}</str>\n" +
       "\n" +
       "  <shardHandlerFactory name=\"shardHandlerFactory\" class=\"HttpShardHandlerFactory\">\n" +
       "    <str name=\"urlScheme\">${urlScheme:}</str>\n" +
       "    <int name=\"socketTimeout\">${socketTimeout:90000}</int>\n" +
       "    <int name=\"connTimeout\">${connTimeout:15000}</int>\n" +
-      "    <str name=\"urlAllowList\">${"+ TEST_URL_ALLOW_LIST +":}</str>\n" +
       "  </shardHandlerFactory>\n" +
       "\n" +
       "  <solrcloud>\n" +


### PR DESCRIPTION
There are many touched files. Most of them are modified only for the renaming of 'shardHandlerFactory:shardsWhitelist' to a top level property 'allowUrls'. I chose 'allowUrls' name to stay consistent with the existing 'allowPaths', otherwise I would have named it 'urlAllowList'.

The doc is modified accordingly.

At the core of this PR:
- New AllowListUrlChecker (extraction of HttpShardHandlerFactory.WhitelistChecker).
- HttpShardHandlerFactory and HttpShardHandler adapted.
- IndexFetcher now uses AllowListUrlChecker.
- New AllowListUrlCheckerTest.
- New TestReplicationHandler.testUrlAllowList().

Once this PR is reviewed, I think I'll create another PR for branch 8x without the renaming and the move to stay backward compatible. I suppose HttpShardHandlerFactory checker could still be used more broadly.