### PR TITLE
SOLR-15438: Simplify SolrDispatchFilter.destroy

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1012,6 +1012,9 @@ public class CoreContainer {
   }
 
   public void shutdown() {
+    if (isShutDown) {
+      return;
+    }
 
     ZkController zkController = getZkController();
     if (zkController != null) {


### PR DESCRIPTION
and JettySolrRunner.stop.
CoreContainer.shutdown should no-op if already shut down.

Don't null out things; not needed.
closeOnDestroy not needed
Use FilterHolder.stop; simplifies our logic.
Remove unused ThreadPool.

https://issues.apache.org/jira/browse/SOLR-15438

Tests passed.
My original scope was to remove the cores==null checks in SDF as well because I assumed it was only for the shutdown scenario but it's actually also there for initialization, which shocked me because I assumed init() *must* complete before doFilter is called.  Mikhail in SOLR-10615 discovered the contrary; I'm still in disbelief but I'll not pursue that further right now.