### PR TITLE
SOLR-15590 Fix SSL, init order misplaced by prior commit for this ticket.

### DIFF
--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
@@ -73,6 +73,7 @@ import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.servlet.CoreContainerProvider;
 import org.apache.solr.servlet.SolrDispatchFilter;
 import org.apache.solr.util.TimeOut;
+import org.apache.solr.util.configuration.SSLConfigurationsFactory;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http2.HTTP2Cipher;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
@@ -387,6 +388,7 @@ public class JettySolrRunner {
 
         root.getServletContext().setAttribute(SolrDispatchFilter.PROPERTIES_ATTRIBUTE, nodeProperties);
         root.getServletContext().setAttribute(SolrDispatchFilter.SOLRHOME_ATTRIBUTE, solrHome);
+        SSLConfigurationsFactory.current().init(); // normally happens in jetty-ssl.xml
         coreContainerProvider = new CoreContainerProvider();
         coreContainerProvider.init(root.getServletContext());
         log.info("Jetty properties: {}", nodeProperties);

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -35,7 +35,6 @@ import org.apache.solr.security.AuthenticationPlugin;
 import org.apache.solr.security.PKIAuthenticationPlugin;
 import org.apache.solr.security.PublicKeyHandler;
 import org.apache.solr.servlet.CoreContainerProvider.ServiceHolder;
-import org.apache.solr.util.configuration.SSLConfigurationsFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,7 +130,7 @@ public class SolrDispatchFilter extends BaseSolrFilter implements PathExcluder {
   public void init(FilterConfig config) throws ServletException {
     try {
       coreService = CoreContainerProvider.serviceForContext(config.getServletContext());
-      SSLConfigurationsFactory.current().init();
+
       if (log.isTraceEnabled()) {
         log.trace("SolrDispatchFilter.init(): {}", this.getClass().getClassLoader());
       }

--- a/solr/server/etc/jetty-ssl.xml
+++ b/solr/server/etc/jetty-ssl.xml
@@ -8,6 +8,9 @@
 <!-- ============================================================= -->
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
   <Call class="org.apache.solr.util.configuration.SSLConfigurationsFactory" name="current">
+    <Call name="init" />
+  </Call>
+  <Call class="org.apache.solr.util.configuration.SSLConfigurationsFactory" name="current">
     <Get name="keyStorePassword" id="keyStorePassword"/>
     <Get name="trustStorePassword" id="trustStorePassword"/>
   </Call>


### PR DESCRIPTION
Moves init into jetty-ssl.xml to ensure ssl is ready before any of our https request related code needs it, and remove such concerns form request and servlet related classes.
