### PR TITLE
SOLR-15808: The jattach tool for Docker image is now installed with apt

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -409,6 +409,8 @@ Other Changes
 
 * SOLR-15784: Remove SolrJ dependency on commons-io. (Mike Drob)
 
+* SOLR-15808: [Docker] The jattach tool is now installed with apt (janhoy)
+
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -43,11 +43,8 @@ ARG GITHUB_URL=github.com
 
 RUN set -ex; \
     apt-get update; \
-    apt-get -y install acl dirmngr lsof procps wget netcat gosu tini; \
-    rm -rf /var/lib/apt/lists/*; \
-    cd /usr/local/bin; wget -nv https://${GITHUB_URL}/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
-    echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
-    sha512sum -c jattach.sha512; rm jattach.sha512
+    apt-get -y install acl dirmngr lsof procps wget netcat gosu tini jattach; \
+    rm -rf /var/lib/apt/lists/*;
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15808

Just yet another simplification of Dockerfile, shaved off 4 lines :) 