### PR TITLE
Fix typo in audit example JSON

### DIFF
--- a/solr/solr-ref-guide/src/audit-logging.adoc
+++ b/solr/solr-ref-guide/src/audit-logging.adoc
@@ -47,7 +47,7 @@ By default any AuditLogger plugin configured will log asynchronously in the back
     "blockAsync" : false,
     "numThreads" : 2,
     "queueSize" : 4096,
-    "eventTypes": ["REJECTED", "ANONYMOUS_REJECTED", "UNAUTHORIZED", "COMPLETED" "ERROR"]
+    "eventTypes": ["REJECTED", "ANONYMOUS_REJECTED", "UNAUTHORIZED", "COMPLETED", "ERROR"]
   }
 }
 ----


### PR DESCRIPTION
Since it's an invalid JSON, it hurts my OCD 😄