### PR TITLE
SOLR-15830 Concurrent core reloads mess up commits when using Schema API

### DIFF
--- a/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
+++ b/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
@@ -129,7 +129,7 @@ public class SchemaManager {
           }
 
           try {
-            SolrConfigHandler configHandler = ((SolrConfigHandler)core.getRequestHandler("/config"));
+            SolrConfigHandler configHandler = ((SolrConfigHandler)req.getCore().getRequestHandler("/config"));
             if (configHandler.getReloadLock().tryLock()) {
               latestVersion =
                   ZkController.persistConfigResourceToZooKeeper(

--- a/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
+++ b/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
@@ -45,6 +45,7 @@ import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.handler.SolrConfigHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.rest.BaseSolrResource;
 import org.apache.solr.util.TimeOut;
@@ -128,17 +129,22 @@ public class SchemaManager {
           }
 
           try {
-            latestVersion =
-                ZkController.persistConfigResourceToZooKeeper(
-                    zkLoader,
-                    managedIndexSchema.getSchemaZkVersion(),
-                    managedIndexSchema.getResourceName(),
-                    sw.toString().getBytes(StandardCharsets.UTF_8),
-                    true);
-            req.getCore()
-                .getCoreContainer()
-                .reload(req.getCore().getName(), req.getCore().uniqueId);
-            break;
+            SolrConfigHandler configHandler = ((SolrConfigHandler)core.getRequestHandler("/config"));
+            if (configHandler.getReloadLock().tryLock()) {
+              latestVersion =
+                  ZkController.persistConfigResourceToZooKeeper(
+                      zkLoader,
+                      managedIndexSchema.getSchemaZkVersion(),
+                      managedIndexSchema.getResourceName(),
+                      sw.toString().getBytes(StandardCharsets.UTF_8),
+                      true);
+              req.getCore()
+                  .getCoreContainer()
+                  .reload(req.getCore().getName(), req.getCore().uniqueId);
+              break;
+            } else {
+              log.info("Another reload is in progress. Not doing anything.");
+            }
           } catch (ZkController.ResourceModifiedInZkException e) {
             log.info("Schema was modified by another node. Retrying..");
           }

--- a/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
+++ b/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
@@ -129,7 +129,8 @@ public class SchemaManager {
           }
 
           try {
-            SolrConfigHandler configHandler = ((SolrConfigHandler)req.getCore().getRequestHandler("/config"));
+            SolrConfigHandler configHandler =
+                ((SolrConfigHandler) req.getCore().getRequestHandler("/config"));
             if (configHandler.getReloadLock().tryLock()) {
               latestVersion =
                   ZkController.persistConfigResourceToZooKeeper(

--- a/solr/core/src/test-files/solr/configsets/cloud-managed-autocommit/conf/managed-schema
+++ b/solr/core/src/test-files/solr/configsets/cloud-managed-autocommit/conf/managed-schema
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<schema name="minimal" version="1.1">
+  <fieldType name="string" class="solr.StrField"/>
+  <fieldType name="int" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="long" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <dynamicField name="*" type="string" indexed="true" stored="true"/>
+  <!-- for versioning -->
+  <field name="_version_" type="long" indexed="true" stored="true"/>
+  <field name="_root_" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
+  <field name="id" type="string" indexed="true" stored="true"/>
+  <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
+  <uniqueKey>id</uniqueKey>
+</schema>

--- a/solr/core/src/test-files/solr/configsets/cloud-managed-autocommit/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/configsets/cloud-managed-autocommit/conf/solrconfig.xml
@@ -40,7 +40,7 @@
     <updateLog class="${solr.ulog:solr.UpdateLog}"></updateLog>
 
     <autoCommit>
-      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <maxTime>${solr.autoCommit.maxTime:-1}</maxTime>
       <openSearcher>false</openSearcher>
     </autoCommit>
 
@@ -58,4 +58,3 @@
 
   </requestHandler>
 </config>
-

--- a/solr/core/src/test-files/solr/configsets/cloud-managed-autocommit/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/configsets/cloud-managed-autocommit/conf/solrconfig.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- Minimal solrconfig.xml with /select, /admin and /update only -->
+
+<config>
+
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <directoryFactory name="DirectoryFactory"
+                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+
+  <schemaFactory class="ManagedIndexSchemaFactory">
+    <bool name="mutable">${managed.schema.mutable}</bool>
+    <str name="managedSchemaResourceName">managed-schema</str>
+  </schemaFactory>
+
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <commitWithin>
+      <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
+    </commitWithin>
+    <updateLog class="${solr.ulog:solr.UpdateLog}"></updateLog>
+
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+    <autoSoftCommit>
+      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+    </autoSoftCommit>
+  </updateHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="indent">true</str>
+      <str name="df">text</str>
+    </lst>
+
+  </requestHandler>
+</config>
+

--- a/solr/core/src/test/org/apache/solr/schema/TestManagedSchemaWithMultipleAdd.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestManagedSchemaWithMultipleAdd.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.schema;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class TestManagedSchemaWithMultipleAdd extends SolrCloudTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @BeforeClass
+    public static void createClusterAndInitSysProperties() throws Exception {
+        System.setProperty("managed.schema.mutable", "true");
+        System.setProperty("solr.autoCommit.maxTime", "10000");
+        System.setProperty("solr.autoSoftCommit.maxTime", "3000");
+        configureCluster(1)
+                .addConfig("conf1", TEST_PATH().resolve("configsets").resolve("cloud-managed-autocommit").resolve("conf"))
+                .configure();
+    }
+
+    @AfterClass
+    public static void afterRestartWhileUpdatingTest() {
+        System.clearProperty("managed.schema.mutable");
+        System.clearProperty("solr.autoCommit.maxTime");
+        System.clearProperty("solr.autoSoftCommit.maxTime");
+    }
+
+    @Test
+    public void test() throws Exception {
+        String collection = "testschemaapi";
+        CollectionAdminRequest.createCollection(collection, "conf1", 1, 1)
+                .process(cluster.getSolrClient());
+        testAddFieldAndMultipleDocument(collection);
+    }
+
+    private void testAddFieldAndMultipleDocument(String collection) throws IOException, SolrServerException, InterruptedException {
+
+        CloudSolrClient cloudClient = cluster.getSolrClient();
+
+        String fieldName = "myNewField1";
+        addStringField(fieldName, collection, cloudClient);
+
+        UpdateRequest ureq = new UpdateRequest();
+        int numDocs = 1000;
+        for (int i=0;i<numDocs;i++) {
+            SolrInputDocument doc = new SolrInputDocument();
+            doc.addField("id", i);
+            doc.addField(fieldName, "value" + i);
+            ureq = ureq.add(doc);
+        }
+        cloudClient.request(ureq, collection);
+
+        // Wait for autoCommit to finish if there is one.
+        Thread.sleep(3500);
+
+        assertEquals(numDocs, cloudClient.query(collection, new SolrQuery("*:*")).getResults().getNumFound());
+    }
+
+
+    private void addStringField(String fieldName, String collection, CloudSolrClient cloudClient) throws IOException, SolrServerException {
+        Map<String, Object> fieldAttributes = new LinkedHashMap<>();
+        fieldAttributes.put("name", fieldName);
+        fieldAttributes.put("type", "string");
+        SchemaRequest.AddField addFieldUpdateSchemaRequest = new SchemaRequest.AddField(fieldAttributes);
+        SchemaResponse.UpdateResponse addFieldResponse = addFieldUpdateSchemaRequest.process(cloudClient, collection);
+        assertEquals(0, addFieldResponse.getStatus());
+        assertNull(addFieldResponse.getResponse().get("errors"));
+
+        if (log.isInfoEnabled()) {
+            log.info("added new field = {}", fieldName);
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15830

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

When using Schema API SchemaManager class triggers a core reload here: https://github.com/apache/solr/blob/cfc953b6b906ef742bba57024d327fbde5d564c2/solr/core/src/java/org/apache/solr/schema/SchemaManager.java#L132

As I understand this was introduced in SOLR-9832 and is useful to avoid accidentally reloading to an older version of the config. The problem is that in the solr core a listener is implemented to initiate a reload whenever a config change happens in ZK, this can be found here: https://github.com/apache/solr/blob/cfc953b6b906ef742bba57024d327fbde5d564c2/solr/core/src/java/org/apache/solr/core/SolrCore.java#L3140

When updating the schema using the Schema API both of these reloads get triggered and this can result in a strange bug, where not all the indexed documents are visible if the indexing is started just after the schema API returned.

# Solution

I added a check and lock which is the same as in SolrCore to check if there is another reload in progress and makes sure no other reload can be started.

# Tests

I added a test which points out this bug: when the test is run without the lock in SchemaManager the test fails because the query returns less documents than the expected but more than 0. If the lock is in place the test succeeds.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
