### PR TITLE
SOLR-15569: Split on the right subtree when node value == threshold on MultipleAdditiveTreesModel

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/model/MultipleAdditiveTreesModel.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/model/MultipleAdditiveTreesModel.java
@@ -122,7 +122,6 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
   }
 
   public class RegressionTreeNode {
-    private static final float NODE_SPLIT_SLACK = 1E-6f;
 
     private float value = 0f;
     private String feature;
@@ -149,11 +148,11 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
     }
 
     public void setThreshold(float threshold) {
-      this.threshold = threshold + NODE_SPLIT_SLACK;
+      this.threshold = threshold;
     }
 
     public void setThreshold(String threshold) {
-      this.threshold = Float.parseFloat(threshold) + NODE_SPLIT_SLACK;
+      this.threshold = Float.parseFloat(threshold);
     }
 
     @SuppressWarnings({"unchecked"})
@@ -177,7 +176,7 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
         sb.append(value);
       } else {
         sb.append("(feature=").append(feature);
-        sb.append(",threshold=").append(threshold.floatValue()-NODE_SPLIT_SLACK);
+        sb.append(",threshold=").append(threshold.floatValue());
         sb.append(",left=").append(left);
         sb.append(",right=").append(right);
         sb.append(')');
@@ -292,10 +291,10 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
         return 0f;
       }
 
-      if (featureVector[regressionTreeNode.featureIndex] <= regressionTreeNode.threshold) {
-        regressionTreeNode = regressionTreeNode.left;
-      } else {
+      if (featureVector[regressionTreeNode.featureIndex] >= regressionTreeNode.threshold) {
         regressionTreeNode = regressionTreeNode.right;
+      } else {
+        regressionTreeNode = regressionTreeNode.left;
       }
     }
   }

