### PR TITLE
SOLR-15173: replace 'master' with 'main' in release wizard

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -116,7 +116,7 @@ def expand_jinja(text, vars=None):
         'set_java_home': set_java_home,
         'latest_version': state.get_latest_version(),
         'latest_lts_version': state.get_latest_lts_version(),
-        'master_version': state.get_master_version(),
+        'main_version': state.get_main_version(),
         'mirrored_versions': state.get_mirrored_versions(),
         'mirrored_versions_to_delete': state.get_mirrored_versions_to_delete(),
         'home': os.path.expanduser("~")
@@ -365,7 +365,7 @@ class ReleaseState:
             raise Exception("Release version %s must have same major version as current minor or lts release")
         return [ver for ver in versions if ver not in to_keep]
 
-    def get_master_version(self):
+    def get_main_version(self):
         v = Version.parse(self.get_latest_version())
         return "%s.%s.%s" % (v.major + 1, 0, 0)
 
@@ -394,10 +394,10 @@ class ReleaseState:
             if not ver.is_minor_release():
                 sys.exit("You can only release minor releases from an existing stable branch")
         elif branch_type == BranchType.unstable:
-            if not branch == 'master':
+            if not branch == 'main':
                 sys.exit("Incompatible branch and branch_type")
             if not ver.is_major_release():
-                sys.exit("You can only release a new major version from master branch")
+                sys.exit("You can only release a new major version from main branch")
         if not getScriptVersion() == release_version:
             print("WARNING: Expected release version %s when on branch %s, but got %s" % (
                 getScriptVersion(), branch, release_version))
@@ -405,7 +405,7 @@ class ReleaseState:
     def get_base_branch_name(self):
         v = Version.parse(self.release_version)
         if v.is_major_release():
-            return 'master'
+            return 'main'
         elif v.is_minor_release():
             return self.get_stable_branch_name()
         elif v.major == Version.parse(self.get_latest_version()).major:
@@ -573,7 +573,7 @@ class ReleaseState:
 
     def get_stable_branch_name(self):
         if self.release_type == 'major':
-            v = Version.parse(self.get_master_version())
+            v = Version.parse(self.get_main_version())
         else:
             v = Version.parse(self.get_latest_version())
         return "branch_%sx" % v.major

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -410,7 +410,7 @@ groups:
         cmd: "{{ gradle_cmd }} clean check -x test"
   - !Todo
     id: create_stable_branch
-    title: Create a new stable branch, off from master
+    title: Create a new stable branch, off from main
     description: In our case we'll create {{ stable_branch }}
     types:
     - major
@@ -420,7 +420,7 @@ groups:
       commands_text: Run these commands to create a stable branch
       commands:
       - !Command
-        cmd: git checkout master
+        cmd: git checkout main
         tee: true
       - !Command
         cmd: git pull --ff-only
@@ -467,7 +467,7 @@ groups:
         tee: true
   - !Todo
     id: add_version_major
-    title: Add a new major version on master branch
+    title: Add a new major version on main branch
     types:
     - major
     depends: clean_git_checkout
@@ -475,10 +475,10 @@ groups:
       next_version: "{{ release_version_major + 1 }}.0.0"
     commands: !Commands
       root_folder: '{{ git_checkout_folder }}'
-      commands_text: Run these commands to add the new major version {{ next_version }} to the master branch
+      commands_text: Run these commands to add the new major version {{ next_version }} to the main branch
       commands:
       - !Command
-        cmd: git checkout master
+        cmd: git checkout main
         tee: true
       - !Command
         cmd: python3 -u dev-tools/scripts/addVersion.py {{ next_version }}
@@ -632,7 +632,7 @@ groups:
       Go to the JIRA "Manage Versions" Administration pages and add the new version:
 
       {% if release_type == 'major' -%}
-      . Change name of version `master ({{ release_version_major }}.0)` into `{{ release_version_major }}.0`
+      . Change name of version `main ({{ release_version_major }}.0)` into `{{ release_version_major }}.0`
       {%- endif %}
       . Create a new (unreleased) version `{{ get_next_version }}`
 
@@ -972,7 +972,7 @@ groups:
         logfile: svn_rm_containing.log
         comment: Clean up containing folder on the staging repo
         tee: true
-    post_description: 'Note at this point you will see the Jenkins job "Lucene-Solr-SmokeRelease-master" begin to fail, until you run the "Generate Backcompat Indexes" '
+    post_description: 'Note at this point you will see the Jenkins job "Lucene-Solr-SmokeRelease-main" begin to fail, until you run the "Generate Backcompat Indexes" '
   - !Todo
     id: stage_maven
     title: Stage the maven artifacts for publishing
@@ -1190,7 +1190,7 @@ groups:
     depends:
     - prepare_announce_solr
     description: |
