### PR TITLE
SOLR-15873: deprecate the public LTR[Interleaving]Rescorer.scoreFeatures method

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -153,6 +153,10 @@ public class LTRRescorer extends Rescorer {
     return hits;
   }
 
+  /**
+   * @deprecated From Solr 9.1.0 onwards this method will become private.
+   */
+  @Deprecated
   public void scoreFeatures(IndexSearcher indexSearcher,
                             int topN, LTRScoringQuery.ModelWeight modelWeight, ScoreDoc[] hits, List<LeafReaderContext> leaves,
                             ScoreDoc[] reranked) throws IOException {

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
@@ -112,6 +112,10 @@ public class LTRInterleavingRescorer extends LTRRescorer {
     return reRankedPerModel;
   }
 
+  /**
+   * @deprecated From Solr 9.1.0 onwards this method will become private.
+   */
+  @Deprecated
   public void scoreFeatures(IndexSearcher indexSearcher,
                             int topN, LTRScoringQuery.ModelWeight[] modelWeights, ScoreDoc[] hits, List<LeafReaderContext> leaves,
                             ScoreDoc[][] rerankedPerModel) throws IOException {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15873

The method is but probably need not be public.

In future e.g. as part of SOLR-15873 we may wish to change the method signature (e.g. `topN` argument removal) which could be considered a backwards incompatible change. If (say) Solr 9.0.0 marked the method deprecated then (say) Solr 9.1.0 could remove the method (or make it private with a changed signature).