### PR TITLE
SOLR-15829: IllegalStateException when using Managed resources (e.g. ManagedSynonymGraphFilterFactory)

### DIFF
--- a/solr/core/src/test-files/solr/configsets/cloud-managed-resource/conf/schema.xml
+++ b/solr/core/src/test-files/solr/configsets/cloud-managed-resource/conf/schema.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<schema name="minimal" version="1.1">
+  <fieldType name="string" class="solr.StrField"/>
+  <fieldType name="int" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="long" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <!-- for versioning -->
+  <field name="_version_" type="long" indexed="true" stored="true"/>
+  <field name="_root_" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
+  <field name="id" type="string" indexed="true" stored="true"/>
+  <field name="text" type="sortabletext" indexed="true" stored="true"/>
+
+  <fieldType name="sortabletext" class="solr.SortableTextField" positionIncrementGap="100" multiValued="true">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <uniqueKey>id</uniqueKey>
+
+  <!-- needed for IllegalStateExceptionManagedSynonymGraphFilterTest -->
+  <field name="text_syn" type="text_synonyms_en" indexed="true" stored="false"/>
+  <fieldType name="text_synonyms_en" class="solr.TextField" autoGeneratePhraseQueries="false"
+             enableGraphQueries="false" positionIncrementGap="100" multiValued="false">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.ManagedSynonymGraphFilterFactory" managed="en"/>
+      <filter class="solr.EnglishMinimalStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+
+</schema>

--- a/solr/core/src/test-files/solr/configsets/cloud-managed-resource/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/configsets/cloud-managed-resource/conf/solrconfig.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- Minimal solrconfig.xml with /select, /admin and /update only -->
+
+<config>
+
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <directoryFactory name="DirectoryFactory"
+                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+
+  <schemaFactory class="ManagedIndexSchemaFactory"/>
+
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <commitWithin>
+      <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
+    </commitWithin>
+    <updateLog></updateLog>
+  </updateHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="indent">true</str>
+      <str name="df">text</str>
+    </lst>
+
+  </requestHandler>
+</config>

--- a/solr/core/src/test/org/apache/solr/cloud/IllegalStateExceptionManagedSynonymGraphFilterTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/IllegalStateExceptionManagedSynonymGraphFilterTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.cloud;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.lucene.util.IOUtils;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrException;
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+
+public class IllegalStateExceptionManagedSynonymGraphFilterTest extends SolrCloudTestCase {
+
+  private static final String COLLECTION = "collection1";
+  private static final String CONFIG_NAME = "myconf";
+
+  private CloseableHttpClient httpClient;
+  private CloudSolrClient solrClient;
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    configureCluster(1)
+        .addConfig(CONFIG_NAME, configset("cloud-managed-resource"))
+        .configure();
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    solrClient = getCloudSolrClient(cluster);
+    httpClient = (CloseableHttpClient) solrClient.getHttpClient();
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    IOUtils.close(solrClient, httpClient);
+
+    cluster.deleteAllCollections();
+  }
+
+  @Test
+  public void test() throws Exception {
+    CollectionAdminRequest.createCollection(COLLECTION, CONFIG_NAME, 2, 1).process(solrClient);
+
+    cluster.waitForActiveCollection(COLLECTION, 2, 2);
+
+    waitForState("Expected collection1 to be created with 2 shards and 1 replica", COLLECTION, clusterShape(2, 2));
+
+    // index time exception
+    try {
+      new UpdateRequest()
+          .add("id", "6", "text_syn", "humpty dumpy sat on a wall")
+          .add("id", "7", "text_syn", "humpty dumpy3 sat on a walls")
+          .add("id", "8", "text_syn", "humpty dumpy2 sat on a walled")
+          .commit(solrClient, COLLECTION);
+      MatcherAssert.assertThat("Exception should be raised - so should not raise AssertionError", 0, is(1));
+    } catch (SolrException e) {
+      MatcherAssert.assertThat(e.getRootThrowable(), is("java.lang.IllegalStateException"));
+      MatcherAssert.assertThat(e.toString(), containsString("Exception writing document id"));
+      MatcherAssert.assertThat(e.toString(), containsString("to the index; possible analysis error."));
+    }
+
+    // query time exception
+    final SolrQuery solrQuery = new SolrQuery("q", "text_syn:dumpy2", "rows", "0");
+    try {
+      solrClient.query(COLLECTION, solrQuery);
+      MatcherAssert.assertThat("Exception should be raised - so should not raise AssertionError", 0, is(1));
+    } catch (Exception e) {
+      MatcherAssert.assertThat((((SolrServerException) e).getRootCause()).getMessage(), containsString("org.apache.solr.rest.schema.analysis.ManagedSynonymGraphFilterFactory not initialized correctly! The SynonymFilterFactory delegate was not initialized."));
+    }
+
+    // no exception after reloading
+    CollectionAdminRequest.reloadCollection(COLLECTION).process(solrClient);
+    new UpdateRequest()
+        .add("id", "6", "text_syn", "humpty dumpy sat on a wall")
+        .add("id", "7", "text_syn", "humpty dumpy3 sat on a walls")
+        .add("id", "8", "text_syn", "humpty dumpy2 sat on a walled")
+        .commit(solrClient, COLLECTION);
+    final SolrQuery solrQuery2 = new SolrQuery("q", "text_syn:dumpy2", "rows", "0");
+    QueryResponse response = solrClient.query(COLLECTION, solrQuery2);
+    MatcherAssert.assertThat(response.getResults().getNumFound(), is(1L));
+  }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15829 

# Description

Introduce test case that demonstrates the issue:  IllegalStateException thrown at index and at query time

# Solution

TBD (likely a follow up of SOLR-13739)

# Tests

When problem is solved test should be amended to demonstrate that the problem is solved.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
