### PR TITLE
SOLR-15658: First pass of testing with findify/s3mock

### DIFF
--- a/solr/contrib/s3-repository/build.gradle
+++ b/solr/contrib/s3-repository/build.gradle
@@ -48,6 +48,8 @@ dependencies {
         exclude group: 'org.codehaus.woodstox', module: 'stax2-api'
     }
 
+    testImplementation('io.findify:s3mock_2.13:0.2.6')
+
     testImplementation project(':solr:test-framework')
 }
 

--- a/solr/contrib/s3-repository/src/java/org/apache/solr/s3/S3BackupRepository.java
+++ b/solr/contrib/s3-repository/src/java/org/apache/solr/s3/S3BackupRepository.java
@@ -254,7 +254,11 @@ public class S3BackupRepository implements BackupRepository {
       log.debug("getPathType for '{}'", s3Path);
     }
 
-    return client.isDirectory(s3Path) ? PathType.DIRECTORY : PathType.FILE;
+    try {
+      return client.isDirectory(s3Path) ? PathType.DIRECTORY : PathType.FILE;
+    } catch (S3NotFoundException nfe) {
+      return PathType.FILE;
+    }
   }
 
   /**

--- a/solr/contrib/s3-repository/src/test/org/apache/solr/s3/S3PathsTest.java
+++ b/solr/contrib/s3-repository/src/test/org/apache/solr/s3/S3PathsTest.java
@@ -46,9 +46,11 @@ public class S3PathsTest extends AbstractS3ClientTest {
   public void testDirectory() throws S3Exception {
 
     client.createDirectory("/simple-directory");
-    assertTrue(client.pathExists("/simple-directory"));
     assertTrue("Dir should exist without a leading slash", client.pathExists("simple-directory/"));
     assertTrue("Dir should exist with a leading slash", client.pathExists("/simple-directory/"));
+    assertTrue(
+        "Ending slash should be irrelevant for determining if dir is a dir",
+        client.isDirectory("simple-directory"));
     assertTrue(
         "Leading slash should be irrelevant for determining if dir is a dir",
         client.isDirectory("simple-directory/"));

--- a/solr/contrib/s3-repository/src/test/org/apache/solr/s3/S3ReadWriteTest.java
+++ b/solr/contrib/s3-repository/src/test/org/apache/solr/s3/S3ReadWriteTest.java
@@ -90,8 +90,8 @@ public class S3ReadWriteTest extends AbstractS3ClientTest {
         assertThrows(
             "Getting length on a dir should throw exception",
             S3Exception.class,
-            () -> client.length("/directory"));
-    assertEquals("Path is Directory", exception.getMessage());
+            () -> client.length("/directory/"));
+    assertEquals("Invalid Path. Path for file can't end with '/'", exception.getMessage());
   }
 
   /** Check various method throws the expected exception of a missing S3 key. */

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractBackupRepositoryTest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractBackupRepositoryTest.java
@@ -78,8 +78,8 @@ public abstract class AbstractBackupRepositoryTest extends SolrTestCaseJ4 {
     public void testCanDetermineWhetherFilesAndDirectoriesExist() throws Exception {
         try (BackupRepository repo = getRepository()) {
             // Create 'emptyDir/', 'nonEmptyDir/', and 'nonEmptyDir/file.txt'
-            final URI emptyDirUri = repo.resolve(getBaseUri(), "emptyDir");
-            final URI nonEmptyDirUri = repo.resolve(getBaseUri(), "nonEmptyDir");
+            final URI emptyDirUri = repo.resolveDirectory(getBaseUri(), "emptyDir");
+            final URI nonEmptyDirUri = repo.resolveDirectory(getBaseUri(), "nonEmptyDir");
             final URI nestedFileUri = repo.resolve(nonEmptyDirUri, "file.txt");
             repo.createDirectory(emptyDirUri);
             repo.createDirectory(nonEmptyDirUri);
@@ -96,8 +96,8 @@ public abstract class AbstractBackupRepositoryTest extends SolrTestCaseJ4 {
     @Test
     public void testCanDistinguishBetweenFilesAndDirectories() throws Exception {
         try (BackupRepository repo = getRepository()) {
-            final URI emptyDirUri = repo.resolve(getBaseUri(), "emptyDir");
-            final URI nonEmptyDirUri = repo.resolve(getBaseUri(), "nonEmptyDir");
+            final URI emptyDirUri = repo.resolveDirectory(getBaseUri(), "emptyDir");
+            final URI nonEmptyDirUri = repo.resolveDirectory(getBaseUri(), "nonEmptyDir");
             final URI nestedFileUri = repo.resolve(nonEmptyDirUri, "file.txt");
             repo.createDirectory(emptyDirUri);
             repo.createDirectory(nonEmptyDirUri);
@@ -150,10 +150,10 @@ public abstract class AbstractBackupRepositoryTest extends SolrTestCaseJ4 {
             assertFalse(repo.exists(fileUri));
 
             // Delete the middle directory in a deeply nested structure (/nest1/nest2/nest3/nest4)
-            final URI level1DeeplyNestedUri = repo.resolve(getBaseUri(), "nest1");
-            final URI level2DeeplyNestedUri = repo.resolve(level1DeeplyNestedUri, "nest2");
-            final URI level3DeeplyNestedUri = repo.resolve(level2DeeplyNestedUri, "nest3");
-            final URI level4DeeplyNestedUri = repo.resolve(level3DeeplyNestedUri, "nest4");
+            final URI level1DeeplyNestedUri = repo.resolveDirectory(getBaseUri(), "nest1");
+            final URI level2DeeplyNestedUri = repo.resolveDirectory(level1DeeplyNestedUri, "nest2");
+            final URI level3DeeplyNestedUri = repo.resolveDirectory(level2DeeplyNestedUri, "nest3");
+            final URI level4DeeplyNestedUri = repo.resolveDirectory(level3DeeplyNestedUri, "nest4");
             repo.createDirectory(level1DeeplyNestedUri);
             repo.createDirectory(level2DeeplyNestedUri);
             repo.createDirectory(level3DeeplyNestedUri);
@@ -206,10 +206,10 @@ public abstract class AbstractBackupRepositoryTest extends SolrTestCaseJ4 {
     @Test
     public void testCanListFullOrEmptyDirectories() throws Exception {
         try (BackupRepository repo = getRepository()) {
-            final URI rootUri = repo.resolve(getBaseUri(), "containsOtherDirs");
-            final URI otherDir1Uri = repo.resolve(rootUri, "otherDir1");
-            final URI otherDir2Uri = repo.resolve(rootUri, "otherDir2");
-            final URI otherDir3Uri = repo.resolve(rootUri, "otherDir3");
+            final URI rootUri = repo.resolveDirectory(getBaseUri(), "containsOtherDirs");
+            final URI otherDir1Uri = repo.resolveDirectory(rootUri, "otherDir1");
+            final URI otherDir2Uri = repo.resolveDirectory(rootUri, "otherDir2");
+            final URI otherDir3Uri = repo.resolveDirectory(rootUri, "otherDir3");
             final URI file1Uri = repo.resolve(otherDir3Uri, "file1.txt");
             final URI file2Uri = repo.resolve(otherDir3Uri, "file2.txt");
             repo.createDirectory(rootUri);
@@ -218,20 +218,14 @@ public abstract class AbstractBackupRepositoryTest extends SolrTestCaseJ4 {
             repo.createDirectory(otherDir3Uri);
             addFile(repo, file1Uri);
             addFile(repo, file2Uri);
+            addFile(repo, repo.resolve(otherDir1Uri, "file1.txt"));
+            addFile(repo, repo.resolve(otherDir2Uri, "file1.txt"));
 
-            final List<String> rootChildren = Lists.newArrayList(repo.listAll(rootUri));
-            assertEquals(3, rootChildren.size());
-            assertTrue(rootChildren.contains("otherDir1"));
-            assertTrue(rootChildren.contains("otherDir2"));
-            assertTrue(rootChildren.contains("otherDir3"));
+            assertArrayEquals(new String[]{"otherDir1", "otherDir2", "otherDir3"}, repo.listAll(rootUri));
 
-            final String[] otherDir2Children = repo.listAll(otherDir2Uri);
-            assertEquals(0, otherDir2Children.length);
+            assertEquals(0, repo.listAll(otherDir2Uri).length);
 
-            final List<String> otherDir3Children = Lists.newArrayList(repo.listAll(otherDir3Uri));
-            assertEquals(2, otherDir3Children.size());
-            assertTrue(otherDir3Children.contains("file1.txt"));
-            assertTrue(otherDir3Children.contains("file2.txt"));
+            assertArrayEquals(new String[]{"file1.txt", "file2.txt"}, repo.listAll(otherDir3Uri));
         }
     }
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractIncrementalBackupTest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractIncrementalBackupTest.java
@@ -533,7 +533,7 @@ public abstract class AbstractIncrementalBackupTest extends SolrCloudTestCase {
             BackupId prevBackupId = new BackupId(Math.max(0, numBackup - 1));
 
             URI backupPropertiesFile = repository.resolve(backupURI, "backup_"+numBackup+".properties");
-            URI zkBackupFolder = repository.resolve(backupURI, "zk_backup_"+numBackup);
+            URI zkBackupFolder = repository.resolveDirectory(backupURI, "zk_backup_"+numBackup);
             assertTrue(repository.exists(backupPropertiesFile));
             assertTrue(repository.exists(zkBackupFolder));
             assertFolderAreSame(repository.resolveDirectory(backupURI, BackupFilePaths.getZkStateDir(prevBackupId)), zkBackupFolder);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15658

Still very much a work in progress.

There are two tests that will fail consistently:
- `S3BackupRepositoryTest.testCanListFullOrEmptyDirectories`
- `S3IncrementalBackupTest.testBackupIncremental`

The rest of the tests are either the same speed or much faster than using adobe/S3Mock, except for the following which take 30s each, for no discernible reason:
- `S3BackupRepositoryTest.testBackwardRandomAccess`
- `S3BackupRepositoryTest.testCopyFiles`
- `S3BackupRepositoryTest.testRandomAccessInput`

This s3Mock also requires that directory paths end in `/` for all operations including reads, which AWS S3 does not require. Some code had to be changed for this.

I still also need to remove the Old S3 Mock from the codebase.