### PR TITLE
SOLR-15496 LTRRescorer unnecessarily (re)creates Comparator

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -381,7 +381,7 @@ Optimizations
 ---------------------
 * SOLR-15433: Replace transient core cache LRU by Caffeine cache. (Bruno Roustant)
 
-* SOLR-15496: Reuse comparator objects in contrib/ltr rescorer classes. (Marcos Pontes via Christine Poerschke)
+* SOLR-15496: Reuse comparator objects in contrib/ltr rescorer classes. (marcosfpr via Christine Poerschke)
 
 Bug Fixes
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -381,6 +381,8 @@ Optimizations
 ---------------------
 * SOLR-15433: Replace transient core cache LRU by Caffeine cache. (Bruno Roustant)
 
+* SOLR-15496: Reuse comparator objects in contrib/ltr rescorer classes. (Marcos Pontes via Christine Poerschke)
+
 Bug Fixes
 ---------------------
 * SOLR-15311: Support async parameter in MODIFYCOLLECTION

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -53,7 +53,7 @@ public class LTRRescorer extends Rescorer {
     this.scoringQuery = scoringQuery;
   }
 
-  final protected static Comparator<ScoreDoc> docComparator = (a, b) -> a.doc - b.doc;
+  final private static Comparator<ScoreDoc> docComparator = Comparator.comparingInt(a -> a.doc);
 
   final protected static Comparator<ScoreDoc> scoreComparator = (a, b) -> {
     // Sort by score descending, then docID ascending:
@@ -141,10 +141,11 @@ public class LTRRescorer extends Rescorer {
 
     scoreFeatures(searcher,topN, modelWeight, firstPassResults, leaves, reranked);
     // Must sort all documents that we reranked, and then select the top
-    sortByScore(reranked);
+    Arrays.sort(reranked, scoreComparator);
     return reranked;
   }
 
+  @Deprecated
   protected static void sortByScore(ScoreDoc[] reranked) {
     Arrays.sort(reranked, scoreComparator);
   }

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -53,6 +53,21 @@ public class LTRRescorer extends Rescorer {
     this.scoringQuery = scoringQuery;
   }
 
+  final protected static Comparator<ScoreDoc> docComparator = (a, b) -> a.doc - b.doc;
+
+  final protected static Comparator<ScoreDoc> scoreComparator = (a, b) -> {
+    // Sort by score descending, then docID ascending:
+    if (a.score > b.score) {
+      return -1;
+    } else if (a.score < b.score) {
+      return 1;
+    } else {
+      // This subtraction can't overflow int
+      // because docIDs are >= 0:
+      return a.doc - b.doc;
+    }
+  };
+
   protected static void heapAdjust(ScoreDoc[] hits, int size, int root) {
     final ScoreDoc doc = hits[root];
     final float score = doc.score;
@@ -131,31 +146,12 @@ public class LTRRescorer extends Rescorer {
   }
 
   protected static void sortByScore(ScoreDoc[] reranked) {
-    Arrays.sort(reranked, new Comparator<ScoreDoc>() {
-      @Override
-      public int compare(ScoreDoc a, ScoreDoc b) {
-        // Sort by score descending, then docID ascending:
-        if (a.score > b.score) {
-          return -1;
-        } else if (a.score < b.score) {
-          return 1;
-        } else {
-          // This subtraction can't overflow int
-          // because docIDs are >= 0:
-          return a.doc - b.doc;
-        }
-      }
-    });
+    Arrays.sort(reranked, scoreComparator);
   }
 
   protected static ScoreDoc[] getFirstPassDocsRanked(TopDocs firstPassTopDocs) {
     final ScoreDoc[] hits = firstPassTopDocs.scoreDocs;
-    Arrays.sort(hits, new Comparator<ScoreDoc>() {
-      @Override
-      public int compare(ScoreDoc a, ScoreDoc b) {
-        return a.doc - b.doc;
-      }
-    });
+    Arrays.sort(hits, docComparator);
 
     assert firstPassTopDocs.totalHits.relation == TotalHits.Relation.EQUAL_TO;
     return hits;

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
@@ -18,6 +18,7 @@ package org.apache.solr.ltr.interleaving;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -104,7 +105,7 @@ public class LTRInterleavingRescorer extends LTRRescorer {
 
     for (int i = 0; i < rerankingQueries.length; i++) {
       if (originalRankingIndex == null || originalRankingIndex != i) {
-        sortByScore(reRankedPerModel[i]);
+        Arrays.sort(reRankedPerModel[i], scoreComparator);
       }
     }
 


### PR DESCRIPTION
…objects

https://issues.apache.org/jira/browse/SOLR-15496

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

A static instance of the comparator(s) could be created and reused.

# Solution

I just created two static comparators instead of creating both each call

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
