### PR TITLE
SOLR-13360: Collation code fails with non-increasing token order

### DIFF
--- a/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
+++ b/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
@@ -194,6 +194,7 @@ public class SpellCheckCollator {
                               List<SpellCheckCorrection> corrections) {
     StringBuilder collation = new StringBuilder(origQuery);
     int offset = 0;
+    int lastOffset = 0;
     String corr = "";
     for(int i=0 ; i<corrections.size() ; i++) {
       SpellCheckCorrection correction = corrections.get(i);   
@@ -202,6 +203,9 @@ public class SpellCheckCollator {
       // illegal offsets due to previous replacements.
       if (tok.getPositionIncrement() == 0)
         continue;
+      if (tok.startOffset() < lastOffset)
+        continue;
+      lastOffset = tok.endOffset();
       corr = correction.getCorrection();
       boolean addParenthesis = false;
       Character requiredOrProhibited = null;


### PR DESCRIPTION
The collation code assumes the tokens to replace have disjoint startOffset and endOffset in increasing order in the original query string.

When synonyms add additional tokens not present in the original query, this assumption fails.

Make sure we skip token replacements which refer to the same original query string position or are not in increasing offset order.

https://issues.apache.org/jira/browse/SOLR-13360
