### PR TITLE
SOLR-15760: Improve the default distributed facet overrequest function/heuristic

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -118,6 +118,31 @@ public class TestJsonFacets extends SolrTestCaseHS {
     FacetField.FacetMethod.DEFAULT_METHOD = defMethod; // note: the real default is restored in afterTests
   }
 
+  @Test
+  public void testOverrequestFunctionStability() {
+    //sanity-check input/output thresholds to verify expected behavior
+    int i = 0;
+    do {
+      // f(0..6) => 12
+      assertEquals(12, FacetFieldProcessor.applyOverrequestFunction(i));
+    } while (++i < 7);
+    long previousOutput = 13;
+    // f(7) => 13
+    assertEquals(previousOutput, FacetFieldProcessor.applyOverrequestFunction(i));
+    for ( ; ; i++) {
+      long nextOutput = FacetFieldProcessor.applyOverrequestFunction(i);
+      // output never decreases
+      assertTrue(nextOutput >= previousOutput);
+      // output always greater than input, until ...
+      if (nextOutput <= i) {
+        // output should equal input only once we reach the asymptote
+        assertEquals(FacetFieldProcessor.OVERREQUEST_ASYMPTOTE_THRESHOLD, i);
+        break;
+      }
+      previousOutput = nextOutput;
+    }
+  }
+
   // attempt to reproduce https://github.com/Heliosearch/heliosearch/issues/33
   @Test
   public void testComplex() throws Exception {


### PR DESCRIPTION
See: [SOLR-15760](https://issues.apache.org/jira/browse/SOLR-15760)

For logical consistency, distributed facet overrequest should make no distinction between offset and limit; instead, distributed overrequest should be calculated as a function of the sum of offset+limit, boosting relatively heavily when few values are requested, and decaying asymptotically to `f(x)=x` for larger numbers of requested values.