### PR TITLE
SOLR-15620: Download Config button in Schema Designer screen should not require user to re-login when already authenticated

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -452,6 +452,8 @@ Bug Fixes
 
 * SOLR-15595: Partial results from shard queries needlessly discarded for queries without sort field (Michael Kosten via Mike Drob, Eric Pugh)
 
+* SOLR-15620: Download Config button in Schema Designer screen should not require user to re-login when already authenticated (Timothy Potter)
+
 Other Changes
 ---------------------
 * SOLR-15566: Clarify ref guide documentation about SQL queries with `SELECT *` requiring a `LIMIT` clause (Timothy Potter)

--- a/solr/webapp/web/js/angular/controllers/schema-designer.js
+++ b/solr/webapp/web/js/angular/controllers/schema-designer.js
@@ -1513,7 +1513,29 @@ solrAdminApp.controller('SchemaDesignerController', function ($scope, $timeout, 
   };
 
   $scope.downloadConfig = function () {
-    location.href = "/api/schema-designer/download/"+$scope.currentSchema+"_configset.zip?wt=raw&configSet=" + $scope.currentSchema;
+    // have to use an AJAX request so we can supply the Authorization header
+    if (sessionStorage.getItem("auth.header")) {
+      var fileName = $scope.currentSchema+"_configset.zip";
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", "/api/schema-designer/download/"+fileName+"?wt=raw&configSet="+$scope.currentSchema, true);
+      xhr.setRequestHeader('Authorization', sessionStorage.getItem("auth.header"));
+      xhr.responseType = 'blob';
+      xhr.addEventListener('load',function() {
+        if (xhr.status === 200) {
+          var url = window.URL.createObjectURL(xhr.response);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = fileName;
+          document.body.append(a);
+          a.click();
+          a.remove();
+          window.URL.revokeObjectURL(url);
+        }
+      })
+      xhr.send();
+    } else {
+      location.href = "/api/schema-designer/download/"+$scope.currentSchema+"_configset.zip?wt=raw&configSet=" + $scope.currentSchema;
+    }
   };
 
   function docsToTree(docs) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15620

When basic auth is enabled, we need to make the request to download the zip using XMLHttpRequest so we can pass the Authorization header.

Testing is manual in FF, Chrome, and Safari