### PR TITLE
SOLR-15382: Remove PDF Checks from gradle ref-guide generation.

### DIFF
--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -177,16 +177,11 @@ class ValidateSourcePatternsTask extends DefaultTask {
     def javaCommentPattern = ~$/(?sm)^\Q/*\E(.*?)\Q*/\E/$;
     def xmlCommentPattern = ~$/(?sm)\Q<!--\E(.*?)\Q-->\E/$;
     def lineSplitter = ~$/[\r\n]+/$;
-    def singleLineSplitter = ~$/\r?\n/$;
     def licenseMatcher = Defaults.createDefaultMatcher();
     def validLoggerPattern = ~$/(?s)\b(private\s|static\s|final\s){3}+\s*Logger\s+\p{javaJavaIdentifierStart}+\s+=\s+\QLoggerFactory.getLogger(MethodHandles.lookup().lookupClass());\E/$;
     def validLoggerNamePattern = ~$/(?s)\b(private\s|static\s|final\s){3}+\s*Logger\s+log+\s+=\s+\QLoggerFactory.getLogger(MethodHandles.lookup().lookupClass());\E/$;
     def packagePattern = ~$/(?m)^\s*package\s+org\.apache.*;/$;
     def xmlTagPattern = ~$/(?m)\s*<[a-zA-Z].*/$;
-    def sourceHeaderPattern = ~$/\[source\b.*/$;
-    def blockBoundaryPattern = ~$/----\s*/$;
-    def blockTitlePattern = ~$/\..*/$;
-    def unescapedSymbolPattern = ~$/(?<=[^\\]|^)([-=]>|<[-=])/$; // SOLR-10883
     def extendsLuceneTestCasePattern = ~$/public.*?class.*?extends.*?LuceneTestCase[^\n]*?\n/$;
     def validSPINameJavadocTag = ~$/(?s)\s*\*\s*@lucene\.spi\s+\{@value #NAME\}/$;
 
@@ -215,33 +210,6 @@ class ValidateSourcePatternsTask extends DefaultTask {
     def checkMockitoAssume = { f, text ->
       if (text.contains("mockito") && !text.contains("assumeWorkingMockito()")) {
         reportViolation(f, 'File uses Mockito but has no assumeWorkingMockito() call');
-      }
-    }
-
-    def checkForUnescapedSymbolSubstitutions = { f, text ->
-      def inCodeBlock = false;
-      def underSourceHeader = false;
-      def lineNumber = 0;
-      singleLineSplitter.split(text).each {
-        ++lineNumber;
-        if (underSourceHeader) { // This line is either a single source line, or the boundary of a code block
-          inCodeBlock = blockBoundaryPattern.matcher(it).matches();
-          if ( ! blockTitlePattern.matcher(it).matches()) {
-            underSourceHeader = false;
-          }
-        } else {
-          if (inCodeBlock) {
-            inCodeBlock = ! blockBoundaryPattern.matcher(it).matches();
-          } else {
-            underSourceHeader = sourceHeaderPattern.matcher(it).lookingAt();
-            if ( ! underSourceHeader) {
-              def unescapedSymbolMatcher = unescapedSymbolPattern.matcher(it);
-              if (unescapedSymbolMatcher.find()) {
-                reportViolation(f, 'Unescaped symbol "' + unescapedSymbolMatcher.group(1) + '" on line #' + lineNumber);
-              }
-            }
-          }
-        }
       }
     }
 
@@ -305,9 +273,6 @@ class ValidateSourcePatternsTask extends DefaultTask {
       }
       if (f.name.endsWith('.xml')) {
         checkLicenseHeaderPrecedes(f, '<tag>', xmlTagPattern, xmlCommentPattern, text, ratDocument);
-      }
-      if (f.name.endsWith('.adoc')) {
-        checkForUnescapedSymbolSubstitutions(f, text);
       }
     }
     progress.completed()

--- a/solr/solr-ref-guide/src/analytics-expression-sources.adoc
+++ b/solr/solr-ref-guide/src/analytics-expression-sources.adoc
@@ -69,10 +69,10 @@ There are two possible ways of specifying constant strings, as shown below.
 
 * Surrounded by double quotes, inside the quotes both `"` and `\` must be escaped with a `\` character.
 +
-`"Inside of 'double' \\ \"quotes\""` \=> `Inside of 'double' \ "quotes"`
+`"Inside of 'double' \\ \"quotes\""` => `Inside of 'double' \ "quotes"`
 * Surrounded by single quotes, inside the quotes both `'` and `\` must be escaped with a `\` character.
 +
-`'Inside of "single" \\ \'quotes\''` \=> `Inside of "double" \ 'quotes'`
+`'Inside of "single" \\ \'quotes\''` => `Inside of "double" \ 'quotes'`
 
 === Dates
 

--- a/solr/solr-ref-guide/src/analytics-mapping-functions.adoc
+++ b/solr/solr-ref-guide/src/analytics-mapping-functions.adoc
@@ -26,112 +26,112 @@ These mappings can be chained together to implement more complex functionality.
 === Negation
 Negates the result of a numeric expression.
 
-`neg(<_Numeric_ T>)` \=> `<T>`::
-    * `neg(10.53)` \=> `-10.53`
-    * `neg([1, -4])` \=> `[-1, 4]`
+`neg(<_Numeric_ T>)` => `<T>`::
+    * `neg(10.53)` => `-10.53`
+    * `neg([1, -4])` => `[-1, 4]`
 
 === Absolute Value
 Returns the absolute value of the numeric expression.
 
-`abs(< _Numeric_ T >)` \=> `< T >`::
-    * `abs(-10.53)` \=> `10.53`
-    * `abs([1, -4])` \=> `[1, 4]`
+`abs(< _Numeric_ T >)` => `< T >`::
+    * `abs(-10.53)` => `10.53`
+    * `abs([1, -4])` => `[1, 4]`
 
 [[analytics-round]]
 === Round
 Rounds the numeric expression to the nearest `Integer` or `Long` value.
 
-`round(< _Float_ >)` \=> `< _Int_ >`::
-`round(< _Double_ >)` \=> `< _Long_ >`::
-    * `round(-1.5)` \=> `-1`
-    * `round([1.75, 100.34])` \=> `[2, 100]`
+`round(< _Float_ >)` => `< _Int_ >`::
+`round(< _Double_ >)` => `< _Long_ >`::
+    * `round(-1.5)` => `-1`
+    * `round([1.75, 100.34])` => `[2, 100]`
 
 === Ceiling
 Rounds the numeric expression to the nearest `Integer` or `Long` value that is greater than or equal to the original value.
 
-`ceil(< _Float_ >)` \=> `< _Int_ >`::
-`ceil(< _Double_ >)` \=> `< _Long_ >`::
-    * `ceil(5.01)` \=> `5`
-    * `ceil([-4.999, 6.99])` \=> `[-4, 7]`
+`ceil(< _Float_ >)` => `< _Int_ >`::
+`ceil(< _Double_ >)` => `< _Long_ >`::
+    * `ceil(5.01)` => `5`
+    * `ceil([-4.999, 6.99])` => `[-4, 7]`
 
 [[analytics-floor]]
 === Floor
 Rounds the numeric expression to the nearest `Integer` or `Long` value that is less than or equal to the original value.
 
-`floor(< _Float_ >)` \=> `< _Int_ >`::
-`floor(< _Double_ >)` \=> `< _Long_ >`::
-    * `floor(5.75)` \=> `5`
-    * `floor([-4.001, 6.01])` \=> `[-5, 6]`
+`floor(< _Float_ >)` => `< _Int_ >`::
+`floor(< _Double_ >)` => `< _Long_ >`::
+    * `floor(5.75)` => `5`
+    * `floor([-4.001, 6.01])` => `[-5, 6]`
 
 === Addition
 Adds the values of the numeric expressions.
 
-`add(< _Multi Double_ >)` \=> `< _Single Double_ >`::
-    * `add([1, -4])` \=> `-3.0`
-`add(< _Single Double_ >, < _Multi Double_ >)` \=> `< _Multi Double_ >`::
-    * `add(3.5, [1, -4])` \=> `[4.5, -0.5]`
-`add(< _Multi Double_ >, < _Single Double_ >)` \=> `< _Multi Double_ >`::
-    * `add([1, -4], 3.5)` \=> `[4.5, -0.5]`
-`add(< _Single Double_ >, ...)` \=> `< _Single Double_ >`::
-    * `add(3.5, 100, -27.6)` \=> `75.9`
+`add(< _Multi Double_ >)` => `< _Single Double_ >`::
+    * `add([1, -4])` => `-3.0`
+`add(< _Single Double_ >, < _Multi Double_ >)` => `< _Multi Double_ >`::
+    * `add(3.5, [1, -4])` => `[4.5, -0.5]`
+`add(< _Multi Double_ >, < _Single Double_ >)` => `< _Multi Double_ >`::
+    * `add([1, -4], 3.5)` => `[4.5, -0.5]`
+`add(< _Single Double_ >, ...)` => `< _Single Double_ >`::
+    * `add(3.5, 100, -27.6)` => `75.9`
 
 === Subtraction
 Subtracts the values of the numeric expressions.
 
-`sub(< _Single Double_ >, < _Single Double_ >)` \=> `< _Single Double_ >`::
-    * `sub(3.5, 100)` \=> `-76.5`
-`sub(< _Single Double_ >, < _Multi Double_ >)` \=> `< _Multi Double_ >`::
-    * `sub(3.5, [1, -4])` \=> `[2.5, 7.5]`
-`sub(< _Multi Double_ >, < _Single Double_ >)` \=> `< _Multi Double_ >`::
-    * `sub([1, -4], 3.5)` \=> `[-2.5, -7.5]`
+`sub(< _Single Double_ >, < _Single Double_ >)` => `< _Single Double_ >`::
+    * `sub(3.5, 100)` => `-76.5`
+`sub(< _Single Double_ >, < _Multi Double_ >)` => `< _Multi Double_ >`::
+    * `sub(3.5, [1, -4])` => `[2.5, 7.5]`
+`sub(< _Multi Double_ >, < _Single Double_ >)` => `< _Multi Double_ >`::
+    * `sub([1, -4], 3.5)` => `[-2.5, -7.5]`
 
 === Multiplication
 Multiplies the values of the numeric expressions.
 
-`mult(< _Multi Double_ >)` \=> `< _Single Double_ >`::
-    * `mult([1, -4])` \=> `-4.0`
-`mult(< _Single Double_ >, < _Multi Double_ >)` \=> `< _Multi Double_ >`::
-    * `mult(3.5, [1, -4])` \=> `[3.5, -16.0]`
-`mult(< _Multi Double_ >, < _Single Double_ >)` \=> `< _Multi Double_ >`::
-    * `mult([1, -4], 3.5)` \=> `[3.5, 16.0]`
-`mult(< _Single Double_ >, ...)` \=> `< _Single Double_ >`::
-    * `mult(3.5, 100, -27.6)` \=> `-9660`
+`mult(< _Multi Double_ >)` => `< _Single Double_ >`::
+    * `mult([1, -4])` => `-4.0`
+`mult(< _Single Double_ >, < _Multi Double_ >)` => `< _Multi Double_ >`::
+    * `mult(3.5, [1, -4])` => `[3.5, -16.0]`
+`mult(< _Multi Double_ >, < _Single Double_ >)` => `< _Multi Double_ >`::
+    * `mult([1, -4], 3.5)` => `[3.5, 16.0]`
+`mult(< _Single Double_ >, ...)` => `< _Single Double_ >`::
+    * `mult(3.5, 100, -27.6)` => `-9660`
 
 === Division
 Divides the values of the numeric expressions.
 
-`div(< _Single Double_ >, < _Single Double_ >)` \=> `< _Single Double_ >`::
-    * `div(3.5, 100)` \=> `.035`
-`div(< _Single Double_ >, < _Multi Double_ >)` \=> `< _Multi Double_ >`::
-    * `div(3.5, [1, -4])` \=> `[3.5, -0.875]`
-`div(< _Multi Double_ >, < _Single Double_ >)` \=> `< _Multi Double_ >`::
-    * `div([1, -4], 25)` \=> `[0.04, -0.16]`
+`div(< _Single Double_ >, < _Single Double_ >)` => `< _Single Double_ >`::
+    * `div(3.5, 100)` => `.035`
+`div(< _Single Double_ >, < _Multi Double_ >)` => `< _Multi Double_ >`::
+    * `div(3.5, [1, -4])` => `[3.5, -0.875]`
+`div(< _Multi Double_ >, < _Single Double_ >)` => `< _Multi Double_ >`::
+    * `div([1, -4], 25)` => `[0.04, -0.16]`
 
 === Power
 Takes one numeric expression to the power of another.
 
 *NOTE:* The square root function `sqrt(< _Double_ >)` can be used as shorthand for  `pow(< _Double_ >, .5)`
 
-`pow(< _Single Double_ >, < _Single Double_ >)` \=> `< _Single Double_ >`::
-    * `pow(2, 4)` \=> `16.0`
-`pow(< _Single Double_ >, < _Multi Double_ >)` \=> `< _Multi Double_ >`::
-    * `pow(16, [-1, 0])` \=> `[0.0625, 1]`
-`pow(< _Multi Double_ >, < _Single Double_ >)` \=> `< _Multi Double_ >`::
-    * `pow([1, 16], .25)` \=> `[1.0, 2.0]`
+`pow(< _Single Double_ >, < _Single Double_ >)` => `< _Single Double_ >`::
+    * `pow(2, 4)` => `16.0`
+`pow(< _Single Double_ >, < _Multi Double_ >)` => `< _Multi Double_ >`::
+    * `pow(16, [-1, 0])` => `[0.0625, 1]`
+`pow(< _Multi Double_ >, < _Single Double_ >)` => `< _Multi Double_ >`::
+    * `pow([1, 16], .25)` => `[1.0, 2.0]`
 
 === Logarithm
 Takes one logarithm of numeric expressions, with an optional second numeric expression as the base.
 If only one expression is given, the natural log is used.
 
-`log(< _Double_ >)` \=> `< _Double_ >`::
-    * `log(5)` \=> `1.6094...`
-    * `log([1.0, 100.34])` \=> `[0.0, 4.6085...]`
-`log(< _Single Double_ >, < _Single Double_ >)` \=> `< _Single Double_ >`::
-    * `log(2, 4)` \=> `0.5`
-`log(< _Single Double_ >, < _Multi Double_ >)` \=> `< _Multi Double_ >`::
-    * `log(16, [2, 4])` \=> `[4, 2]`
-`log(< _Multi Double_ >, < _Single Double_ >)` \=> `< _Multi Double_ >`::
-    * `log([81, 3], 9)` \=> `[2.0, 0.5]`
+`log(< _Double_ >)` => `< _Double_ >`::
+    * `log(5)` => `1.6094...`
+    * `log([1.0, 100.34])` => `[0.0, 4.6085...]`
+`log(< _Single Double_ >, < _Single Double_ >)` => `< _Single Double_ >`::
+    * `log(2, 4)` => `0.5`
+`log(< _Single Double_ >, < _Multi Double_ >)` => `< _Multi Double_ >`::
+    * `log(16, [2, 4])` => `[4, 2]`
+`log(< _Multi Double_ >, < _Single Double_ >)` => `< _Multi Double_ >`::
+    * `log([81, 3], 9)` => `[2.0, 0.5]`
 
 == Logic
 
@@ -139,100 +139,100 @@ If only one expression is given, the natural log is used.
 === Negation
 Negates the result of a boolean expression.
 
-`neg(< _Bool_ >)` \=> `< _Bool_>`::
-    *  `neg(F)` \=> `T`
-    * `neg([F, T])` \=> `[T, F]`
+`neg(< _Bool_ >)` => `< _Bool_>`::
+    *  `neg(F)` => `T`
+    * `neg([F, T])` => `[T, F]`
 
 [[analytics-and]]
 === And
 ANDs the values of the boolean expressions.
 
-`and(< _Multi Bool_ >)` \=> `< _Single Bool_ >`::
-    * `and([T, F, T])` \=> `F`
-`and(< _Single Bool_ >, < _Multi Bool_ >)` \=> `< _Multi Bool_ >`::
-    * `and(F, [T, T])` \=> `[F, F]`
-`and(< _Multi Bool_ >, < _Single Bool_ >)` \=> `< _Multi Bool_ >`::
-    * `and([F, T], T)` \=> `[F, T]`
-`and(< _Single Bool_ >, ...)` \=> `< _Single Bool_ >`::
-    * `and(T, T, T)` \=> `T`
+`and(< _Multi Bool_ >)` => `< _Single Bool_ >`::
+    * `and([T, F, T])` => `F`
+`and(< _Single Bool_ >, < _Multi Bool_ >)` => `< _Multi Bool_ >`::
+    * `and(F, [T, T])` => `[F, F]`
+`and(< _Multi Bool_ >, < _Single Bool_ >)` => `< _Multi Bool_ >`::
+    * `and([F, T], T)` => `[F, T]`
+`and(< _Single Bool_ >, ...)` => `< _Single Bool_ >`::
+    * `and(T, T, T)` => `T`
 
 [[analytics-or]]
 === Or
 ORs the values of the boolean expressions.
 
-`or(< _Multi Bool_ >)` \=> `< _Single Bool_ >`::
-    * `or([T, F, T])` \=> `T`
-`or(< _Single Bool_ >, < _Multi Bool_ >)` \=> `< _Multi Bool_ >`::
-    * `or(F, [F, T])` \=> `[F, T]`
-`or(< _Multi Bool_ >, < _Single Bool_ >)` \=> `< _Multi Bool_ >`::
-    * `or([F, T], T)` \=> `[T, T]`
-`or(< _Single Bool_ >, ...)` \=> `< _Single Bool_ >`::
-    * `or(F, F, F)` \=> `F`
+`or(< _Multi Bool_ >)` => `< _Single Bool_ >`::
+    * `or([T, F, T])` => `T`
+`or(< _Single Bool_ >, < _Multi Bool_ >)` => `< _Multi Bool_ >`::
+    * `or(F, [F, T])` => `[F, T]`
+`or(< _Multi Bool_ >, < _Single Bool_ >)` => `< _Multi Bool_ >`::
+    * `or([F, T], T)` => `[T, T]`
+`or(< _Single Bool_ >, ...)` => `< _Single Bool_ >`::
+    * `or(F, F, F)` => `F`
 
 ==== Exists
 Checks whether any value(s) exist for the expression.
 
-`exists( T )` \=> `< _Single Bool_ >`::
-    * `exists([1, 2, 3])` \=> `T`
-    * `exists([])` \=> `F`
-    * `exists(_empty_)` \=> `F`
-    * `exists('abc')` \=> `T`
+`exists( T )` => `< _Single Bool_ >`::
+    * `exists([1, 2, 3])` => `T`
+    * `exists([])` => `F`
+    * `exists(_empty_)` => `F`
+    * `exists('abc')` => `T`
 
 == Comparison
 
 === Equality
 Checks whether two expressions' values are equal. The parameters must be the same type, after implicit casting.
 
-`equal(< _Single_ T >, < _Single_ T >)` \=> `< _Single Bool_ >`::
-    * `equal(F, F)` \=> `T`
-`equal(< _Single_ T >, < _Multi_ T >)` \=> `< _Multi Bool_ >`::
-    * `equal("a", ["a", "ab"])` \=> `[T, F]`
-`equal(< _Multi_ T >, < _Single_ T >)` \=> `< _Multi Bool_ >`::
-    * `equal([1.5, -3.0], -3)` \=> `[F, T]`
+`equal(< _Single_ T >, < _Single_ T >)` => `< _Single Bool_ >`::
+    * `equal(F, F)` => `T`
+`equal(< _Single_ T >, < _Multi_ T >)` => `< _Multi Bool_ >`::
+    * `equal("a", ["a", "ab"])` => `[T, F]`
+`equal(< _Multi_ T >, < _Single_ T >)` => `< _Multi Bool_ >`::
+    * `equal([1.5, -3.0], -3)` => `[F, T]`
 
 === Greater Than
 Checks whether a numeric or `Date` expression's values are greater than another expression's values.
 The parameters must be the same type, after implicit casting.
 
-`gt(< _Single Numeric/Date_ T >, < _Single_ T >)` \=> `< _Single Bool_ >`::
-    * `gt(1800-01-02, 1799-12-20)` \=> `F`
-`gt(< _Single Numeric/Date_ T >, < _Multi_ T >)` \=> `< _Multi Bool_ >`::
-    * `gt(30.756, [30, 100])` \=> `[F, T]`
-`gt(< _Multi Numeric/Date_ T >, < _Single_ T >)` \=> `< _Multi Bool_ >`::
-    * `gt([30, 75.6], 30)` \=> `[F, T]`
+`gt(< _Single Numeric/Date_ T >, < _Single_ T >)` => `< _Single Bool_ >`::
+    * `gt(1800-01-02, 1799-12-20)` => `F`
+`gt(< _Single Numeric/Date_ T >, < _Multi_ T >)` => `< _Multi Bool_ >`::
+    * `gt(30.756, [30, 100])` => `[F, T]`
+`gt(< _Multi Numeric/Date_ T >, < _Single_ T >)` => `< _Multi Bool_ >`::
+    * `gt([30, 75.6], 30)` => `[F, T]`
 
 === Greater Than or Equals
 Checks whether a numeric or `Date` expression's values are greater than or equal to another expression's values.
 The parameters must be the same type, after implicit casting.
 
-`gte(< _Single Numeric/Date_ T >, < _Single_ T >)` \=> `< _Single Bool_ >`::
-    * `gte(1800-01-02, 1799-12-20)` \=> `F`
-`gte(< _Single Numeric/Date_ T >, < _Multi_ T >)` \=> `< _Multi Bool_ >`::
-    * `gte(30.756, [30, 100])` \=> `[F, T]`
-`gte(< _Multi Numeric/Date_ T >, < _Single_ T >)` \=> `< _Multi Bool_ >`::
-    * `gte([30, 75.6], 30)` \=> `[T, T]`
+`gte(< _Single Numeric/Date_ T >, < _Single_ T >)` => `< _Single Bool_ >`::
+    * `gte(1800-01-02, 1799-12-20)` => `F`
+`gte(< _Single Numeric/Date_ T >, < _Multi_ T >)` => `< _Multi Bool_ >`::
+    * `gte(30.756, [30, 100])` => `[F, T]`
+`gte(< _Multi Numeric/Date_ T >, < _Single_ T >)` => `< _Multi Bool_ >`::
+    * `gte([30, 75.6], 30)` => `[T, T]`
 
 === Less Than
 Checks whether a numeric or `Date` expression's values are less than another expression's values.
 The parameters must be the same type, after implicit casting.
 
-`lt(< _Single Numeric/Date_ T >, < _Single_ T >)` \=> `< _Single Bool_ >`::
-    * `lt(1800-01-02, 1799-12-20)` \=> `T`
-`lt(< _Single Numeric/Date_ T >, < _Multi_ T >)` \=> `< _Multi Bool_ >`::
-    * `lt(30.756, [30, 100])` \=> `[T, F]`
-`lt(< _Multi Numeric/Date_ T >, < _Single_ T >)` \=> `< _Multi Bool_ >`::
-    * `lt([30, 75.6], 30)` \=> `[F, F]`
+`lt(< _Single Numeric/Date_ T >, < _Single_ T >)` => `< _Single Bool_ >`::
+    * `lt(1800-01-02, 1799-12-20)` => `T`
+`lt(< _Single Numeric/Date_ T >, < _Multi_ T >)` => `< _Multi Bool_ >`::
+    * `lt(30.756, [30, 100])` => `[T, F]`
+`lt(< _Multi Numeric/Date_ T >, < _Single_ T >)` => `< _Multi Bool_ >`::
+    * `lt([30, 75.6], 30)` => `[F, F]`
 
 === Less Than or Equals
 Checks whether a numeric or `Date` expression's values are less than or equal to another expression's values.
 The parameters must be the same type, after implicit casting.
 
-`lte(< _Single Numeric/Date_ T >, < _Single_ T >)` \=> `< _Single Bool_ >`::
-    * `lte(1800-01-02, 1799-12-20)` \=> `T`
-`lte(< _Single Numeric/Date_ T >, < _Multi_ T >)` \=> `< _Multi Bool_ >`::
-    * `lte(30.756, [30, 100])` \=> `[T, F]`
-`lte(< _Multi Numeric/Date_ T >, < _Single_ T >)` \=> `< _Multi Bool_ >`::
-    * `lte([30, 75.6], 30)` \=> `[T, F]`
+`lte(< _Single Numeric/Date_ T >, < _Single_ T >)` => `< _Single Bool_ >`::
+    * `lte(1800-01-02, 1799-12-20)` => `T`
+`lte(< _Single Numeric/Date_ T >, < _Multi_ T >)` => `< _Multi Bool_ >`::
+    * `lte(30.756, [30, 100])` => `[T, F]`
+`lte(< _Multi Numeric/Date_ T >, < _Single_ T >)` => `< _Multi Bool_ >`::
+    * `lte([30, 75.6], 30)` => `[T, F]`
 
 [[analytics-top]]
 === Top
@@ -240,20 +240,20 @@ Returns the maximum of the numeric, `Date` or `String` expression(s)' values.
 The parameters must be the same type, after implicit casting.
 (Currently the only type not compatible is `Boolean`, which will be converted to a `String` implicitly in order to compile the expression)
 
-`top(< _Multi_ T >)` \=> `< _Single_ T >`::
-    * `top([30, 400, -10, 0])` \=> `400`
-`top(< _Single_ T >, ...)` \=> `< _Single_ T >`::
-    * `top("a", 1, "d")` \=> `"d"`
+`top(< _Multi_ T >)` => `< _Single_ T >`::
+    * `top([30, 400, -10, 0])` => `400`
+`top(< _Single_ T >, ...)` => `< _Single_ T >`::
+    * `top("a", 1, "d")` => `"d"`
 
 === Bottom
 Returns the minimum of the numeric, `Date` or `String` expression(s)' values.
 The parameters must be the same type, after implicit casting.
 (Currently the only type not compatible is `Boolean`, which will be converted to a `String` implicitly in order to compile the expression)
 
-`bottom(< _Multi_ T >)` \=> `< _Single_ T >`::
-    * `bottom([30, 400, -10, 0])` \=> `-10`
-`bottom(< _Single_ T >, ...)` \=> `< _Single_ T >`::
-    * `bottom("a", 1, "d")` \=> `"1"`
+`bottom(< _Multi_ T >)` => `< _Single_ T >`::
+    * `bottom([30, 400, -10, 0])` => `-10`
+`bottom(< _Single_ T >, ...)` => `< _Single_ T >`::
+    * `bottom("a", 1, "d")` => `"1"`
 
 == Conditional
 
@@ -262,98 +262,98 @@ The parameters must be the same type, after implicit casting.
 Returns the value(s) of the `THEN` or `ELSE` expressions depending on whether the boolean conditional expression's value is `true` or `false`.
 The `THEN` and `ELSE` expressions must be of the same type and cardinality after implicit casting is done.
 
-`if(< _Single Bool_>, < T >, < T >)` \=> `< T >`::
-    * `if(true, "abc", [1,2])` \=> `["abc"]`
-    * `if(false, "abc", 123)` \=> `"123"`
+`if(< _Single Bool_>, < T >, < T >)` => `< T >`::
+    * `if(true, "abc", [1,2])` => `["abc"]`
+    * `if(false, "abc", 123)` => `"123"`
 
 === Replace
 Replace all values from the 1^st^ expression that are equal to the value of the 2^nd^ expression with the value of the 3^rd^ expression.
 All parameters must be the same type after implicit casting is done.
 
-`replace(< T >, < _Single_ T >, < _Single_ T >)` \=> `< T >`::
-    * `replace([1,3], 3, "4")` \=> `["1", "4"]`
-    * `replace("abc", "abc", 18)` \=> `"18"`
-    * `replace("abc", 1, "def")` \=> `"abc"`
+`replace(< T >, < _Single_ T >, < _Single_ T >)` => `< T >`::
+    * `replace([1,3], 3, "4")` => `["1", "4"]`
+    * `replace("abc", "abc", 18)` => `"18"`
+    * `replace("abc", 1, "def")` => `"abc"`
 
 === Fill Missing
 If the 1^st^ expression does not have values, fill it with the values for the 2^nd^ expression.
 Both expressions must be of the same type and cardinality after implicit casting is done.
 
-`fill_missing(< T >, < T >)` \=> `< T >`::
-    * `fill_missing([], 3)` \=> `[3]`
-    * `fill_missing(_empty_, "abc")` \=> `"abc"`
-    * `fill_missing("abc", [1])` \=> `["abc"]`
+`fill_missing(< T >, < T >)` => `< T >`::
+    * `fill_missing([], 3)` => `[3]`
+    * `fill_missing(_empty_, "abc")` => `"abc"`
+    * `fill_missing("abc", [1])` => `["abc"]`
 
 === Remove
 Remove all occurrences of the 2^nd^ expression's value from the values of the 1^st^ expression.
 Both expressions must be of the same type after implicit casting is done.
 
-`remove(< T >, < _Single_ T >)` \=> `< T >`::
-    * `remove([1,2,3,2], 2)` \=> `[1, 3]`
-    * `remove("1", 1)` \=> `_empty_`
-    * `remove(1, "abc")` \=> `"1"`
+`remove(< T >, < _Single_ T >)` => `< T >`::
+    * `remove([1,2,3,2], 2)` => `[1, 3]`
+    * `remove("1", 1)` => `_empty_`
+    * `remove(1, "abc")` => `"1"`
 
 === Filter
 Return the values of the 1^st^ expression if the value of the 2^nd^ expression is `true`, otherwise return no values.
 
-`filter(< T >, < _Single Boolean_ >)` \=> `< T >`::
-    * `filter([1,2,3], true)` \=> `[1,2,3]`
-    * `filter([1,2,3], false)` \=> `[]`
-    * `filter("abc", false)` \=> `_empty_`
-    * `filter("abc", true)` \=> `1`
+`filter(< T >, < _Single Boolean_ >)` => `< T >`::
+    * `filter([1,2,3], true)` => `[1,2,3]`
+    * `filter([1,2,3], false)` => `[]`
+    * `filter("abc", false)` => `_empty_`
+    * `filter("abc", true)` => `1`
 
 == Date
 
 === Date Parse
 Explicitly converts the values of a `String` or `Long` expression into `Dates`.
 
-`date(< _String_ >)` \=> `< _Date_ >`::
-    * `date('1800-01-02')` \=> `1800-01-02T&#8203;00:00:00Z`
-    * `date(['1800-01-02', '2016-05-23'])` \=> `[1800-01-02T..., 2016-05-23T...]`
-`date(< _Long_ >)` \=> `< _Date_ >`::
-    * `date(1232343246648)` \=> `2009-01-19T&#8203;05:34:06Z`
-    * `date([1232343246648, 223234324664])` \=> `[2009-01-19T..., 1977-01-27T...]`
+`date(< _String_ >)` => `< _Date_ >`::
+    * `date('1800-01-02')` => `1800-01-02T&#8203;00:00:00Z`
+    * `date(['1800-01-02', '2016-05-23'])` => `[1800-01-02T..., 2016-05-23T...]`
+`date(< _Long_ >)` => `< _Date_ >`::
+    * `date(1232343246648)` => `2009-01-19T&#8203;05:34:06Z`
+    * `date([1232343246648, 223234324664])` => `[2009-01-19T..., 1977-01-27T...]`
 
 [[analytics-date-math]]
 === Date Math
 Compute the given date math strings for the values of a `Date` expression. The date math strings *must* be <<analytics-expression-sources.adoc#strings, constant>>.
 
-`date_math(< _Date_ >, < _Constant String_ >...)` \=> `< _Date_ >`::
-    * `date_math(1800-04-15, '+1DAY', '-1MONTH')` \=> `1800-03-16`
-    * `date_math([1800-04-15,2016-05-24], '+1DAY', '-1MONTH')` \=> `[1800-03-16, 2016-04-25]`
+`date_math(< _Date_ >, < _Constant String_ >...)` => `< _Date_ >`::
+    * `date_math(1800-04-15, '+1DAY', '-1MONTH')` => `1800-03-16`
+    * `date_math([1800-04-15,2016-05-24], '+1DAY', '-1MONTH')` => `[1800-03-16, 2016-04-25]`
 
 == String
 
 === Explicit Casting
 Explicitly casts the expression to a `String` expression.
 
-`string(< _String_ >)` \=> `< _String_ >`::
-    * `string(1)` \=> `'1'`
-    * `string([1.5, -2.0])` \=> `['1.5', '-2.0']`
+`string(< _String_ >)` => `< _String_ >`::
+    * `string(1)` => `'1'`
+    * `string([1.5, -2.0])` => `['1.5', '-2.0']`
 
 === Concatenation
 Concatenations the values of the `String` expression(s) together.
 
-`concat(< _Multi String_ >)` \=> `< _Single String_ >`::
-    * `concat(['a','b','c'])` \=> `'abc'`
-`concat(< _Single String_ >, < _Multi String_ >)` \=> `< _Multi String_ >`::
-    * `concat(1, ['a','b','c'])` \=> `['1a','1b','1c']`
-`concat(< _Multi String_ >, < _Single String_ >)` \=> `< _Multi String_ >`::
-    * `concat(['a','b','c'], 1)` \=> `['a1','b1','c1']`
-`concat(< _Single String_ >...)` \=> `< _Single String_ >`::
-    * `concat('a','b','c')` \=> `'abc'`
-    * `concat('a',_empty_,'c')` \=> `'ac'` +
+`concat(< _Multi String_ >)` => `< _Single String_ >`::
+    * `concat(['a','b','c'])` => `'abc'`
+`concat(< _Single String_ >, < _Multi String_ >)` => `< _Multi String_ >`::
+    * `concat(1, ['a','b','c'])` => `['1a','1b','1c']`
+`concat(< _Multi String_ >, < _Single String_ >)` => `< _Multi String_ >`::
+    * `concat(['a','b','c'], 1)` => `['a1','b1','c1']`
+`concat(< _Single String_ >...)` => `< _Single String_ >`::
+    * `concat('a','b','c')` => `'abc'`
+    * `concat('a',_empty_,'c')` => `'ac'` +
     _Empty values are ignored_
 
 === Separated Concatenation
 Concatenations the values of the `String` expression(s) together using the given <<analytics-expression-sources.adoc#strings, constant string>> value as a separator.
 
-`concat_sep(< _Constant String_ >, < _Multi String_ >)` \=> `< _Single String_ >`::
-    * `concat_sep('-', ['a','b'])` \=> `'a-b'`
-`concat_sep(< _Constant String_ >, < _Single String_ >, < _Multi String_ >)` \=> `< _Multi String_ >`::
-    * `concat_sep(2,1,['a','b'])` \=> `['12a','12b']`
-`concat_sep(< _Constant String_ >, < _Multi String_ >, < _Single String_ >)` \=> `< _Multi String_ >`::
-    * `concat_sep(2,['a','b'],1)` \=> `['a21','b21']`
-    * `concat_sep('-','a',2,3)` \=> `'a-2-3'`
-    * `concat_sep(';','a',_empty_,'c')` \=> `'a;c'` +
+`concat_sep(< _Constant String_ >, < _Multi String_ >)` => `< _Single String_ >`::
+    * `concat_sep('-', ['a','b'])` => `'a-b'`
+`concat_sep(< _Constant String_ >, < _Single String_ >, < _Multi String_ >)` => `< _Multi String_ >`::
+    * `concat_sep(2,1,['a','b'])` => `['12a','12b']`
+`concat_sep(< _Constant String_ >, < _Multi String_ >, < _Single String_ >)` => `< _Multi String_ >`::
+    * `concat_sep(2,['a','b'],1)` => `['a21','b21']`
+    * `concat_sep('-','a',2,3)` => `'a-2-3'`
+    * `concat_sep(';','a',_empty_,'c')` => `'a;c'` +
 _Empty values are ignored_

--- a/solr/solr-ref-guide/src/analytics-reduction-functions.adoc
+++ b/solr/solr-ref-guide/src/analytics-reduction-functions.adoc
@@ -30,54 +30,55 @@ These can be combined using mapping functions to implement more complex function
 The number of existing values for an expression. For single-valued expressions, this is equivalent to `docCount`.
 If no expression is given, the number of matching documents is returned.
 
-`count()` \=> `< _Single Long_ >`
-`count(< T >)` \=> `< _Single Long_ >`
+`count()` => `< _Single Long_ >`
+
+`count(< T >)` => `< _Single Long_ >`
 
 === Doc Count
 The number of documents for which an expression has existing values. For single-valued expressions, this is equivalent to `count`.
 If no expression is given, the number of matching documents is returned.
 
-`doc_count()` \=> `< _Single Long_ >`
+`doc_count()` => `< _Single Long_ >`
 
-`doc_count(< T >)` \=> `< _Single Long_ >`
+`doc_count(< T >)` => `< _Single Long_ >`
 
 === Missing
 The number of documents for which an expression has no existing value.
 
-`missing(< T >)` \=> `< _Single Long_ >`
+`missing(< T >)` => `< _Single Long_ >`
 
 [[analytics-unique]]
 === Unique
 The number of unique values for an expression. This function accepts `Numeric`, `Date` and `String` expressions.
 
-`unique(< T >)` \=> `< _Single Long_ >`
+`unique(< T >)` => `< _Single Long_ >`
 
 == Math Reductions
 
 === Sum
 Returns the sum of all values for the expression.
 
-`sum(< _Double_ >)` \=> `< _Single Double_ >`
+`sum(< _Double_ >)` => `< _Single Double_ >`
 
 === Variance
 Returns the variance of all values for the expression.
 
-`variance(< _Double_ >)` \=> `< _Single Double_ >`
+`variance(< _Double_ >)` => `< _Single Double_ >`
 
 === Standard Deviation
 Returns the standard deviation of all values for the expression.
 
-`stddev(< _Double_ >)` \=> `< _Single Double_ >`
+`stddev(< _Double_ >)` => `< _Single Double_ >`
 
 === Mean
 Returns the arithmetic mean of all values for the expression.
 
-`mean(< _Double_ >)` \=> `< _Single Double_ >`
+`mean(< _Double_ >)` => `< _Single Double_ >`
 
 === Weighted Mean
 Returns the arithmetic mean of all values for the second expression weighted by the values of the first expression.
 
-`wmean(< _Double_ >, < _Double_ >)` \=> `< _Single Double_ >`
+`wmean(< _Double_ >, < _Double_ >)` => `< _Single Double_ >`
 
 NOTE: The expressions must satisfy the rules for `mult` function parameters.
 
@@ -86,17 +87,17 @@ NOTE: The expressions must satisfy the rules for `mult` function parameters.
 === Minimum
 Returns the minimum value for the expression. This function accepts `Numeric`, `Date` and `String` expressions.
 
-`min(< T >)` \=> `< _Single_ T >`
+`min(< T >)` => `< _Single_ T >`
 
 === Maximum
 Returns the maximum value for the expression. This function accepts `Numeric`, `Date` and `String` expressions.
 
-`max(< T >)` \=> `< _Single_ T >`
+`max(< T >)` => `< _Single_ T >`
 
 === Median
 Returns the median of all values for the expression. This function accepts `Numeric` and `Date` expressions.
 
-`median(< T >)` \=> `< _Single_ T >`
+`median(< T >)` => `< _Single_ T >`
 
 === Percentile
 Calculates the given percentile of all values for the expression.
@@ -104,7 +105,7 @@ This function accepts `Numeric`, `Date` and `String` expressions for the 2^nd^ p
 
 The percentile, given as the 1^st^ parameter, must be a <<analytics-expression-sources.adoc#numeric,constant double>> between [0, 100).
 
-`percentile(<Constant Double>, < T >)` \=> `< _Single_ T >`
+`percentile(<Constant Double>, < T >)` => `< _Single_ T >`
 
 === Ordinal
 Calculates the given ordinal of all values for the expression.
@@ -116,4 +117,4 @@ If the ordinal is positive, the returned value will be the _n_^th^ smallest valu
 
 If the ordinal is negative, the returned value will be the _n_^th^ largest value.
 
-`ordinal(<Constant Int>, < T >)` \=> `< _Single_ T >`
+`ordinal(<Constant Int>, < T >)` => `< _Single_ T >`

--- a/solr/solr-ref-guide/src/command-line-utilities.adoc
+++ b/solr/solr-ref-guide/src/command-line-utilities.adoc
@@ -146,7 +146,7 @@ This can be useful to create a chroot path in ZooKeeper before first cluster sta
 
 === Set a Cluster Property
 
-This command will add or modify a single cluster property in `clusterprops.json`. Use this command instead of the usual getfile \-> edit \-> putfile cycle.
+This command will add or modify a single cluster property in `clusterprops.json`. Use this command instead of the usual getfile -> edit -> putfile cycle.
 
 Unlike the CLUSTERPROP command on the <<cluster-node-management.adoc#clusterprop,Collections API>>, this command does *not* require a running Solr cluster.
 

--- a/solr/solr-ref-guide/src/faceting.adoc
+++ b/solr/solr-ref-guide/src/faceting.adoc
@@ -549,9 +549,9 @@ Intervals must begin with either '(' or '[', be followed by the start value, the
 
 For example:
 
-* (1,10) \-> will include values greater than 1 and lower than 10
-* [1,10) \-> will include values greater or equal to 1 and lower than 10
-* [1,10] \-> will include values greater or equal to 1 and lower or equal to 10
+* (1,10) -> will include values greater than 1 and lower than 10
+* [1,10) -> will include values greater or equal to 1 and lower than 10
+* [1,10] -> will include values greater or equal to 1 and lower or equal to 10
 
 The initial and end values cannot be empty.
 

--- a/solr/solr-ref-guide/src/field-type-definitions-and-properties.adoc
+++ b/solr/solr-ref-guide/src/field-type-definitions-and-properties.adoc
@@ -92,7 +92,7 @@ Query used to combine scores of overlapping query terms (i.e., synonyms). Consid
 +
 Use `as_same_term` (default) to blend terms, i.e., `SynonymQuery(tshirt,tee)` where each term will be treated as equally important. Use `pick_best` to select the most significant synonym when scoring `Dismax(tee,tshirt)`. Use `as_distinct_terms` to bias scoring towards the most significant synonym `(pants OR slacks)`.
 +
-`as_same_term` is appropriate when terms are true synonyms (television, tv). Use `pick_best` or `as_distinct_terms` when synonyms are expanding to hyponyms `(q=jeans w/ jeans\=>jeans,pants)` and you want exact to come before parent and sibling concepts. See this http://opensourceconnections.com/blog/2017/11/21/solr-synonyms-mea-culpa/[blog article].
+`as_same_term` is appropriate when terms are true synonyms (television, tv). Use `pick_best` or `as_distinct_terms` when synonyms are expanding to hyponyms `(q=jeans w/ jeans=>jeans,pants)` and you want exact to come before parent and sibling concepts. See this http://opensourceconnections.com/blog/2017/11/21/solr-synonyms-mea-culpa/[blog article].
 
 `enableGraphQueries`::
 For text fields, applicable when querying with <<the-standard-query-parser.adoc#standard-query-parser-parameters,`sow=false`>> (which is the default for the `sow` parameter). Use `true`, the default, for field types with query analyzers including graph-aware filters, e.g., <<filter-descriptions.adoc#synonym-graph-filter,Synonym Graph Filter>> and <<filter-descriptions.adoc#word-delimiter-graph-filter,Word Delimiter Graph Filter>>.

--- a/solr/solr-ref-guide/src/filter-descriptions.adoc
+++ b/solr/solr-ref-guide/src/filter-descriptions.adoc
@@ -111,7 +111,7 @@ This filter converts alphabetic, numeric, and symbolic Unicode characters which 
 
 *Arguments:*
 
-`preserveOriginal`:: (boolean, default false) If true, the original token is preserved: "thé" \-> "the", "thé"
+`preserveOriginal`:: (boolean, default false) If true, the original token is preserved: "thé" -> "the", "thé"
 
 *Example:*
 
@@ -2693,35 +2693,35 @@ Note: although this filter produces correct token graphs, it cannot consume an i
 
 The rules for determining delimiters are determined as follows:
 
-* A change in case within a word: "CamelCase" \-> "Camel", "Case". This can be disabled by setting `splitOnCaseChange="0"`.
+* A change in case within a word: "CamelCase" -> "Camel", "Case". This can be disabled by setting `splitOnCaseChange="0"`.
 
-* A transition from alpha to numeric characters or vice versa: "Gonzo5000" \-> "Gonzo", "5000" "4500XL" \-> "4500", "XL". This can be disabled by setting `splitOnNumerics="0"`.
+* A transition from alpha to numeric characters or vice versa: "Gonzo5000" -> "Gonzo", "5000" "4500XL" -> "4500", "XL". This can be disabled by setting `splitOnNumerics="0"`.
 
-* Non-alphanumeric characters (discarded): "hot-spot" \-> "hot", "spot"
+* Non-alphanumeric characters (discarded): "hot-spot" -> "hot", "spot"
 
-* A trailing "'s" is removed: "O'Reilly's" \-> "O", "Reilly"
+* A trailing "'s" is removed: "O'Reilly's" -> "O", "Reilly"
 
-* Any leading or trailing delimiters are discarded: "--hot-spot--" \-> "hot", "spot"
+* Any leading or trailing delimiters are discarded: "--hot-spot--" -> "hot", "spot"
 
 *Factory class:* `solr.WordDelimiterGraphFilterFactory`
 
 *Arguments:*
 
-`generateWordParts`:: (integer, default 1) If non-zero, splits words at delimiters. For example:"CamelCase", "hot-spot" \-> "Camel", "Case", "hot", "spot"
+`generateWordParts`:: (integer, default 1) If non-zero, splits words at delimiters. For example:"CamelCase", "hot-spot" -> "Camel", "Case", "hot", "spot"
 
-`generateNumberParts`:: (integer, default 1) If non-zero, splits numeric strings at delimiters:"1947-32" \->*"1947", "32"
+`generateNumberParts`:: (integer, default 1) If non-zero, splits numeric strings at delimiters:"1947-32" -> *"1947", "32"
 
-`splitOnCaseChange`:: (integer, default 1) If 0, words are not split on camel-case changes:"BugBlaster-XL" \-> "BugBlaster", "XL". Example 1 below illustrates the default (non-zero) splitting behavior.
+`splitOnCaseChange`:: (integer, default 1) If 0, words are not split on camel-case changes:"BugBlaster-XL" -> "BugBlaster", "XL". Example 1 below illustrates the default (non-zero) splitting behavior.
 
-`splitOnNumerics`:: (integer, default 1) If 0, don't split words on transitions from alpha to numeric:"FemBot3000" \-> "Fem", "Bot3000"
+`splitOnNumerics`:: (integer, default 1) If 0, don't split words on transitions from alpha to numeric:"FemBot3000" -> "Fem", "Bot3000"
 
-`catenateWords`:: (integer, default 0) If non-zero, maximal runs of word parts will be joined: "hot-spot-sensor's" \-> "hotspotsensor"
+`catenateWords`:: (integer, default 0) If non-zero, maximal runs of word parts will be joined: "hot-spot-sensor's" -> "hotspotsensor"
 
-`catenateNumbers`:: (integer, default 0) If non-zero, maximal runs of number parts will be joined: 1947-32" \-> "194732"
+`catenateNumbers`:: (integer, default 0) If non-zero, maximal runs of number parts will be joined: 1947-32" -> "194732"
 
-`catenateAll`:: (0/1, default 0) If non-zero, runs of word and number parts will be joined: "Zap-Master-9000" \-> "ZapMaster9000"
+`catenateAll`:: (0/1, default 0) If non-zero, runs of word and number parts will be joined: "Zap-Master-9000" -> "ZapMaster9000"
 
-`preserveOriginal`:: (integer, default 0) If non-zero, the original token is preserved: "Zap-Master-9000" \-> "Zap-Master-9000", "Zap", "Master", "9000"
+`preserveOriginal`:: (integer, default 0) If non-zero, the original token is preserved: "Zap-Master-9000" -> "Zap-Master-9000", "Zap", "Master", "9000"
 
 `protected`:: (optional) The pathname of a file that contains a list of protected words that should be passed through without splitting.
 

--- a/solr/solr-ref-guide/src/language-analysis.adoc
+++ b/solr/solr-ref-guide/src/language-analysis.adoc
@@ -896,9 +896,9 @@ There are two filters written specifically for dealing with Bengali language. Th
 ====
 --
 
-*Normalisation* - `মানুষ` \-> `মানুস`
+*Normalisation* - `মানুষ` -> `মানুস`
 
-*Stemming* - `সমস্ত` \-> `সমস্`
+*Stemming* - `সমস্ত` -> `সমস্`
 
 
 === Brazilian Portuguese
@@ -2374,7 +2374,7 @@ Swedish å, ä, ö are in fact the same letters as Norwegian and Danish å, æ, 
 
 In that situation almost all Swedish people use a, a, o instead of å, ä, ö. Norwegians and Danes on the other hand usually type aa, ae and oe instead of å, æ and ø. Some do however use a, a, o, oo, ao and sometimes permutations of everything above.
 
-There are two filters for helping with normalization between Scandinavian languages: one is `solr.ScandinavianNormalizationFilterFactory` trying to preserve the special characters (æäöå) and another `solr.ScandinavianFoldingFilterFactory` which folds these to the more broad ø/ö\->o, etc.
+There are two filters for helping with normalization between Scandinavian languages: one is `solr.ScandinavianNormalizationFilterFactory` trying to preserve the special characters (æäöå) and another `solr.ScandinavianFoldingFilterFactory` which folds these to the more broad ø/ö -> o, etc.
 
 See also each language section for other relevant filters.
 
@@ -2426,7 +2426,7 @@ It's a semantically less destructive solution than `ScandinavianFoldingFilter`, 
 
 ==== Scandinavian Folding Filter
 
-This filter folds Scandinavian characters åÅäæÄÆ\->a and öÖøØ\->o. It also discriminate against use of double vowels aa, ae, ao, oe and oo, leaving just the first one.
+This filter folds Scandinavian characters åÅäæÄÆ -> a and öÖøØ -> o. It also discriminate against use of double vowels aa, ae, ao, oe and oo, leaving just the first one.
 
 It's a semantically more destructive solution than `ScandinavianNormalizationFilter`, but can in addition help with matching raksmorgas as räksmörgås.
 

--- a/solr/solr-ref-guide/src/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/src/solr-control-script-reference.adoc
@@ -650,7 +650,7 @@ All parameters below are required.
 `-n <name>`::
 Name of the configuration set in ZooKeeper. This command will upload the configuration set to the "configs" ZooKeeper node giving it the name specified.
 +
-You can see all uploaded configuration sets in the Admin UI via the Cloud screens. Choose Cloud \-> Tree \-> configs to see them.
+You can see all uploaded configuration sets in the Admin UI via the Cloud screens. Choose Cloud -> Tree -> configs to see them.
 +
 If a pre-existing configuration set is specified, it will be overwritten in ZooKeeper.
 +
@@ -691,7 +691,7 @@ Use the `zk downconfig` command to download a configuration set from ZooKeeper t
 All parameters listed below are required.
 
 `-n <name>`::
-Name of the configset in ZooKeeper to download. The Admin UI Cloud \-> Tree \-> configs node lists all available configuration sets.
+Name of the configset in ZooKeeper to download. The Admin UI Cloud -> Tree -> configs node lists all available configuration sets.
 +
 *Example*: `-n myconfig`
 

--- a/solr/solr-ref-guide/src/solr-jdbc-apache-zeppelin.adoc
+++ b/solr/solr-ref-guide/src/solr-jdbc-apache-zeppelin.adoc
@@ -40,7 +40,7 @@ For most installations, Apache Zeppelin configures PostgreSQL as the JDBC interp
 
 == Create a Notebook
 
-.Click Notebook \-> Create new note
+.Click Notebook -> Create new note
 image::images/solr-jdbc-apache-zeppelin/zeppelin_solrjdbc_4.png[image,width=517,height=400]
 
 .Provide a name and click "Create Note"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15382

Included:

- Removed the Gradle check for unescaped `=>` and `->`.
- Went through and un-escaped all arrows, which did not mean to explicitly be the ascii-character arrows.
  - Plenty were actually meant to be escaped, e.g. the entries in charFilters.