### PR TITLE
[SOLR-11904] Provide basic auth credentials for TLOG/PULL replica ensembles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ __pycache__
 
 # Emacs backup
 *~
+
+# VSCode
+**/.settings
+**/.classpath
+**/.project

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -262,6 +262,14 @@ public class IndexFetcher {
 
     String httpBasicAuthUser = (String) initArgs.get(HttpClientUtil.PROP_BASIC_AUTH_USER);
     String httpBasicAuthPassword = (String) initArgs.get(HttpClientUtil.PROP_BASIC_AUTH_PASS);
+
+    if (httpBasicAuthUser == null && httpBasicAuthPassword == null) {
+      httpBasicAuthUser = System.getProperty("replication." + HttpClientUtil.PROP_BASIC_AUTH_USER, 
+        System.getenv("SOLR_REPLICATION_HTTP_BASIC_AUTH_USER"));
+      httpBasicAuthPassword = System.getProperty("replication." + HttpClientUtil.PROP_BASIC_AUTH_PASS, 
+        System.getenv("SOLR_REPLICATION_HTTP_BASIC_AUTH_PASSWORD");
+    }
+
     myHttpClient = createHttpClient(solrCore, httpBasicAuthUser, httpBasicAuthPassword, useExternalCompression);
   }
 


### PR DESCRIPTION
# Description

Currently it's not possible to set up a _TLOG/PULL_ replica ensemble in a basic auth secured Solr cluster. On the _PULL_ replica, the `IndexFetcher` is utilized to fetch changes from the _TLOG_ leader replica. If the leader replica is secured via basic auth, there's currently no way to supply an credentials.

# Solution

This PR reads basic auth credentials (if given) either as system property or (if not found) as environment variable. 

The HTTP basic auth user and password are read from the `replication.httpBasicAuthUser` and `replication.httpBasicAuthPassword` respectively. If not found in the system properties, they are read from the `SOLR_REPLICATION_HTTP_BASIC_AUTH_USER` and `SOLR_REPLICATION_HTTP_BASIC_AUTH_PASSWORD` environment variables.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
