### PR TITLE
SOLR-15665: Move polling logic under main

### DIFF
--- a/dev-tools/scripts/poll-mirrors.py
+++ b/dev-tools/scripts/poll-mirrors.py
@@ -101,75 +101,75 @@ def check_mirror(url):
     p('\nFAIL: ' + url + '\n' if args.details else 'X')
     return url
 
+if __name__ == '__main__':
+  desc = 'Periodically checks that all Lucene/Solr mirrors contain either a copy of a release or a specified path'
+  parser = argparse.ArgumentParser(description=desc)
+  parser.add_argument('-version', '-v', help='Lucene/Solr version to check')
+  parser.add_argument('-path', '-p', help='instead of a versioned release, check for some/explicit/path')
+  parser.add_argument('-interval', '-i', help='seconds to wait before re-querying mirrors', type=int, default=300)
+  parser.add_argument('-details', '-d', help='print missing mirror URLs', action='store_true', default=False)
+  parser.add_argument('-once', '-o', help='run only once', action='store_true', default=False)
+  args = parser.parse_args()
 
-desc = 'Periodically checks that all Lucene/Solr mirrors contain either a copy of a release or a specified path'
-parser = argparse.ArgumentParser(description=desc)
-parser.add_argument('-version', '-v', help='Lucene/Solr version to check')
-parser.add_argument('-path', '-p', help='instead of a versioned release, check for some/explicit/path')
-parser.add_argument('-interval', '-i', help='seconds to wait before re-querying mirrors', type=int, default=300)
-parser.add_argument('-details', '-d', help='print missing mirror URLs', action='store_true', default=False)
-parser.add_argument('-once', '-o', help='run only once', action='store_true', default=False)
-args = parser.parse_args()
+  if (args.version is None and args.path is None) \
+      or (args.version is not None and args.path is not None):
+    p('You must specify either -version or -path but not both!\n')
+    sys.exit(1)
 
-if (args.version is None and args.path is None) \
-    or (args.version is not None and args.path is not None):
-  p('You must specify either -version or -path but not both!\n')
-  sys.exit(1)
+  try:
+    conn = http.HTTPConnection('www.apache.org')
+    conn.request('GET', '/mirrors/')
+    response = conn.getresponse()
+    html = response.read()
+  except Exception as e:
+    p('Unable to fetch the Apache mirrors list!\n')
+    sys.exit(1)
 
-try:
-  conn = http.HTTPConnection('www.apache.org')
-  conn.request('GET', '/mirrors/')
-  response = conn.getresponse()
-  html = response.read()
-except Exception as e:
-  p('Unable to fetch the Apache mirrors list!\n')
-  sys.exit(1)
+  mirror_path = args.path if args.path is not None else 'lucene/java/{}/changes/Changes.html'.format(args.version)
+  maven_url = None if args.version is None else 'https://repo1.maven.org/maven2/' \
+      'org/apache/lucene/lucene-core/{0}/lucene-core-{0}.pom.asc'.format(args.version)
+  maven_available = False
 
-mirror_path = args.path if args.path is not None else 'lucene/java/{}/changes/Changes.html'.format(args.version)
-maven_url = None if args.version is None else 'https://repo1.maven.org/maven2/' \
-    'org/apache/lucene/lucene-core/{0}/lucene-core-{0}.pom.asc'.format(args.version)
-maven_available = False
+  pending_mirrors = []
+  for match in re.finditer('<TR>(.*?)</TR>', str(html), re.MULTILINE | re.IGNORECASE | re.DOTALL):
+    row = match.group(1)
+    if not '<TD>ok</TD>' in row:
+      # skip bad mirrors
+      continue
 
-pending_mirrors = []
-for match in re.finditer('<TR>(.*?)</TR>', str(html), re.MULTILINE | re.IGNORECASE | re.DOTALL):
-  row = match.group(1)
-  if not '<TD>ok</TD>' in row:
-    # skip bad mirrors
-    continue
+    match = re.search('<A\s+HREF\s*=\s*"([^"]+)"\s*>', row, re.MULTILINE | re.IGNORECASE)
+    if match:
+      pending_mirrors.append(match.group(1) + mirror_path)
 
