### PR TITLE
SOLR-15501: GCSBackupRepository operations without credentials

### DIFF
--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
@@ -83,14 +83,15 @@ public class GCSBackupRepository implements BackupRepository {
             return storage;
 
         try {
-            if (credentialPath == null) {
-                throw new IllegalArgumentException(GCSConfigParser.missingCredentialErrorMsg());
+            if (credentialPath != null) {
+                log.info("Creating GCS client using credential at {}", credentialPath);
+                // 'GoogleCredentials.fromStream' closes the input stream, so we don't
+                GoogleCredentials credential = GoogleCredentials.fromStream(new FileInputStream(credentialPath));
+                storageOptionsBuilder.setCredentials(credential);
+            } else {
+                // nowarn compile time string concatenation
+                log.info(GCSConfigParser.missingCredentialMsg()); //nowarn
             }
-
-            log.info("Creating GCS client using credential at {}", credentialPath);
-            // 'GoogleCredentials.fromStream' closes the input stream, so we don't
-            GoogleCredentials credential = GoogleCredentials.fromStream(new FileInputStream(credentialPath));
-            storageOptionsBuilder.setCredentials(credential);
             storage = storageOptionsBuilder.build().getService();
         } catch (IOException e) {
             throw new IllegalStateException(e);

--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
@@ -93,9 +93,11 @@ public class GCSConfigParser {
     return envVars.get(GCS_CREDENTIAL_ENV_VAR_NAME);
   }
 
-  public static String missingCredentialErrorMsg() {
-    return "GCSBackupRepository requires a credential for GCS communication, but none was provided.  Please specify a " +
-            "path to this GCS credential by adding a '" + GCS_CREDENTIAL_PARAM_NAME + "' property to the repository " +
+  public static String missingCredentialMsg() {
+    return "GCSBackupRepository credential path is missing. GCSBackupRepository will only work within GCP when role " +
+            "based access is configured for backup bucket." +
+            "If you'd like to use credentials, set path to this GCS credential by adding a '" +
+            GCS_CREDENTIAL_PARAM_NAME + "' property to the repository " +
             "definition in your solrconfig, or by setting the path value in an env-var named '" +
             GCS_CREDENTIAL_ENV_VAR_NAME + "'";
   }

--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
@@ -28,8 +28,8 @@ import java.util.Map;
  * Parses configuration for {@link GCSBackupRepository} from NamedList and environment variables
  */
 public class GCSConfigParser {
-  private static final String GCS_BUCKET_ENV_VAR_NAME = "GCS_BUCKET";
-  private static final String GCS_CREDENTIAL_ENV_VAR_NAME = "GCS_CREDENTIAL_PATH";
+  protected static final String GCS_BUCKET_ENV_VAR_NAME = "GCS_BUCKET";
+  protected static final String GCS_CREDENTIAL_ENV_VAR_NAME = "GCS_CREDENTIAL_PATH";
 
   private static final String GCS_BUCKET_PARAM_NAME = "gcsBucket";
   private static final String GCS_CREDENTIAL_PARAM_NAME = "gcsCredentialPath";

--- a/solr/contrib/gcs-repository/src/test/org/apache/solr/gcs/GCSBackupRepositoryTest.java
+++ b/solr/contrib/gcs-repository/src/test/org/apache/solr/gcs/GCSBackupRepositoryTest.java
@@ -17,18 +17,23 @@
 
 package org.apache.solr.gcs;
 
+import static org.apache.solr.common.params.CoreAdminParams.BACKUP_LOCATION;
+import static org.apache.solr.gcs.GCSConfigParser.GCS_BUCKET_ENV_VAR_NAME;
+import static org.apache.solr.gcs.GCSConfigParser.GCS_CREDENTIAL_ENV_VAR_NAME;
+
 import com.google.common.collect.Lists;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import org.apache.solr.cloud.api.collections.AbstractBackupRepositoryTest;
-import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.backup.repository.BackupRepository;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Locale;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link GCSBackupRepository} that use an in-memory Storage object
@@ -56,7 +61,7 @@ public class GCSBackupRepositoryTest extends AbstractBackupRepositoryTest {
     @Override
     protected BackupRepository getRepository() {
         final NamedList<Object> config = new NamedList<>();
-        config.add(CoreAdminParams.BACKUP_LOCATION, "backup1");
+        config.add(BACKUP_LOCATION, "backup1");
         final GCSBackupRepository repository = new LocalStorageGCSBackupRepository();
         repository.init(config);
 
@@ -66,5 +71,19 @@ public class GCSBackupRepositoryTest extends AbstractBackupRepositoryTest {
     @Override
     protected URI getBaseUri() throws URISyntaxException {
         return new URI("tmp");
+    }
+
+    @Test
+    public void testInitStoreDoesNotFailWithMissingCredentials()
+    {
+        Map<String, String> config = new HashMap<>();
+        config.put(GCS_BUCKET_ENV_VAR_NAME, "a_bucket_name");
+        // explicitely setting credential name to null; will work inside google-cloud project
+        config.put(GCS_CREDENTIAL_ENV_VAR_NAME, null);
+        config.put(BACKUP_LOCATION, "/==");
+
+        BackupRepository gcsBackupRepository = getRepository();
+
+        gcsBackupRepository.init(new NamedList<>(config));
     }
 }

--- a/solr/solr-ref-guide/src/backup-restore.adoc
+++ b/solr/solr-ref-guide/src/backup-restore.adoc
@@ -485,7 +485,7 @@ If both values are absent, the value `solrBackupsBucket` will be used as a defau
 +
 A path on the local filesystem (accessible by Solr) to a https://cloud.google.com/iam/docs/creating-managing-service-account-keys[Google Cloud service account key] file.
 If not specified, GCSBackupRepository will use the value of the `GCS_CREDENTIAL_PATH` environment variable.
-If both values are absent, an error will be thrown as GCS requires credentials for most usage.
+If both values are absent, no error will be thrown, as running solr in google cloud will handle authentication/authorization internally.
 
 `location`::
 +


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15501

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR-

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Given that access to GCS buckets from within Google Cloud Platform can be configured based on roles and not on passwords, it is now possible to use GCSBackupRepository plugin to work also in case when no credentials are given. 
This works 'automatically' given that google libraries are used and they support this 'out of the box'

# Solution

Simply allow no credentials to be given.

# Tests

A test to run 'without credentials' is added. 
I have also built this and manually tested within GCP environment a BACKUP and RESTORE calls (after obviously configuring the plugin) and they do work as expected.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
