### PR TITLE
SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to   allow PULL replicas to replicate from security-enabled leaders

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -299,6 +299,9 @@ Bug Fixes
 
 * SOLR-15334: Return error response when failing auth in PKIAuthPlugin (Mike Drob)
 
+* SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to
+  allow PULL replicas to replicate from security-enabled leaders (Timothy Potter)
+
 ==================  8.9.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -299,9 +299,6 @@ Bug Fixes
 
 * SOLR-15334: Return error response when failing auth in PKIAuthPlugin (Mike Drob)
 
-* SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to
-  allow PULL replicas to replicate from security-enabled leaders (Timothy Potter)
-
 ==================  8.9.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.
@@ -375,6 +372,9 @@ Bug Fixes
   that modify the SortSpec in prepare(), as well as possible custom "search" components other then QueryComponent.  (hossman)
 
 * SOLR-15383: Solr Zookeeper status page shows green even when some Zookeepers are not serving requests (janhoy)
+
+* SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to
+  allow PULL replicas to replicate from security-enabled leaders (Timothy Potter)
 
 Other Changes
 ---------------------

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1208,6 +1208,7 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
         log.info("Poll disabled");
         return;
       }
+      ExecutorUtil.setServerThreadFlag(true); // so PKI auth works
       try {
         log.debug("Polling for index modifications");
         markScheduledExecutionStart();

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.cloud;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.util.LuceneTestCase.Slow;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.CollectionAdminResponse;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.cloud.DocCollection;
+import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.cloud.Slice;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.security.BasicAuthPlugin;
+import org.apache.solr.security.RuleBasedAuthorizationPlugin;
+import org.apache.solr.util.LogLevel;
+import org.apache.solr.util.TestInjection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.solr.cloud.TestPullReplica.assertNumberOfReplicas;
+import static org.apache.solr.cloud.TestPullReplica.assertUlogPresence;
+import static org.apache.solr.cloud.TestPullReplica.waitForDeletion;
+import static org.apache.solr.cloud.TestPullReplica.waitForNumDocsInAllReplicas;
+import static org.apache.solr.security.Sha256AuthenticationProvider.getSaltedHashedValue;
+
+@Slow
+@LogLevel("org.apache.solr.handler.ReplicationHandler=DEBUG,org.apache.solr.handler.IndexFetcher=DEBUG")
+public class TestPullReplicaWithAuth extends SolrCloudTestCase {
+
+  private static final String USER = "solr";
+  private static final String PASS = "SolrRocksAgain";
+  private static final String collectionName = "testPullReplicaWithAuth";
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    final String SECURITY_JSON = Utils.toJSONString
+        (Utils.makeMap("authorization",
+            Utils.makeMap("class", RuleBasedAuthorizationPlugin.class.getName(),
+                "user-role", singletonMap(USER, "admin"),
+                "permissions", singletonList(Utils.makeMap("name", "all", "role", "admin"))),
+            "authentication",
+            Utils.makeMap("class", BasicAuthPlugin.class.getName(),
+                "blockUnknown", true,
+                "credentials", singletonMap(USER, getSaltedHashedValue(PASS)))));
+
+    configureCluster(3)
+        .addConfig("conf", configset("cloud-minimal"))
+        .withSecurityJson(SECURITY_JSON)
+        .configure();
+  }
+
+  @AfterClass
+  public static void tearDownCluster() {
+    TestInjection.reset();
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  private static <T extends SolrRequest> T withBasicAuth(T req) {
+    req.setBasicAuthCredentials(USER, PASS);
+    return req;
+  }
+
+  private QueryResponse queryWithBasicAuth(HttpSolrClient client, SolrQuery q) throws IOException, SolrServerException {
+    return withBasicAuth(new QueryRequest(q)).process(client);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testPKIAuthWorksForPullReplication() throws Exception {
+    int numPullReplicas = 2;
+    withBasicAuth(CollectionAdminRequest.createCollection(collectionName, "conf", 1, 1, 0, numPullReplicas))
+        .process(cluster.getSolrClient());
+    waitForState("Expected collection to be created with 1 shard and " + (numPullReplicas + 1) + " replicas",
+        collectionName, clusterShape(1, numPullReplicas + 1));
+    DocCollection docCollection =
+        assertNumberOfReplicas(collectionName, 1, 0, numPullReplicas, false, true);
+
+    int numDocs = 0;
+    CloudSolrClient solrClient = cluster.getSolrClient();
+    for (int i = 0; i < 5; i++) {
+      numDocs++;
+
+      UpdateRequest ureq = withBasicAuth(new UpdateRequest());
+      ureq.add(new SolrInputDocument("id", String.valueOf(numDocs), "foo", "bar"));
+      ureq.process(solrClient, collectionName);
+      ureq.commit(solrClient, collectionName);
+
+      Slice s = docCollection.getSlices().iterator().next();
+      try (HttpSolrClient leaderClient = getHttpSolrClient(s.getLeader().getCoreUrl())) {
+        assertEquals(numDocs, queryWithBasicAuth(leaderClient, new SolrQuery("*:*")).getResults().getNumFound());
+      }
+
+      List<Replica> pullReplicas = s.getReplicas(EnumSet.of(Replica.Type.PULL));
+      waitForNumDocsInAllReplicas(numDocs, pullReplicas, "*:*", USER, PASS);
+
+      for (Replica r : pullReplicas) {
+        try (HttpSolrClient pullReplicaClient = getHttpSolrClient(r.getCoreUrl())) {
+          QueryResponse statsResponse = queryWithBasicAuth(pullReplicaClient, new SolrQuery("qt", "/admin/plugins", "stats", "true"));
+          // adds is a gauge, which is null for PULL replicas
+          assertNull("Replicas shouldn't process the add document request: " + statsResponse,
+              ((Map<String, Object>) (statsResponse.getResponse()).findRecursive("plugins", "UPDATE", "updateHandler", "stats")).get("UPDATE.updateHandler.adds"));
+          assertEquals("Replicas shouldn't process the add document request: " + statsResponse,
+              0L, ((Map<String, Object>) (statsResponse.getResponse()).findRecursive("plugins", "UPDATE", "updateHandler", "stats")).get("UPDATE.updateHandler.cumulativeAdds.count"));
+        }
+      }
+    }
+
+    CollectionAdminResponse response =
+        withBasicAuth(CollectionAdminRequest.reloadCollection(collectionName)).process(cluster.getSolrClient());
+    assertEquals(0, response.getStatus());
+    assertUlogPresence(docCollection);
+
+    // add another pull replica to ensure it can pull the indexes
+    Slice s = docCollection.getSlices().iterator().next();
+    List<Replica> pullReplicas = s.getReplicas(EnumSet.of(Replica.Type.PULL));
+    assertEquals(2, pullReplicas.size());
+    response = withBasicAuth(CollectionAdminRequest.addReplicaToShard(collectionName, s.getName(), Replica.Type.PULL)).process(cluster.getSolrClient());
+    assertEquals(0, response.getStatus());
+
+    numPullReplicas = numPullReplicas + 1; // added a PULL
+    waitForState("Expected collection to be created with 1 shard and " + (numPullReplicas + 1) + " replicas",
+        collectionName, clusterShape(1, numPullReplicas + 1));
+
+    docCollection =
+        assertNumberOfReplicas(collectionName, 1, 0, numPullReplicas, false, true);
+    s = docCollection.getSlices().iterator().next();
+    pullReplicas = s.getReplicas(EnumSet.of(Replica.Type.PULL));
+    assertEquals(3, pullReplicas.size());
+    waitForNumDocsInAllReplicas(numDocs, pullReplicas, "*:*", USER, PASS);
+
+    withBasicAuth(CollectionAdminRequest.deleteCollection(collectionName)).process(cluster.getSolrClient());
+    waitForDeletion(collectionName);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
@@ -153,7 +153,7 @@ public class TestPullReplicaWithAuth extends SolrCloudTestCase {
         assertNumberOfReplicas(collectionName, 1, 0, numPullReplicas, false, true);
     s = docCollection.getSlices().iterator().next();
     pullReplicas = s.getReplicas(EnumSet.of(Replica.Type.PULL));
-    assertEquals(3, pullReplicas.size());
+    assertEquals(numPullReplicas, pullReplicas.size());
     waitForNumDocsInAllReplicas(numDocs, pullReplicas, "*:*", USER, PASS);
 
     withBasicAuth(CollectionAdminRequest.deleteCollection(collectionName)).process(cluster.getSolrClient());


### PR DESCRIPTION
# Description

Fixes SOLR-11904

# Solution

The PKI interceptor relies on a check that the requesting thread is a Solr server thread. The ReplicationHandler's polling thread is not created using the ExecutorUtil (since it's a scheduled), so needs to explicitly mark itself as a server thread so the PKI interceptor kicks in for calling out to leaders.

# Tests

Added unit test `TestPullReplicaWithAuth`; unfortunately, I'm leaving `TestPullReplica` disabled with `AwaitsFix` b/c it was still failing occasionally with beasting locally :-(

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
