### PR TITLE
SOLR-15576: Allow filtering on ISO-8601 formatted timestamp literals in SQL WHERE clause

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -387,6 +387,8 @@ Improvements
 
 * SOLR-15564: Improve filtering expressions in /admin/metrics. (ab)
 
+* SOLR-15576: Allow filtering on ISO-8601 formatted timestamp literals in SQL WHERE clause (Timothy Potter)
+
 Optimizations
 ---------------------
 * SOLR-15433: Replace transient core cache LRU by Caffeine cache. (Bruno Roustant)

--- a/solr/core/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/core/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rex.*;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -218,7 +219,8 @@ class SolrFilter extends Filter implements SolrRel {
       terms = terms.replace("'", "").replace('%', '*').replace('_', '?');
       boolean wrappedQuotes = false;
       if (!terms.startsWith("(") && !terms.startsWith("[") && !terms.startsWith("{")) {
-        terms = "\"" + terms + "\"";
+        // restore the * and ? after escaping
+        terms = "\"" + ClientUtils.escapeQueryChars(terms).replace("\\*", "*").replace("\\?", "?") + "\"";
         wrappedQuotes = true;
       }
 
@@ -271,7 +273,7 @@ class SolrFilter extends Filter implements SolrRel {
 
       boolean wrappedQuotes = false;
       if (!terms.startsWith("(") && !terms.startsWith("[") && !terms.startsWith("{")) {
-        terms = "\"" + terms + "\"";
+        terms = "\"" + ClientUtils.escapeQueryChars(terms) + "\"";
         wrappedQuotes = true;
       }
 

--- a/solr/core/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/core/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -348,6 +348,14 @@ class SolrFilter extends Filter implements SolrRel {
         return translateBinary2(((RexCall)left).operands.get(0), ((RexCall)right).operands.get(0));
       }
 
+      // for WHERE clause like: pdatex >= '2021-07-13T15:12:10.037Z'
+      if (left.getKind() == SqlKind.INPUT_REF && right.getKind() == SqlKind.CAST) {
+        final RexCall cast = ((RexCall)right);
+        if (cast.operands.size() == 1 && cast.operands.get(0).getKind() == SqlKind.LITERAL) {
+          return translateBinary2(left, cast.operands.get(0));
+        }
+      }
+
       throw new AssertionError("cannot translate call " + call);
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/core/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -339,9 +339,13 @@ class SolrFilter extends Filter implements SolrRel {
       if (a != null) {
         return a;
       }
-      final Pair<String, RexLiteral> b = translateBinary2(right, left);
-      if (b != null) {
-        return b;
+
+      // we can swap these if doing an equals
+      if (call.op.kind == SqlKind.EQUALS) {
+        final Pair<String, RexLiteral> b = translateBinary2(right, left);
+        if (b != null) {
+          return b;
+        }
       }
 
       if (left.getKind() == SqlKind.CAST && right.getKind() == SqlKind.CAST) {
@@ -501,10 +505,14 @@ class SolrFilter extends Filter implements SolrRel {
         }
         return a;
       }
-      final Pair<String, RexLiteral> b = translateBinary2(right, left);
-      if (b != null) {
-        return b;
+
+      if (call.op.kind == SqlKind.EQUALS) {
+        final Pair<String, RexLiteral> b = translateBinary2(right, left);
+        if (b != null) {
+          return b;
+        }
       }
+
       throw new AssertionError("cannot translate call " + call);
     }
 

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -452,6 +452,8 @@ public class TestSQLHandler extends SolrCloudTestCase {
     tuple = tuples.get(1);
     assertEquals("8", tuple.get("id"));
 
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE str_s = 'a'", 2);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE 'a' = str_s", 2);
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -338,10 +338,10 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "2", "text_t", "XXXX XXXX", "str_s", "b", "field_i", "8")
         .add("id", "3", "text_t", "XXXX XXXX", "str_s", "a", "field_i", "20")
         .add("id", "4", "text_t", "XXXX XXXX", "str_s", "b", "field_i", "11")
-        .add("id", "5", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "30")
-        .add("id", "6", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "40")
-        .add("id", "7", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "50")
-        .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
+        .add("id", "5", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "30", "specialchars_s", "witha|pipe")
+        .add("id", "6", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "40", "specialchars_s", "witha\\slash")
+        .add("id", "7", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "50", "specialchars_s", "witha!bang")
+        .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60", "specialchars_s", "witha\"quote")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
@@ -456,6 +456,10 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults("SELECT id FROM $ALIAS WHERE 'a' = str_s", 2);
     expectResults("SELECT id FROM $ALIAS WHERE str_s <> 'c'", 4);
     expectResults("SELECT id FROM $ALIAS WHERE 'c' <> str_s", 4);
+    expectResults("SELECT id FROM $ALIAS WHERE specialchars_s = 'witha\"quote'", 1);
+    expectResults("SELECT id FROM $ALIAS WHERE specialchars_s = 'witha|pipe'", 1);
+    expectResults("SELECT id FROM $ALIAS WHERE specialchars_s LIKE 'with%'", 4);
+    expectResults("SELECT id FROM $ALIAS WHERE specialchars_s LIKE 'witha|%'", 1);
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -452,8 +452,10 @@ public class TestSQLHandler extends SolrCloudTestCase {
     tuple = tuples.get(1);
     assertEquals("8", tuple.get("id"));
 
-    expectResults("SELECT id, pdatex FROM $ALIAS WHERE str_s = 'a'", 2);
-    expectResults("SELECT id, pdatex FROM $ALIAS WHERE 'a' = str_s", 2);
+    expectResults("SELECT id FROM $ALIAS WHERE str_s = 'a'", 2);
+    expectResults("SELECT id FROM $ALIAS WHERE 'a' = str_s", 2);
+    expectResults("SELECT id FROM $ALIAS WHERE str_s <> 'c'", 4);
+    expectResults("SELECT id FROM $ALIAS WHERE 'c' <> str_s", 4);
   }
 
   @Test
@@ -2072,6 +2074,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= '2021-07-13T15:12:10.037Z'", 2);
     expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex < '2021-07-13T15:12:10.037Z'", 1);
     expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex = '2021-07-13T15:12:10.037Z'", 1);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex <> '2021-07-13T15:12:10.037Z'", 2);
     expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex BETWEEN '2021-07-13T15:12:09.037Z' AND '2021-07-13T15:12:10.037Z' ORDER BY pdatex ASC", 2);
     expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= '2021-07-13T15:12:10.037Z'", 2);
     expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= '2021-07-13T15:12:10.037Z' ORDER BY pdatex ASC LIMIT 10", 2);

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -1649,6 +1649,17 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assert (tuple.EOF);
     assert (tuple.EXCEPTION);
     assert (tuple.getException().contains("No match found for function signature blah"));
+
+    // verify exception message formatting with wildcard query
+    sParams = mapParams(CommonParams.QT, "/sql", "aggregationMode", "map_reduce",
+        "stmt",
+        "select str_s from collection1 where not_a_field LIKE 'foo%'");
+
+    solrStream = new SolrStream(baseUrl, sParams);
+    tuple = getTuple(new ExceptionStream(solrStream));
+    assert (tuple.EOF);
+    assert (tuple.EXCEPTION);
+    assert (tuple.getException().contains("Column 'not_a_field' not found in any table"));
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -2059,6 +2059,23 @@ public class TestSQLHandler extends SolrCloudTestCase {
   }
 
   @Test
+  public void testISO8601TimestampFiltering() throws Exception {
+    new UpdateRequest()
+        .add("id", "1", "pdatex", "2021-07-13T15:12:09.037Z")
+        .add("id", "2", "pdatex", "2021-07-13T15:12:10.037Z")
+        .add("id", "3", "pdatex", "2021-07-13T15:12:11.037Z")
+        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= CAST('2021-07-13 15:12:10.037' as TIMESTAMP)", 2);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= '2021-07-13T15:12:10.037Z'", 2);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex < '2021-07-13T15:12:10.037Z'", 1);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex = '2021-07-13T15:12:10.037Z'", 1);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex BETWEEN '2021-07-13T15:12:09.037Z' AND '2021-07-13T15:12:10.037Z' ORDER BY pdatex ASC", 2);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= '2021-07-13T15:12:10.037Z'", 2);
+    expectResults("SELECT id, pdatex FROM $ALIAS WHERE pdatex >= '2021-07-13T15:12:10.037Z' ORDER BY pdatex ASC LIMIT 10", 2);
+  }
+
+  @Test
   public void testAggsOnCustomFieldType() throws Exception {
     new UpdateRequest()
         .add(withMultiValuedField("pintxs", Arrays.asList(1,5),"id", "1", "tintx", "1", "pintx", "2", "tfloatx", "3.33", "pfloatx", "3.33", "tlongx", "1623875868000", "plongx", "1623875868000", "tdoublex", "3.14159265359", "pdoublex", "3.14159265359", "stringx", "A", "textx", "aaa", "pdatex", "2021-06-17T00:00:00Z"))

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
@@ -283,9 +283,7 @@ public class JDBCStream extends TupleStream implements Expressible {
       resultSet = statement.executeQuery(sqlQuery);
       resultSet.setFetchSize(fetchSize);
     } catch (SQLException e) {
-      // don't embed the exception message in the format template as wildcard '%' will throw off the formatter
-      throw new IOException(
-          String.format(Locale.ROOT, "Failed to execute sqlQuery '%s' against JDBC connection '%s'.\n", sqlQuery, connectionUrl)+e.getMessage(), e);
+      throw new IOException(String.format(Locale.ROOT, "Failed to execute sqlQuery '%s' against JDBC connection '%s'.%nCaused by: %s", sqlQuery, connectionUrl, e.getMessage()), e);
     }
     
     try{

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
@@ -283,8 +283,9 @@ public class JDBCStream extends TupleStream implements Expressible {
       resultSet = statement.executeQuery(sqlQuery);
       resultSet.setFetchSize(fetchSize);
     } catch (SQLException e) {
-      throw new IOException(String.format(Locale.ROOT, "Failed to execute sqlQuery '%s' against JDBC connection '%s'.\n"
-          + e.getMessage(), sqlQuery, connectionUrl), e);
+      // don't embed the exception message in the format template as wildcard '%' will throw off the formatter
+      throw new IOException(
+          String.format(Locale.ROOT, "Failed to execute sqlQuery '%s' against JDBC connection '%s'.\n", sqlQuery, connectionUrl)+e.getMessage(), e);
     }
     
     try{


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15576

# Description

Minor improvement for robustness of the SQL backend to allow filtering with ISO-8601 timestamp formatted literals.

# Solution

Just needed to fix the proper handling of RexNode types in the translateBinary call. Also found a bug where the left and right operands were being swapped but that's only valid for equals operator. I mean we could also adapt the operator to the swap but that seems awkward, so leaving that as an open issue for now.

# Tests

Added new unit test

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
