### PR TITLE
SOLR-15611: Fix ignored phrase slop after nested query parsing

### DIFF
--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -555,7 +555,7 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
 
     // only set slop of the phrase query was a result of this parser
     // and not a sub-parser.
-    if (subQParser == null) {
+    if (!field.equals(lastMagicField)) {
       if (query instanceof PhraseQuery) {
         PhraseQuery pq = (PhraseQuery) query;
         Term[] terms = pq.getTerms();
@@ -1028,8 +1028,7 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
     return out == null ? part : out.utf8ToString();
   }
 
-
-  private QParser subQParser = null;
+  private String lastMagicField = null;
 
   // Create a "normal" query from a RawQuery (or just return the current query if it's not raw)
   Query rawToNormal(Query q) {
@@ -1079,7 +1078,8 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
       if (allowSubQueryParsing && field.startsWith("_") && parser != null) {
         MagicFieldName magic = MagicFieldName.get(field);
         if (null != magic) {
-          subQParser = parser.subQuery(queryText, magic.subParser);
+          QParser subQParser = parser.subQuery(queryText, magic.subParser);
+          lastMagicField = field;
           return subQParser.getQuery();
         }
       }
@@ -1127,7 +1127,8 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
       if (allowSubQueryParsing && field.startsWith("_") && parser != null) {
         MagicFieldName magic = MagicFieldName.get(field);
         if (null != magic) {
-          subQParser = parser.subQuery(String.join(" ", queryTerms), magic.subParser);
+          QParser subQParser = parser.subQuery(String.join(" ", queryTerms), magic.subParser);
+          lastMagicField = field;
           return subQParser.getQuery();
         }
       }

--- a/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
@@ -1642,4 +1642,15 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
       }
     }
   }
+
+  @Test
+  public void testSlopAfterSubQParser() throws SyntaxError {
+    SolrQueryRequest req = req("df", "text");
+
+    String qstr1 = "foo \"foo bar\"~1";
+    String qstr2 = "_query_:\"{!term f=text}foo\" \"foo bar\"~1";
+    Query q1 = QParser.getParser(qstr1, req).getQuery();
+    Query q2 = QParser.getParser(qstr2, req).getQuery();
+    assertEquals(q1, q2);
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15611

# Description
Solr query parser is dropping phrase slops after any nested queries parsed in same query because `subQParser` not cleared after magic field processing.

# Solution
Replace `subQParser` field by `lastMagicField` and check current field name in `getFieldQuery(String field, String queryText, int slop)`.

# Tests
`_query_:"{!term f=text}foo" "foo bar"~1` and `foo "foo bar"~1` should be parsed to same queries, a new test added to TestSolrQueryParser.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
