### PR TITLE
SOLR-15700: Make include paths in bin/solr consistent

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -406,6 +406,8 @@ Improvements
 
 * SOLR-15702: Stabilize S3 tests by using waiters after directory creation (Houston Putman)
 
+* SOLR-15700: Make include paths in bin/solr consistent (turnertg, janhoy via Eric Pugh)
+
 Optimizations
 ---------------------
 (No changes)

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -26,7 +26,8 @@
 # $HOME/.solr.in.sh
 # /usr/share/solr
 # /usr/local/share/solr
-# /var/solr/
+# /etc/default
+# /var/solr
 # /opt/solr
 #
 # Another option is to specify the full path to the include file in the
@@ -86,6 +87,7 @@ if [ -z "$SOLR_INCLUDE" ]; then
                /usr/share/solr/solr.in.sh \
                /usr/local/share/solr/solr.in.sh \
                /etc/default/solr.in.sh \
+               /var/solr/solr.in.sh \
                /opt/solr/solr.in.sh; do
     if [ -r "$include" ]; then
         SOLR_INCLUDE="$include"

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -22,7 +22,7 @@
 # file named solr.in.sh to set environment variables. Specifically,
 # the following locations are searched in this order:
 #
-# ./
+# <script location>/.
 # $HOME/.solr.in.sh
 # /usr/share/solr
 # /usr/local/share/solr


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15700

# Description

In the `bin/solr` bash script, the header comment specifies which paths are searched for the environment file `solr.in.sh`, however this does not match the logic that actually finds and includes the file. This results in unexpected behavior if the user is packaging Solr to run under `/var/solr`, and the fairly common `/etc/default` path is undocumented. Both of these paths are already used in the reference guide, namely [Taking Solr to Production](https://github.com/apache/solr/blob/main/solr/solr-ref-guide/src/taking-solr-to-production.adoc) and [Upgrading a Solr Cluster](https://github.com/apache/solr/blob/main/solr/solr-ref-guide/src/upgrading-a-solr-cluster.adoc).

# Solution

Added `/etc/default` to the script's header comment (was only in logic) and added `/var/solr` to the `for` loop (was only in comment) for consistency.

# Tests

- Tested against a Solr 8.10.1 host and verified each `solr.in.sh` include path took precedence as required.
- Verified logic using bash's `-x` debug flag with a command along the lines of `sudo -u solr /usr/bin/bash -x /usr/bin/solr status` to check status and create a few test cores without issue.
- There are currently no tests in `bin-test/solr` checking for environment information or expected paths, but performing these without root is slightly thorny and likely out of scope for this particular issue. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
