### PR TITLE
SOLR-15525: Allow Zookeeper ACL credentials to be passed via env vars instead of Java system properties

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -374,6 +374,8 @@ Improvements
 * SOLR-15499: StatsStream implement ParallelMetricsRollup to allow for tiered computation of SQL metrics
   over collection aliases backed by many collections, potentially with many shards in each (Timothy Potter)
 
+* SOLR-15525: Allow Zookeeper ACL credentials to be passed via env vars instead of Java system properties (Timothy Potter)
+
 Optimizations
 ---------------------
 * SOLR-15433: Replace transient core cache LRU by Caffeine cache. (Bruno Roustant)

--- a/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
@@ -251,7 +251,7 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
     System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME, "readonlyACLPassword");
   }
   
-  private void setSecuritySystemProperties() {
+  protected void setSecuritySystemProperties() {
     System.setProperty(SolrZkClient.ZK_ACL_PROVIDER_CLASS_NAME_VM_PARAM_NAME, VMParamsAllAndReadonlyDigestZkACLProvider.class.getName());
     System.setProperty(SolrZkClient.ZK_CRED_PROVIDER_CLASS_NAME_VM_PARAM_NAME, VMParamsSingleSetCredentialsDigestZkCredentialsProvider.class.getName());
     System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, "connectAndAllACLUsername");
@@ -260,7 +260,7 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
     System.setProperty(VMParamsAllAndReadonlyDigestZkACLProvider.DEFAULT_DIGEST_READONLY_PASSWORD_VM_PARAM_NAME, "readonlyACLPassword");
   }
   
