### PR TITLE
SOLR-15845 Add a new SolrVersion class

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -424,6 +424,8 @@ Other Changes
 
 * SOLR-15807: New LogListener class for tests to use to make assertions about what Log messages should or should not be produced by a test (hossman)
 
+* SOLR-15845: Add a new SolrVersion class to manage Solr's version independently from the Lucene version we consume (janhoy)
+
 Bug Fixes
 ---------------------
 * SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).

--- a/solr/core/src/java/org/apache/solr/packagemanager/RepositoryManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/RepositoryManager.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.lucene.util.Version;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
@@ -54,6 +53,7 @@ import org.apache.solr.packagemanager.SolrPackage.SolrPackageRelease;
 import org.apache.solr.pkg.PackageAPI;
 import org.apache.solr.pkg.PackageLoader;
 import org.apache.solr.util.SolrCLI;
+import org.apache.solr.util.SolrVersion;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -68,7 +68,7 @@ public class RepositoryManager {
 
   final private PackageManager packageManager;
 
-  public static final String systemVersion = Version.LATEST.toString();
+  public static final String systemVersion = SolrVersion.LATEST.toString();
 
   final HttpSolrClient solrClient;
 

--- a/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.client.HttpClient;
-import org.apache.lucene.util.Version;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
@@ -39,6 +38,7 @@ import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricManager.ResolutionStrategy;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.servlet.RateLimitManager.Builder;
+import org.apache.solr.util.SolrVersion;
 import org.apache.solr.util.StartupLoggingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -267,7 +267,7 @@ public class CoreContainerProvider implements ServletContextListener {
     }
   }
   private String solrVersion() {
-    String specVer = Version.LATEST.toString();
+    String specVer = SolrVersion.LATEST.toString();
     try {
       String implVer = SolrCore.class.getPackage().getImplementationVersion();
       return (specVer.equals(implVer.split(" ")[0])) ? specVer : implVer;

--- a/solr/core/src/java/org/apache/solr/util/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrCLI.java
@@ -46,7 +46,6 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.util.Version;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;

--- a/solr/core/src/java/org/apache/solr/util/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrCLI.java
@@ -268,7 +268,7 @@ public class SolrCLI implements CLIO {
 
     if (args.length == 1 && Arrays.asList("-v","-version","version").contains(args[0])) {
       // Simple version tool, no need for its own class
-      CLIO.out(Version.LATEST.toString());
+      CLIO.out(SolrVersion.LATEST.toString());
       exit(0);
     }
 

--- a/solr/core/src/java/org/apache/solr/util/SolrVersion.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.util;
 
 import java.text.ParseException;

--- a/solr/core/src/java/org/apache/solr/util/SolrVersion.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrVersion.java
@@ -1,10 +1,7 @@
 package org.apache.solr.util;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.text.ParseException;
 import java.util.Locale;
-import java.util.jar.Manifest;
 
 /**
  * Use by certain classes to match version compatibility across releases of Solr.
@@ -27,9 +24,6 @@ public final class SolrVersion {
    * <b>WARNING</b>: Be careful where you use this constant. Usually you should use the exact version constants
    */
   public static final SolrVersion LATEST = SOLR_9_0_0;
-
-  /** @see #getPackageImplementationVersion() */
-  private static String implementationVersion;
 
   /**
    * Parse a version number of the form {@code "major.minor.bugfix.prerelease"}.
@@ -259,48 +253,6 @@ public final class SolrVersion {
   @Override
   public int hashCode() {
     return encodedValue;
-  }
-
-  /**
-   * Return Solr's full implementation version. This version is saved in Solr's metadata at
-   * build time (JAR manifest, module info). If it is not available, an {@code unknown}
-   * implementation version is returned.
-   *
-   * @return Solr implementation version string, never {@code null}.
-   */
-  public static String getPackageImplementationVersion() {
-    // Initialize the lazy value.
-    synchronized (SolrVersion.class) {
-      if (implementationVersion == null) {
-        String version;
-
-        Package p = SolrVersion.class.getPackage();
-        version = p.getImplementationVersion();
-
-        if (version == null) {
-          var module = SolrVersion.class.getModule();
-          if (module.isNamed()) {
-            // Running as a module? Try parsing the manifest manually.
-            try (var is = module.getResourceAsStream("/META-INF/MANIFEST.MF")) {
-              if (is != null) {
-                Manifest m = new Manifest(is);
-                version = m.getMainAttributes().getValue("Implementation-Version");
-              }
-            } catch (IOException e) {
-              throw new UncheckedIOException(e);
-            }
-          }
-        }
-
-        if (version == null) {
-          version = "unknown";
-        }
-
-        implementationVersion = version;
-      }
-
-      return implementationVersion;
-    }
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/util/SolrVersion.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrVersion.java
@@ -1,0 +1,343 @@
+package org.apache.solr.util;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.text.ParseException;
+import java.util.Locale;
+import java.util.jar.Manifest;
+
+/**
+ * Use by certain classes to match version compatibility across releases of Solr.
+ */
+public final class SolrVersion {
+
+  /** @deprecated (9.0.0) Use latest */
+  @Deprecated public static final SolrVersion SOLR_8_11_1 = new SolrVersion(8, 11, 1);
+
+  /**
+   * Latest current version of Solr
+   */
+  public static final SolrVersion SOLR_9_0_0 = new SolrVersion(9, 0, 0);
+
+  // To add a new version:
+  //  * Only add above this comment
+  //  * If the new version is the newest, change LATEST below and deprecate the previous LATEST
+
+  /**
+   * <b>WARNING</b>: Be careful where you use this constant. Usually you should use the exact version constants
+   */
+  public static final SolrVersion LATEST = SOLR_9_0_0;
+
+  /** @see #getPackageImplementationVersion() */
+  private static String implementationVersion;
+
+  /**
+   * Parse a version number of the form {@code "major.minor.bugfix.prerelease"}.
+   *
+   * <p>Part {@code ".bugfix"} and part {@code ".prerelease"} are optional. Note that this is
+   * forwards compatible: the parsed version does not have to exist as a constant.
+   */
+  public static SolrVersion parse(String version) throws ParseException {
+
+    StrictStringTokenizer tokens = new StrictStringTokenizer(version, '.');
+    if (!tokens.hasMoreTokens()) {
+      throw new ParseException(
+          "Version is not in form major.minor.bugfix(.prerelease) (got: " + version + ")", 0);
+    }
+
+    int major;
+    String token = tokens.nextToken();
+    try {
+      major = Integer.parseInt(token);
+    } catch (NumberFormatException nfe) {
+      ParseException p =
+          new ParseException(
+              "Failed to parse major version from \"" + token + "\" (got: " + version + ")", 0);
+      p.initCause(nfe);
+      throw p;
+    }
+
+    if (!tokens.hasMoreTokens()) {
+      throw new ParseException(
+          "Version is not in form major.minor.bugfix(.prerelease) (got: " + version + ")", 0);
+    }
+
+    int minor;
+    token = tokens.nextToken();
+    try {
+      minor = Integer.parseInt(token);
+    } catch (NumberFormatException nfe) {
+      ParseException p =
+          new ParseException(
+              "Failed to parse minor version from \"" + token + "\" (got: " + version + ")", 0);
+      p.initCause(nfe);
+      throw p;
+    }
+
+    int bugfix = 0;
+    int prerelease = 0;
+    if (tokens.hasMoreTokens()) {
+
+      token = tokens.nextToken();
+      try {
+        bugfix = Integer.parseInt(token);
+      } catch (NumberFormatException nfe) {
+        ParseException p =
+            new ParseException(
+                "Failed to parse bugfix version from \"" + token + "\" (got: " + version + ")", 0);
+        p.initCause(nfe);
+        throw p;
+      }
+
+      if (tokens.hasMoreTokens()) {
+        token = tokens.nextToken();
+        try {
+          prerelease = Integer.parseInt(token);
+        } catch (NumberFormatException nfe) {
+          ParseException p =
+              new ParseException(
+                  "Failed to parse prerelease version from \""
+                      + token
+                      + "\" (got: "
+                      + version
+                      + ")",
+                  0);
+          p.initCause(nfe);
+          throw p;
+        }
+        if (prerelease == 0) {
+          throw new ParseException(
+              "Invalid value "
+                  + prerelease
+                  + " for prerelease; should be 1 or 2 (got: "
+                  + version
+                  + ")",
+              0);
+        }
+
+        if (tokens.hasMoreTokens()) {
+          // Too many tokens!
+          throw new ParseException(
+              "Version is not in form major.minor.bugfix(.prerelease) (got: " + version + ")", 0);
+        }
+      }
+    }
+
+    try {
+      return new SolrVersion(major, minor, bugfix, prerelease);
+    } catch (IllegalArgumentException iae) {
+      ParseException pe =
+          new ParseException(
+              "failed to parse version string \"" + version + "\": " + iae.getMessage(), 0);
+      pe.initCause(iae);
+      throw pe;
+    }
+  }
+
+  /**
+   * Parse the given version number as a constant or dot based version.
+   *
+   * <p>This method allows to use {@code "SOLR_X_Y"} constant names, or version numbers in the
+   * format {@code "x.y.z"}.
+   */
+  public static SolrVersion parseLeniently(String version) throws ParseException {
+    String versionOrig = version;
+    version = version.toUpperCase(Locale.ROOT);
+    switch (version) {
+      case "LATEST":
+      case "SOLR_CURRENT":
+        return LATEST;
+      default:
+        version =
+            version
+                .replaceFirst("^SOLR_(\\d+)_(\\d+)_(\\d+)$", "$1.$2.$3")
+                .replaceFirst("^SOLR_(\\d+)_(\\d+)$", "$1.$2.0")
+                .replaceFirst("^SOLR_(\\d)(\\d)$", "$1.$2.0");
+        try {
+          return parse(version);
+        } catch (ParseException pe) {
+          ParseException pe2 =
+              new ParseException(
+                  "failed to parse lenient version string \""
+                      + versionOrig
+                      + "\": "
+                      + pe.getMessage(),
+                  0);
+          pe2.initCause(pe);
+          throw pe2;
+        }
+    }
+  }
+
+  /**
+   * Returns a new version based on raw numbers
+   */
+  public static SolrVersion fromBits(int major, int minor, int bugfix) {
+    return new SolrVersion(major, minor, bugfix);
+  }
+
+  /** Major version, the difference between stable and trunk */
+  public final int major;
+  /** Minor version, incremented within the stable branch */
+  public final int minor;
+  /** Bugfix number, incremented on release branches */
+  public final int bugfix;
+  /** Prerelease version, currently 0 (alpha), 1 (beta), or 2 (final) */
+  public final int prerelease;
+
+  // stores the version pieces, with most significant pieces in high bits
+  // ie:  | 1 byte | 1 byte | 1 byte |   2 bits   |
+  //         major   minor    bugfix   prerelease
+  private final int encodedValue;
+
+  private SolrVersion(int major, int minor, int bugfix) {
+    this(major, minor, bugfix, 0);
+  }
+
+  private SolrVersion(int major, int minor, int bugfix, int prerelease) {
+    this.major = major;
+    this.minor = minor;
+    this.bugfix = bugfix;
+    this.prerelease = prerelease;
+    // NOTE: do not enforce major version so we remain future proof, except to
+    // make sure it fits in the 8 bits we encode it into:
+    if (major > 255 || major < 0) {
+      throw new IllegalArgumentException("Illegal major version: " + major);
+    }
+    if (minor > 255 || minor < 0) {
+      throw new IllegalArgumentException("Illegal minor version: " + minor);
+    }
+    if (bugfix > 255 || bugfix < 0) {
+      throw new IllegalArgumentException("Illegal bugfix version: " + bugfix);
+    }
+    if (prerelease > 2 || prerelease < 0) {
+      throw new IllegalArgumentException("Illegal prerelease version: " + prerelease);
+    }
+    if (prerelease != 0 && (minor != 0 || bugfix != 0)) {
+      throw new IllegalArgumentException(
+          "Prerelease version only supported with major release (got prerelease: "
+              + prerelease
+              + ", minor: "
+              + minor
+              + ", bugfix: "
+              + bugfix
+              + ")");
+    }
+
+    encodedValue = major << 18 | minor << 10 | bugfix << 2 | prerelease;
+
+    assert encodedIsValid();
+  }
+
+  /** Returns true if this version is the same or after the version from the argument. */
+  public boolean onOrAfter(SolrVersion other) {
+    return encodedValue >= other.encodedValue;
+  }
+
+  @Override
+  public String toString() {
+    if (prerelease == 0) {
+      return "" + major + "." + minor + "." + bugfix;
+    }
+    return "" + major + "." + minor + "." + bugfix + "." + prerelease;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof SolrVersion && ((SolrVersion) o).encodedValue == encodedValue;
+  }
+
+  // Used only by assert:
+  private boolean encodedIsValid() {
+    assert major == ((encodedValue >>> 18) & 0xFF);
+    assert minor == ((encodedValue >>> 10) & 0xFF);
+    assert bugfix == ((encodedValue >>> 2) & 0xFF);
+    assert prerelease == (encodedValue & 0x03);
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return encodedValue;
+  }
+
+  /**
+   * Return Solr's full implementation version. This version is saved in Solr's metadata at
+   * build time (JAR manifest, module info). If it is not available, an {@code unknown}
+   * implementation version is returned.
+   *
+   * @return Solr implementation version string, never {@code null}.
+   */
+  public static String getPackageImplementationVersion() {
+    // Initialize the lazy value.
+    synchronized (SolrVersion.class) {
+      if (implementationVersion == null) {
+        String version;
+
+        Package p = SolrVersion.class.getPackage();
+        version = p.getImplementationVersion();
+
+        if (version == null) {
+          var module = SolrVersion.class.getModule();
+          if (module.isNamed()) {
+            // Running as a module? Try parsing the manifest manually.
+            try (var is = module.getResourceAsStream("/META-INF/MANIFEST.MF")) {
+              if (is != null) {
+                Manifest m = new Manifest(is);
+                version = m.getMainAttributes().getValue("Implementation-Version");
+              }
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          }
+        }
+
+        if (version == null) {
+          version = "unknown";
+        }
+
+        implementationVersion = version;
+      }
+
+      return implementationVersion;
+    }
+  }
+
+  /**
+   * Copied from Lucene
+   */
+  static final class StrictStringTokenizer {
+
+    public StrictStringTokenizer(String s, char delimiter) {
+      this.s = s;
+      this.delimiter = delimiter;
+    }
+
+    public String nextToken() {
+      if (pos < 0) {
+        throw new IllegalStateException("no more tokens");
+      }
+
+      int pos1 = s.indexOf(delimiter, pos);
+      String s1;
+      if (pos1 >= 0) {
+        s1 = s.substring(pos, pos1);
+        pos = pos1 + 1;
+      } else {
+        s1 = s.substring(pos);
+        pos = -1;
+      }
+
+      return s1;
+    }
+
+    public boolean hasMoreTokens() {
+      return pos >= 0;
+    }
+
+    private final String s;
+    private final char delimiter;
+    private int pos;
+  }
+
+}

--- a/solr/core/src/test/org/apache/solr/util/TestSolrVersion.java
+++ b/solr/core/src/test/org/apache/solr/util/TestSolrVersion.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.util;
+
+import org.apache.lucene.util.LuceneTestCase;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.text.ParseException;
+import java.util.Locale;
+import java.util.Random;
+
+@SuppressWarnings("deprecation")
+public class TestSolrVersion extends LuceneTestCase {
+
+  public void testOnOrAfter() throws Exception {
+    for (Field field : SolrVersion.class.getDeclaredFields()) {
+      if (Modifier.isStatic(field.getModifiers()) && field.getType() == SolrVersion.class) {
+        SolrVersion v = (SolrVersion) field.get(SolrVersion.class);
+        assertTrue("LATEST must be always onOrAfter(" + v + ")", SolrVersion.LATEST.onOrAfter(v));
+      }
+    }
+    assertTrue(SolrVersion.SOLR_9_0_0.onOrAfter(SolrVersion.SOLR_8_11_1));
+  }
+
+  public void testToString() {
+    assertEquals("9.0.0", SolrVersion.SOLR_9_0_0.toString());
+    assertEquals("8.11.1", SolrVersion.SOLR_8_11_1.toString());
+  }
+
+  public void testParseLeniently() throws Exception {
+    assertEquals(SolrVersion.SOLR_9_0_0, SolrVersion.parseLeniently("9.0"));
+    assertEquals(SolrVersion.SOLR_9_0_0, SolrVersion.parseLeniently("9.0.0"));
+    assertEquals(SolrVersion.SOLR_9_0_0, SolrVersion.parseLeniently("SOLR_90"));
+    assertEquals(SolrVersion.SOLR_9_0_0, SolrVersion.parseLeniently("SOLR_9_0"));
+    assertEquals(SolrVersion.SOLR_9_0_0, SolrVersion.parseLeniently("SOLR_9_0_0"));
+
+    assertEquals(SolrVersion.LATEST, SolrVersion.parseLeniently("LATEST"));
+    assertEquals(SolrVersion.LATEST, SolrVersion.parseLeniently("latest"));
+    assertEquals(SolrVersion.LATEST, SolrVersion.parseLeniently("SOLR_CURRENT"));
+    assertEquals(SolrVersion.LATEST, SolrVersion.parseLeniently("solr_current"));
+  }
+
+  public void testParseLenientlyExceptions() {
+    ParseException expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parseLeniently("SOLR"));
+    assertTrue(expected.getMessage().contains("SOLR"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parseLeniently("SOLR_610"));
+    assertTrue(expected.getMessage().contains("SOLR_610"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parseLeniently("SOLR61"));
+    assertTrue(expected.getMessage().contains("SOLR61"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parseLeniently("SOLR_7.0.0"));
+    assertTrue(expected.getMessage().contains("SOLR_7.0.0"));
+  }
+
+  public void testParseLenientlyOnAllConstants() throws Exception {
+    boolean atLeastOne = false;
+    for (Field field : SolrVersion.class.getDeclaredFields()) {
+      if (Modifier.isStatic(field.getModifiers()) && field.getType() == SolrVersion.class) {
+        atLeastOne = true;
+        SolrVersion v = (SolrVersion) field.get(SolrVersion.class);
+        assertEquals(v, SolrVersion.parseLeniently(v.toString()));
+        assertEquals(v, SolrVersion.parseLeniently(field.getName()));
+        assertEquals(v, SolrVersion.parseLeniently(field.getName().toLowerCase(Locale.ROOT)));
+      }
+    }
+    assertTrue(atLeastOne);
+  }
+
+  public void testParse() throws Exception {
+    assertEquals(SolrVersion.SOLR_8_11_1, SolrVersion.parse("8.11.1"));
+    assertEquals(SolrVersion.SOLR_9_0_0, SolrVersion.parse("9.0.0"));
+
+    // SolrVersion does not pass judgement on the major version:
+    assertEquals(1, SolrVersion.parse("1.0").major);
+    assertEquals(7, SolrVersion.parse("7.0.0").major);
+  }
+
+  public void testForwardsCompatibility() throws Exception {
+    assertTrue(SolrVersion.parse("9.10.20").onOrAfter(SolrVersion.SOLR_9_0_0));
+  }
+
+  public void testParseExceptions() {
+    ParseException expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("SOLR_7_0_0"));
+    assertTrue(expected.getMessage().contains("SOLR_7_0_0"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.256"));
+    assertTrue(expected.getMessage().contains("7.256"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.-1"));
+    assertTrue(expected.getMessage().contains("7.-1"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.1.256"));
+    assertTrue(expected.getMessage().contains("7.1.256"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.1.-1"));
+    assertTrue(expected.getMessage().contains("7.1.-1"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.1.1.3"));
+    assertTrue(expected.getMessage().contains("7.1.1.3"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.1.1.-1"));
+    assertTrue(expected.getMessage().contains("7.1.1.-1"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.1.1.1"));
+    assertTrue(expected.getMessage().contains("7.1.1.1"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.1.1.2"));
+    assertTrue(expected.getMessage().contains("7.1.1.2"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.0.0.0"));
+    assertTrue(expected.getMessage().contains("7.0.0.0"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7.0.0.1.42"));
+    assertTrue(expected.getMessage().contains("7.0.0.1.42"));
+
+    expected =
+        expectThrows(
+            ParseException.class,
+            () -> SolrVersion.parse("7..0.1"));
+    assertTrue(expected.getMessage().contains("7..0.1"));
+  }
+
+  public void testDeprecations() throws Exception {
+    // all but the latest version should be deprecated
+    boolean atLeastOne = false;
+    for (Field field : SolrVersion.class.getDeclaredFields()) {
+      if (Modifier.isStatic(field.getModifiers()) && field.getType() == SolrVersion.class) {
+        atLeastOne = true;
+        SolrVersion v = (SolrVersion) field.get(SolrVersion.class);
+        final boolean dep = field.isAnnotationPresent(Deprecated.class);
+        if (v.equals(SolrVersion.LATEST) && !field.getName().equals("SOLR_CURRENT")) {
+          assertFalse(field.getName() + " should not be deprecated", dep);
+        } else {
+          assertTrue(field.getName() + " should be deprecated", dep);
+        }
+      }
+    }
+    assertTrue(atLeastOne);
+  }
+
+  public void testNonFloatingPointCompliantVersionNumbers() throws ParseException {
+    SolrVersion version800 = SolrVersion.parse("8.0.0");
+    assertTrue(SolrVersion.parse("8.10.0").onOrAfter(version800));
+    assertTrue(SolrVersion.parse("8.10.0").onOrAfter(SolrVersion.parse("8.9.255")));
+    assertTrue(SolrVersion.parse("8.128.0").onOrAfter(version800));
+    assertTrue(SolrVersion.parse("8.255.0").onOrAfter(version800));
+
+    SolrVersion version400 = SolrVersion.parse("4.0.0");
+    assertTrue(version800.onOrAfter(version400));
+    assertTrue(SolrVersion.parse("8.128.0").onOrAfter(version400));
+    assertFalse(version400.onOrAfter(version800));
+  }
+
+  public void testLatestVersionCommonBuild() {
+    // common-build.xml sets 'tests.SOLR_VERSION', if not, we skip this test!
+    String commonBuildVersion = System.getProperty("tests.SOLR_VERSION");
+    assumeTrue(
+        "Null 'tests.SOLR_VERSION' test property. You should run the tests with the official Solr build file",
+        commonBuildVersion != null);
+    assertEquals(
+        "SolrVersion.LATEST does not match the one given in tests.SOLR_VERSION property",
+        SolrVersion.LATEST.toString(),
+        commonBuildVersion);
+  }
+
+  public void testEqualsHashCode() throws Exception {
+    Random random = random();
+    String version =
+        "" + (4 + random.nextInt(1)) + "." + random.nextInt(10) + "." + random.nextInt(10);
+    SolrVersion v1 = SolrVersion.parseLeniently(version);
+    SolrVersion v2 = SolrVersion.parseLeniently(version);
+    assertEquals(v1.hashCode(), v2.hashCode());
+    assertEquals(v1, v2);
+    final int iters = 10 + random.nextInt(20);
+    for (int i = 0; i < iters; i++) {
+      String v = "" + (4 + random.nextInt(1)) + "." + random.nextInt(10) + "." + random.nextInt(10);
+      if (v.equals(version)) {
+        assertEquals(SolrVersion.parseLeniently(v).hashCode(), v1.hashCode());
+        assertEquals(SolrVersion.parseLeniently(v), v1);
+      } else {
+        assertNotEquals(SolrVersion.parseLeniently(v), v1);
+      }
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/util/TestSolrVersion.java
+++ b/solr/core/src/test/org/apache/solr/util/TestSolrVersion.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.util;
 
-import org.apache.lucene.util.LuceneTestCase;
+import org.apache.solr.SolrTestCase;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -25,7 +25,7 @@ import java.util.Locale;
 import java.util.Random;
 
 @SuppressWarnings("deprecation")
-public class TestSolrVersion extends LuceneTestCase {
+public class TestSolrVersion extends SolrTestCase {
 
   public void testOnOrAfter() throws Exception {
     for (Field field : SolrVersion.class.getDeclaredFields()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15845

This PR introduces the SolrVersion class.
There are many places where we keep Lucene Version checks, everywhere related to index version compatibility,
but I have cut over the places I could see Solr either printing or checking compatibility based on version.

Basically the only place which is not pure display of current version is the Package Manager which needs to make package compatibility decision based on the declared supported Solr versions. @noblepaul 

When reviewing, ask yourself whether there are other places in our code base where we process versions, that should use this new class instead.

It passes precommit, but leaving it in DRAFT state for now.