### PR TITLE
SOLR-15517: Remove unnecessary no-op implementation of SolrCoreAware in ExpandComponent and TermVectorComponent.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -344,6 +344,8 @@ Other Changes
 
 * SOLR-15461: SOLR-15461: Upgrade Apache Calcite to 1.27.0. (Mark Miller, Timothy Potter)
 
+* SOLR-15517: Remove unnecessary no-op implementation of SolrCoreAware in ExpandComponent and TermVectorComponent. (Christine Poerschke)
+
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution

--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -71,7 +71,6 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.PluginInfo;
-import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
@@ -87,7 +86,6 @@ import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SortSpecParsing;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
-import org.apache.solr.util.plugin.SolrCoreAware;
 
 /**
  * The ExpandComponent is designed to work with the CollapsingPostFilter.
@@ -106,7 +104,7 @@ import org.apache.solr.util.plugin.SolrCoreAware;
  * expand.fq=type:child (optional, overrides the main filter queries)<br>
  * expand.field=field (mandatory, if the not used with the CollapsingQParserPlugin. This is given higher priority when both are present)<br>
  */
-public class ExpandComponent extends SearchComponent implements PluginInfoInitialized, SolrCoreAware {
+public class ExpandComponent extends SearchComponent implements PluginInfoInitialized {
   public static final String COMPONENT_NAME = "expand";
   private static final int finishingStage = ResponseBuilder.STAGE_GET_FIELDS;
   private PluginInfo info = PluginInfo.EMPTY_INFO;
@@ -124,11 +122,6 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       }
       rb.doExpand = true;
     }
-  }
-
-  @Override
-  public void inform(SolrCore core) {
-
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java
@@ -41,7 +41,6 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.TermVectorParams;
 import org.apache.solr.common.util.Base64;
 import org.apache.solr.common.util.NamedList;
-import org.apache.solr.core.SolrCore;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.DocList;
@@ -51,7 +50,6 @@ import org.apache.solr.search.SolrDocumentFetcher;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SolrReturnFields;
 import org.apache.solr.util.SolrPluginUtils;
-import org.apache.solr.util.plugin.SolrCoreAware;
 
 /**
  * Return term vectors for the documents in a query result set.
@@ -75,7 +73,7 @@ import org.apache.solr.util.plugin.SolrCoreAware;
  *
  *
  */
-public class TermVectorComponent extends SearchComponent implements SolrCoreAware {
+public class TermVectorComponent extends SearchComponent {
 
 
   public static final String COMPONENT_NAME = "tv";
@@ -456,11 +454,6 @@ public class TermVectorComponent extends SearchComponent implements SolrCoreAwar
   public void init(NamedList<?> args) {
     super.init(args);
     this.initParams = args;
-  }
-
-  @Override
-  public void inform(SolrCore core) {
-
   }
 
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15517