-  private void clearSecuritySystemProperties() {
+  protected void clearSecuritySystemProperties() {
     System.clearProperty(SolrZkClient.ZK_ACL_PROVIDER_CLASS_NAME_VM_PARAM_NAME);
     System.clearProperty(SolrZkClient.ZK_CRED_PROVIDER_CLASS_NAME_VM_PARAM_NAME);
     System.clearProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME);

--- a/solr/core/src/test/org/apache/solr/common/cloud/EnvZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/common/cloud/EnvZkACLAndCredentialsProvidersTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.cloud;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.solr.cloud.AbstractZkTestCase;
+import org.apache.solr.cloud.VMParamsZkACLAndCredentialsProvidersTest;
+import org.junit.Test;
+
+import static org.apache.solr.common.cloud.EnvAllAndReadonlyDigestZkACLProvider.ZK_READ_ACL_PASSWORD;
+import static org.apache.solr.common.cloud.EnvAllAndReadonlyDigestZkACLProvider.ZK_READ_ACL_USERNAME;
+import static org.apache.solr.common.cloud.EnvSingleSetCredentialsDigestZkCredentialsProvider.ZK_ALL_ACL_PASSWORD;
+import static org.apache.solr.common.cloud.EnvSingleSetCredentialsDigestZkCredentialsProvider.ZK_ALL_ACL_USERNAME;
+
+public class EnvZkACLAndCredentialsProvidersTest extends VMParamsZkACLAndCredentialsProvidersTest {
+
+  @Test
+  public void testAllCredentialsFromEnv() throws Exception {
+    useAllCredentialsFromEnv();
+
+    try (SolrZkClient zkClient = new SolrZkClient(zkServer.getZkAddress(), AbstractZkTestCase.TIMEOUT)) {
+      doTest(zkClient,
+          true, true, true, true, true,
+          true, true, true, true, true);
+    }
+  }
+
+  @Test
+  public void testReadonlyCredentialsFromEnv() throws Exception {
+    useReadonlyCredentialsFromEnv();
+
+    try (SolrZkClient zkClient = new SolrZkClient(zkServer.getZkAddress(), AbstractZkTestCase.TIMEOUT)) {
+      doTest(zkClient,
+          true, true, false, false, false,
+          false, false, false, false, false);
+    }
+  }
+
+  private void useAllCredentialsFromEnv() {
+    clearSecuritySystemProperties();
+
+    System.setProperty(SolrZkClient.ZK_CRED_PROVIDER_CLASS_NAME_VM_PARAM_NAME, EnvSingleSetCredentialsDigestZkCredentialsProvider.class.getName());
+
+    Map<String, String> testEnv = ImmutableMap.of(ZK_ALL_ACL_USERNAME, "connectAndAllACLUsername",
+        ZK_ALL_ACL_PASSWORD, "connectAndAllACLPassword");
+    EnvSingleSetCredentialsDigestZkCredentialsProvider.setEnvVars(testEnv);
+  }
+
+  private void useReadonlyCredentialsFromEnv() {
+    clearSecuritySystemProperties();
+
+    System.setProperty(SolrZkClient.ZK_CRED_PROVIDER_CLASS_NAME_VM_PARAM_NAME, EnvSingleSetCredentialsDigestZkCredentialsProvider.class.getName());
+
+    Map<String, String> testEnv =
+        ImmutableMap.of(ZK_ALL_ACL_USERNAME, "readonlyACLUsername", ZK_ALL_ACL_PASSWORD, "readonlyACLPassword");
+    EnvSingleSetCredentialsDigestZkCredentialsProvider.setEnvVars(testEnv);
+  }
+
+  @Override
+  protected void setSecuritySystemProperties() {
+    System.setProperty(SolrZkClient.ZK_ACL_PROVIDER_CLASS_NAME_VM_PARAM_NAME, EnvAllAndReadonlyDigestZkACLProvider.class.getName());
+    System.setProperty(SolrZkClient.ZK_CRED_PROVIDER_CLASS_NAME_VM_PARAM_NAME, EnvSingleSetCredentialsDigestZkCredentialsProvider.class.getName());
+
+    Map<String, String> testEnv = ImmutableMap.of(ZK_ALL_ACL_USERNAME, "connectAndAllACLUsername",
+        ZK_ALL_ACL_PASSWORD, "connectAndAllACLPassword",
+        ZK_READ_ACL_USERNAME, "readonlyACLUsername", ZK_READ_ACL_PASSWORD, "readonlyACLPassword");
+    EnvSingleSetCredentialsDigestZkCredentialsProvider.setEnvVars(testEnv);
+    EnvAllAndReadonlyDigestZkACLProvider.setEnvVars(testEnv);
+  }
+}

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/EnvAllAndReadonlyDigestZkACLProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/EnvAllAndReadonlyDigestZkACLProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.cloud;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.zookeeper.data.ACL;
+
+public class EnvAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkACLProvider {
+
+  public static final String ZK_READ_ACL_USERNAME = "ZK_READ_ACL_USERNAME";
+  public static final String ZK_READ_ACL_PASSWORD = "ZK_READ_ACL_PASSWORD";
+
+  private static Map<String, String> envVars = null;
+
+  static String getEnvVar(String name) {
+    return envVars != null ? envVars.get(name) : System.getenv(name);
+  }
+
+  // for testing only!
+  static void setEnvVars(Map<String, String> env) {
+    envVars = env;
+  }
+
+  /**
+   * @return Set of ACLs to return for non-security related znodes
+   */
+  @Override
+  protected List<ACL> createNonSecurityACLsToAdd() {
+    return createACLsToAdd(true);
+  }
+
+  /**
+   * @return Set of ACLs to return security-related znodes
+   */
+  @Override
+  protected List<ACL> createSecurityACLsToAdd() {
+    return createACLsToAdd(false);
+  }
+
+  protected List<ACL> createACLsToAdd(boolean includeReadOnly) {
+    String digestAllUsername = getEnvVar(EnvSingleSetCredentialsDigestZkCredentialsProvider.ZK_ALL_ACL_USERNAME);
+    String digestAllPassword = getEnvVar(EnvSingleSetCredentialsDigestZkCredentialsProvider.ZK_ALL_ACL_PASSWORD);
+    String digestReadonlyUsername = getEnvVar(ZK_READ_ACL_USERNAME);
+    String digestReadonlyPassword = getEnvVar(ZK_READ_ACL_PASSWORD);
+
+    return createACLsToAdd(includeReadOnly,
+        digestAllUsername, digestAllPassword,
+        digestReadonlyUsername, digestReadonlyPassword);
+  }
+}
+

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/EnvSingleSetCredentialsDigestZkCredentialsProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/EnvSingleSetCredentialsDigestZkCredentialsProvider.java
@@ -20,37 +20,37 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.solr.common.StringUtils;
 
-public class VMParamsSingleSetCredentialsDigestZkCredentialsProvider extends DefaultZkCredentialsProvider {
-  
-  public static final String DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME = "zkDigestUsername";
-  public static final String DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME = "zkDigestPassword";
-  
-  final String zkDigestUsernameVMParamName;
-  final String zkDigestPasswordVMParamName;
-  
-  public VMParamsSingleSetCredentialsDigestZkCredentialsProvider() {
-    this(DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME);
+public class EnvSingleSetCredentialsDigestZkCredentialsProvider extends DefaultZkCredentialsProvider {
+
+  public static final String ZK_ALL_ACL_USERNAME = "ZK_ALL_ACL_USERNAME";
+  public static final String ZK_ALL_ACL_PASSWORD = "ZK_ALL_ACL_PASSWORD";
+
+  private static Map<String, String> envVars = null;
+
+  static String getEnvVar(String name) {
+    return envVars != null ? envVars.get(name) : System.getenv(name);
   }
-  
-  public VMParamsSingleSetCredentialsDigestZkCredentialsProvider(String zkDigestUsernameVMParamName, String zkDigestPasswordVMParamName) {
-    this.zkDigestUsernameVMParamName = zkDigestUsernameVMParamName;
-    this.zkDigestPasswordVMParamName = zkDigestPasswordVMParamName;
+
+  // for testing only!
+  static void setEnvVars(Map<String, String> env) {
+    envVars = env;
   }
 
   @Override
   protected Collection<ZkCredentials> createCredentials() {
-    List<ZkCredentials> result = new ArrayList<ZkCredentials>();
-    String digestUsername = System.getProperty(zkDigestUsernameVMParamName);
-    String digestPassword = System.getProperty(zkDigestPasswordVMParamName);
+    List<ZkCredentials> result = new ArrayList<>();
+    String digestUsername = getEnvVar(ZK_ALL_ACL_USERNAME);
+    String digestPassword = getEnvVar(ZK_ALL_ACL_PASSWORD);
+
     if (!StringUtils.isEmpty(digestUsername) && !StringUtils.isEmpty(digestPassword)) {
       result.add(new ZkCredentials("digest",
           (digestUsername + ":" + digestPassword).getBytes(StandardCharsets.UTF_8)));
     }
     return result;
   }
-  
 }
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsAllAndReadonlyDigestZkACLProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsAllAndReadonlyDigestZkACLProvider.java
@@ -30,6 +30,12 @@ public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkAC
 
   public static final String DEFAULT_DIGEST_READONLY_USERNAME_VM_PARAM_NAME = "zkDigestReadonlyUsername";
   public static final String DEFAULT_DIGEST_READONLY_PASSWORD_VM_PARAM_NAME = "zkDigestReadonlyPassword";
+
+  // fallback env vars if system props not set
+  public static final String ZK_ALL_ACL_USERNAME = "ZK_ALL_ACL_USERNAME";
+  public static final String ZK_ALL_ACL_PASSWORD = "ZK_ALL_ACL_PASSWORD";
+  public static final String ZK_READ_ACL_USERNAME = "ZK_READ_ACL_USERNAME";
+  public static final String ZK_READ_ACL_PASSWORD = "ZK_READ_ACL_PASSWORD";
   
   final String zkDigestAllUsernameVMParamName;
   final String zkDigestAllPasswordVMParamName;
@@ -70,10 +76,10 @@ public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkAC
   }
 
   protected List<ACL> createACLsToAdd(boolean includeReadOnly) {
-    String digestAllUsername = System.getProperty(zkDigestAllUsernameVMParamName);
-    String digestAllPassword = System.getProperty(zkDigestAllPasswordVMParamName);
-    String digestReadonlyUsername = System.getProperty(zkDigestReadonlyUsernameVMParamName);
-    String digestReadonlyPassword = System.getProperty(zkDigestReadonlyPasswordVMParamName);
+    String digestAllUsername = getPropertyWithEnvFallback(zkDigestAllUsernameVMParamName, ZK_ALL_ACL_USERNAME);
+    String digestAllPassword = getPropertyWithEnvFallback(zkDigestAllPasswordVMParamName, ZK_ALL_ACL_PASSWORD);
+    String digestReadonlyUsername = getPropertyWithEnvFallback(zkDigestReadonlyUsernameVMParamName, ZK_READ_ACL_USERNAME);
+    String digestReadonlyPassword = getPropertyWithEnvFallback(zkDigestReadonlyPasswordVMParamName, ZK_READ_ACL_PASSWORD);
 
     return createACLsToAdd(includeReadOnly,
         digestAllUsername, digestAllPassword,
@@ -113,5 +119,9 @@ public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkAC
     }
   }
 
+  private String getPropertyWithEnvFallback(final String propName, final String envVarFallback) {
+    String propValue = VMParamsSingleSetCredentialsDigestZkCredentialsProvider.getProperty(propName);
+    return propValue != null ? propValue : System.getenv(envVarFallback);
+  }
 }
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsSingleSetCredentialsDigestZkCredentialsProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsSingleSetCredentialsDigestZkCredentialsProvider.java
@@ -27,7 +27,17 @@ public class VMParamsSingleSetCredentialsDigestZkCredentialsProvider extends Def
   
   public static final String DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME = "zkDigestUsername";
   public static final String DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME = "zkDigestPassword";
-  
+
+  private static final String ENV_VAR_PREFIX = "env:";
+
+  static String getProperty(final String propName) {
+    String propValue = System.getProperty(propName);
+    if (propValue != null && propValue.startsWith(ENV_VAR_PREFIX) && propValue.length() > ENV_VAR_PREFIX.length()) {
+      propValue = System.getenv(propValue.substring(ENV_VAR_PREFIX.length()));
+    }
+    return propValue;
+  }
+
   final String zkDigestUsernameVMParamName;
   final String zkDigestPasswordVMParamName;
   
@@ -43,14 +53,14 @@ public class VMParamsSingleSetCredentialsDigestZkCredentialsProvider extends Def
   @Override
   protected Collection<ZkCredentials> createCredentials() {
     List<ZkCredentials> result = new ArrayList<ZkCredentials>();
-    String digestUsername = System.getProperty(zkDigestUsernameVMParamName);
-    String digestPassword = System.getProperty(zkDigestPasswordVMParamName);
+    String digestUsername = getProperty(zkDigestUsernameVMParamName);
+    String digestPassword = getProperty(zkDigestPasswordVMParamName);
+
     if (!StringUtils.isEmpty(digestUsername) && !StringUtils.isEmpty(digestPassword)) {
       result.add(new ZkCredentials("digest",
           (digestUsername + ":" + digestPassword).getBytes(StandardCharsets.UTF_8)));
     }
     return result;
   }
-  
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15525

# Description

Get zk acl username and/or password from either a Java sys prop (current behavior) or from an environment variable. Introduced new provider impl classes that read from env vars ...

# Solution

See code changes.

# Tests

See unit test introduced here.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
