### PR TITLE
SOLR-13138: remove deprecated SolrIndexSearcher.getLiveDocs() method

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -818,11 +818,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   private static Query matchAllDocsQuery = new MatchAllDocsQuery();
   private volatile BitDocSet liveDocs;
 
-  @Deprecated // TODO remove for 8.0
-  public BitDocSet getLiveDocs() throws IOException {
-    return getLiveDocSet();
-  }
-
   /**
    * Returns an efficient random-access {@link DocSet} of the live docs.  It's cached.  Never null.
    * @lucene.internal the type of DocSet returned may change in the future


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-13138

The method was deprecated in https://github.com/apache/solr/commit/1e63b32731bedf108aaeeb5d0a04d671f5663102 for https://issues.apache.org/jira/browse/SOLR-12366 i.e. Solr 7.4 version.