-      Push the website changes to 'master' branch, and check the staging site.
+      Push the website changes to 'main' branch, and check the staging site.
       You will get a chance to preview the diff of all changes before you push.
       If you need to do changes, do the changes (e.g. by re-running previous step 'Update rest of webpage')
       and commit your changes. Then re-run this step and push when everything is OK.
@@ -1201,7 +1201,7 @@ groups:
         You have to exit the editor after review to continue.
       commands:
       - !Command
-        cmd: git checkout master && git status
+        cmd: git checkout main && git status
         stdout: true
       - !Command
         cmd: git diff
@@ -1240,7 +1240,7 @@ groups:
           cmd: git checkout production && git pull --ff-only
           stdout: true
         - !Command
-          cmd: git merge master
+          cmd: git merge main
           stdout: true
         - !Command
           cmd: git push origin
@@ -1269,9 +1269,9 @@ groups:
       commands_text: Edit DOAP files
       commands:
       - !Command
-        cmd: git checkout master && git pull --ff-only
+        cmd: git checkout main && git pull --ff-only
         stdout: true
-        comment: Goto master branch
+        comment: Goto main branch
       - !Command
         cmd: "{{ editor }} dev-tools/doap/lucene.rdf"
         comment: Edit Lucene DOAP, add version {{ release_version }}
@@ -1288,16 +1288,16 @@ groups:
         cmd: git push origin
         logfile: push.log
         stdout: true
-        comment: Push the master branch
+        comment: Push the main branch
       - !Command
         cmd: "git checkout {{ stable_branch }} && git pull --ff-only"
         stdout: true
         comment: Checkout the stable branch
       - !Command
-        cmd: "git cherry-pick master"
+        cmd: "git cherry-pick main"
         logfile: commit.log
         stdout: true
-        comment: Cherrypick the DOAP changes from master onto the stable branch.
+        comment: Cherrypick the DOAP changes from main onto the stable branch.
       - !Command
         cmd: git show HEAD
         stdout: true
@@ -1407,24 +1407,24 @@ groups:
     commands: !Commands
       root_folder: '{{ git_checkout_folder }}'
       commands_text: |
-        Update versions on master and stable branch.
+        Update versions on main and stable branch.
         You may have to hand-edit some files before commit, so go slowly :)
       confirm_each_command: true
       commands:
       - !Command
-        cmd: git checkout master && git pull --ff-only && git clean -df && git checkout -- .
-        comment: Go to master branch
-        logfile: checkout-master.log
+        cmd: git checkout main && git pull --ff-only && git clean -df && git checkout -- .
+        comment: Go to main branch
+        logfile: checkout-main.log
       - !Command
         cmd: python3 -u dev-tools/scripts/addVersion.py {{ release_version }}
-        logfile: addversion-master.log
+        logfile: addversion-main.log
       - !Command
         cmd: git diff
-        logfile: diff-master.log
+        logfile: diff-main.log
         tee: true
       - !Command
         cmd: git add -u .  && git commit -m "Add bugfix version {{ release_version }}"  && git push
-        logfile: commit-master.log
+        logfile: commit-main.log
       - !Command
         cmd: git checkout {{ stable_branch }} && git pull --ff-only && git clean -df && git checkout -- .
         logfile: checkout-stable.log
@@ -1465,9 +1465,9 @@ groups:
         tee: true
         comment: Find version regexes
       - !Command
-        cmd: git checkout master && git pull --ff-only && git clean -df && git checkout -- .
-        comment: Go to master branch
-        logfile: checkout-master.log
+        cmd: git checkout main && git pull --ff-only && git clean -df && git checkout -- .
+        comment: Go to main branch
+        logfile: checkout-main.log
       - !Command
         cmd: "{{ editor }} solr/CHANGES.txt"
         comment: Edit Solr CHANGES, do necessary changes
@@ -1478,7 +1478,7 @@ groups:
         stdout: true
       - !Command
         cmd: git add -u .  && git commit -m "Sync CHANGES for {{ release_version }}"  && git push
-        logfile: commit-master.log
+        logfile: commit-main.log
       - !Command
         cmd: git checkout {{ stable_branch }} && git pull --ff-only && git clean -df && git checkout -- .
         comment: Go to stable branch

--- a/dev-tools/scripts/scriptutil.py
+++ b/dev-tools/scripts/scriptutil.py
@@ -124,7 +124,7 @@ def find_branch_type():
   else:
     raise Exception('git status missing branch name')
 
-  if branchName == b'master':
+  if branchName == b'main':
     return BranchType.unstable
   if re.match(r'branch_(\d+)x', branchName.decode('UTF-8')):
     return BranchType.stable


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15173

https://github.com/apache/lucene/pull/305 is for `lucene/main` branch equivalent, i tried having one `lucene-solr/branch_8x` commit and cherry-picking back to `lucene/main` and `solr/main` but there were conflicts, so separate pull requests seems easier.