### PR TITLE
SOLR-15663: JsonFaceting benchmark should flush by doc count for better reproducible behavior.

### DIFF
--- a/solr/benchmark/src/resources/configs/cloud-minimal/conf/solrconfig.xml
+++ b/solr/benchmark/src/resources/configs/cloud-minimal/conf/solrconfig.xml
@@ -38,7 +38,8 @@
 
     <useCompoundFile>${useCompoundFile:true}</useCompoundFile>
 
-    <ramBufferSizeMB>${ramBufferSizeMB:100}</ramBufferSizeMB>
+    <ramBufferSizeMB>${ramBufferSizeMB:160}</ramBufferSizeMB>
+    <maxBufferedDocs>${maxBufferedDocs:250000}</maxBufferedDocs>     <!-- Force the common case to flush by doc count  -->
     <!-- <ramPerThreadHardLimitMB>60</ramPerThreadHardLimitMB> -->
 
     <!-- <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler">


### PR DESCRIPTION
[SOLR-15663 JsonFaceting benchmark should flush by doc count for better reproducible behavior.](https://app.gitkraken.com/glo/view/card/560bf6f8fc4043328abe0c351a6c6a2e)