### PR TITLE
Make JSHint a little quieter

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,0 +1,7 @@
+# This file can configure Lift's PR static analysis.
+# Docs for adding, removing or changing checks can be found here:
+# https://help.sonatype.com/display/LIFT/Configuration+Reference
+
+jdk11 = true
+
+ignoreRules = [ "W069" ]


### PR DESCRIPTION
It appears JSHint was making a nuisance of itself (in https://github.com/apache/solr/pull/43). This PR makes that particular warning disappear. At the same time we are considering which steps to take product wide to reign in JSHint's verbosity.