### PR TITLE
SOLR-15788 Remove configset/sample_techproducts_config from being used in unit tests

### DIFF
--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
@@ -16,17 +16,11 @@
  */
 package org.apache.solr.client.solrj;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.client.solrj.request.RequestWriter;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.BeforeClass;
-
-import java.io.File;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * A subclass of SolrExampleTests that explicitly uses the xml codec for
@@ -34,17 +28,9 @@ import java.util.TreeMap;
  */
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class SolrExampleXMLTest extends SolrExampleTests {
-
   @BeforeClass
   public static void beforeTest() throws Exception {
-    File tmpSolrHome = createTempDir().toFile();
-    FileUtils.copyDirectory(new File(getFile("solrj/solr/testproducts/conf").getParent()), new File(tmpSolrHome.getAbsoluteFile(), "collection1"));
-
-    FileUtils.copyFile(getFile("solrj/solr/solr.xml"), new File(tmpSolrHome.getAbsoluteFile(), "solr.xml"));
-
-    final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();
-
-    createAndStartJetty(tmpSolrHome.getAbsolutePath(), "solrconfig.xml", "managed-schema", "/solr", true, extraServlets);
+    createAndStartJetty(legacyExampleCollection1SolrHome());
   }
   
   @Override

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
@@ -16,11 +16,17 @@
  */
 package org.apache.solr.client.solrj;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.client.solrj.request.RequestWriter;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.BeforeClass;
+
+import java.io.File;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * A subclass of SolrExampleTests that explicitly uses the xml codec for
@@ -28,9 +34,17 @@ import org.junit.BeforeClass;
  */
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class SolrExampleXMLTest extends SolrExampleTests {
+
   @BeforeClass
   public static void beforeTest() throws Exception {
-    createAndStartJetty(legacyExampleCollection1SolrHome());
+    File tmpSolrHome = createTempDir().toFile();
+    FileUtils.copyDirectory(new File(getFile("solrj/solr/testproducts/conf").getParent()), new File(tmpSolrHome.getAbsoluteFile(), "collection1"));
+
+    FileUtils.copyFile(getFile("solrj/solr/solr.xml"), new File(tmpSolrHome.getAbsoluteFile(), "solr.xml"));
+
+    final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();
+
+    createAndStartJetty(tmpSolrHome.getAbsolutePath(), "solrconfig.xml", "managed-schema", "/solr", true, extraServlets);
   }
   
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15788


# Description

Break link between our example configset and the run of the mill unit testing.

# Solution

introduce a `solr/solrj/src/test-files/solrj/solr/testproducts` configset based on the old `techproducts` configset, and then start removing files that aren't used by the solrj tests.

Maybe it should be called `collection2` instead?   

# Tests

Running the unit tests.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
