### PR TITLE
source patterns: allow "var" usage

### DIFF
--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -161,8 +161,7 @@ class ValidateSourcePatternsTask extends DefaultTask {
 
     // Python and others merrily use var declarations, this is a problem _only_ in Java at least for 8x where we're forbidding var declarations
     def invalidJavaOnlyPatterns = [
-      (~$/\n\s*var\s+.*=.*<>.*/$) : 'Diamond operators should not be used with var',
-      (~$/\n\s*var\s+/$) : 'var is not allowed in until we stop development on the 8x code line'
+      (~$/\n\s*var\s+.*=.*<>.*/$) : 'Diamond operators should not be used with var'
     ]
 
     def found = 0;


### PR DESCRIPTION
I think we should stop the blockade on Java "var" now that 8.x is only going to get one (maybe two) more releases?

FYI in #115 I started using it.