### PR TITLE
SOLR-15566: Clarify ref guide documentation about SQL queries with SELECT * requiring a LIMIT clause

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -396,7 +396,7 @@ Bug Fixes
 
 Other Changes
 ---------------------
-(No changes)
+* SOLR-15566: Clarify ref guide documentation about SQL queries with `SELECT *` requiring a `LIMIT` clause (Timothy Potter)
 
 ==================  8.9.0 ==================
 

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -2218,4 +2218,18 @@ public class TestSQLHandler extends SolrCloudTestCase {
     String country = id % 2 == 0 ? "US" : "CA";
     return updateRequest.add("id", String.valueOf(id), "str_s", String.format(Locale.ROOT, padFmt, id % cardinality), "country_s", country);
   }
+
+  @Test
+  public void testSelectStarWithLimit() throws Exception {
+    new UpdateRequest()
+        .add("id", "1", "a_s", "hello-1", "b_s", "foo", "c_s", "bar", "d_s", "x")
+        .add("id", "2", "a_s", "world-2", "b_s", "foo", "a_i", "2", "d_s", "a")
+        .add("id", "3", "a_s", "hello-3", "b_s", "foo", "c_s", "bar", "d_s", "x")
+        .add("id", "4", "a_s", "world-4", "b_s", "foo", "a_i", "3", "d_s", "b")
+        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    expectResults("SELECT * FROM $ALIAS LIMIT 100", 4);
+    // select * w/o limit is not supported by Solr SQL
+    expectThrows(IOException.class, () -> expectResults("SELECT * FROM $ALIAS", -1));
+  }
 }

--- a/solr/solr-ref-guide/src/parallel-sql-interface.adoc
+++ b/solr/solr-ref-guide/src/parallel-sql-interface.adoc
@@ -201,10 +201,14 @@ The SQL parser being used by Solr to translate the SQL statements is case insens
 However, for ease of reading, all examples on this page use capitalized keywords.
 ====
 
-.SELECT * is not supported
+.SELECT * is only supported when using LIMIT
 [IMPORTANT]
 ====
-The SQL parser being used by Solr does not support the SELECT * syntax, you must specify each field you wish to return.
+In general, you should project the fields you need to return for each query explicitly and avoid using `select *`, which is generally considered a bad practice and
+can lead to unexpected results when the underlying Solr schema changes.
+However, Solr does support `select *` for queries that also include a `LIMIT` clause.
+All stored fields and the `score` will be included in the results.
+Without a `LIMIT` clause, only fields with docValues enabled can be returned.
 ====
 
 === Escaping Reserved Words


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-15566


# Description

Improved the docs around `select *` in the ref guide

# Tests

Added a simple unit test for coverage of `select *`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
