### PR TITLE
SOLR-15808: Remove the GITHUB_URL arg from the docker build

### DIFF
--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -28,7 +28,6 @@ def dockerImageRepo = propertyOrEnvOrDefault("solr.docker.imageRepo", "SOLR_DOCK
 def dockerImageTag = propertyOrEnvOrDefault("solr.docker.imageTag", "SOLR_DOCKER_IMAGE_TAG", "${version}")
 def dockerImageName = propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}:${dockerImageTag}")
 def baseDockerImage = propertyOrEnvOrDefault("solr.docker.baseImage", "SOLR_DOCKER_BASE_IMAGE", 'openjdk:11-jre-slim')
-def githubUrlOrMirror = propertyOrEnvOrDefault("solr.docker.githubUrl", "SOLR_DOCKER_GITHUB_URL", 'github.com')
 
 def releaseGpgFingerprint = propertyOrDefault('signing.gnupg.keyName','');
 
@@ -111,8 +110,7 @@ task dockerBuild(dependsOn: configurations.solrTgz) {
 
   // Ensure that the docker image is rebuilt on build-arg changes or changes in the docker context
   inputs.properties([
-          baseDockerImage: baseDockerImage,
-          githubUrlOrMirror: githubUrlOrMirror
+          baseDockerImage: baseDockerImage
   ])
   inputs.files(configurations.solrTgz)
 
@@ -123,7 +121,6 @@ task dockerBuild(dependsOn: configurations.solrTgz) {
               "-f", "solr-${version}/docker/Dockerfile.local",
               "--iidfile", imageIdFile,
               "--build-arg", "BASE_IMAGE=${inputs.properties.baseDockerImage}",
-              "--build-arg", "GITHUB_URL=${inputs.properties.githubUrlOrMirror}",
               "-"
     }
   }
@@ -393,7 +390,6 @@ task testBuildDockerfileOfficial(type: Copy) {
             "--iidfile", imageIdFileOfficial,
             '--build-arg', "SOLR_CLOSER_URL=http://mock-solr-dl-server:9876/solr-${version}.tgz",
             '--build-arg', "SOLR_ARCHIVE_URL=http://mock-solr-dl-server:9876/solr-${version}.tgz",
-            "--build-arg", "GITHUB_URL=${githubUrlOrMirror}",
             '-'
         }
         

--- a/solr/docker/gradle-help.txt
+++ b/solr/docker/gradle-help.txt
@@ -21,11 +21,6 @@ Base Docker Image: (The docker image used for the "FROM" in the Solr Dockerfile)
    EnvVar: SOLR_DOCKER_BASE_IMAGE
    Gradle Property: -Psolr.docker.baseImage
 
-Github URL or Mirror: (The URL of github or a mirror of github releases. This is of use when building the docker image behind a firewall that does not have access to external Github.)
-   Default: "github.com"
-   EnvVar: SOLR_DOCKER_GITHUB_URL
-   Gradle Property: -Psolr.docker.githubUrl
-
 Tagging and Pushing
 -------
 

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -37,9 +37,6 @@ RUN set -ex; \
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/apache/lucene-solr"
-  
-# Override the default github URL to provide a mirror for github releases.
-ARG GITHUB_URL=github.com
 
 RUN set -ex; \
     apt-get update; \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15808

Cleaning up the GITHUB_URL option after updating the dockerfiles to download jattach from `apt-get` instead of github.