### PR TITLE
SOLR-15044: JSON Loading: nested docs don't need ID

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -361,6 +361,10 @@ Improvements
 * SOLR-15156: [child] doc transformer's childFilter param no longer applies query syntax escaping.
   It was inconsistent with other Solr options.  It did this escaping since 8.0 but not prior.  (David Smiley)
 
+* SOLR-15044: When indexing nested docs via JSON, it is no longer necessary to provide child doc IDs.
+  This was already working for XML & "javabin"/SolrJ.  Previously, omitting the ID would be confused
+  for a partial/atomic update.  (David Smiley)
+
 Optimizations
 ---------------------
 * SOLR-15079: Block Collapse - Faster collapse code when groups are co-located via Block Join style nested doc indexing.

--- a/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
@@ -22,7 +22,7 @@ import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -608,21 +608,26 @@ public class JsonLoader extends ContentStreamLoader {
       assert ev == JSONParser.OBJECT_START;
 
       SolrInputDocument extendedSolrDocument = parseDoc(ev);
-      // is this a partial update or a child doc?
+      // Is this a child doc (true) or a partial update (false)
       if (isChildDoc(extendedSolrDocument)) {
         return extendedSolrDocument;
-      } else {
-        //return extendedSolrDocument.toMap(new HashMap<>(extendedSolrDocument.size()));  not quite right
-        Map<String, Object> map = new HashMap<>(extendedSolrDocument.size());
-        for (SolrInputField inputField : extendedSolrDocument) {
-          map.put(inputField.getName(), inputField.getValue());
-        }
-        return map;
+      } else { // partial update
+        assert extendedSolrDocument.size() == 1;
+        final SolrInputField pair = extendedSolrDocument.iterator().next();
+        return Collections.singletonMap(pair.getName(), pair.getValue());
       }
     }
 
+    /** Is this a child doc (true) or a partial update (false)? */
     private boolean isChildDoc(SolrInputDocument extendedFieldValue) {
-      return extendedFieldValue.containsKey(req.getSchema().getUniqueKeyField().getName());
+      if (extendedFieldValue.size() != 1) {
+        return true;
+      }
+      // if the only key is a field in the schema, assume it's a child doc
+      final String fieldName = extendedFieldValue.iterator().next().getName();
+      return req.getSchema().getFieldOrNull(fieldName) != null;
+      // otherwise, assume it's "set" or some other verb for a partial update.
+      // NOTE: it's fundamentally ambiguous with JSON; this is a best effort try.
     }
 
     private boolean mapEntryIsChildDoc(Object val) {

--- a/solr/core/src/test/org/apache/solr/handler/JsonLoaderTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/JsonLoaderTest.java
@@ -791,6 +791,14 @@ public class JsonLoaderTest extends SolrTestCaseJ4 {
     checkTwoAnonymousChildDocs(DUP_KEYS_ANON_CHILD_DOCS_JSON, false);
   }
 
+  @Test
+  public void testChildDocWithoutId() throws Exception {
+    final String json = DUP_KEYS_ANON_CHILD_DOCS_JSON.replace("\"id\": \"3\",\n", "");
+    assert !json.equals(DUP_KEYS_ANON_CHILD_DOCS_JSON);
+    checkTwoAnonymousChildDocs(
+        json, false);
+  }
+
   // rawJsonStr has "_childDocuments_" key.  if anonChildDocs then we want to test with something else.
   private void checkTwoAnonymousChildDocs(String rawJsonStr, boolean anonChildDocs) throws Exception {
     if (!anonChildDocs) {
@@ -824,7 +832,11 @@ public class JsonLoaderTest extends SolrTestCaseJ4 {
       cd = (SolrInputDocument)((List)(d.getField("childLabel")).getValue()).get(1);
     }
     cf = cd.getField( "id" );
-    assertEquals("3", cf.getValue());
+    if (rawJsonStr.contains("\"3\"")) {
+      assertEquals("3", cf.getValue());
+    } else { // ID 3 was removed previously to test we don't need an ID to have a child doc
+      assertNull("child doc should have no ID", cf);
+    }
     cf = cd.getField( "foo_i" );
     assertEquals(2, cf.getValueCount());
 


### PR DESCRIPTION
When indexing nested docs via JSON, it is no longer necessary to provide child doc IDs.
This was already working for XML & "javabin"/SolrJ.
Previously, omitting the ID would be confused for a partial/atomic update.

https://issues.apache.org/jira/browse/SOLR-15044