### PR TITLE
SOLR-15873: factor out a ReRankRescorer class

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -25,13 +25,13 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Rescorer;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.solr.ltr.interleaving.OriginalRankingLTRScoringQuery;
+import org.apache.solr.search.ReRankRescorer;
 import org.apache.solr.search.SolrIndexSearcher;
 
 
@@ -41,7 +41,7 @@ import org.apache.solr.search.SolrIndexSearcher;
  * new score to each document. The top documents will be resorted based on the
  * new score.
  * */
-public class LTRRescorer extends Rescorer {
+public class LTRRescorer extends ReRankRescorer {
 
   final private LTRScoringQuery scoringQuery;
 
@@ -110,6 +110,19 @@ public class LTRRescorer extends Rescorer {
   }
 
   /**
+   * rescores all the documents:
+   *
+   * @param searcher
+   *          current IndexSearcher
+   * @param firstPassTopDocs
+   *          documents to rerank;
+   */
+  @Override
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs) throws IOException {
+    return rescore(searcher, firstPassTopDocs, firstPassTopDocs.scoreDocs.length);
+  }
+
+  /**
    * rescores the documents:
    *
    * @param searcher
@@ -118,7 +131,11 @@ public class LTRRescorer extends Rescorer {
    *          documents to rerank;
    * @param topN
    *          documents to return;
+
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be removed.
    */
+  @Deprecated
   @Override
   public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs,
       int topN) throws IOException {

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
@@ -54,6 +54,19 @@ public class LTRInterleavingRescorer extends LTRRescorer {
   }
 
   /**
+   * rescores all the documents:
+   *
+   * @param searcher
+   *          current IndexSearcher
+   * @param firstPassTopDocs
+   *          documents to rerank;
+   */
+  @Override
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs) throws IOException {
+    return rescore(searcher, firstPassTopDocs, firstPassTopDocs.scoreDocs.length);
+  }
+
+  /**
    * rescores the documents:
    *
    * @param searcher
@@ -62,7 +75,11 @@ public class LTRInterleavingRescorer extends LTRRescorer {
    *          documents to rerank;
    * @param topN
    *          documents to return;
+
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be removed.
    */
