### PR TITLE
SOLR-15676: UpdateLog.RecentUpdates.getVersions to not return duplicate versions

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -1454,10 +1454,18 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
 
     public List<Long> getVersions(int n, long maxVersion) {
       List<Long> ret = new ArrayList<>(n);
+      Set<Long> set = new HashSet<>(n);
+      final int nInput = n;
 
       for (List<Update> singleList : updateList) {
         for (Update ptr : singleList) {
           if(Math.abs(ptr.version) > Math.abs(maxVersion)) continue;
+          if (!set.add(ptr.version)) {
+            if (debug) {
+              log.debug("getVersions(n={}, maxVersion={}) not returning duplicate version = {}", nInput, maxVersion, ptr.version);
+            }
+            continue;
+          }
           ret.add(ptr.version);
           if (--n <= 0) return ret;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15676

(Keeping this pull request as draft for now since there's no associated test changes for this as yet.)

(And potentially #329 and this PR here could/should be combined into a single pull request.)