### PR TITLE
SOLR-15525: Read ZK credentials from a file specified using a system property instead of exposing plain-text credentials

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -374,6 +374,9 @@ Improvements
 * SOLR-15499: StatsStream implement ParallelMetricsRollup to allow for tiered computation of SQL metrics
   over collection aliases backed by many collections, potentially with many shards in each (Timothy Potter)
 
+* SOLR-15525: Read ZK credentials from a file specified using a system property instead of exposing plain-text
+  credentials as system properties (Timothy Potter)
+
 Optimizations
 ---------------------
 * SOLR-15433: Replace transient core cache LRU by Caffeine cache. (Bruno Roustant)

--- a/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
@@ -297,11 +297,11 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
   }
 
   private void saveCredentialsFile(Properties props) throws IOException {
-    File credentialsFile = createTempFile("zk-creds", "properties").toFile();
-    try (FileWriter writer = new FileWriter(credentialsFile, StandardCharsets.UTF_8)) {
-      props.store(writer, "test");
+    Path tmp = createTempFile("zk-creds", "properties");
+    try (OutputStream os = Files.newOutputStream(tmp)) {
+      props.store(os, "test");
     }
-    System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_FILE_VM_PARAM_NAME, credentialsFile.getAbsolutePath());
+    System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_FILE_VM_PARAM_NAME, tmp.toAbsolutePath().toString());
   }
   
   private void setSecuritySystemProperties() {

--- a/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.solr.cloud;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 

--- a/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.solr.cloud;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Properties;
 
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.cloud.SecurityAwareZkACLProvider;
@@ -70,7 +74,7 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
     zkServer.run(false);
     
     System.setProperty("zkHost", zkServer.getZkAddress());
-    
+
     setSecuritySystemProperties();
 
     SolrZkClient zkClient = new SolrZkClient(zkServer.getZkHost(),
@@ -151,6 +155,28 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
       doTest(zkClient,
               true, true, false, false, false,
               false, false, false, false, false);
+    }
+  }
+
+  @Test
+  public void testReadonlyCredentialsFromFile() throws Exception {
+    useReadonlyCredentialsFromFile();
+
+    try (SolrZkClient zkClient = new SolrZkClient(zkServer.getZkAddress(), AbstractZkTestCase.TIMEOUT)) {
+      doTest(zkClient,
+          true, true, false, false, false,
+          false, false, false, false, false);
+    }
+  }
+
+  @Test
+  public void testAllCredentialsFromFile() throws Exception {
+    useAllCredentialsFromFile();
+
+    try (SolrZkClient zkClient = new SolrZkClient(zkServer.getZkAddress(), AbstractZkTestCase.TIMEOUT)) {
+      doTest(zkClient,
+          true, true, true, true, true,
+          true, true, true, true, true);
     }
   }
 
@@ -250,6 +276,33 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
     System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, "readonlyACLUsername");
     System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME, "readonlyACLPassword");
   }
+
+  private void useReadonlyCredentialsFromFile() throws IOException {
+    useCredentialsFromFile("readonlyACLUsername", "readonlyACLPassword");
+  }
+
+  private void useAllCredentialsFromFile() throws IOException {
+    useCredentialsFromFile("connectAndAllACLUsername", "connectAndAllACLPassword");
+  }
+
+  private void useCredentialsFromFile(String username, String password) throws IOException {
+    clearSecuritySystemProperties();
+
+    System.setProperty(SolrZkClient.ZK_CRED_PROVIDER_CLASS_NAME_VM_PARAM_NAME, VMParamsSingleSetCredentialsDigestZkCredentialsProvider.class.getName());
+
+    Properties props = new Properties();
+    props.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, username);
+    props.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME, password);
+    saveCredentialsFile(props);
+  }
+
+  private void saveCredentialsFile(Properties props) throws IOException {
+    File credentialsFile = createTempFile("zk-creds", "properties").toFile();
+    try (FileWriter writer = new FileWriter(credentialsFile, StandardCharsets.UTF_8)) {
+      props.store(writer, "test");
+    }
+    System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_FILE_VM_PARAM_NAME, credentialsFile.getAbsolutePath());
+  }
   
   private void setSecuritySystemProperties() {
     System.setProperty(SolrZkClient.ZK_ACL_PROVIDER_CLASS_NAME_VM_PARAM_NAME, VMParamsAllAndReadonlyDigestZkACLProvider.class.getName());
@@ -267,6 +320,7 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
     System.clearProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME);
     System.clearProperty(VMParamsAllAndReadonlyDigestZkACLProvider.DEFAULT_DIGEST_READONLY_USERNAME_VM_PARAM_NAME);
     System.clearProperty(VMParamsAllAndReadonlyDigestZkACLProvider.DEFAULT_DIGEST_READONLY_PASSWORD_VM_PARAM_NAME);
