### PR TITLE
LUCENE-8682: remove deprecated WordDelimiterFilter[Factory] classes

### DIFF
--- a/solr/core/src/test-files/solr/collection1/conf/schema-tagger.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-tagger.xml
@@ -86,7 +86,7 @@
       </analyzer>
     </fieldType>
 
-    <!-- adds a WordDelimiterFilter producing stacked/synonym tokens -->
+    <!-- adds a WordDelimiterGraphFilter producing stacked/synonym tokens -->
     <fieldType name="tagWDF" class="solr.TextField" positionIncrementGap="100"
                postingsFormat="FST50" omitTermFreqAndPositions="true" omitNorms="true">
       <analyzer type="index">

--- a/solr/core/src/test-files/solr/collection1/conf/schema.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema.xml
@@ -205,7 +205,7 @@
     <analyzer type="index">
       <tokenizer class="solr.MockTokenizerFactory"/>
       <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" expand="true"/>
-      <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
               catenateNumbers="1" catenateAll="1" splitOnCaseChange="1"/>
       <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.FlattenGraphFilterFactory"/>
@@ -213,7 +213,7 @@
     <analyzer type="query">
       <tokenizer class="solr.MockTokenizerFactory"/>
       <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" expand="true"/>
-      <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
               catenateNumbers="1" catenateAll="1" splitOnCaseChange="1"/>
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>

--- a/solr/core/src/test/org/apache/solr/analysis/TestWordDelimiterGraphFilterFactory.java
+++ b/solr/core/src/test/org/apache/solr/analysis/TestWordDelimiterGraphFilterFactory.java
@@ -30,7 +30,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * New WordDelimiterFilter tests... most of the tests are in ConvertedLegacyTest
+ * New WordDelimiterGraphFilter tests... most of the tests are in ConvertedLegacyTest
  */
 // TODO: add a low-level test for this factory
 public class TestWordDelimiterGraphFilterFactory extends SolrTestCaseJ4 {
@@ -122,24 +122,6 @@ public class TestWordDelimiterGraphFilterFactory extends SolrTestCaseJ4 {
     );
     clearIndex();
   }