--- a/solr/contrib/ltr/src/test-files/modelExamples/multipleadditivetreesmodel_split_at_threshold.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/multipleadditivetreesmodel_split_at_threshold.json
@@ -1,0 +1,23 @@
+{
+    "class":"org.apache.solr.ltr.model.MultipleAdditiveTreesModel",
+    "name":"multipleadditivetreesmodel_split_at_threshold",
+    "features":[
+        { "name": "constantScoreToForceMultipleAdditiveTreesScoreAllDocs"}
+    ],
+    "params":{
+        "trees": [
+            {
+                "weight" : "1f",
+                "root": {
+                    "feature": "constantScoreToForceMultipleAdditiveTreesScoreAllDocs",
+                    "threshold": "1.0f",
+                    "left" : {
+                        "value" : "-100"
+                    }, "right": {
+                        "value" : "100"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/solr/contrib/ltr/src/test-files/modelExamples/multipleadditivetreesmodel_split_left_at_threshold.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/multipleadditivetreesmodel_split_left_at_threshold.json
@@ -1,0 +1,24 @@
+{
+    "class":"org.apache.solr.ltr.model.MultipleAdditiveTreesModel",
+    "name":"multipleadditivetreesmodel_split_at_threshold",
+    "features":[
+        { "name": "constantScoreToForceMultipleAdditiveTreesScoreAllDocs"}
+    ],
+    "params":{
+        "splitToRight": false,
+        "trees": [
+            {
+                "weight" : "1f",
+                "root": {
+                    "feature": "constantScoreToForceMultipleAdditiveTreesScoreAllDocs",
+                    "threshold": "1.0f",
+                    "left" : {
+                        "value" : "-100"
+                    }, "right": {
+                        "value" : "100"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/solr/contrib/ltr/src/test-files/modelExamples/multipleadditivetreesmodel_split_right_at_threshold.json
+++ b/solr/contrib/ltr/src/test-files/modelExamples/multipleadditivetreesmodel_split_right_at_threshold.json
@@ -5,6 +5,7 @@
         { "name": "constantScoreToForceMultipleAdditiveTreesScoreAllDocs"}
     ],
     "params":{
+        "splitToRight": true,
         "trees": [
             {
                 "weight" : "1f",

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRQParserExplain.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRQParserExplain.java
@@ -143,14 +143,14 @@ public class TestLTRQParserExplain extends TestRerankBase {
         "/query" + query.toQueryString(),
         "/debug/explain/7=='\n" +
             "65.0 = MultipleAdditiveTreesModel(name=external_model_binary_feature,trees="+trees+") model applied to features, sum of:\n" +
-            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.500001, Go Left | val: 0.0\n" +
-            "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.500001, Go Right | val: 65.0\n'}");
+            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.5, Go Left | val: 0.0\n" +
+            "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.5, Go Right | val: 65.0\n'}");
     assertJQ(
         "/query" + query.toQueryString(),
         "/debug/explain/9=='\n" +
             "65.0 = MultipleAdditiveTreesModel(name=external_model_binary_feature,trees="+trees+") model applied to features, sum of:\n" +
-            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.500001, Go Left | val: 0.0\n" +
-            "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.500001, Go Right | val: 65.0\n'}");
+            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.5, Go Left | val: 0.0\n" +
+            "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.5, Go Right | val: 65.0\n'}");
   }
 
   @Test

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRQParserExplain.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRQParserExplain.java
@@ -143,13 +143,13 @@ public class TestLTRQParserExplain extends TestRerankBase {
         "/query" + query.toQueryString(),
         "/debug/explain/7=='\n" +
             "65.0 = MultipleAdditiveTreesModel(name=external_model_binary_feature,trees="+trees+") model applied to features, sum of:\n" +
-            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.5, Go Left | val: 0.0\n" +
+            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 < 0.5, Go Left | val: 0.0\n" +
             "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.5, Go Right | val: 65.0\n'}");
     assertJQ(
         "/query" + query.toQueryString(),
         "/debug/explain/9=='\n" +
             "65.0 = MultipleAdditiveTreesModel(name=external_model_binary_feature,trees="+trees+") model applied to features, sum of:\n" +
-            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 <= 0.5, Go Left | val: 0.0\n" +
+            "  0.0 = tree 0 | \\'user_device_smartphone\\':0.0 < 0.5, Go Left | val: 0.0\n" +
             "  65.0 = tree 1 | \\'user_device_tablet\\':1.0 > 0.5, Go Right | val: 65.0\n'}");
   }
 

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/model/TestMultipleAdditiveTreesModel.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/model/TestMultipleAdditiveTreesModel.java
@@ -119,6 +119,31 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
+  public void testMultipleAdditiveTreesSplitAtThreshold() throws Exception {
+    loadFeatures("multipleadditivetreesmodel_features.json");
+    loadModels("multipleadditivetreesmodel_split_at_threshold.json");
+
+    doTestSplitsRightAtIntegerThresholdValues();
+  }
+
+  private void doTestSplitsRightAtIntegerThresholdValues() throws Exception {
+
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    query.add("rows", "3");
+    query.add("fl", "*,score");
+
+    // Regular scores
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==1.0");
+
+    // No match scores since user_query not passed in to external feature info
+    // and feature depended on it.
+    query.add("rq", "{!ltr reRankDocs=3 model=multipleadditivetreesmodel_split_at_threshold efi.user_query=dsjkafljjk}");
+
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/score==100.0");
+  }
+
+  @Test
   public void multipleAdditiveTreesTestNoParams() throws Exception {
     final ModelException expectedException =
         new ModelException("no trees declared for model multipleadditivetreesmodel_no_params");
@@ -249,5 +274,5 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
     });
     assertEquals(expectedException.toString(), ex.toString());
   }
- 
+
 }

--- a/solr/solr-ref-guide/src/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/src/learning-to-rank.adoc
@@ -863,6 +863,7 @@ Changes made to managed resources are not applied to the active Solr components 
     { "name" : "originalScore" }
   ],
   "params" : {
+    "splitToRight": false,
     "trees" : [
       {
         "weight" : "1",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15569

# Description
Fixes an issue where the MultipleAdditiveTreesModel does not split correctly when the tree node value equals the split threshold. This was discovered while testing a translated XGBoost model for LTR and getting slightly different score results.

*NOTE:* The previous logic split to the left and also added a NODE_SPLIT_SLACK that has been removed. Not sure if this original logic was part of another model, or served another purpose.

# Solution

- Changed split logic to split on the right subtree when the node value equals the threshold
- Removed NODE_SPLIT_SLACK completely

# Tests

- Added TestMultipleAdditiveTreesModel.testMultipleAdditiveTreesSplitAtThreshold test to showcase the issue

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
