### PR TITLE
SOLR-15804 Support leading slash for "file" parameter and text/javascript

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/ShowFileRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ShowFileRequestHandler.java
@@ -105,6 +105,7 @@ public class ShowFileRequestHandler extends RequestHandlerBase implements Permis
   static {
     KNOWN_MIME_TYPES = new HashSet<>(MimeTypes.getKnownMimeTypes());
     KNOWN_MIME_TYPES.add("text/xml");
+    KNOWN_MIME_TYPES.add("text/javascript");
   }
 
   public ShowFileRequestHandler()
@@ -374,7 +375,8 @@ public class ShowFileRequestHandler extends RequestHandlerBase implements Permis
         rsp.setException(new SolrException( SolrException.ErrorCode.FORBIDDEN, "Can not access: "+fname ));
         return null;
       }
-      Path filePath = configdir.toPath().resolve(fname);
+      // A leading slash is unnecessary but supported and interpreted as start of config dir
+      Path filePath = configdir.toPath().resolve(fname.startsWith("/") ? fname.substring(1) : fname);
       req.getCore().getCoreContainer().assertPathAllowed(filePath);
       adminFile = filePath.toFile();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15804

I tested Velociry Response Writer in 8.11.1, and it appears that it uses ShowFile handler to get its css and js files from within the configset folder. But the VM templates uses `file=/velocity/foo.css`, i.e. absolute paths, which are now disallowed. So the simple fix is to strip leading slash and interpret that to mean start of config folder. We also add back support for `text/javascript`, as that is also used by Velocity.

Tested to work well with Admin UI files view. This is mainly done in main branch so that the 3rd party velocity package will still work in 9.0.