-
-  /*
-  public void testPerformance() throws IOException {
-    String s = "now is the time-for all good men to come to-the aid of their country.";
-    Token tok = new Token();
-    long start = System.currentTimeMillis();
-    int ret=0;
-    for (int i=0; i<1000000; i++) {
-      StringReader r = new StringReader(s);
-      TokenStream ts = new WhitespaceTokenizer(r);
-      ts = new WordDelimiterFilter(ts, 1,1,1,1,0);
-
-      while (ts.next(tok) != null) ret++;
-    }
-
-    System.out.println("ret="+ret+" time="+(System.currentTimeMillis()-start));
-  }
-  ***/
 
   @Test
   public void testAlphaNumericWords(){

--- a/solr/core/src/test/org/apache/solr/analysis/TestWordDelimiterGraphFilterFactory.java
+++ b/solr/core/src/test/org/apache/solr/analysis/TestWordDelimiterGraphFilterFactory.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilterFactory;
 import org.apache.lucene.util.ResourceLoader;
 import org.apache.lucene.util.Version;
 import org.apache.solr.SolrTestCaseJ4;
@@ -33,7 +33,7 @@ import org.junit.Test;
  * New WordDelimiterFilter tests... most of the tests are in ConvertedLegacyTest
  */
 // TODO: add a low-level test for this factory
-public class TestWordDelimiterFilterFactory extends SolrTestCaseJ4 {
+public class TestWordDelimiterGraphFilterFactory extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -207,16 +207,16 @@ public class TestWordDelimiterFilterFactory extends SolrTestCaseJ4 {
     args.put("splitOnCaseChange", "1");
     
     /* default behavior */
-    WordDelimiterFilterFactory factoryDefault = new WordDelimiterFilterFactory(args);
+    WordDelimiterGraphFilterFactory factoryDefault = new WordDelimiterGraphFilterFactory(args);
     factoryDefault.inform(loader);
     
     TokenStream ts = factoryDefault.create(whitespaceMockTokenizer(testText));
     BaseTokenStreamTestCase.assertTokenStreamContents(ts, 
-        new String[] { "I", "borrowed", "5", "540000", "400", "00", "at", "25", "interest", "interestrate", "rate" });
+        new String[] { "I", "borrowed", "540000", "5", "400", "00", "at", "25", "interestrate", "interest", "rate" });
 
     ts = factoryDefault.create(whitespaceMockTokenizer("foo\u200Dbar"));
     BaseTokenStreamTestCase.assertTokenStreamContents(ts, 
-        new String[] { "foo", "foobar", "bar" });
+        new String[] { "foobar", "foo", "bar" });
 
     
     /* custom behavior */
@@ -230,12 +230,12 @@ public class TestWordDelimiterFilterFactory extends SolrTestCaseJ4 {
     args.put("catenateAll", "0");
     args.put("splitOnCaseChange", "1");
     args.put("types", "wdftypes.txt");
-    WordDelimiterFilterFactory factoryCustom = new WordDelimiterFilterFactory(args);
+    WordDelimiterGraphFilterFactory factoryCustom = new WordDelimiterGraphFilterFactory(args);
     factoryCustom.inform(loader);
     
     ts = factoryCustom.create(whitespaceMockTokenizer(testText));
     BaseTokenStreamTestCase.assertTokenStreamContents(ts, 
-        new String[] { "I", "borrowed", "$5,400.00", "at", "25%", "interest", "interestrate", "rate" });
+        new String[] { "I", "borrowed", "$5,400.00", "at", "25%", "interestrate", "interest", "rate" });
     
     /* test custom behavior with a char > 0x7F, because we had to make a larger byte[] */
     ts = factoryCustom.create(whitespaceMockTokenizer("foo\u200Dbar"));

--- a/solr/solr-ref-guide/src/filter-descriptions.adoc
+++ b/solr/solr-ref-guide/src/filter-descriptions.adoc
@@ -2685,20 +2685,6 @@ This filter blacklists or whitelists a specified list of token types, assuming t
 ====
 --
 
-== Word Delimiter Filter
-
-This filter splits tokens at word delimiters.
-
-.Word Delimiter Filter has been Deprecated
-[WARNING]
-====
-Word Delimiter Filter has been deprecated in favor of Word Delimiter Graph Filter, which is required to produce a correct token graph so that e.g., phrase queries can work correctly.
-====
-
-*Factory class:* `solr.WordDelimiterFilterFactory`
-
-For a full description, including arguments and examples, see the Word Delimiter Graph Filter below.
-
 == Word Delimiter Graph Filter
 
 This filter splits tokens at word delimiters.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/LukeResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/LukeResponse.java
@@ -87,7 +87,7 @@ public class LukeResponse extends SolrResponseBase {
       boolean={fields=[inStock],tokenized=false,analyzer=org.apache.solr.schema.BoolField$1@354949},
       textTight={fields=[sku],tokenized=true,analyzer=TokenizerChain(org.apache.solr.analysis.WhitespaceTokenizerFactory@5e88f7,
        org.apache.solr.analysis.SynonymFilterFactory@723646, org.apache.solr.analysis.StopFilterFactory@492ff1,
-       org.apache.solr.analysis.WordDelimiterFilterFactory@eaabad, org.apache.solr.analysis.LowerCaseFilterFactory@ad1355,
+       org.apache.solr.analysis.WordDelimiterGraphFilterFactory@eaabad, org.apache.solr.analysis.LowerCaseFilterFactory@ad1355,
         org.apache.solr.analysis.EnglishPorterFilterFactory@d03a00, org.apache.solr.analysis.RemoveDuplicatesTokenFilterFactory@900079)},
         long={fields=null,tokenized=false,analyzer=org.apache.solr.schema.FieldType$DefaultAnalyzer@f3b83},
         double={fields=null,tokenized=false,analyzer=org.apache.solr.schema.FieldType$DefaultAnalyzer@c2b07},


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-8682

@romseygeek's Feb 2019 patch applied to past point in repo history and then rebased forward with import related conflict resolved plus small twaks and Solr Reference Guide update too.

The changes affects tests and documentation only so no CHANGES.txt entry and separate SOLR JIRA issue needed here in my opinion, but happy to have either or both if others think that would be better.
