### PR TITLE
SOLR-15791: Remove remaining <admin> clauses from solrconfigs

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -391,6 +391,8 @@ Other Changes
 
 * SOLR-15728: Remove dead, unused log rotation code from SolrCLI (janhoy)
 
+* SOLR-15791: Remove remaining unused <admin/> clauses from solrconfigs. (Eric Pugh)
+
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution

--- a/solr/contrib/extraction/src/test-files/extraction/solr/collection1/conf/solrconfig.xml
+++ b/solr/contrib/extraction/src/test-files/extraction/solr/collection1/conf/solrconfig.xml
@@ -33,10 +33,10 @@
 
   <updateHandler class="solr.DirectUpdateHandler2">
 
-    <!-- autocommit pending docs if certain criteria are met 
-    <autoCommit> 
+    <!-- autocommit pending docs if certain criteria are met
+    <autoCommit>
       <maxDocs>10000</maxDocs>
-      <maxTime>3600000</maxTime> 
+      <maxTime>3600000</maxTime>
     </autoCommit>
     -->
 
@@ -198,11 +198,6 @@
       <cacheControl>max-age=30, public</cacheControl>
     </httpCaching>
   </requestDispatcher>
-
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
 
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"

--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
@@ -175,19 +175,22 @@ public class GCSBackupRepository implements BackupRepository {
 
     @Override
     public boolean exists(URI path) throws IOException {
-        if (path.toString().equals(getConfigProperty(CoreAdminParams.BACKUP_LOCATION))) {
+        return exists(path.toString());
+    }
+
+    public boolean exists(String path) throws IOException {
+        if (path.equals(getConfigProperty(CoreAdminParams.BACKUP_LOCATION))) {
             return true;
         }
 
-        if (path.toString().endsWith("/")) {
-            return storage.get(bucketName, path.toString(), Storage.BlobGetOption.fields()) != null;
+        if (path.endsWith("/")) {
+            return storage.get(bucketName, path, Storage.BlobGetOption.fields()) != null;
         } else {
-            final String filePath = path.toString();
-            final String directoryPath = path.toString() + "/";
+            final String filePath = path;
+            final String directoryPath = path + "/";
             return storage.get(bucketName, filePath, Storage.BlobGetOption.fields()) != null ||
-                    storage.get(bucketName, directoryPath, Storage.BlobGetOption.fields()) != null;
+                storage.get(bucketName, directoryPath, Storage.BlobGetOption.fields()) != null;
         }
-
     }
 
     @Override
@@ -293,7 +296,9 @@ public class GCSBackupRepository implements BackupRepository {
     @Override
     public void createDirectory(URI path) throws IOException {
         final String name = appendTrailingSeparatorIfNecessary(path.toString());
-        storage.create(BlobInfo.newBuilder(bucketName, name).build()) ;
+        if (!exists(name)) {
+            storage.create(BlobInfo.newBuilder(bucketName, name).build());
+        }
     }
 
     @Override

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-analytics-query.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-analytics-query.xml
@@ -219,11 +219,6 @@
     </httpCaching>
   </requestDispatcher>
 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
-
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"
             attr2="${non.existent.sys.prop:default-from-config}">prefix-${solr.test.sys.prop2}-suffix</propTest>
@@ -273,4 +268,3 @@
   </updateRequestProcessorChain>
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-collapseqparser.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-collapseqparser.xml
@@ -222,11 +222,6 @@
     </httpCaching>
   </requestDispatcher>
 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
-
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"
             attr2="${non.existent.sys.prop:default-from-config}">prefix-${solr.test.sys.prop2}-suffix</propTest>
@@ -281,4 +276,3 @@
     </lst>
   </initParams>
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-components-name.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-components-name.xml
@@ -38,7 +38,7 @@
   <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
 
   <updateHandler class="solr.DirectUpdateHandler2"></updateHandler>
-  
+
   <queryResponseWriter name="xml" default="true"
                        class="solr.XMLResponseWriter" />
 
@@ -59,11 +59,6 @@
     </httpCaching>
   </requestDispatcher>
 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
-  
  <searchComponent name="component1" class="org.apache.solr.search.MockSearchComponent">
      <str name="testParam">foo</str>
  </searchComponent>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-doctransformers.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-doctransformers.xml
@@ -43,10 +43,4 @@
     <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="-1" />
   </requestDispatcher>
 
-  <!-- config for the admin interface -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-elevate.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-elevate.xml
@@ -36,10 +36,10 @@
 
   <updateHandler class="solr.DirectUpdateHandler2">
 
-    <!-- autocommit pending docs if certain criteria are met 
-    <autoCommit> 
+    <!-- autocommit pending docs if certain criteria are met
+    <autoCommit>
       <maxDocs>10000</maxDocs>
-      <maxTime>3600000</maxTime> 
+      <maxTime>3600000</maxTime>
     </autoCommit>
     -->
 
@@ -120,11 +120,6 @@
       <cacheControl>max-age=30, public</cacheControl>
     </httpCaching>
   </requestDispatcher>
-
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
 
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-hash.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-hash.xml
@@ -52,10 +52,4 @@
 
   <requestHandler name="/select" class="solr.SearchHandler" />
 
-  <!-- config for the admin interface -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
@@ -46,7 +46,7 @@
     <double name="maxWriteMBPerSecMerge">3000000</double>
     <double name="maxWriteMBPerSecRead">4000000</double>
     <str name="solr.hdfs.home">${solr.hdfs.home:}</str>
-    <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool> 
+    <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool>
     <bool name="solr.hdfs.blockcache.global">${solr.hdfs.blockcache.global:true}</bool>
     <bool name="solr.hdfs.blockcache.write.enabled">${solr.hdfs.blockcache.write.enabled:false}</bool>
     <int name="solr.hdfs.blockcache.blocksperbank">${solr.hdfs.blockcache.blocksperbank:10}</int>
@@ -73,11 +73,11 @@
       <maxTime>3600000</maxTime>
     </autoCommit>
     -->
-    
+
     <updateLog enable="${enable.update.log:true}">
       <str name="dir">${solr.ulog.dir:}</str>
-    </updateLog> 
-    
+    </updateLog>
+
     <commitWithin>
       <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
     </commitWithin>
@@ -169,7 +169,7 @@
     <slowQueryThresholdMillis>2000</slowQueryThresholdMillis>
 
   </query>
-  
+
   <queryResponseWriter name="xml" default="true"
                        class="solr.XMLResponseWriter" />
 
@@ -240,7 +240,7 @@
     </lst>
     <lst name="spellchecker">
       <str name="name">wordbreak</str>
-      <str name="classname">solr.WordBreakSolrSpellChecker</str>      
+      <str name="classname">solr.WordBreakSolrSpellChecker</str>
       <str name="field">lowerfilt</str>
       <str name="combineWords">true</str>
       <str name="breakWords">true</str>
@@ -354,7 +354,7 @@
         <str>spellcheck</str>
       </arr>
  </requestHandler>
- 
+
   <requestHandler name="/mltrh" class="org.apache.solr.handler.component.SearchHandler">
 
   </requestHandler>
@@ -441,11 +441,6 @@
       <str name="facet.query">foo_s:bar</str>
     </lst>
   </requestHandler>
-  
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
 
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"
@@ -459,10 +454,10 @@
         <str>uniq</str>
         <str>uniq2</str>
         <str>uniq3</str>
-      </arr>      
+      </arr>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>  
+  </updateRequestProcessorChain>
 
   <updateRequestProcessorChain name="distrib-dup-test-chain-explicit">
     <!-- explicit test using processors before and after distrib -->
@@ -478,7 +473,7 @@
       <str name="replacement">x_x</str>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>  
+  </updateRequestProcessorChain>
 
   <updateRequestProcessorChain name="distrib-dup-test-chain-implicit">
     <!-- implicit test w/o distrib declared-->
@@ -493,10 +488,10 @@
       <str name="replacement">x_x</str>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>  
+  </updateRequestProcessorChain>
 
   <restManager>
-    <!-- 
+    <!--
     IMPORTANT: Due to the Lucene SecurityManager, tests can only write to their runtime directory or below.
     But it's easier to just keep everything in memory for testing so no remnants are left behind.
     -->
@@ -513,4 +508,3 @@
   <queryParser name="minhash" class="org.apache.solr.search.MinHashQParserPlugin" />
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
@@ -431,10 +431,6 @@
       <cacheControl>max-age=30, public</cacheControl>
     </httpCaching>
   </requestDispatcher>
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
 
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"
@@ -491,4 +487,3 @@
   </initParams>
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-sql.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-sql.xml
@@ -63,10 +63,4 @@
     <str name="healthcheckFile">server-enabled.txt</str>
   </requestHandler>
 
-  <!-- config for the admin interface -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-test-misc.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-test-misc.xml
@@ -28,18 +28,12 @@
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
-  <!-- see TestConfig.testAutomaticDeprecationSupport -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
-
   <!-- see TestConfig.testLib() -->
   <lib dir="../../lib-dirs/a" />
   <lib dir="../../lib-dirs/b" regex="b." />
   <lib dir="../../lib-dirs/c" regex="c1" />
   <lib path="../../lib-dirs/d/d1/" />
-  
+
   <!-- see TestConfig.testJavaProperty -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"
             attr2="${non.existent.sys.prop:default-from-config}">prefix-${solr.test.sys.prop2}-suffix</propTest>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -46,7 +46,7 @@
     <double name="maxWriteMBPerSecMerge">3000000</double>
     <double name="maxWriteMBPerSecRead">4000000</double>
     <str name="solr.hdfs.home">${solr.hdfs.home:}</str>
-    <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool> 
+    <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool>
     <bool name="solr.hdfs.blockcache.global">${solr.hdfs.blockcache.global:true}</bool>
     <bool name="solr.hdfs.blockcache.write.enabled">${solr.hdfs.blockcache.write.enabled:false}</bool>
     <int name="solr.hdfs.blockcache.blocksperbank">${solr.hdfs.blockcache.blocksperbank:10}</int>
@@ -73,11 +73,11 @@
       <maxTime>3600000</maxTime>
     </autoCommit>
     -->
-    
+
     <updateLog enable="${enable.update.log:true}">
       <str name="dir">${solr.ulog.dir:}</str>
-    </updateLog> 
-    
+    </updateLog>
+
     <commitWithin>
       <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
     </commitWithin>
@@ -169,7 +169,7 @@
     <slowQueryThresholdMillis>2000</slowQueryThresholdMillis>
 
   </query>
-  
+
   <queryResponseWriter name="xml" default="true"
                        class="solr.XMLResponseWriter" />
 
@@ -240,7 +240,7 @@
     </lst>
     <lst name="spellchecker">
       <str name="name">wordbreak</str>
-      <str name="classname">solr.WordBreakSolrSpellChecker</str>      
+      <str name="classname">solr.WordBreakSolrSpellChecker</str>
       <str name="field">lowerfilt</str>
       <str name="combineWords">true</str>
       <str name="breakWords">true</str>
@@ -304,8 +304,8 @@
     </arr>
   </requestHandler>
   -->
-  
-  
+
+
   <!--
   The SpellingQueryConverter to convert raw (CommonParams.Q) queries into tokens.  Uses a simple regular expression
    to strip off field markup, boosts, ranges, etc. but it is not guaranteed to match an exact parse from the query parser.
@@ -365,7 +365,7 @@
         <str>spellcheck</str>
       </arr>
  </requestHandler>
- 
+
   <requestHandler name="/mltrh" class="org.apache.solr.handler.component.SearchHandler">
 
   </requestHandler>
@@ -452,11 +452,6 @@
       <str name="facet.query">foo_s:bar</str>
     </lst>
   </requestHandler>
-  
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
 
   <!-- test getting system property -->
   <propTest attr1="${solr.test.sys.prop1}-$${literal}"
@@ -470,10 +465,10 @@
         <str>uniq</str>
         <str>uniq2</str>
         <str>uniq3</str>
-      </arr>      
+      </arr>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>  
+  </updateRequestProcessorChain>
 
   <updateRequestProcessorChain name="distrib-dup-test-chain-explicit">
     <!-- explicit test using processors before and after distrib -->
@@ -489,7 +484,7 @@
       <str name="replacement">x_x</str>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>  
+  </updateRequestProcessorChain>
 
   <updateRequestProcessorChain name="distrib-dup-test-chain-implicit">
     <!-- implicit test w/o distrib declared-->
@@ -504,10 +499,10 @@
       <str name="replacement">x_x</str>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>  
+  </updateRequestProcessorChain>
 
   <restManager>
-    <!-- 
+    <!--
     IMPORTANT: Due to the Lucene SecurityManager, tests can only write to their runtime directory or below.
     But it's easier to just keep everything in memory for testing so no remnants are left behind.
     -->
@@ -530,4 +525,3 @@
   </transformer>
 
 </config>
-

--- a/solr/core/src/test-files/solr/crazy-path-to-config.xml
+++ b/solr/core/src/test-files/solr/crazy-path-to-config.xml
@@ -52,11 +52,6 @@
   <queryResponseWriter name="standard" class="solr.XMLResponseWriter"/>
   <queryResponseWriter name="useless" class="org.apache.solr.OutputWriterTest$UselessOutputWriter" startup="lazy"/>
 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-    <gettableFiles>solrconfig.xml schema.xml</gettableFiles>
-  </admin>
-
   <initParams path="/select,/crazy_custom_qt">
     <lst name="defaults">
       <str name="df">subject</str>

--- a/solr/core/src/test/org/apache/solr/core/TestConfig.java
+++ b/solr/core/src/test/org/apache/solr/core/TestConfig.java
@@ -28,7 +28,6 @@ import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.util.InfoStream;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.ConfigNode;
-import org.apache.solr.handler.admin.ShowFileRequestHandler;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.IndexSchemaFactory;
 import org.apache.solr.search.CacheConfig;

--- a/solr/core/src/test/org/apache/solr/core/TestConfig.java
+++ b/solr/core/src/test/org/apache/solr/core/TestConfig.java
@@ -99,18 +99,9 @@ public class TestConfig extends SolrTestCaseJ4 {
     assertEquals("prefix-proptwo-suffix", solrConfig.get("propTest").txt());
   }
 
-  // sometime if the config referes to old things, it must be replaced with new stuff
-  @Test
-  public void testAutomaticDeprecationSupport() {
-    // make sure the "admin/file" handler is registered
-    ShowFileRequestHandler handler = (ShowFileRequestHandler) h.getCore().getRequestHandler("/admin/file");
-    assertTrue("file handler should have been automatically registered", handler != null);
-
-  }
-  
  @Test
  public void testCacheEnablingDisabling() throws Exception {
-   // ensure if cache is not defined in the config then cache is disabled 
+   // ensure if cache is not defined in the config then cache is disabled
    SolrConfig sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-defaults.xml");
    assertNull(sc.filterCacheConfig);
    assertNull(sc.queryResultCacheConfig);
@@ -118,14 +109,14 @@ public class TestConfig extends SolrTestCaseJ4 {
    //
    assertNotNull(sc.userCacheConfigs);
    assertEquals(Collections.<String, CacheConfig>emptyMap(), sc.userCacheConfigs);
-   
-   // enable all the core caches (and one user cache) via system properties and verify 
+
+   // enable all the core caches (and one user cache) via system properties and verify
    System.setProperty("filterCache.enabled", "true");
    System.setProperty("queryResultCache.enabled", "true");
    System.setProperty("documentCache.enabled", "true");
    System.setProperty("user_defined_cache_XXX.enabled","true");
    // user_defined_cache_ZZZ.enabled defaults to false in config
-   
+
    sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-cache-enable-disable.xml");
    assertNotNull(sc.filterCacheConfig);
    assertNotNull(sc.queryResultCacheConfig);
@@ -134,7 +125,7 @@ public class TestConfig extends SolrTestCaseJ4 {
    assertNotNull(sc.userCacheConfigs);
    assertEquals(1, sc.userCacheConfigs.size());
    assertNotNull(sc.userCacheConfigs.get("user_defined_cache_XXX"));
-   
+
    // disable all the core caches (and enable both user caches) via system properties and verify
    System.setProperty("filterCache.enabled", "false");
    System.setProperty("queryResultCache.enabled", "false");
@@ -151,14 +142,14 @@ public class TestConfig extends SolrTestCaseJ4 {
    assertEquals(2, sc.userCacheConfigs.size());
    assertNotNull(sc.userCacheConfigs.get("user_defined_cache_XXX"));
    assertNotNull(sc.userCacheConfigs.get("user_defined_cache_ZZZ"));
-   
+
    System.clearProperty("user_defined_cache_XXX.enabled");
    System.clearProperty("user_defined_cache_ZZZ.enabled");
    System.clearProperty("filterCache.enabled");
    System.clearProperty("queryResultCache.enabled");
    System.clearProperty("documentCache.enabled");
  }
-  
+
 
   // If defaults change, add test methods to cover each version
   @Test
@@ -245,12 +236,12 @@ public class TestConfig extends SolrTestCaseJ4 {
     SolrConfig sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-basic.xml");
     SolrIndexConfig sic = sc.indexConfig;
 
-    assertEquals("ramBufferSizeMB sysprop", 
-                 Double.parseDouble(System.getProperty("solr.tests.ramBufferSizeMB")), 
+    assertEquals("ramBufferSizeMB sysprop",
+                 Double.parseDouble(System.getProperty("solr.tests.ramBufferSizeMB")),
                                     sic.ramBufferSizeMB, 0.0D);
     assertEquals("ramPerThreadHardLimitMB sysprop",
         Integer.parseInt(System.getProperty("solr.tests.ramPerThreadHardLimitMB")), sic.ramPerThreadHardLimitMB);
-    assertEquals("useCompoundFile sysprop", 
+    assertEquals("useCompoundFile sysprop",
                  Boolean.parseBoolean(System.getProperty("useCompoundFile")), sic.useCompoundFile);
   }
 

--- a/solr/solrj/src/test-files/solrj/solr/collection1/conf/solrconfig-sql.xml
+++ b/solr/solrj/src/test-files/solrj/solr/collection1/conf/solrconfig-sql.xml
@@ -63,10 +63,4 @@
     <str name="healthcheckFile">server-enabled.txt</str>
   </requestHandler>
 
-  <!-- config for the admin interface -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
 </config>
-

--- a/solr/solrj/src/test-files/solrj/solr/collection1/conf/solrconfig.xml
+++ b/solr/solrj/src/test-files/solrj/solr/collection1/conf/solrconfig.xml
@@ -17,8 +17,8 @@
 -->
 
 <!--
- This is a stripped down config file used for a simple example...  
- It is *not* a good example to work from. 
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
 -->
 <config>
   <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
@@ -51,10 +51,4 @@
     <str name="healthcheckFile">server-enabled.txt</str>
   </requestHandler>
 
-  <!-- config for the admin interface --> 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
 </config>
-

--- a/solr/solrj/src/test-files/solrj/solr/configsets/ml/conf/solrconfig.xml
+++ b/solr/solrj/src/test-files/solrj/solr/configsets/ml/conf/solrconfig.xml
@@ -42,10 +42,4 @@
 
   <requestHandler name="/select" class="solr.SearchHandler"/>
 
-  <!-- config for the admin interface -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
 </config>
-

--- a/solr/solrj/src/test-files/solrj/solr/configsets/shared/conf/solrconfig.xml
+++ b/solr/solrj/src/test-files/solrj/solr/configsets/shared/conf/solrconfig.xml
@@ -17,8 +17,8 @@
 -->
 
 <!--
- This is a stripped down config file used for a simple example...  
- It is *not* a good example to work from. 
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
 -->
 <config>
   <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
@@ -41,11 +41,6 @@
 
   <requestHandler name="/select" class="solr.SearchHandler"/>
 
-  <!-- config for the admin interface --> 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
   <initParams path="/select">
     <lst name="defaults">
       <str name="df">name</str>
@@ -53,4 +48,3 @@
   </initParams>
 
 </config>
-

--- a/solr/solrj/src/test-files/solrj/solr/configsets/streaming/conf/solrconfig.xml
+++ b/solr/solrj/src/test-files/solrj/solr/configsets/streaming/conf/solrconfig.xml
@@ -47,11 +47,6 @@
 
   <requestHandler name="/select" class="solr.SearchHandler"/>
 
-  <!-- config for the admin interface -->
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
   <initParams path="/select">
     <lst name="defaults">
       <str name="df">text</str>
@@ -59,4 +54,3 @@
   </initParams>
 
 </config>
-

--- a/solr/solrj/src/test-files/solrj/solr/multicore/core0/conf/solrconfig.xml
+++ b/solr/solrj/src/test-files/solrj/solr/multicore/core0/conf/solrconfig.xml
@@ -17,8 +17,8 @@
 -->
 
 <!--
- This is a stripped down config file used for a simple example...  
- It is *not* a good example to work from. 
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
 -->
 <config>
   <luceneMatchVersion>6.0.0</luceneMatchVersion>
@@ -30,24 +30,24 @@
   <dataDir>${solr.core0.data.dir:}</dataDir>
 
   <!-- To enable dynamic schema REST APIs, use the following for <schemaFactory>:
-  
+
        <schemaFactory class="ManagedIndexSchemaFactory">
          <bool name="mutable">true</bool>
          <str name="managedSchemaResourceName">managed-schema</str>
        </schemaFactory>
-       
+
        When ManagedIndexSchemaFactory is specified, Solr will load the schema from
        the resource named in 'managedSchemaResourceName', rather than from schema.xml.
        Note that the managed schema resource CANNOT be named schema.xml.  If the managed
        schema does not exist, Solr will create it after reading schema.xml, then rename
-       'schema.xml' to 'schema.xml.bak'. 
-       
+       'schema.xml' to 'schema.xml.bak'.
+
        Do NOT hand edit the managed schema - external modifications will be ignored and
        overwritten as a result of schema modification REST API calls.
 
        When ManagedIndexSchemaFactory is specified with mutable = true, schema
        modification REST API calls will be allowed; otherwise, error responses will be
-       sent back for these requests. 
+       sent back for these requests.
   -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
@@ -63,11 +63,6 @@
 
   <requestHandler name="/select" class="solr.SearchHandler"/>
 
-  <!-- config for the admin interface --> 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
   <initParams path="/select">
     <lst name="defaults">
       <str name="df">name</str>
@@ -75,4 +70,3 @@
   </initParams>
 
 </config>
-

--- a/solr/solrj/src/test-files/solrj/solr/multicore/core1/conf/solrconfig.xml
+++ b/solr/solrj/src/test-files/solrj/solr/multicore/core1/conf/solrconfig.xml
@@ -17,8 +17,8 @@
 -->
 
 <!--
- This is a stripped down config file used for a simple example...  
- It is *not* a good example to work from. 
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
 -->
 <config>
   <luceneMatchVersion>6.0.0</luceneMatchVersion>
@@ -30,24 +30,24 @@
   <dataDir>${solr.core1.data.dir:}</dataDir>
 
   <!-- To enable dynamic schema REST APIs, use the following for <schemaFactory>:
-  
+
        <schemaFactory class="ManagedIndexSchemaFactory">
          <bool name="mutable">true</bool>
          <str name="managedSchemaResourceName">managed-schema</str>
        </schemaFactory>
-       
+
        When ManagedIndexSchemaFactory is specified, Solr will load the schema from
        the resource named in 'managedSchemaResourceName', rather than from schema.xml.
        Note that the managed schema resource CANNOT be named schema.xml.  If the managed
        schema does not exist, Solr will create it after reading schema.xml, then rename
-       'schema.xml' to 'schema.xml.bak'. 
-       
+       'schema.xml' to 'schema.xml.bak'.
+
        Do NOT hand edit the managed schema - external modifications will be ignored and
        overwritten as a result of schema modification REST API calls.
 
        When ManagedIndexSchemaFactory is specified with mutable = true, schema
        modification REST API calls will be allowed; otherwise, error responses will be
-       sent back for these requests. 
+       sent back for these requests.
   -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
@@ -63,11 +63,6 @@
 
   <requestHandler name="/select" class="solr.SearchHandler"/>
 
-  <!-- config for the admin interface --> 
-  <admin>
-    <defaultQuery>solr</defaultQuery>
-  </admin>
-
   <initParams path="/select">
     <lst name="defaults">
       <str name="df">name</str>
@@ -75,4 +70,3 @@
   </initParams>
 
 </config>
-

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
@@ -16,17 +16,11 @@
  */
 package org.apache.solr.client.solrj;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.client.solrj.request.RequestWriter;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.BeforeClass;
-
-import java.io.File;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * A subclass of SolrExampleTests that explicitly uses the xml codec for
@@ -34,17 +28,9 @@ import java.util.TreeMap;
  */
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class SolrExampleXMLTest extends SolrExampleTests {
-
   @BeforeClass
   public static void beforeTest() throws Exception {
-    File tmpSolrHome = createTempDir().toFile();
-    FileUtils.copyDirectory(new File(getFile("solrj/solr/testproducts/conf").getParent()), new File(tmpSolrHome.getAbsoluteFile(), "collection1"));
-
-    FileUtils.copyFile(getFile("solrj/solr/solr.xml"), new File(tmpSolrHome.getAbsoluteFile(), "solr.xml"));
-
-    final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();
-
-    createAndStartJetty(tmpSolrHome.getAbsolutePath(), "solrconfig.xml", "managed-schema", "/solr", true, extraServlets);
+    createAndStartJetty(legacyExampleCollection1SolrHome());
   }
   
   @Override

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
@@ -16,11 +16,17 @@
  */
 package org.apache.solr.client.solrj;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.client.solrj.request.RequestWriter;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.BeforeClass;
+
+import java.io.File;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * A subclass of SolrExampleTests that explicitly uses the xml codec for
@@ -28,9 +34,17 @@ import org.junit.BeforeClass;
  */
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class SolrExampleXMLTest extends SolrExampleTests {
+
   @BeforeClass
   public static void beforeTest() throws Exception {
-    createAndStartJetty(legacyExampleCollection1SolrHome());
+    File tmpSolrHome = createTempDir().toFile();
+    FileUtils.copyDirectory(new File(getFile("solrj/solr/testproducts/conf").getParent()), new File(tmpSolrHome.getAbsoluteFile(), "collection1"));
+
+    FileUtils.copyFile(getFile("solrj/solr/solr.xml"), new File(tmpSolrHome.getAbsoluteFile(), "solr.xml"));
+
+    final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();
+
+    createAndStartJetty(tmpSolrHome.getAbsolutePath(), "solrconfig.xml", "managed-schema", "/solr", true, extraServlets);
   }
   
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15791
# Description

Removing old `<admin/>` xml stanza from solrconfigs that no longer is used.  Clean up!

# Solution

Removed the xml, ran the tests.  I found one unit test, TestConfig.testAutomaticDeprecationSupport() that didn't seem to add any value anymore.

# Tests

Ran existing tests.

# Checklist

Please review the following and check all that apply:

- [x ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x ] I have created a Jira issue and added the issue ID to my pull request title.
- [x ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
