### PR TITLE
SOLR-15575: Propagate request level basic auth creds from the top-level request to internally used async requests

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -404,6 +404,9 @@ Bug Fixes
 
 * SOLR-14506: Fix NPE in COLSTATUS for collections using implicit routing. (Austin Weidler, ab)
 
+* SOLR-15575: Propagate request level basic auth creds from the top-level async CollectionAdminRequest to internally
+  used async requests, such as async status checking (Timothy Potter)
+
 Other Changes
 ---------------------
 * SOLR-15566: Clarify ref guide documentation about SQL queries with `SELECT *` requiring a `LIMIT` clause (Timothy Potter)

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
@@ -89,7 +89,7 @@ public class TestPullReplicaWithAuth extends SolrCloudTestCase {
   public void testPKIAuthWorksForPullReplication() throws Exception {
     int numPullReplicas = 2;
     withBasicAuth(CollectionAdminRequest.createCollection(collectionName, "conf", 1, 1, 0, numPullReplicas))
-        .process(cluster.getSolrClient());
+        .processAndWait(cluster.getSolrClient(), 10);
     waitForState("Expected collection to be created with 1 shard and " + (numPullReplicas + 1) + " replicas",
         collectionName, clusterShape(1, numPullReplicas + 1));
     DocCollection docCollection =

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
@@ -127,6 +127,19 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse> 
   }
 
   /**
+   * Take the request specific basic auth creds on this admin request and propagate them to a related request if does
+   * not already have credentials set, such as a CollectionAdminRequest.RequestStatus when doing async requests.
+   */
+  protected <T extends CollectionAdminRequest<? extends CollectionAdminResponse>> T propagateBasicAuthCreds(T req) {
+    String user = getBasicAuthUser();
+    String pass = getBasicAuthPassword();
+    if (user != null && pass != null && req.getBasicAuthUser() == null) {
+      req.setBasicAuthCredentials(user, pass);
+    }
+    return req;
+  }
+
+  /**
    * Base class for asynchronous collection admin requests
    */
   public abstract static class AsyncCollectionAdminRequest extends CollectionAdminRequest<CollectionAdminResponse> {
@@ -207,7 +220,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse> 
     public RequestStatusState processAndWait(String asyncId, SolrClient client, long timeoutSeconds)
         throws IOException, SolrServerException, InterruptedException {
       processAsync(asyncId, client);
-      return requestStatus(asyncId).waitFor(client, timeoutSeconds);
+      return propagateBasicAuthCreds(requestStatus(asyncId)).waitFor(client, timeoutSeconds);
     }
 
     @Override
@@ -1617,7 +1630,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse> 
       while (System.nanoTime() < finishTime) {
         state = this.process(client).getRequestStatus();
         if (state == RequestStatusState.COMPLETED || state == RequestStatusState.FAILED) {
-          deleteAsyncId(requestId).process(client);
+          propagateBasicAuthCreds(deleteAsyncId(requestId)).process(client);
           return state;
         }
         TimeUnit.SECONDS.sleep(1);


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-15575

See trivial code changes

Updated an existing unit test that already has the security wired into test cluster setup to verify this fix.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
