### PR TITLE
SOLR-15826 Simplify some code in SolrResourceLoader after review

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
@@ -91,7 +91,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
   };
   private static final Charset UTF_8 = StandardCharsets.UTF_8;
   public static final String SOLR_ALLOW_UNSAFE_RESOURCELOADING_PARAM = "solr.allow.unsafe.resourceloading";
-  private boolean allowUnsafeResourceloading;
+  private final boolean allowUnsafeResourceloading;
 
 
   private String name = "";
@@ -104,9 +104,9 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
   private PackageListeningClassLoader schemaLoader ;
 
   private PackageListeningClassLoader coreReloadingClassLoader ;
-  private final List<SolrCoreAware> waitingForCore = Collections.synchronizedList(new ArrayList<SolrCoreAware>());
-  private final List<SolrInfoBean> infoMBeans = Collections.synchronizedList(new ArrayList<SolrInfoBean>());
-  private final List<ResourceLoaderAware> waitingForResources = Collections.synchronizedList(new ArrayList<ResourceLoaderAware>());
+  private final List<SolrCoreAware> waitingForCore = Collections.synchronizedList(new ArrayList<>());
+  private final List<SolrInfoBean> infoMBeans = Collections.synchronizedList(new ArrayList<>());
+  private final List<ResourceLoaderAware> waitingForResources = Collections.synchronizedList(new ArrayList<>());
 
   private volatile boolean live;
 
@@ -274,12 +274,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
    * @throws IOException on error
    */
   public static List<URL> getURLs(Path libDir) throws IOException {
-    return getURLs(libDir, new DirectoryStream.Filter<Path>() {
-      @Override
-      public boolean accept(Path entry) throws IOException {
-        return true;
-      }
-    });
+    return getURLs(libDir, entry -> true);
   }
 
   /**
@@ -292,12 +287,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
    */
   public static List<URL> getFilteredURLs(Path libDir, String regex) throws IOException {
     final PathMatcher matcher = libDir.getFileSystem().getPathMatcher("regex:" + regex);
-    return getURLs(libDir, new DirectoryStream.Filter<Path>() {
-      @Override
-      public boolean accept(Path entry) throws IOException {
-        return matcher.matches(entry.getFileName());
-      }
-    });
+    return getURLs(libDir, entry -> matcher.matches(entry.getFileName()));
   }
 
   public Path getConfigPath() {
@@ -341,7 +331,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
     Path instanceDir = getInstancePath().normalize();
     Path inInstanceDir = getInstancePath().resolve(resource).normalize();
     Path inConfigDir = instanceDir.resolve("conf").resolve(resource).normalize();
-    if (inInstanceDir.startsWith(instanceDir) || allowUnsafeResourceloading) {
+    if (allowUnsafeResourceloading || inInstanceDir.startsWith(instanceDir)) {
       // The resource is either inside instance dir or we allow unsafe loading, so allow testing if file exists
       if (Files.exists(inConfigDir) && Files.isReadable(inConfigDir)) {
         return Files.newInputStream(inConfigDir);
@@ -378,8 +368,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
     }
     Path inInstanceDir = instanceDir.resolve(resource).normalize();
     Path inConfigDir = instanceDir.resolve("conf").resolve(resource).normalize();
-    boolean isRelativeToInstanceDir = inInstanceDir.startsWith(instanceDir.normalize());
-    if (isRelativeToInstanceDir || allowUnsafeResourceloading) {
+    if (allowUnsafeResourceloading || inInstanceDir.startsWith(instanceDir.normalize())) {
       if (Files.exists(inConfigDir) && Files.isReadable(inConfigDir))
         return inConfigDir.normalize().toString();
 
@@ -484,7 +473,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
         }
       }
     }
-    Class<? extends T> clazz = null;
+    Class<? extends T> clazz;
     clazz = getPackageClass(cname, expectedType);
     if(clazz != null) return clazz;
     try {
@@ -588,10 +577,10 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
               "Can not find class: " + cName + " in " + classLoader);
     }
 
-    T obj = null;
+    T obj;
     try {
 
-      Constructor<? extends T> constructor = null;
+      Constructor<? extends T> constructor;
       try {
         constructor = clazz.getConstructor(params);
         obj = constructor.newInstance(args);

--- a/solr/core/src/test/org/apache/solr/schema/PrimitiveFieldTypeTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/PrimitiveFieldTypeTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.core.SolrConfig;
-import org.apache.solr.core.SolrResourceLoader;
 import org.junit.Test;
 
 /**
@@ -43,7 +42,6 @@ public class PrimitiveFieldTypeTest extends SolrTestCaseJ4 {
     System.setProperty("enable.update.log", "false"); // schema12 doesn't support _version_
     System.setProperty("solr.test.sys.prop1", "propone");
     System.setProperty("solr.test.sys.prop2", "proptwo");
-    System.setProperty(SolrResourceLoader.SOLR_ALLOW_UNSAFE_RESOURCELOADING_PARAM, "true");
 
     initMap = new HashMap<>();
     config = new SolrConfig(TEST_PATH().resolve("collection1"), testConfHome + "solrconfig.xml");
@@ -51,7 +49,6 @@ public class PrimitiveFieldTypeTest extends SolrTestCaseJ4 {
   
   @Override
   public void tearDown() throws Exception {
-    System.clearProperty(SolrResourceLoader.SOLR_ALLOW_UNSAFE_RESOURCELOADING_PARAM);
     super.tearDown();
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15826

This is round 2 with further improvement
* `allowUnsafeResourceloading` is now final
* Remove unnecessary use of `solr.allow.unsafe.resourceloading` in `PrimitiveFieldTypeTest.java`
* Simplify some code in ResourceLoader for Java8, use empty `<>`, shorter lambda functions and remove implicit null's
* Swap order of or'ed clauses in if test for tiny efficiency gain