### PR TITLE
SOLR-15067 Child doc transformer should use the perSegFilter cache

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -341,6 +341,8 @@ Optimizations
 
 * SOLR-15120 Reduce duplicated core creation work (Mike Drob, Mark Miller)
 
+* SOLR-15067 ChildDocTransformerFactory uses perSegFilter cache (Bence Szabo via David Smiley)
+
 Bug Fixes
 ---------------------
 * SOLR-15078: Fix ExpandComponent behavior when expanding on numeric fields to differentiate '0' group from null group (hossman)


### PR DESCRIPTION
Change-Id: I6cc22a9e13aeaef37a1e005b111a59bb7412023d

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

The ChildDocTransformerFactory creates a QueryBitSetProducer every time.  These are heavy to compute; they should be cached.  BlockJoinParentQParserPlugin does this correctly, using the "perSegFilter" named Solr cache.

# Solution

The solution for this was to copy the implementation of the cache usage from BlockJoinParentQParser. We decided not to create a new class for this since the solution was quite simple

# Tests

Unit tests.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
