### PR TITLE
SOLR-15839: Don't mock oal.search.Sort class (why the hell was this needed?)

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/component/MockSortSpecBuilder.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/MockSortSpecBuilder.java
@@ -34,8 +34,7 @@ public class MockSortSpecBuilder {
     }
 
     public MockSortSpecBuilder withSortFields(SortField[] sortFields) {
-        Sort sort = Mockito.mock(Sort.class);
-        Mockito.when(sort.getSort()).thenReturn(sortFields);
+        Sort sort = new Sort(sortFields);
         Mockito.when(sortSpec.getSort()).thenReturn(sort);
         return this;
     }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SOLR-15839