### PR TITLE
SOLR-15531: significantTerms streaming function should not fail on empty collections

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -383,6 +383,8 @@ Bug Fixes
 * SOLR-15311: Support async parameter in MODIFYCOLLECTION
   (Nazerke Seidan, Christine Poerschke, David Smiley)
 
+* SOLR-15531: SignificantTerms streaming function should not fail on empty collections (Benedikt Arnold via Mike Drob)
+
 Other Changes
 ---------------------
 (No changes)

--- a/solr/core/src/java/org/apache/solr/search/SignificantTermsQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SignificantTermsQParserPlugin.java
@@ -28,7 +28,9 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.apache.solr.common.params.SolrParams;
@@ -114,7 +116,7 @@ public class SignificantTermsQParserPlugin extends QParserPlugin {
 
       LinkedHashMap<String, Object> response = new LinkedHashMap<>();
 
-      rb.rsp.add("significantTerms", response);
+      rb.rsp.add(NAME, response);
 
       response.put("numDocs", 0);
       response.put("sterms", outTerms);

--- a/solr/core/src/test/org/apache/solr/search/SignificantTermsQParserPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SignificantTermsQParserPluginTest.java
@@ -36,7 +36,11 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class SignificantTermsQParserPluginTest extends SolrTestCaseJ4 {
 

--- a/solr/core/src/test/org/apache/solr/search/SignificantTermsQParserPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SignificantTermsQParserPluginTest.java
@@ -17,19 +17,130 @@
 
 package org.apache.solr.search;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.MapSolrParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.request.LocalSolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.update.AddUpdateCommand;
+import org.apache.solr.update.CommitUpdateCommand;
+import org.apache.solr.update.DeleteUpdateCommand;
+import org.apache.solr.util.RefCounted;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 public class SignificantTermsQParserPluginTest extends SolrTestCaseJ4 {
 
-  /**
-   * Test the backwards compatibility for a typo in the SignificantTermsQParserPlugin. It will fail if the backwards
-   * compatibility is broken.
-   */
-  @Test
-  public void testQParserBackwardsCompatibility() {
-    assertEquals("significantTerms", SignificantTermsQParserPlugin.NAME);
-    assertEquals(SignificantTermsQParserPlugin.class,
-        QParserPlugin.standardPlugins.get(SignificantTermsQParserPlugin.NAME).getClass());
-  }
+    @BeforeClass
+    public static void setUpCore() throws Exception {
+        String tmpSolrHome = createTempDir().toFile().getAbsolutePath();
+        FileUtils.copyDirectory(new File(TEST_HOME()), new File(tmpSolrHome).getAbsoluteFile());
+        initCore("solrconfig.xml", "schema.xml", new File(tmpSolrHome).getAbsolutePath());
+    }
+
+    /**
+     * Test the backwards compatibility for a typo in the SignificantTermsQParserPlugin. It will fail if the backwards
+     * compatibility is broken.
+     */
+    @Test
+    public void testQParserBackwardsCompatibility() {
+        assertEquals("significantTerms", SignificantTermsQParserPlugin.NAME);
+        assertEquals(SignificantTermsQParserPlugin.class,
+                QParserPlugin.standardPlugins.get(SignificantTermsQParserPlugin.NAME).getClass());
+    }
+
+    @Test
+    public void testEmptyCollectionDoesNotThrow() throws Exception {
+        SolrCore emptyCore = h.getCore();
+        QParserPlugin qParserPlugin = QParserPlugin.standardPlugins.get(SignificantTermsQParserPlugin.NAME);
+        Map<String, String> params = new HashMap<>();
+        params.put("field", "cat");
+        QParser parser = qParserPlugin.createParser("", new MapSolrParams(params), new MapSolrParams(new HashMap<>()), null);
+        AnalyticsQuery query = (AnalyticsQuery) parser.parse();
+        SolrQueryResponse resp = new SolrQueryResponse();
+
+        RefCounted<SolrIndexSearcher> searcher = emptyCore.getSearcher();
+        try {
+            DelegatingCollector analyticsCollector = query.getAnalyticsCollector(new ResponseBuilder(null, resp, Collections.emptyList()), searcher.get());
+            assertNotNull(analyticsCollector);
+            analyticsCollector.finish();
+            LinkedHashMap<String, Object> expectedValues = new LinkedHashMap<>();
+            expectedValues.put("numDocs", 0);
+            expectedValues.put("sterms", new ArrayList<String>());
+            expectedValues.put("scores", new ArrayList<Integer>());
+            expectedValues.put("docFreq", new ArrayList<Integer>());
+            expectedValues.put("queryDocFreq", new ArrayList<Double>());
+            assertEquals(expectedValues, resp.getValues().get("significantTerms"));
+        } finally {
+            searcher.decref();
+        }
+
+    }
+
+    @Test
+    public void testCollectionWithDocuments() throws Exception {
+        SolrCore dataCore = h.getCore();
+        addTestDocs(dataCore);
+
+        QParserPlugin qParserPlugin = QParserPlugin.standardPlugins.get(SignificantTermsQParserPlugin.NAME);
+        Map<String, String> params = new HashMap<>();
+        params.put("field", "cat");
+        QParser parser = qParserPlugin.createParser("", new MapSolrParams(params), new MapSolrParams(new HashMap<>()), null);
+        AnalyticsQuery query = (AnalyticsQuery) parser.parse();
+        SolrQueryResponse resp = new SolrQueryResponse();
+
+        ResponseBuilder responseBuilder = new ResponseBuilder(null, resp, Collections.emptyList());
+        RefCounted<SolrIndexSearcher> searcher = dataCore.getSearcher();
+        try {
+
+            DelegatingCollector analyticsCollector = query.getAnalyticsCollector(responseBuilder, searcher.get());
+            assertNotNull(analyticsCollector);
+            analyticsCollector.finish();
+
+            LinkedHashMap<String, Object> expectedValues = new LinkedHashMap<>();
+            expectedValues.put("numDocs", 1);
+            expectedValues.put("sterms", new ArrayList<String>());
+            expectedValues.put("scores", new ArrayList<Integer>());
+            expectedValues.put("docFreq", new ArrayList<Integer>());
+            expectedValues.put("queryDocFreq", new ArrayList<Double>());
+
+            assertEquals(expectedValues, resp.getValues().get("significantTerms"));
+
+        } finally {
+            searcher.decref();
+        }
+
+        deleteTestDocs(dataCore);
+    }
+
+    private void addTestDocs(SolrCore core) throws IOException {
+        SolrQueryRequest coreReq = new LocalSolrQueryRequest(core, new ModifiableSolrParams());
+        AddUpdateCommand cmd = new AddUpdateCommand(coreReq);
+        cmd.solrDoc = new SolrInputDocument();
+        cmd.solrDoc.addField("id", "1");
+        cmd.solrDoc.addField("cat", "foo");
+        core.getUpdateHandler().addDoc(cmd);
+
+        core.getUpdateHandler().commit(new CommitUpdateCommand(coreReq, true));
+        coreReq.close();
+    }
+
+    private void deleteTestDocs(SolrCore core) throws IOException {
+        SolrQueryRequest coreReq = new LocalSolrQueryRequest(core, new ModifiableSolrParams());
+        DeleteUpdateCommand cmd = new DeleteUpdateCommand(coreReq);
+        cmd.id = "1";
+        core.getUpdateHandler().delete(cmd);
+        core.getUpdateHandler().commit(new CommitUpdateCommand(coreReq, true));
+        coreReq.close();
+    }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15531
# Description

The `SignificantTermsQParserPlugin` uses the class `SparseFixedBitSet` internall that requires a length parameter >= 1. In order to fill the parameter, the result of `searcher.indexReader().maxDoc()` which is 0 for shards without any document.

# Solution
Before the Plugin creates the analytics collector, the proposed solution checks `maxDocs` and decides if it should return the `SignifcantTermsCollector` or a no op collector.

# Tests

1. A test to check the existing behavior for collections with at least one document
2. A test to verify the error against a collection with 0 documents.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
