### PR TITLE
SOLR-15051: Pull files from the repository when BlobDirectory is created.

### DIFF
--- a/solr/contrib/blob-directory/src/java/org/apache/solr/blob/BlobRepository.java
+++ b/solr/contrib/blob-directory/src/java/org/apache/solr/blob/BlobRepository.java
@@ -114,9 +114,10 @@ public class BlobRepository implements Closeable {
 
   /**
    * Pulls selected files from a directory in the repository.
+   * The file selection is done on the current thread. Then the files are pulled by multiple threads.
    * @param blobDirPath The path to the directory where to list the files.
    * @param outputSupplier Supplies the {@link IndexOutput} to write each file.
-   * @param fileFilter Selects the files to pull.
+   * @param fileFilter Selects the files to pull. Does not need to be thread safe.
    */
   public void pull(
       String blobDirPath,

--- a/solr/contrib/blob-directory/src/test/org/apache/solr/blob/BlobDirectoryTest.java
+++ b/solr/contrib/blob-directory/src/test/org/apache/solr/blob/BlobDirectoryTest.java
@@ -175,7 +175,6 @@ public class BlobDirectoryTest extends SolrTestCaseJ4 {
         // When
         // - The local files are wiped (e.g. host crash).
         MoreFiles.deleteRecursively(Path.of(directoryPath), RecursiveDeleteOption.ALLOW_INSECURE);
-        assertFalse(Files.exists(Path.of(directoryPath)));
         // - The directory is released and reopened.
         directoryFactory.doneWithDirectory(directory);
         directoryFactory.release(directory);


### PR DESCRIPTION
BlobPusher now is able to pull files, so I needed to rename it. I didn't find a nice name that satisfies me, at the moment it is named BlobStoreConnection. Would you have a better name?