### PR TITLE
SOLR-15793: ref-guide jrubyPrepare fails due to gems trying to compile native code

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -174,6 +174,8 @@ Build
 
 * SOLR-13671: Remove check for bare "var" declarations in validate-source-patterns (Erick Erickson, Alex Bulygin, janhoy)
 
+* SOLR-15793: Pin http_parser.rb to specific version to allow Solr Ref Guide on Jekyll to run (Eric Pugh)
+
 Other Changes
 ----------------------
 * SOLR-15603: Add an option to activate Gradle build cache, build task cleanups (Alexis Tual, Dawid Weiss)

--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     gems 'rubygems:tilt:2.0.10'
     gems 'rubygems:slim:4.1.0'
     gems 'rubygems:concurrent-ruby:1.1.9'
+    gems 'rubygems:http_parser.rb:0.6.0'
+
+
 }
 
 sourceSets {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
@@ -16,17 +16,11 @@
  */
 package org.apache.solr.client.solrj;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.client.solrj.request.RequestWriter;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.BeforeClass;
-
-import java.io.File;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * A subclass of SolrExampleTests that explicitly uses the xml codec for
@@ -34,17 +28,9 @@ import java.util.TreeMap;
  */
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class SolrExampleXMLTest extends SolrExampleTests {
-
   @BeforeClass
   public static void beforeTest() throws Exception {
-    File tmpSolrHome = createTempDir().toFile();
-    FileUtils.copyDirectory(new File(getFile("solrj/solr/testproducts/conf").getParent()), new File(tmpSolrHome.getAbsoluteFile(), "collection1"));
-
-    FileUtils.copyFile(getFile("solrj/solr/solr.xml"), new File(tmpSolrHome.getAbsoluteFile(), "solr.xml"));
-
-    final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();
-
-    createAndStartJetty(tmpSolrHome.getAbsolutePath(), "solrconfig.xml", "managed-schema", "/solr", true, extraServlets);
+    createAndStartJetty(legacyExampleCollection1SolrHome());
   }
   
   @Override

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleXMLTest.java
@@ -16,11 +16,17 @@
  */
 package org.apache.solr.client.solrj;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.client.solrj.request.RequestWriter;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.BeforeClass;
+
+import java.io.File;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * A subclass of SolrExampleTests that explicitly uses the xml codec for
@@ -28,9 +34,17 @@ import org.junit.BeforeClass;
  */
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class SolrExampleXMLTest extends SolrExampleTests {
+
   @BeforeClass
   public static void beforeTest() throws Exception {
-    createAndStartJetty(legacyExampleCollection1SolrHome());
+    File tmpSolrHome = createTempDir().toFile();
+    FileUtils.copyDirectory(new File(getFile("solrj/solr/testproducts/conf").getParent()), new File(tmpSolrHome.getAbsoluteFile(), "collection1"));
+
+    FileUtils.copyFile(getFile("solrj/solr/solr.xml"), new File(tmpSolrHome.getAbsoluteFile(), "solr.xml"));
+
+    final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();
+
+    createAndStartJetty(tmpSolrHome.getAbsolutePath(), "solrconfig.xml", "managed-schema", "/solr", true, extraServlets);
   }
   
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15793



# Description
pin http_parser.rb gem dependency to an older version that compiles.

# Solution
pin an older version!    I tested in branch_8x and it didn't seem to have the same issue.

# Tests
ran the build

# Checklist

Please review the following and check all that apply:

- [ X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
