### PR TITLE
GitHub PR Template: Add JIRA issue URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+https://issues.apache.org/jira/browse/SOLR-XXXXX
+
 <!--
 _(If you are a project committer then you may remove some/all of the following template.)_
 


### PR DESCRIPTION
I wish our PRs *always* started with a convenient link to the JIRA issue.  Here, I am modifying the PR template to put it up front.