### PR TITLE
SOLR-15570: Check stored or docValues when merging fields from the Luke schema response

### DIFF
--- a/solr/core/src/test-files/solr/configsets/sql/conf/schema.xml
+++ b/solr/core/src/test-files/solr/configsets/sql/conf/schema.xml
@@ -66,6 +66,9 @@
   <field name="pdatex" type="pdatex" indexed="true" stored="true"/>
   <field name="pdatexs" type="pdatex" indexed="true" stored="true" multiValued="true"/>
 
+  <field name="notstored" type="string" indexed="true" docValues="false" stored="false"/>
+  <field name="dvonly" type="string" docValues="true" stored="false"/>
+
   <!-- Field type demonstrating an Analyzer failure -->
   <fieldType name="failtype1" class="solr.TextField">
     <analyzer type="index">

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -2236,16 +2236,21 @@ public class TestSQLHandler extends SolrCloudTestCase {
   @Test
   public void testSelectEmptyField() throws Exception {
     new UpdateRequest()
-        .add("id", "01")
-        .add("id", "02")
-        .add("id", "03")
-        .add("id", "04")
-        .add("id", "05")
+        .add("id", "01", "notstored", "X", "dvonly", "Y")
+        .add("id", "02", "notstored", "X", "dvonly", "Y")
+        .add("id", "03", "notstored", "X", "dvonly", "Y")
+        .add("id", "04", "notstored", "X", "dvonly", "Y")
+        .add("id", "05", "notstored", "X", "dvonly", "Y")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     // stringx is declared in the schema but has no docs
     expectResults("SELECT id, stringx FROM $ALIAS", 5);
+    expectResults("SELECT id, stringx FROM $ALIAS LIMIT 10", 5);
+    expectResults("SELECT id, stringx, dvonly FROM $ALIAS", 5);
+    expectResults("SELECT id, stringx, dvonly FROM $ALIAS LIMIT 10", 5);
+
     // notafield_i matches a dynamic field pattern but has no docs, so don't allow this
     expectThrows(IOException.class, () -> expectResults("SELECT id, stringx, notafield_i FROM $ALIAS", 5));
+    expectThrows(IOException.class, () -> expectResults("SELECT id, stringx, notstored FROM $ALIAS", 5));
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15570

# Description

Adding to previous commit: https://github.com/apache/solr/commit/6056b6814de1a93cfbf14858bfa5e6026e86d16d
Need to check if a field is either stored or has docValues enabled.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
