### PR TITLE
SOLR-15650: make not picking a defType more explicit in UI

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -148,6 +148,9 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-15630: Logging MDC values no longer include a hardcoded prefix, allowing custom logging configurations access to the plain values.
   The default log4j2.xml PatternLayout has been updated to ensure the values are formatted with the existing prefixes. (hossman)
 
+* SOLR-15650: Choosing lucene defType in Solr Admin now is passed explicitly through UI, not relying on default solrconfig.xml behavior.  (Eric Pugh)
+
+
 Build
 ---------------------
 

--- a/solr/webapp/web/partials/query.html
+++ b/solr/webapp/web/partials/query.html
@@ -120,14 +120,15 @@ limitations under the License.
           <label for="defType" class="checkbox" title="Choose defType">
             defType
             <select ng-model="val['defType']" name="defType" id="defType">
-              <option ng-selected="selected" value=''>lucene</option>
-              <option>dismax</option>
-              <option>edismax</option>
+              <option ng-selected="selected" value=''>------</option>
+              <option value="lucene">lucene</option>
+              <option value="dismax">dismax</option>
+              <option value="edismax">edismax</option>
             </select>
           </label>
         </legend>
 
-        <div class="fieldset" ng-show="val['defType']!=''">
+        <div class="fieldset" ng-show="val['defType']=='dismax' || val['defType']=='edismax'">
           <label for="q_alt" title="Alternate query when 'q' is absent.">q.alt</label>
           <input type="text" ng-model="val['q.alt']" name="q.alt" id="q_alt"  title="Alternate query when 'q' is absent.">
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15650

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Make picking a defType in the Solr Admin an explicit choice, otherwise you use the default.

# Solution

Make the defType selection box follow the pattern of other selection boxes.

# Tests

Manually, and paired on this work with @paul-blanchaert

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ x] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
