### PR TITLE
SOLR-15828: AuthTool (in SolrCLI) should include the config-read, collection-admin-read, core-admin-read, and all permissions in the initial security.json

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -461,6 +461,9 @@ Bug Fixes
 * SOLR-15825: Security UI 'hasPermission' check should check if the user has the "all" permission if the requested permission is not defined
   to match how the backend works (Timothy Potter)
 
+* SOLR-15828: AuthTool (in SolrCLI) should include the config-read, collection-admin-read, core-admin-read, and all permissions in the initial security.json
+  to avoid warnings in the security UI (Timothy Potter)
+
 ==================  8.11.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/core/src/java/org/apache/solr/util/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrCLI.java
@@ -3998,8 +3998,8 @@ public class SolrCLI implements CLIO {
               "\n {\"name\":\"config-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"collection-admin-edit\", \"role\":\"admin\"}," +
               "\n {\"name\":\"collection-admin-read\", \"role\":\"admin\"}," +
-              "\n {\"name\":\"core-admin-edit\", \"role\":\"admin\"}" +
-              "\n {\"name\":\"core-admin-read\", \"role\":\"admin\"}" +
+              "\n {\"name\":\"core-admin-edit\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"core-admin-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"all\", \"role\":\"admin\"}" +
               "\n   ]," +
               "\n   \"user-role\":{\"" + username + "\":\"admin\"}" +

--- a/solr/core/src/java/org/apache/solr/util/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrCLI.java
@@ -3995,8 +3995,12 @@ public class SolrCLI implements CLIO {
               "\n {\"name\":\"security-edit\", \"role\":\"admin\"}," +
               "\n {\"name\":\"security-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"config-edit\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"config-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"collection-admin-edit\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"collection-admin-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"core-admin-edit\", \"role\":\"admin\"}" +
+              "\n {\"name\":\"core-admin-read\", \"role\":\"admin\"}" +
+              "\n {\"name\":\"all\", \"role\":\"admin\"}" +
               "\n   ]," +
               "\n   \"user-role\":{\"" + username + "\":\"admin\"}" +
               "\n  }" +


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15828

Manually tested by running:
```
bin/solr auth enable -type basicAuth -prompt true -z localhost:2181
```
And then reload the security UI to ensure no warnings.