### PR TITLE
SOLR-14321: SolrJ with Kerberos docs update invalid HttpClientUtil.setConfigurer

### DIFF
--- a/solr/solr-ref-guide/src/kerberos-authentication-plugin.adoc
+++ b/solr/solr-ref-guide/src/kerberos-authentication-plugin.adoc
@@ -463,7 +463,7 @@ To use Kerberos authentication in a SolrJ application, you need the following tw
 [source,java]
 ----
 System.setProperty("java.security.auth.login.config", "/home/foo/jaas-client.conf");
-HttpClientUtil.setConfigurer(new Krb5HttpClientConfigurer());
+HttpClientUtil.setHttpClientBuilder(new Krb5HttpClientBuilder().getBuilder());
 ----
 
 You need to specify a Kerberos service principal for the client and a corresponding keytab in the JAAS client configuration file above.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14321

# Description

replace `HttpClientUtil.setConfigurer(...)` with `HttpClientUtil.setHttpClientBuilder(new Krb5HttpClientBuilder().getBuilder());`
