### PR TITLE
SOLR-15696: Fix ShardBackupId parsing for backups

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/backup/ShardBackupId.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/ShardBackupId.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.core.backup;
 
+import java.util.Arrays;
+
 /**
  * Represents the ID of a particular backup point for a particular shard.
  *
@@ -55,12 +57,14 @@ public class ShardBackupId {
 
     public static ShardBackupId from(String idString) {
         final String[] idComponents = idString.split("_");
-        if (idComponents.length != 3) {
+        if (idComponents.length < 3 || ! idString.startsWith("md_")) {
             throw new IllegalArgumentException("Unable to parse invalid ShardBackupId: " + idString);
         }
 
-        final BackupId containingBackupId = new BackupId(Integer.parseInt(idComponents[2]));
-        return new ShardBackupId(idComponents[1], containingBackupId);
+        final String backupIdString = idComponents[idComponents.length - 1]; // Backup ID is always the last component
+        final String shardId = String.join("_", Arrays.asList(idComponents).subList(1, idComponents.length - 1));
+        final BackupId containingBackupId = new BackupId(Integer.parseInt(backupIdString));
+        return new ShardBackupId(shardId, containingBackupId);
     }
 
     public static ShardBackupId fromShardMetadataFilename(String filenameString) {

--- a/solr/core/src/test/org/apache/solr/core/backup/ShardBackupIdTest.java
+++ b/solr/core/src/test/org/apache/solr/core/backup/ShardBackupIdTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.Test;
+
+public class ShardBackupIdTest extends SolrTestCaseJ4 {
+
+    @Test
+    public void testCanParseIDFromStringWithUnsplitShardName() {
+        final String idString = "md_shard1_0";
+
+        final ShardBackupId parsedId = ShardBackupId.from(idString);
+
+        assertEquals("shard1", parsedId.getShardName());
+        assertEquals(new BackupId(0), parsedId.getContainingBackupId());
+    }
+
+    @Test
+    public void testCanParseIdFromStringWithSplitShardName() {
+        final String idString = "md_shard2_0_5";
+
+        final ShardBackupId parsedId = ShardBackupId.from(idString);
+
+        assertEquals("shard2_0", parsedId.getShardName());
+        assertEquals(new BackupId(5), parsedId.getContainingBackupId());
+    }
+
+    @Test
+    public void testCanParseIdFromStringWithManySplitShardName() {
+        final String idString = "md_shard2_0_1_3";
+        final ShardBackupId parsedId = ShardBackupId.from(idString);
+
+        assertEquals("shard2_0_1", parsedId.getShardName());
+        assertEquals(new BackupId(3), parsedId.getContainingBackupId());
+    }
+}


### PR DESCRIPTION
# Description

Incremental backups store metadata files whose names are constructed in
part on the name of individual shards.  These filenames are then parsed
later on to extract the shard name and "backup ID".

The parsing in question was overly-brittle though, not accounting for
the variations that shard-splitting etc. produce in shard names.  This
caused incremental backups to fail for any collection that had
previously performed a shard-split.

This commit updates the parsing logic to handle these cases more
flexibly, allowing post-shardsplit backups to now succeed.

# Tests

See the new test file, `ShardBackupIdTest`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
