### PR TITLE
ensures that test code does not depend on log level

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/CollectionPropsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionPropsTest.java
@@ -201,9 +201,8 @@ public class CollectionPropsTest extends SolrCloudTestCase {
     // Trigger a value change event
     log.info("setting value2");
     collectionProps.setCollectionProperty(collectionName, "property", "value2");
-    if (log.isInfoEnabled()) {
-      log.info("(value2) waitForTrigger=={}", watcher.waitForTrigger());
-    }
+    int wft = watcher.waitForTrigger();
+    log.info("(value2) waitForTrigger=={}", wft);
     assertEquals("value2", watcher.getProps().get("property"));
 
     // Delete the properties znode


### PR DESCRIPTION
There is no associated JIRA.
This is a simple test code cleanup.

Current code will not wait if log level is not at INFO