### PR TITLE
SOLR-15849 Incorrect use Zookeeper 4LW

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -420,6 +420,8 @@ Other Changes
 
 Bug Fixes
 ---------------------
+* SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).
+
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution
   of Collection API tasks competing for a lock (Ilan Ginzburg).
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperStatusHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperStatusHandler.java
@@ -297,7 +297,8 @@ public class ZookeeperStatusHandler extends RequestHandlerBase {
         Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
         PrintWriter out = new PrintWriter(writer, true);
         BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
-      out.println(fourLetterWordCommand);
+      out.print(fourLetterWordCommand);
+      out.flush();
       List<String> response = in.lines().collect(Collectors.toList());
       log.debug("Got response from ZK on host {} and port {}: {}", host, port, response);
       return response;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15849

# Description

Zookeeper only accepts 4LW, but solr socket sends 4LW with \n.

# Solution

Remove \n.

# Tests

You can use the Wireshark to view network data and close the connection.

