### PR TITLE
SOLR-15351: Convert /v2/c/<coll> APIs to POJO impl

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -100,6 +100,7 @@ import org.apache.solr.handler.CollectionBackupsAPI;
 import org.apache.solr.handler.CollectionsAPI;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.handler.SnapShooter;
+import org.apache.solr.handler.SpecificCollectionAPI;
 import org.apache.solr.handler.admin.CollectionsHandler;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 import org.apache.solr.handler.admin.ContainerPluginsApi;
@@ -763,6 +764,9 @@ public class CoreContainer {
     final CollectionsAPI collectionsAPI = new CollectionsAPI(collectionsHandler);
     containerHandlers.getApiBag().registerObject(collectionsAPI);
     containerHandlers.getApiBag().registerObject(collectionsAPI.collectionsCommands);
+    final SpecificCollectionAPI specificCollectionAPI = new SpecificCollectionAPI(collectionsHandler);
+    containerHandlers.getApiBag().registerObject(specificCollectionAPI);
+    containerHandlers.getApiBag().registerObject(specificCollectionAPI.specificCollectionCommands);
     final CollectionBackupsAPI collectionBackupsAPI = new CollectionBackupsAPI(collectionsHandler);
     containerHandlers.getApiBag().registerObject(collectionBackupsAPI);
     configSetsHandler = createHandler(CONFIGSETS_HANDLER_PATH, cfg.getConfigSetsHandlerClass(), ConfigSetsHandler.class);

--- a/solr/core/src/java/org/apache/solr/handler/CollectionsAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/CollectionsAPI.java
@@ -217,15 +217,4 @@ public class CollectionsAPI {
             toFlatten.forEach((k, v) -> destination.put(additionalPrefix + k, v));
         }
   }
-
-  @EndPoint(path = {"/c/{collection}", "/collections/{collection}"},
-      method = DELETE,
-      permission = COLL_EDIT_PERM)
-  public void deleteCollection(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    req = wrapParams(req, ACTION,
-        CollectionAction.DELETE.toString(),
-        NAME, req.getPathTemplateValues().get(ZkStateReader.COLLECTION_PROP));
-    collectionsHandler.handleRequestBody(req, rsp);
-  }
-
 }

