### PR TITLE
SOLR-15390: Deprecate "segmentTerminateEarly" in favor of "minExactCount

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/QueryCommand.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryCommand.java
@@ -223,6 +223,7 @@ public class QueryCommand {
     return (flags & SolrIndexSearcher.SEGMENT_TERMINATE_EARLY) != 0;
   }
 
+  @Deprecated
   public QueryCommand setSegmentTerminateEarly(boolean segmentSegmentTerminateEarly) {
     if (segmentSegmentTerminateEarly) {
       return setFlags(SolrIndexSearcher.SEGMENT_TERMINATE_EARLY);

--- a/solr/core/src/test/org/apache/solr/cloud/SegmentTerminateEarlyTestState.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SegmentTerminateEarlyTestState.java
@@ -254,8 +254,9 @@ class SegmentTerminateEarlyTestState {
     query.setRows(1);
     query.set(CommonParams.SEGMENT_TERMINATE_EARLY, true);
     final QueryResponse rsp = cloudSolrClient.query(query);
-    // check correctness of the results count
-    TestSegmentSorting.assertEquals("numFound", numDocs/2, rsp.getResults().getNumFound());
+    // When using minExactCount (replacement for segmentTerminateEarly), the collector will still attempt to skip over non-competitive
+    // documents (even with a different sort order). See SOLR-15390
+//    TestSegmentSorting.assertEquals("numFound", numDocs/2, rsp.getResults().getNumFound());
     // check correctness of the first result
     if (rsp.getResults().getNumFound() > 0) {
       final SolrDocument solrDocument0 = rsp.getResults().get(0);
@@ -268,8 +269,9 @@ class SegmentTerminateEarlyTestState {
     // check segmentTerminatedEarly flag
     TestSegmentSorting.assertNotNull("responseHeader.segmentTerminatedEarly missing in "+rsp.getResponseHeader(),
         rsp.getResponseHeader().get(SolrQueryResponse.RESPONSE_HEADER_SEGMENT_TERMINATED_EARLY_KEY));
-    // segmentTerminateEarly cannot be used with incompatible sort orders
-    TestSegmentSorting.assertTrue("responseHeader.segmentTerminatedEarly missing/true in "+rsp.getResponseHeader(),
-        Boolean.FALSE.equals(rsp.getResponseHeader().get(SolrQueryResponse.RESPONSE_HEADER_SEGMENT_TERMINATED_EARLY_KEY)));
+    // When using minExactCount (replacement for segmentTerminateEarly), the collector will still attempt to skip over non-competitive
+    // documents (even with a different sort order). See SOLR-15390
+//    TestSegmentSorting.assertTrue("responseHeader.segmentTerminatedEarly missing/true in "+rsp.getResponseHeader(),
+//        Boolean.FALSE.equals(rsp.getResponseHeader().get(SolrQueryResponse.RESPONSE_HEADER_SEGMENT_TERMINATED_EARLY_KEY)));
   }
 }

--- a/solr/solr-ref-guide/src/common-query-parameters.adoc
+++ b/solr/solr-ref-guide/src/common-query-parameters.adoc
@@ -250,18 +250,6 @@ This value is only checked at the time of:
 
 As this check is periodically performed, the actual time for which a request can be processed before it is aborted would be marginally greater than or equal to the value of `timeAllowed`. If the request consumes more time in other stages, custom components, etc., this parameter is not expected to abort the request. Regular search, JSON Facet and the Analytics component abandon requests in accordance with this parameter.
 
-== segmentTerminateEarly Parameter
-
-This parameter may be set to either `true` or `false`.
-
-If set to `true`, and if <<indexconfig-in-solrconfig.adoc#mergepolicyfactory,the mergePolicyFactory>> for this collection is a {solr-javadocs}/core/org/apache/solr/index/SortingMergePolicyFactory.html[`SortingMergePolicyFactory`] which uses a `sort` option compatible with <<sort Parameter,the sort parameter>> specified for this query, then Solr will be able to skip documents on a per-segment basis that are definitively not candidates for the current page of results.
-
-If early termination is used, a `segmentTerminatedEarly` header will be included in the `responseHeader`.
-
-Similar to using <<timeAllowed Parameter,the `timeAllowed` Parameter>>, when early segment termination happens values such as `numFound`, <<faceting.adoc#,Facet>> counts, and result <<the-stats-component.adoc#,Stats>> may not be accurate for the entire result set.
-
-The default value of this parameter is `false`.
-
 == omitHeader Parameter
 
 This parameter may be set to either `true` or `false`.

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
@@ -151,7 +151,9 @@ public interface CommonParams {
   
   /**
    * Whether or not the search may be terminated early within a segment.
+   * @deprecated Use {@link #MIN_EXACT_COUNT}. See SOLR-15390
    */
+  @Deprecated
   String SEGMENT_TERMINATE_EARLY = "segmentTerminateEarly";
   boolean SEGMENT_TERMINATE_EARLY_DEFAULT = false;
 


### PR DESCRIPTION
SOLR-15390: Deprecate "segmentTerminateEarly" in favor of "minExactCount

Also, if segmentTerminateEarly param is used, set minExactCount to 0 and use the TopDocsCollector instead of the deprecated EarlyTerminatingSortingCollector