### PR TITLE
SOLR-15555 Make Async Cache the default

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -127,7 +127,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase implements SolrCache<K, V
     int maxRamMB = str == null ? -1 : Double.valueOf(str).intValue();
     maxRamBytes = maxRamMB < 0 ? Long.MAX_VALUE : maxRamMB * 1024L * 1024L;
     cleanupThread = Boolean.parseBoolean(args.get(CLEANUP_THREAD_PARAM));
-    async = Boolean.parseBoolean(args.get(ASYNC_PARAM));
+    async = Boolean.parseBoolean(args.getOrDefault(ASYNC_PARAM, "true"));
     if (async) {
       // We record futures in the map to decrease bucket-lock contention, but need computation handled in same thread
       executor = Runnable::run;
@@ -231,7 +231,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase implements SolrCache<K, V
       recordRamBytes(key, null, value);
       inserts.increment();
       return value;
-    } catch (RuntimeException | IOException e) {
+    } catch (Error | RuntimeException | IOException e) {
       // TimeExceeded exception is runtime and will bubble up from here
       future.completeExceptionally(e); // This will remove the future from the cache
       throw e;

--- a/solr/solr-ref-guide/src/caches-warming.adoc
+++ b/solr/solr-ref-guide/src/caches-warming.adoc
@@ -79,8 +79,11 @@ Reasonable values, depending on the query volume and patterns, may lie somewhere
 The `maxRamMB` attribute limits the maximum amount of memory a cache may consume.
 When both `size` and `maxRamMB` limits are specified the `maxRamMB` limit will take precedence and the `size` limit will be ignored.
 
-The `async` attribute determines whether the cache stores direct results (`async=false`, the default) or whether it will store indirect references to the computation (`async=true`). Enabling `async` will use more slightly more memory per cache entry, but may result in reduced CPU cycles generating results or doing garbage collection. The most noticable improvements will be seen when there are many queries racing to compute the same results before they are inserted into the cache. In some use cases, increasing autowarming may be a better alternative to enabling an async cache. Additionally, an async cache will not prevent a data race for time-limited queries, as those may return differing sets of partial results.
-This value is most effective on a filter cache, and likely less relevant on the other cache usages.
+The `async` attribute determines whether the cache stores direct results (`async=false`, disabled) or whether it will store indirect references to the computation (`async=true`, enabled by default).
+If your queries include child documents or join queries, then async cache must be enabled to function properly.
+Disabling the async option may use slightly less memory per cache entry at the expense of increased CPU.
+The async cache provides most significant improvement with many concurrent queries requesting the same result set that has not yet been cached, as an alternative to larger cache sizes or increased auto-warming counts.
+However, the async cache will not prevent data races for time-limited queries, since those are expected to provide partial results.
 
 All caches can be disabled using the parameter `enabled` with a value of `false`.
 Caches can also be disabled on a query-by-query basis with the `cache` parameter, as described in the section <<common-query-parameters.adoc#cache-local-parameter,cache Local Parameter>>.

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -304,7 +304,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     System.setProperty("tests.shardhandler.randomSeed", Long.toString(random().nextLong()));
     System.setProperty("solr.clustering.enabled", "false");
     System.setProperty("solr.cloud.wait-for-updates-with-stale-state-pause", "500");
-    System.setProperty("solr.filterCache.async", Boolean.toString(usually()));
+    System.setProperty("solr.filterCache.async", String.valueOf(random().nextBoolean()));
 
     System.setProperty("pkiHandlerPrivateKeyPath", SolrTestCaseJ4.class.getClassLoader().getResource("cryptokeys/priv_key512_pkcs8.pem").toExternalForm());
     System.setProperty("pkiHandlerPublicKeyPath", SolrTestCaseJ4.class.getClassLoader().getResource("cryptokeys/pub_key512.der").toExternalForm());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15555

Addresses an issue with parent/child join queries by making async caches the default.