### PR TITLE
SOLR-15455: Support building against local Lucene SNAPSHOT version

### DIFF
--- a/gradle/globals.gradle
+++ b/gradle/globals.gradle
@@ -22,12 +22,42 @@ allprojects {
 
   def lucenePrereleaseBuild = '5'
 
+  // We parse this early because it has to run before the configure phase. There
+  // may well be a better way to do this. At a minimum, this parsing should
+  // probably be made less brittle ...
+  def luceneVersionProp = rootProject.file("versions.props").filterLine { line ->
+    line.startsWith('org.apache.lucene:*=')
+  }.toString().trim()
+
+  def luceneVersionLockProp = rootProject.file("versions.lock").filterLine { line ->
+    line.startsWith('org.apache.lucene:lucene-core')
+  }.toString().trim()
+
   // Repositories to fetch dependencies from.
   repositories {
     mavenCentral()
-    maven {
-      name "LucenePrerelease${lucenePrereleaseBuild}"
-      url "https://nightlies.apache.org/solr/lucene-prereleases/${lucenePrereleaseBuild}/"
+    // Lucene dependencies should be fetched from mavenLocal() or nightlies prerelease
+    // repo, mutually exclusive.
+    if (System.properties.containsKey('luceneSnapshot')) {
+      assert luceneVersionProp.endsWith('=9.0.0-SNAPSHOT') : "found version.props spec: ${luceneVersionProp}; change to 9.0.0-SNAPSHOT or run without -DluceneSnapshot property"
+      if (!luceneVersionLockProp.contains('lucene-core:9.0.0-SNAPSHOT ')) {
+        // NOTE: we can't assert/fail hard here, because the `--update-locks` command
+        // prescribed below wouldn't be able to run. One consequence of this is that
+        // the below message will get printed a lot (once for each module that's configured)
+        // ... but the verbosity is harmless, and this is an edge case that's probably
+        // not worth dancing around.
+        // TODO: perhaps we could detect whether `--update-locks` is specified; ignore if
+        // so, assert/fail hard otherwise?
+        logger.warn("found versions.lock spec: ${luceneVersionLockProp}; to use 9.0.0-SNAPSHOT version, run `gradlew -DluceneSnapshot --update-locks 'org.apache.lucene:*'`")
+      }
+      mavenLocal()
+    } else {
+      assert !luceneVersionProp.endsWith("=9.0.0-SNAPSHOT") : "found versions.props spec: ${luceneVersionProp}; run with -DluceneSnapshot property?"
+      assert !luceneVersionLockProp.contains("lucene-core:9.0.0-SNAPSHOT ") : "versions.props specifies ${luceneVersionProp}; conflicts with versions.lock ${luceneVersionLockProp}"
+      maven {
+        name "LucenePrerelease${lucenePrereleaseBuild}"
+        url "https://nightlies.apache.org/solr/lucene-prereleases/${lucenePrereleaseBuild}/"
+      }
     }
   }
 

--- a/gradle/testing/randomization/policies/solr-tests.policy
+++ b/gradle/testing/randomization/policies/solr-tests.policy
@@ -226,4 +226,6 @@ grant {
   permission java.io.FilePermission "${gradle.worker.jar}", "read";
   // Allow reading from classpath JARs (resources).
   permission java.io.FilePermission "${gradle.user.home}${/}-", "read";
+  // Allow reading lucene jars from mavenLocal repository
+  permission java.io.FilePermission "${user.home}${/}.m2${/}repository${/}org${/}apache${/}lucene${/}-", "read";
 };


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/SOLR-15455

Introduced support is passive in the sense that it doesn't change anything on disk. It requires the `-DluceneSnapshot` flag to specified explicitly -- e.g., either on the command-line invocation of gradle, or in `gradle.properties` file (useful for IDE interactions), i.e.:
```
# Uncomment below if developing against a local lucene snapshot
systemProp.luceneSnapshot
```