-  match = re.search('<A\s+HREF\s*=\s*"([^"]+)"\s*>', row, re.MULTILINE | re.IGNORECASE)
-  if match:
-    pending_mirrors.append(match.group(1) + mirror_path)
+  total_mirrors = len(pending_mirrors)
 
-total_mirrors = len(pending_mirrors)
+  label = args.version if args.version is not None else args.path
+  while True:
+    p('\n{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now()))
+    p('\nPolling {} Apache Mirrors'.format(len(pending_mirrors)))
+    if maven_url is not None and not maven_available:
+      p(' and Maven Central')
+    p('...\n')
 
-label = args.version if args.version is not None else args.path
-while True:
-  p('\n{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now()))
-  p('\nPolling {} Apache Mirrors'.format(len(pending_mirrors)))
-  if maven_url is not None and not maven_available:
-    p(' and Maven Central')
-  p('...\n')
+    if maven_url is not None and not maven_available:
+      maven_available = mirror_contains_file(maven_url)
 
-  if maven_url is not None and not maven_available:
-    maven_available = mirror_contains_file(maven_url)
+    start = time.time()
+    with Pool(processes=5) as pool:
+      pending_mirrors = list(filter(lambda x: x is not None, pool.map(check_mirror, pending_mirrors)))
+    stop = time.time()
+    remaining = args.interval - (stop - start)
 
-  start = time.time()
-  with Pool(processes=5) as pool:
-    pending_mirrors = list(filter(lambda x: x is not None, pool.map(check_mirror, pending_mirrors)))
-  stop = time.time()
-  remaining = args.interval - (stop - start)
+    available_mirrors = total_mirrors - len(pending_mirrors)
 
-  available_mirrors = total_mirrors - len(pending_mirrors)
+    if maven_url is not None:
+      p('\n\n{} is{}downloadable from Maven Central'.format(label, ' ' if maven_available else ' not '))
+    p('\n{} is downloadable from {}/{} Apache Mirrors ({:.2f}%)\n'
+      .format(label, available_mirrors, total_mirrors, available_mirrors * 100 / total_mirrors))
+    if len(pending_mirrors) == 0 or args.once == True:
+      break
 
-  if maven_url is not None:
-    p('\n\n{} is{}downloadable from Maven Central'.format(label, ' ' if maven_available else ' not '))
-  p('\n{} is downloadable from {}/{} Apache Mirrors ({:.2f}%)\n'
-    .format(label, available_mirrors, total_mirrors, available_mirrors * 100 / total_mirrors))
-  if len(pending_mirrors) == 0 or args.once == True:
-    break
-
-  if remaining > 0:
-    p('Sleeping for {:d} seconds...\n'.format(int(remaining + 0.5)))
-    time.sleep(remaining)
+    if remaining > 0:
+      p('Sleeping for {:d} seconds...\n'.format(int(remaining + 0.5)))
+      time.sleep(remaining)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15665

Fix was actually borrowed from @HoustonPutman 's change for the Solr operator:
https://github.com/apache/solr-operator/commit/7ef0d8cebb3eb0af297d32c2a5f4dae3bf966c57#diff-cea0c736ffb3ab0d91013274d57de1fddc2539c7941134a887430cfb642374dd

Tested manually:
```
Run this script to check the number and percentage of mirrors (and Maven Central) that have the release

  cd ~/.lucene-releases/8.10.0/lucene-solr
  python3 -u dev-tools/scripts/poll-mirrors.py -version 8.10.0 -o


Q: Do you want me to run these commands now? (y/n): y


Output will be shown live byte by byte

2021-09-29 09:47:47
Polling 104 Apache Mirrors and Maven Central...
........................................................................................................

8.10.0 is downloadable from Maven Central
8.10.0 is downloadable from 104/104 Apache Mirrors (100.00%)
                                                                                
Command completed in 93.41973090171814 seconds
```