--- a/solr/core/src/java/org/apache/solr/handler/SpecificCollectionAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/SpecificCollectionAPI.java
@@ -1,0 +1,89 @@
+package org.apache.solr.handler;
+
+import org.apache.solr.api.Command;
+import org.apache.solr.api.EndPoint;
+import org.apache.solr.api.PayloadObj;
+import org.apache.solr.client.solrj.request.beans.BackupCollectionPayload;
+import org.apache.solr.client.solrj.request.beans.ModifyCollectionPayload;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.handler.admin.CollectionsHandler;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.solr.client.solrj.SolrRequest.METHOD.DELETE;
+import static org.apache.solr.client.solrj.SolrRequest.METHOD.POST;
+import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.REQUESTID;
+import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
+import static org.apache.solr.common.params.CommonParams.ACTION;
+import static org.apache.solr.common.params.CommonParams.NAME;
+import static org.apache.solr.handler.ClusterAPI.wrapParams;
+import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
+
+
+// TODO This classname sucks - I'm trying to convey that the APIs in this class all operate on a single specific
+//  collection (i.e. they're for the /v2/collections/<coll> path).  But the name is a clunky way to do that.
+/**
+ * All V2 APIs for the /v2/collections/{collName} path
+ */
+public class SpecificCollectionAPI {
+
+  private static final String V2_MODIFY_COLLECTION_CMD = "modify";
+
+  public final SpecificCollectionCommands specificCollectionCommands = new SpecificCollectionCommands();
+  private final CollectionsHandler collectionsHandler;
+
+  public SpecificCollectionAPI(CollectionsHandler collectionsHandler) {
+    this.collectionsHandler = collectionsHandler;
+  }
+
+  @EndPoint(path = {"/c/{collection}", "/collections/{collection}"},
+          method = DELETE,
+          permission = COLL_EDIT_PERM)
+  public void deleteCollection(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+    req = wrapParams(req, ACTION,
+            CollectionParams.CollectionAction.DELETE.toString(),
+            NAME, req.getPathTemplateValues().get(ZkStateReader.COLLECTION_PROP));
+    collectionsHandler.handleRequestBody(req, rsp);
+  }
+
+  // TODO What is the purpose of nesting all the POSTs under a separate class in CollectionsAPI.CollectionCommands?
+  //    - try to add the annotation and stuff to the top-level SpecificCollectionAPI once I get everything working in the mirrored, nested fashion
+  @EndPoint(
+          path = {"/c/{collection}", "/collections/{collection}"},
+          method = POST,
+          permission = COLL_EDIT_PERM) // TODO is this the correct permission for all POST commands at this path
+  public class SpecificCollectionCommands {
+
+    @Command(name = V2_MODIFY_COLLECTION_CMD)
+    public void modifyCollection(PayloadObj<ModifyCollectionPayload> obj) throws Exception {
+      final ModifyCollectionPayload v2Body = obj.get();
+
+      final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+      v1Params.put(ACTION, CollectionParams.CollectionAction.MODIFYCOLLECTION.toLower());
+      v1Params.put(COLLECTION, obj.getRequest().getPathTemplateValues().get(COLLECTION));
+      if (v2Body.config != null) {
+        v1Params.remove("config");
+        v1Params.put("collection.configName", v2Body.config);
+      }
+      if (v2Body.properties != null && !v2Body.properties.isEmpty()) {
+        v1Params.remove("properties");
+        flattenMapWithPrefix(v2Body.properties, v1Params, "property.");
+      }
+
+      collectionsHandler.handleRequestBody(wrapParams(obj.getRequest(), v1Params), obj.getResponse());
+    }
+  }
+
+  private void flattenMapWithPrefix(Map<String, Object> toFlatten, Map<String, Object> destination,
+                                    String additionalPrefix) {
+    if (toFlatten == null || toFlatten.isEmpty() || destination == null) {
+      return;
+    }
+
+    toFlatten.forEach((k, v) -> destination.put(additionalPrefix + k, v));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/handler/admin/V2SpecificCollectionAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/V2SpecificCollectionAPIMappingTest.java
@@ -1,0 +1,6 @@
+package org.apache.solr.handler.admin;
+
+import org.apache.solr.SolrTestCaseJ4;
+
+public class V2SpecificCollectionAPIMappingTest extends SolrTestCaseJ4 {
+}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/ModifyCollectionPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/ModifyCollectionPayload.java
@@ -1,0 +1,23 @@
+package org.apache.solr.client.solrj.request.beans;
+
+import org.apache.solr.common.annotation.JsonProperty;
+import org.apache.solr.common.util.ReflectMapWriter;
+
+import java.util.Map;
+
+public class ModifyCollectionPayload implements ReflectMapWriter {
+  @JsonProperty
+  public Integer replicationFactor;
+
+  @JsonProperty
+  public Boolean readOnly;
+
+  @JsonProperty
+  public String config;
+
+  @JsonProperty
+  public Map<String, Object> properties;
+
+  @JsonProperty
+  public String async;
+}


### PR DESCRIPTION
This commit converts MODIFYCOLLECTION, the first of the /v2/c/<coll>
APIs.  None of the other APIs have been touched (yet), just for lack of
time.  This leaves RELOAD, MOVEREPLICA, MIGRATEDOCS, BALANCESHARDUNIQUE,
REBALANCELEADERS, ADDREPLICAPROPERTY, DELETEREPLICAPROPERTY,
and SETCOLLECTIONPROPERTY.

When all these are added, tests are still needed and the apispec file
containing them all needs deleted.

# Description

Solr has two mechanisms for implementing v2 APIs: an apispec (i.e. JSON file) based approach, and a newer approach that uses annotated POJOs.  A consensus has emerged across many JIRAs that the latter approach is preferable going forward, since it reduces duplication and inches the code closer to strongly-typed APIs.  But moving existing APIs over to this new mechanism is a big task.

# Solution

This PR aims to migrated Solr's `/v2/collections/<collection>` APIs to the new preferred mechanism.

# Tests

See the (as yet unimplemented) tests in `V2SpecificCollectionAPIMappingTest`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
