### PR TITLE
SOLR-13608: Sync on TrackingBackupRepo NL changes

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepositoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepositoryFactory.java
@@ -73,9 +73,15 @@ public class BackupRepositoryFactory {
             "Could not find a backup repository with name " + name);
 
     BackupRepository result = loader.newInstance(repo.className, BackupRepository.class);
-    if ("trackingBackupRepository".equals(name) && repo.initArgs.get("factory") == null) {
-      repo.initArgs.add("factory", this);
-      repo.initArgs.add("loader", loader);
+    if ("trackingBackupRepository".equals(name)) {
+      // newInstance can be called by multiple threads, synchronization prevents simultaneous multi-threaded 'adds' from
+      // corrupting the namedlist
+      synchronized (repo.initArgs) {
+        if (repo.initArgs.get("factory") == null) {
+          repo.initArgs.add("factory", this);
+          repo.initArgs.add("loader", loader);
+        }
+      }
     }
 
     result.init(repo.initArgs);


### PR DESCRIPTION
# Description

BackupRepositoryFactory has a special case in its 'newInstance' method.
For 'TrackingBackupRepository' instances, BRF will modify a NamedList
representing the TBF config - adding references to the
SolrResourceLoader and to BRF itself.

In isolation this is innocuous, but becomes a problem when
BRF.newInstance is called concurrently from different threads.  Threads
can race to set these NamedList keys, corrupting the NamedList in the
process.  (i.e. NamedList values ended up in 'key' indices, and vice
versa)

# Solution

This commit adds synchronization to this NL initialization, to ensure
that the NL values are only set by a single thread.

# Tests

This PR itself is a fix for LocalFSCloudIncrementalBackupTest.  It can be validated by beasting that test class to ensure the flakiness has been resolved.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
