### PR TITLE
SOLR-11904: Mark flaky tests as BadApples

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -151,6 +151,8 @@ Other Changes
 * SOLR-14272: Remove autoReplicaFailoverBadNodeExpiration and autoReplicaFailoverWorkLoopDelay for 9.0 as it was
   deprecated in 7.1 (Anshum Gupta)
 
+* SOLR-14258: DocList no longer extends DocSet. (David Smiley)
+
 * SOLR-14256: Remove HashDocSet; add DocSet.getBits() instead.  DocSet is now strictly immutable and ascending order.
   It's now locked-down to external extension; only 2 impls exist.  (David Smiley)
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -151,8 +151,6 @@ Other Changes
 * SOLR-14272: Remove autoReplicaFailoverBadNodeExpiration and autoReplicaFailoverWorkLoopDelay for 9.0 as it was
   deprecated in 7.1 (Anshum Gupta)
 
-* SOLR-14258: DocList no longer extends DocSet. (David Smiley)
-
 * SOLR-14256: Remove HashDocSet; add DocSet.getBits() instead.  DocSet is now strictly immutable and ascending order.
   It's now locked-down to external extension; only 2 impls exist.  (David Smiley)
 
@@ -301,6 +299,9 @@ Bug Fixes
 
 * SOLR-15334: Return error response when failing auth in PKIAuthPlugin (Mike Drob)
 
+* SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to
+  allow PULL replicas to replicate from security-enabled leaders (Timothy Potter, Torsten Bøgh Köster)
+
 ==================  8.9.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.
@@ -380,9 +381,6 @@ Bug Fixes
   that modify the SortSpec in prepare(), as well as possible custom "search" components other then QueryComponent.  (hossman)
 
 * SOLR-15383: Solr Zookeeper status page shows green even when some Zookeepers are not serving requests (janhoy)
-
-* SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to
-  allow PULL replicas to replicate from security-enabled leaders (Timothy Potter, Torsten Bøgh Köster)
 
 Other Changes
 ---------------------

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
@@ -209,6 +209,7 @@ public class TestPullReplica extends SolrCloudTestCase {
   }
 
   @SuppressWarnings("unchecked")
+  @BadApple(bugUrl = "https://issues.apache.org/jira/browse/SOLR-15399")
   public void testAddDocs() throws Exception {
     int numPullReplicas = 1 + random().nextInt(3);
     CollectionAdminRequest.createCollection(collectionName, "conf", 1, 1, 0, numPullReplicas)

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
@@ -84,6 +84,7 @@ public class TestPullReplicaWithAuth extends SolrCloudTestCase {
     return withBasicAuth(new QueryRequest(q)).process(client);
   }
 
+  @BadApple(bugUrl = "https://issues.apache.org/jira/browse/SOLR-15399")
   public void testPKIAuthWorksForPullReplication() throws Exception {
     int numPullReplicas = 2;
     withBasicAuth(CollectionAdminRequest.createCollection(collectionName, "conf", 1, 1, 0, numPullReplicas))


### PR DESCRIPTION
Pull replica tests are still flaky on Jenkins, see: https://jenkins.thetaphi.de/job/Solr-main-Linux/537/
and https://jenkins.thetaphi.de/job/Solr-main-Linux/536/

This PR marks those tests as BadApples, to be fixed by SOLR-15399