### PR TITLE
fix url in docs for listing out daemon stream status

### DIFF
--- a/solr/solr-ref-guide/src/stream-decorator-reference.adoc
+++ b/solr/solr-ref-guide/src/stream-decorator-reference.adoc
@@ -543,28 +543,28 @@ The `/stream` handler supports a small <<stream-api.adoc#plugins,set of commands
 
 [source,text]
 ----
-http://localhost:8983/collection/stream?action=list
+http://localhost:8983/solr/collection/stream?action=list
 ----
 
 This command will provide a listing of the current daemons running on the specific node along with their current state.
 
 [source,text]
 ----
-http://localhost:8983/collection/stream?action=stop&id=daemonId
+http://localhost:8983/solr/collection/stream?action=stop&id=daemonId
 ----
 
 This command will stop a specific daemon function but leave it resident in memory.
 
 [source,text]
 ----
-http://localhost:8983/collection/stream?action=start&id=daemonId
+http://localhost:8983/solr/collection/stream?action=start&id=daemonId
 ----
 
 This command will start a specific daemon function that has been stopped.
 
 [source,text]
 ----
-http://localhost:8983/collection/stream?action=kill&id=daemonId
+http://localhost:8983/solr/collection/stream?action=kill&id=daemonId
 ----
 
 This command will stop a specific daemon function and remove it from memory.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15688

# Description

Fix path to list out Daemon Stream Status in docs.

# Solution

Update the url.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
