### PR TITLE
Bug in V2Request.getCollection

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/V2ApiIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/V2ApiIntegrationTest.java
@@ -160,8 +160,10 @@ public class V2ApiIntegrationTest extends SolrCloudTestCase {
   @Test
   public void testCollectionsApi() throws Exception {
     CloudSolrClient client = cluster.getSolrClient();
+    V2Request req1 = new V2Request.Builder("/c/" + COLL_NAME + "/get/_introspect").build();
+    assertEquals(COLL_NAME, req1.getCollection());
     @SuppressWarnings({"rawtypes"})
-    Map result = resAsMap(client, new V2Request.Builder("/c/"+COLL_NAME+"/get/_introspect").build());
+    Map result = resAsMap(client, req1);
     assertEquals("/c/collection1/get", Utils.getObjectByPath(result, true, "/spec[0]/url/paths[0]"));
     result = resAsMap(client, new V2Request.Builder("/collections/"+COLL_NAME+"/get/_introspect").build());
     assertEquals("/collections/collection1/get", Utils.getObjectByPath(result, true, "/spec[0]/url/paths[0]"));

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/V2Request.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/V2Request.java
@@ -41,7 +41,7 @@ import static org.apache.solr.common.params.CommonParams.JSON_MIME;
 public class V2Request extends SolrRequest<V2Response> implements MapWriter {
   //only for debugging purposes
   public static final ThreadLocal<AtomicLong> v2Calls = new ThreadLocal<>();
-  static final Pattern COLL_REQ_PATTERN = Pattern.compile("/(c|collections)/([^/])+/(?!shards)");
+  static final Pattern COLL_REQ_PATTERN = Pattern.compile("/(c|collections)/([^/]+)/(?!shards)");
   private Object payload;
   private SolrParams solrParams;
   public final boolean useBinary;


### PR DESCRIPTION
Not noticed yet because SolrJ doesn't look at it for V2.

I didn't create a JIRA issue because this appears to impact nobody because SolrJ doesn't call it.

Why does the regular expression have a negative lookahead on "/shards" at the end of the URL?  What does it matter?

Original code was introduced here: https://issues.apache.org/jira/browse/SOLR-11130 9f73bcf11d89f6ee7b2de8bea25be9018f4554cb