+  @Deprecated
   @Override
   public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs,
       int topN) throws IOException {

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -216,12 +216,12 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       // use full firstPassTopDocs (possibly higher than topN)
       for (int topN = 1; topN <= 5; topN++) {
-        hits = searcher.search(bqBuilder.build(), 10);
-        log.info("rerank {} documents, return {} documents", hits.scoreDocs.length, topN);
+        final TopDocs allHits = searcher.search(bqBuilder.build(), 10);
+        log.info("rerank {} documents, return {} documents", allHits.scoreDocs.length, topN);
 
-        TopDocs rescoredHits = rescorer.rescore(searcher, hits, topN);
+        TopDocs rescoredHits = rescorer.rescore(searcher, allHits, topN);
         assertEquals(topN, rescoredHits.scoreDocs.length);
-        for (int i = hits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
+        for (int i = allHits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
           if (log.isInfoEnabled()) {
             log.info("doc {} in pos {}", searcher.doc(rescoredHits.scoreDocs[j].doc)
                 .get("id"), j);

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -192,14 +192,16 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       // test rerank with different topN cuts
 
+      // cap firstPassTopDocs length at topN
       for (int topN = 1; topN <= 5; topN++) {
-        log.info("rerank {} documents ", topN);
+        log.info("rerank {} documents, return {} documents", topN, topN);
         hits = searcher.search(bqBuilder.build(), 10);
 
         final ScoreDoc[] slice = new ScoreDoc[topN];
         System.arraycopy(hits.scoreDocs, 0, slice, 0, topN);
         hits = new TopDocs(hits.totalHits, slice);
         hits = rescorer.rescore(searcher, hits, topN);
+        assertEquals(topN, hits.scoreDocs.length);
         for (int i = topN - 1, j = 0; i >= 0; i--, j++) {
           if (log.isInfoEnabled()) {
             log.info("doc {} in pos {}", searcher.doc(hits.scoreDocs[j].doc)
@@ -208,6 +210,25 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
           assertEquals(i,
                   Integer.parseInt(searcher.doc(hits.scoreDocs[j].doc).get("id")));
           assertEquals((i + 1) * features.size()*featureWeight, hits.scoreDocs[j].score, 0.00001);
+
+        }
+      }
+
+      // use full firstPassTopDocs (possibly higher than topN)
+      for (int topN = 1; topN <= 5; topN++) {
+        hits = searcher.search(bqBuilder.build(), 10);
+        log.info("rerank {} documents, return {} documents", hits.scoreDocs.length, topN);
+
+        TopDocs rescoredHits = rescorer.rescore(searcher, hits, topN);
+        assertEquals(topN, rescoredHits.scoreDocs.length);
+        for (int i = hits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
+          if (log.isInfoEnabled()) {
+            log.info("doc {} in pos {}", searcher.doc(rescoredHits.scoreDocs[j].doc)
+                .get("id"), j);
+          }
+          assertEquals(i,
+                  Integer.parseInt(searcher.doc(rescoredHits.scoreDocs[j].doc).get("id")));
+          assertEquals((i + 1) * features.size()*featureWeight, rescoredHits.scoreDocs[j].score, 0.00001);
 
         }
       }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -132,7 +132,8 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       LTRScoringQuery ltrScoringQuery = new LTRScoringQuery(ltrScoringModel);
       ltrScoringQuery.setRequest(solrQueryRequest);
       final LTRRescorer rescorer = new LTRRescorer(ltrScoringQuery);
-      hits = rescorer.rescore(searcher, hits, 2);
+      assertEquals(2, hits.scoreDocs.length);
+      hits = rescorer.rescore(searcher, hits);
 
       // rerank using the field finalScore
       assertEquals("1", searcher.doc(hits.scoreDocs[0].doc).get("id"));
@@ -200,7 +201,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
         final ScoreDoc[] slice = new ScoreDoc[topN];
         System.arraycopy(hits.scoreDocs, 0, slice, 0, topN);
         hits = new TopDocs(hits.totalHits, slice);
-        hits = rescorer.rescore(searcher, hits, topN);
+        hits = rescorer.rescore(searcher, hits);
         assertEquals(topN, hits.scoreDocs.length);
         for (int i = topN - 1, j = 0; i >= 0; i--, j++) {
           if (log.isInfoEnabled()) {

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -112,8 +112,12 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
 
       mainDocs.scoreDocs = reRankScoreDocs;
 
-      TopDocs rescoredDocs = reRankQueryRescorer
-          .rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
+      final TopDocs rescoredDocs;
+      if (reRankQueryRescorer instanceof ReRankRescorer) {
+        rescoredDocs = ((ReRankRescorer) reRankQueryRescorer).rescore(searcher, mainDocs);
+      } else {
+        rescoredDocs = reRankQueryRescorer.rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
+      }
 
       //Lower howMany to return if we've collected fewer documents.
       howMany = Math.min(howMany, mainScoreDocs.length);

--- a/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.io.IOException;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Rescorer;
+import org.apache.lucene.search.TopDocs;
+
+/**
+ * This class is a variant of Lucene's {@link Rescorer} class for use by the
+ * {@link ReRankCollector} to rescore all results in a {@link TopDocs} object
+ * from an original query.
+ */
+public abstract class ReRankRescorer extends Rescorer {
+
+  /**
+   * Rescore an initial first-pass {@link TopDocs}.
+   *
+   * @param searcher {@link IndexSearcher} used to produce the first pass topDocs
+   * @param firstPassTopDocs Hits from the first pass search that are to be rescored.
+   *     It's very important that these hits were produced by the provided searcher;
+   *     otherwise the doc IDs will not match!
+   */
+  public abstract TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs)
+      throws IOException;
+
+  /**
+   * Throws an {@link UnsupportedOperationException} exception.
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be <code>final</code>.
+   */
+  @Deprecated
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
+      throws IOException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+}


### PR DESCRIPTION
_(Keeping this PR as "draft" whilst the "keep or not keep" discussion in SOLR-15873 is underway and also because this PR includes the #470 changes.)_

https://issues.apache.org/jira/browse/SOLR-15873

The Lucene `Rescorer.rescore` API signature takes three arguments: `rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)`

The Solr `ReRankCollector` caps the number of documents that are passed to the `rescore` method so that `topN == firstPassTopDocs.scoreDocs.length` is always the case.

This pull request introduces a `ReRankRescorer` class for this specific use case i.e. a two arguments API signature variant `rescore(IndexSearcher searcher, TopDocs firstPassTopDocs)` with non-support of the three argument variant.

The motivation is to subsequently simplify the  `LTR[Interleaving]Rescorer` logic by making use of the `topN == firstPassTopDocs.scoreDocs.length` condition.