+    System.clearProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_FILE_VM_PARAM_NAME);
   }
   
 }

--- a/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/VMParamsZkACLAndCredentialsProvidersTest.java
@@ -16,12 +16,11 @@
  */
 package org.apache.solr.cloud;
 
+import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -298,8 +297,8 @@ public class VMParamsZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
 
   private void saveCredentialsFile(Properties props) throws IOException {
     Path tmp = createTempFile("zk-creds", "properties");
-    try (OutputStream os = Files.newOutputStream(tmp)) {
-      props.store(os, "test");
+    try (FileWriter w = new FileWriter(tmp.toFile(), StandardCharsets.UTF_8)) {
+      props.store(w, "test");
     }
     System.setProperty(VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_FILE_VM_PARAM_NAME, tmp.toAbsolutePath().toString());
   }

--- a/solr/solr-ref-guide/src/zookeeper-access-control.adoc
+++ b/solr/solr-ref-guide/src/zookeeper-access-control.adoc
@@ -86,6 +86,7 @@ It supports at most one set of credentials.
 The username and password are defined by system properties `zkDigestUsername` and `zkDigestPassword`.
 This set of credentials will be added to the list of credentials returned by `getCredentials()` if both username and password are provided.
 ** If the one set of credentials above is not added to the list, this implementation will fall back to default behavior and use the (empty) credentials list from `DefaultZkCredentialsProvider`.
+** Alternatively, you can set the `zkDigestCredentialsFile` system property to load the `zkDigestUsername` and `zkDigestPassword` from a file instead of exposing the credentials as system properties. The provided file must be a Java properties file and contain both the `zkDigestUsername` and `zkDigestPassword` properties.
 
 === Controlling ACLs
 
@@ -110,6 +111,7 @@ The two sets of roles will be defined as:
 *** The permission is `READ` and the schema is `digest`.
 *** The username and password are defined by system properties `zkDigestReadonlyUsername` and `zkDigestReadonlyPassword`, respectively.
 *** This ACL will not be added to the list of ACLs unless both username and password are provided.
+** Alternatively, you can set the `zkDigestCredentialsFile` system property to load the `zkDigestUsername` and `zkDigestPassword` from a file instead of exposing the credentials as system properties. The provided file must be a Java properties file and contain both the `zkDigestUsername` and `zkDigestPassword` properties for the `ALL` user, as well as the `zkDigestReadonlyUsername` and `zkDigestReadonlyPassword` properties for the `READONLY` user.
 * `org.apache.solr.common.cloud.SaslZkACLProvider`: Requires SASL authentication.
 Gives all permissions for the user specified in system property `solr.authorization.superuser` (default: `solr`) when using SASL, and gives read permissions for anyone else.
 Designed for a setup where configurations have already been set up and will not be modified, or where configuration changes are controlled via Solr APIs.

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsAllAndReadonlyDigestZkACLProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsAllAndReadonlyDigestZkACLProvider.java
@@ -19,12 +19,16 @@ package org.apache.solr.common.cloud;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.solr.common.StringUtils;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
+
+import static org.apache.solr.common.cloud.VMParamsSingleSetCredentialsDigestZkCredentialsProvider.DEFAULT_DIGEST_FILE_VM_PARAM_NAME;
+import static org.apache.solr.common.cloud.VMParamsSingleSetCredentialsDigestZkCredentialsProvider.readCredentialsFile;
 
 public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkACLProvider {
 
@@ -35,6 +39,7 @@ public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkAC
   final String zkDigestAllPasswordVMParamName;
   final String zkDigestReadonlyUsernameVMParamName;
   final String zkDigestReadonlyPasswordVMParamName;
+  final Properties credentialsProps;
   
   public VMParamsAllAndReadonlyDigestZkACLProvider() {
     this(
@@ -51,6 +56,9 @@ public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkAC
     this.zkDigestAllPasswordVMParamName = zkDigestAllPasswordVMParamName;
     this.zkDigestReadonlyUsernameVMParamName = zkDigestReadonlyUsernameVMParamName;
     this.zkDigestReadonlyPasswordVMParamName = zkDigestReadonlyPasswordVMParamName;
+
+    String pathToFile = System.getProperty(DEFAULT_DIGEST_FILE_VM_PARAM_NAME);
+    credentialsProps = (pathToFile != null) ? readCredentialsFile(pathToFile) : System.getProperties();
   }
 
   /**
@@ -70,10 +78,10 @@ public class VMParamsAllAndReadonlyDigestZkACLProvider extends SecurityAwareZkAC
   }
 
   protected List<ACL> createACLsToAdd(boolean includeReadOnly) {
-    String digestAllUsername = System.getProperty(zkDigestAllUsernameVMParamName);
-    String digestAllPassword = System.getProperty(zkDigestAllPasswordVMParamName);
-    String digestReadonlyUsername = System.getProperty(zkDigestReadonlyUsernameVMParamName);
-    String digestReadonlyPassword = System.getProperty(zkDigestReadonlyPasswordVMParamName);
+    String digestAllUsername = credentialsProps.getProperty(zkDigestAllUsernameVMParamName);
+    String digestAllPassword = credentialsProps.getProperty(zkDigestAllPasswordVMParamName);
+    String digestReadonlyUsername = credentialsProps.getProperty(zkDigestReadonlyUsernameVMParamName);
+    String digestReadonlyPassword = credentialsProps.getProperty(zkDigestReadonlyPasswordVMParamName);
 
     return createACLsToAdd(includeReadOnly,
         digestAllUsername, digestAllPassword,

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsSingleSetCredentialsDigestZkCredentialsProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/VMParamsSingleSetCredentialsDigestZkCredentialsProvider.java
@@ -16,21 +16,38 @@
  */
 package org.apache.solr.common.cloud;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Properties;
 
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.StringUtils;
 
 public class VMParamsSingleSetCredentialsDigestZkCredentialsProvider extends DefaultZkCredentialsProvider {
-  
+
+  public static final String DEFAULT_DIGEST_FILE_VM_PARAM_NAME = "zkDigestCredentialsFile";
   public static final String DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME = "zkDigestUsername";
   public static final String DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME = "zkDigestPassword";
+
+  static Properties readCredentialsFile(String pathToFile) throws SolrException {
+    Properties props = new Properties();
+    try (Reader reader = new InputStreamReader(new FileInputStream(pathToFile), StandardCharsets.UTF_8)) {
+      props.load(reader);
+    } catch (IOException ioExc) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, ioExc);
+    }
+    return props;
+  }
   
   final String zkDigestUsernameVMParamName;
   final String zkDigestPasswordVMParamName;
-  
+
   public VMParamsSingleSetCredentialsDigestZkCredentialsProvider() {
     this(DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME);
   }
@@ -42,9 +59,13 @@ public class VMParamsSingleSetCredentialsDigestZkCredentialsProvider extends Def
 
   @Override
   protected Collection<ZkCredentials> createCredentials() {
-    List<ZkCredentials> result = new ArrayList<ZkCredentials>();
-    String digestUsername = System.getProperty(zkDigestUsernameVMParamName);
-    String digestPassword = System.getProperty(zkDigestPasswordVMParamName);
+    List<ZkCredentials> result = new ArrayList<>();
+
+    String pathToFile = System.getProperty(DEFAULT_DIGEST_FILE_VM_PARAM_NAME);
+    Properties props = (pathToFile != null) ? readCredentialsFile(pathToFile) : System.getProperties();
+
+    String digestUsername = props.getProperty(zkDigestUsernameVMParamName);
+    String digestPassword = props.getProperty(zkDigestPasswordVMParamName);
     if (!StringUtils.isEmpty(digestUsername) && !StringUtils.isEmpty(digestPassword)) {
       result.add(new ZkCredentials("digest",
           (digestUsername + ":" + digestPassword).getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-15525

# Description

Added new Java system property `zkDigestCredentialsFile` to allow loading of zk creds from a file instead of from system properties.

# Tests

Added to existing unit test `VMParamsZkACLAndCredentialsProvidersTest` to use the new `zkDigestCredentialsFile` feature.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
