### PR TITLE
SOLR-15580: Allow setting the base work directory to another location…

### DIFF
--- a/solr/benchmark/README.md
+++ b/solr/benchmark/README.md
@@ -102,6 +102,21 @@ JMH comes with a variety of built-in profilers. Here is an example of using JFR:
 In this example we point to the included configuration file with configName, but you could also do something like
 settings=default or settings=profile.
 
+### Benchmark Outputs
+
+By default, output that benchmarks generate is created in the build/work directory. You can change this location by setting the workBaseDir system property like this:
+
+    -jvmArgsAppend -DworkBaseDir=/data3/bench_work
+
+If a profiler generates output, it will generally be written to the current working directory - that is the benchmark module directory itself. You can usually change this via the dir option, for example:
+
+    ./jmh.sh -prof jfr:dir=build/work/profile-results JsonFaceting
+
+### Using a Separate MiniCluster Base Directory
+
+If you have a special case MiniCluster you have generated, such as one you have prepared with very large indexes for a search benchmark run, you can change the base directory used by the profiler
+for the MiniCluster with the miniClusterBaseDir system property. This is for search based benchmarks in general and the MiniCluster wil not be removed automatically by the benchmark.
+
 ### JMH Options
 
 Some common JMH options are:

--- a/solr/benchmark/log4j2-bench.xml
+++ b/solr/benchmark/log4j2-bench.xml
@@ -48,8 +48,8 @@
 
     <RollingRandomAccessFile
         name="SlowLogFile"
-        fileName="${sys:solr.log.dir}/${sys:solr.log.name}_slow_requests.log"
-        filePattern="${sys:solr.log.dir}/${sys:solr.log.name}_slow_requests.log.%i">
+        fileName="${sys:solr.log.dir:-work/solr-logs}/${sys:solr.log.name:-solr}_slow_requests.log"
+        filePattern="${sys:solr.log.dir:-work/solr-logs}/${sys:solr.log.name:-solr}_slow_requests.log.%i">
       <PatternLayout>
         <Pattern>
           %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}] %c{1.}

--- a/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
@@ -100,7 +100,7 @@ public class MiniClusterState {
     /** The Mini cluster base dir. */
     Path miniClusterBaseDir;
 
-    /** The Allow cluster reuse. */
+    /** To Allow cluster reuse. */
     boolean allowClusterReuse = false;
 
     /** The Is warmup. */


### PR DESCRIPTION
Currently, you can specify an alternate location for a mini-cluster if it's created, but this is a kind of special case where that mini-cluster will not be removed or altered if specified this way. This allows creating something like a 150GB setup in some location and testing against it without have to recreate it each time.

It's also useful to be able to just relocate the work directory itself with no alteration in behaviors - in the case you want to use a partition with more disk space for instance.

Options