### PR TITLE
SOLR-15676: UpdateLog.RecentUpdates.getDeleteByQuery to not return duplicate versions

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -1265,10 +1265,12 @@ public class RealTimeGetComponent extends SearchComponent
 
     // TODO: get this from cache instead of rebuilding?
     try (UpdateLog.RecentUpdates recentUpdates = ulog.getRecentUpdates()) {
+      Set<Long> updateVersions = new HashSet<>();
       for (Long version : versions) {
         try {
           Object o = recentUpdates.lookup(version);
           if (o == null) continue;
+          updateVersions.add(version);
 
           if (version > 0) {
             minVersion = Math.min(minVersion, version);
@@ -1285,7 +1287,7 @@ public class RealTimeGetComponent extends SearchComponent
       // Must return all delete-by-query commands that occur after the first add requested
       // since they may apply.
       if (params.getBool("skipDbq", false)) {
-        updates.addAll(recentUpdates.getDeleteByQuery(minVersion));
+        updates.addAll(recentUpdates.getDeleteByQuery(minVersion, updateVersions));
       }
 
       rb.rsp.add("updates", updates);

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -1474,12 +1474,19 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
     }
 
     /** Returns the list of deleteByQueries that happened after the given version */
-    public List<Object> getDeleteByQuery(long afterVersion) {
+    public List<Object> getDeleteByQuery(long afterVersion, Set<Long> updateVersions) {
       List<Object> result = new ArrayList<>(deleteByQueryList.size());
       for (Update update : deleteByQueryList) {
         if (Math.abs(update.version) > afterVersion) {
-          Object dbq = update.log.lookup(update.pointer);
-          result.add(dbq);
+          if (updateVersions.add(update.version)) {
+            Object dbq = update.log.lookup(update.pointer);
+            result.add(dbq);
+          } else {
+            if (debug) {
+              log.debug("UpdateLog.RecentUpdates.getDeleteByQuery(afterVersion={}) not returning duplicate version = {}",
+                  afterVersion, update.version);
+            }
+          }
         }
       }
       return result;

--- a/solr/core/src/test/org/apache/solr/handler/component/UpdateLogCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/UpdateLogCloudTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.embedded.JettySolrRunner;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.cloud.AbstractDistribZkTestBase;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.util.NamedList;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UpdateLogCloudTest extends SolrCloudTestCase {
+
+  private static String COLLECTION;
+  private static final int NUM_SHARDS = 1;
+  private static final int NUM_REPLICAS = 4;
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+
+    // decide collection name ...
+    COLLECTION = "collection"+(1+random().nextInt(100)) ;
+
+    // create and configure cluster
+    configureCluster(NUM_SHARDS*NUM_REPLICAS /* nodeCount */)
+    .addConfig("conf", configset("cloud-dynamic"))
+    .configure();
+
+    // create an empty collection
+    CollectionAdminRequest
+    .createCollection(COLLECTION, "conf", NUM_SHARDS, NUM_REPLICAS)
+    .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
+    AbstractDistribZkTestBase.waitForRecoveriesToFinish(COLLECTION, cluster.getSolrClient().getZkStateReader(), false, true, DEFAULT_TIMEOUT);
+  }
+
+  @Test
+  public void test() throws Exception {
+
+    final List<SolrClient> solrClients = new ArrayList<>();
+    for (JettySolrRunner jettySolrRunner : cluster.getJettySolrRunners()) {
+      solrClients.add(jettySolrRunner.newClient());
+    }
+
+    cluster.getJettySolrRunner(0).stop();
+
+    new UpdateRequest()
+    .add(sdoc("id", "1", "a_t", "one"))
+    .deleteById("2")
+    .deleteByQuery("a_t:three")
+    .commit(cluster.getSolrClient(), COLLECTION);
+
+    cluster.getJettySolrRunner(0).start();
+    AbstractDistribZkTestBase.waitForRecoveriesToFinish(COLLECTION, cluster.getSolrClient().getZkStateReader(), false, true, DEFAULT_TIMEOUT);
+
+    int idx = 0;
+    for (SolrClient solrClient : solrClients) {
+      implTest(solrClient, idx==0 ? 0 : 3);
+      ++idx;
+    }
+
+    for (SolrClient solrClient : solrClients) {
+      solrClient.close();
+    }
+
+  }
+
+  @SuppressWarnings("unchecked")
+  private void implTest(SolrClient solrClient, int numExpected) throws Exception {
+
+    final QueryRequest reqV = new QueryRequest(params("qt","/get", "getVersions","12345"));
+    final NamedList<?> rspV = solrClient.request(reqV, COLLECTION);
+    final List<Long> versions = (List<Long>)rspV.get("versions");
+    assertEquals(numExpected, versions.size());
+    if (numExpected == 0) {
+      return;
+    }
+
+    final LinkedList<Long> absVersions = new LinkedList<>();
+    for (Long version : versions) {
+      absVersions.add(Math.abs(version));
+    }
+    Collections.sort(absVersions);
+    final Long minVersion = absVersions.getFirst();
+    final Long maxVersion = absVersions.getLast();
+
+    for (boolean skipDbq : new boolean[] { false, true }) {
+      final QueryRequest reqU = new QueryRequest(params("qt","/get", "getUpdates", minVersion + "..."+maxVersion, "skipDbq", Boolean.toString(skipDbq)));
+      final NamedList<?> rspU = solrClient.request(reqU, COLLECTION);
+      final List<?> updatesList = (List<?>)rspU.get("updates");
+      assertEquals(numExpected + (skipDbq ? 1 : 0), updatesList.size());
+    }
+
+  }
+
+}

--- a/solr/core/src/test/org/apache/solr/handler/component/UpdateLogCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/UpdateLogCloudTest.java
@@ -110,7 +110,7 @@ public class UpdateLogCloudTest extends SolrCloudTestCase {
       final QueryRequest reqU = new QueryRequest(params("qt","/get", "getUpdates", minVersion + "..."+maxVersion, "skipDbq", Boolean.toString(skipDbq)));
       final NamedList<?> rspU = solrClient.request(reqU, COLLECTION);
       final List<?> updatesList = (List<?>)rspU.get("updates");
-      assertEquals(numExpected + (skipDbq ? 1 : 0), updatesList.size());
+      assertEquals(numExpected, updatesList.size());
     }
 
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15676

(Keeping this pull request as draft whilst it includes the #328 changes.)