### PR TITLE
SOLR-15398: Faceting page in ref guide doesn't mention the json.nl parameter

### DIFF
--- a/solr/solr-ref-guide/src/faceting.adoc
+++ b/solr/solr-ref-guide/src/faceting.adoc
@@ -622,4 +622,6 @@ This local parameter overrides default logic for `facet.sort`. if `facet.sort` i
 
 == Related Topics
 
-See also <<spatial-search.adoc#,Heatmap Faceting (Spatial)>>.
+See <<spatial-search.adoc#,Spatial Search>> for examples of faceting by distance and generating heatmaps via faceting.
+
+See <<response-writers.adoc#json-nl, Response Writers>> for details on the `json.nl` parameter for controlling the format for writing out field facet data when using the JSON response writer.


### PR DESCRIPTION

# Description
`json.nl` is important when faceting.

# Solution
link in ref guide.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ x] I have created a Jira issue and added the issue ID to my pull request title.
- [ x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
