### PR TITLE
SOLR-15873: factor out a ReRankRescorer class, simplify LTR[Interleaving]Rescorer code

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -25,13 +25,13 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Rescorer;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.solr.ltr.interleaving.OriginalRankingLTRScoringQuery;
+import org.apache.solr.search.ReRankRescorer;
 import org.apache.solr.search.SolrIndexSearcher;
 
 
@@ -41,7 +41,7 @@ import org.apache.solr.search.SolrIndexSearcher;
  * new score to each document. The top documents will be resorted based on the
  * new score.
  * */
-public class LTRRescorer extends Rescorer {
+public class LTRRescorer extends ReRankRescorer {
 
   final private LTRScoringQuery scoringQuery;
 
@@ -110,6 +110,19 @@ public class LTRRescorer extends Rescorer {
   }
 
   /**
+   * rescores all the documents:
+   *
+   * @param searcher
+   *          current IndexSearcher
+   * @param firstPassTopDocs
+   *          documents to rerank;
+   */
+  @Override
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs) throws IOException {
+    return rescore(searcher, firstPassTopDocs, firstPassTopDocs.scoreDocs.length);
+  }
+
+  /**
    * rescores the documents:
    *
    * @param searcher
@@ -118,7 +131,11 @@ public class LTRRescorer extends Rescorer {
    *          documents to rerank;
    * @param topN
    *          documents to return;
+
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be removed.
    */
+  @Deprecated
   @Override
   public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs,
       int topN) throws IOException {

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -110,6 +110,34 @@ public class LTRRescorer extends ReRankRescorer {
   }
 
   /**
+   * rescores the documents:
+   *
+   * @param searcher
+   *          current IndexSearcher
+   * @param firstPassTopDocs
+   *          documents to rerank;
+   * @param topN
+   *          documents to return;
+
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be removed.
+   */
+  @Deprecated
+  @Override
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs,
+      int topN) throws IOException {
+    if ((topN == 0) || (firstPassTopDocs.scoreDocs.length == 0)) {
+      return firstPassTopDocs;
+    }
+    final ScoreDoc[] firstPassResults = getFirstPassDocsRanked(firstPassTopDocs);
+    topN = Math.toIntExact(Math.min(topN, firstPassTopDocs.totalHits.value));
+
+    final ScoreDoc[] reranked = rerank(searcher, topN, firstPassResults);
+
+    return new TopDocs(firstPassTopDocs.totalHits, reranked);
+  }
+
+  /**
    * rescores all the documents:
    *
    * @param searcher
@@ -127,6 +155,23 @@ public class LTRRescorer extends ReRankRescorer {
     final ScoreDoc[] reranked = rerank(searcher, firstPassResults);
 
     return new TopDocs(firstPassTopDocs.totalHits, reranked);
+  }
+
+  /**
+   * @deprecated Use {@link #rerank(IndexSearcher, ScoreDoc[])} instead.
+   * From Solr 9.1.0 onwards this method will be removed.
+   */
+  @Deprecated
+  private ScoreDoc[] rerank(IndexSearcher searcher, int topN, ScoreDoc[] firstPassResults) throws IOException {
+    final ScoreDoc[] reranked = new ScoreDoc[topN];
+    final List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+    final LTRScoringQuery.ModelWeight modelWeight = (LTRScoringQuery.ModelWeight) searcher
+        .createWeight(searcher.rewrite(scoringQuery), ScoreMode.COMPLETE, 1);
+
+    scoreFeatures(searcher,topN, modelWeight, firstPassResults, leaves, reranked);
+    // Must sort all documents that we reranked, and then select the top
+    Arrays.sort(reranked, scoreComparator);
+    return reranked;
   }
 
   private ScoreDoc[] rerank(IndexSearcher searcher, ScoreDoc[] firstPassResults) throws IOException {
@@ -147,6 +192,42 @@ public class LTRRescorer extends ReRankRescorer {
 
     assert firstPassTopDocs.totalHits.relation == TotalHits.Relation.EQUAL_TO;
     return hits;
+  }
+
+  /**
+   * @deprecated From Solr 9.1.0 onwards this method will be removed.
+   */
+  @Deprecated
+  public void scoreFeatures(IndexSearcher indexSearcher,
+                            int topN, LTRScoringQuery.ModelWeight modelWeight, ScoreDoc[] hits, List<LeafReaderContext> leaves,
+                            ScoreDoc[] reranked) throws IOException {
+
+    int readerUpto = -1;
+    int endDoc = 0;
+    int docBase = 0;
+
+    LTRScoringQuery.ModelWeight.ModelScorer scorer = null;
+    int hitUpto = 0;
+
+    while (hitUpto < hits.length) {
+      final ScoreDoc hit = hits[hitUpto];
+      final int docID = hit.doc;
+      LeafReaderContext readerContext = null;
+      while (docID >= endDoc) {
+        readerUpto++;
+        readerContext = leaves.get(readerUpto);
+        endDoc = readerContext.docBase + readerContext.reader().maxDoc();
+      }
+      // We advanced to another segment
+      if (readerContext != null) {
+        docBase = readerContext.docBase;
+        scorer = modelWeight.scorer(readerContext);
+      }
+      if (scoreSingleHit(topN, docBase, hitUpto, hit, docID, scorer, reranked)) {
+        logSingleHit(indexSearcher, modelWeight, hit.doc, scoringQuery);
+      }
+      hitUpto++;
+    }
   }
 
   private void scoreFeatures(IndexSearcher indexSearcher,
@@ -191,32 +272,10 @@ public class LTRRescorer extends ReRankRescorer {
   }
 
   /**
-   * Scores a single document and returns it.
-   */
-  protected static ScoreDoc scoreSingleHit(int docBase, ScoreDoc hit, int docID, LTRScoringQuery.ModelWeight.ModelScorer scorer) throws IOException {
-    // Scorer for a LTRScoringQuery.ModelWeight should never be null since we always have to
-    // call score
-    // even if no feature scorers match, since a model might use that info to
-    // return a
-    // non-zero score. Same applies for the case of advancing a LTRScoringQuery.ModelWeight.ModelScorer
-    // past the target
-    // doc since the model algorithm still needs to compute a potentially
-    // non-zero score from blank features.
-    assert (scorer != null);
-    final int targetDoc = docID - docBase;
-    scorer.docID();
-    scorer.iterator().advance(targetDoc);
-
-    scorer.getDocInfo().setOriginalDocScore(hit.score);
-    hit.score = scorer.score();
-    return hit;
-  }
-
-  /**
    * Scores a single document and returns true if the document's feature info should be logged via the
    * {@link #logSingleHit(IndexSearcher, org.apache.solr.ltr.LTRScoringQuery.ModelWeight, int, LTRScoringQuery)}
    * method. Feature info logging is only necessary for the topN documents.
-   * @deprecated From Solr 9.2.0 onwards this method will be removed.
+   * @deprecated From Solr 9.1.0 onwards this method will be removed.
    */
   @Deprecated
   protected static boolean scoreSingleHit(int topN, int docBase, int hitUpto, ScoreDoc hit, int docID, LTRScoringQuery.ModelWeight.ModelScorer scorer, ScoreDoc[] reranked) throws IOException {
@@ -259,6 +318,28 @@ public class LTRRescorer extends ReRankRescorer {
       }
     }
     return logHit;
+  }
+
+  /**
+   * Scores a single document and returns it.
+   */
+  protected static ScoreDoc scoreSingleHit(int docBase, ScoreDoc hit, int docID, LTRScoringQuery.ModelWeight.ModelScorer scorer) throws IOException {
+    // Scorer for a LTRScoringQuery.ModelWeight should never be null since we always have to
+    // call score
+    // even if no feature scorers match, since a model might use that info to
+    // return a
+    // non-zero score. Same applies for the case of advancing a LTRScoringQuery.ModelWeight.ModelScorer
+    // past the target
+    // doc since the model algorithm still needs to compute a potentially
+    // non-zero score from blank features.
+    assert (scorer != null);
+    final int targetDoc = docID - docBase;
+    scorer.docID();
+    scorer.iterator().advance(targetDoc);
+
+    scorer.getDocInfo().setOriginalDocScore(hit.score);
+    hit.score = scorer.score();
+    return hit;
   }
 
   @Override

--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingRescorer.java
@@ -54,6 +54,19 @@ public class LTRInterleavingRescorer extends LTRRescorer {
   }
 
   /**
+   * rescores all the documents:
+   *
+   * @param searcher
+   *          current IndexSearcher
+   * @param firstPassTopDocs
+   *          documents to rerank;
+   */
+  @Override
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs) throws IOException {
+    return rescore(searcher, firstPassTopDocs, firstPassTopDocs.scoreDocs.length);
+  }
+
+  /**
    * rescores the documents:
    *
    * @param searcher
@@ -62,7 +75,11 @@ public class LTRInterleavingRescorer extends LTRRescorer {
    *          documents to rerank;
    * @param topN
    *          documents to return;
+
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be removed.
    */
+  @Deprecated
   @Override
   public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs,
       int topN) throws IOException {

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -132,8 +132,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       LTRScoringQuery ltrScoringQuery = new LTRScoringQuery(ltrScoringModel);
       ltrScoringQuery.setRequest(solrQueryRequest);
       final LTRRescorer rescorer = new LTRRescorer(ltrScoringQuery);
-      assertEquals(2, hits.scoreDocs.length);
-      hits = rescorer.rescore(searcher, hits);
+      hits = random().nextBoolean() ? rescorer.rescore(searcher, hits) : rescorer.rescore(searcher, hits, 2);
 
       // rerank using the field finalScore
       assertEquals("1", searcher.doc(hits.scoreDocs[0].doc).get("id"));
@@ -184,6 +183,12 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       final LTRRescorer rescorer = new LTRRescorer(scoringQuery);
 
       // rerank @ 0 should not change the order
+      hits = rescorer.rescore(searcher, hits, 0);
+      assertEquals("0", searcher.doc(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.doc(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("2", searcher.doc(hits.scoreDocs[2].doc).get("id"));
+      assertEquals("3", searcher.doc(hits.scoreDocs[3].doc).get("id"));
+      assertEquals("4", searcher.doc(hits.scoreDocs[4].doc).get("id"));
       {
         final TopDocs noHits = new TopDocs(hits.totalHits, new ScoreDoc[0]);
         final TopDocs noHitsRescored = rescorer.rescore(searcher, noHits);
@@ -200,7 +205,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
         final ScoreDoc[] slice = new ScoreDoc[topN];
         System.arraycopy(hits.scoreDocs, 0, slice, 0, topN);
         hits = new TopDocs(hits.totalHits, slice);
-        hits = rescorer.rescore(searcher, hits);
+        hits = random().nextBoolean() ? rescorer.rescore(searcher, hits) : rescorer.rescore(searcher, hits, topN);
         assertEquals(topN, hits.scoreDocs.length);
         for (int i = topN - 1, j = 0; i >= 0; i--, j++) {
           if (log.isInfoEnabled()) {
@@ -215,14 +220,22 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       }
 
       // use full firstPassTopDocs (possibly higher than topN)
-      for (int topN = 0; topN <= 5; topN++) {
+      for (int topN = 1; topN <= 5; topN++) {
         final TopDocs allHits = searcher.search(bqBuilder.build(), 10);
         log.info("rerank {} documents, return {} documents", allHits.scoreDocs.length, topN);
 
-        final int topNN = topN;
-        expectThrows(UnsupportedOperationException.class, () -> {
-          rescorer.rescore(searcher, allHits, topNN);
-        });
+        TopDocs rescoredHits = rescorer.rescore(searcher, allHits, topN);
+        assertEquals(topN, rescoredHits.scoreDocs.length);
+        for (int i = allHits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
+          if (log.isInfoEnabled()) {
+            log.info("doc {} in pos {}", searcher.doc(rescoredHits.scoreDocs[j].doc)
+                .get("id"), j);
+          }
+          assertEquals(i,
+                  Integer.parseInt(searcher.doc(rescoredHits.scoreDocs[j].doc).get("id")));
+          assertEquals((i + 1) * features.size()*featureWeight, rescoredHits.scoreDocs[j].score, 0.00001);
+
+        }
       }
     }
   }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -216,12 +216,12 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       // use full firstPassTopDocs (possibly higher than topN)
       for (int topN = 1; topN <= 5; topN++) {
-        hits = searcher.search(bqBuilder.build(), 10);
-        log.info("rerank {} documents, return {} documents", hits.scoreDocs.length, topN);
+        final TopDocs allHits = searcher.search(bqBuilder.build(), 10);
+        log.info("rerank {} documents, return {} documents", allHits.scoreDocs.length, topN);
 
-        TopDocs rescoredHits = rescorer.rescore(searcher, hits, topN);
+        TopDocs rescoredHits = rescorer.rescore(searcher, allHits, topN);
         assertEquals(topN, rescoredHits.scoreDocs.length);
-        for (int i = hits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
+        for (int i = allHits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
           if (log.isInfoEnabled()) {
             log.info("doc {} in pos {}", searcher.doc(rescoredHits.scoreDocs[j].doc)
                 .get("id"), j);

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -192,14 +192,16 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       // test rerank with different topN cuts
 
+      // cap firstPassTopDocs length at topN
       for (int topN = 1; topN <= 5; topN++) {
-        log.info("rerank {} documents ", topN);
+        log.info("rerank {} documents, return {} documents", topN, topN);
         hits = searcher.search(bqBuilder.build(), 10);
 
         final ScoreDoc[] slice = new ScoreDoc[topN];
         System.arraycopy(hits.scoreDocs, 0, slice, 0, topN);
         hits = new TopDocs(hits.totalHits, slice);
         hits = rescorer.rescore(searcher, hits, topN);
+        assertEquals(topN, hits.scoreDocs.length);
         for (int i = topN - 1, j = 0; i >= 0; i--, j++) {
           if (log.isInfoEnabled()) {
             log.info("doc {} in pos {}", searcher.doc(hits.scoreDocs[j].doc)
@@ -208,6 +210,25 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
           assertEquals(i,
                   Integer.parseInt(searcher.doc(hits.scoreDocs[j].doc).get("id")));
           assertEquals((i + 1) * features.size()*featureWeight, hits.scoreDocs[j].score, 0.00001);
+
+        }
+      }
+
+      // use full firstPassTopDocs (possibly higher than topN)
+      for (int topN = 1; topN <= 5; topN++) {
+        hits = searcher.search(bqBuilder.build(), 10);
+        log.info("rerank {} documents, return {} documents", hits.scoreDocs.length, topN);
+
+        TopDocs rescoredHits = rescorer.rescore(searcher, hits, topN);
+        assertEquals(topN, rescoredHits.scoreDocs.length);
+        for (int i = hits.scoreDocs.length-1, j = 0; i >= 0 && j < topN; i--, j++) {
+          if (log.isInfoEnabled()) {
+            log.info("doc {} in pos {}", searcher.doc(rescoredHits.scoreDocs[j].doc)
+                .get("id"), j);
+          }
+          assertEquals(i,
+                  Integer.parseInt(searcher.doc(rescoredHits.scoreDocs[j].doc).get("id")));
+          assertEquals((i + 1) * features.size()*featureWeight, rescoredHits.scoreDocs[j].score, 0.00001);
 
         }
       }

--- a/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/contrib/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -132,7 +132,8 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       LTRScoringQuery ltrScoringQuery = new LTRScoringQuery(ltrScoringModel);
       ltrScoringQuery.setRequest(solrQueryRequest);
       final LTRRescorer rescorer = new LTRRescorer(ltrScoringQuery);
-      hits = rescorer.rescore(searcher, hits, 2);
+      assertEquals(2, hits.scoreDocs.length);
+      hits = rescorer.rescore(searcher, hits);
 
       // rerank using the field finalScore
       assertEquals("1", searcher.doc(hits.scoreDocs[0].doc).get("id"));
@@ -200,7 +201,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
         final ScoreDoc[] slice = new ScoreDoc[topN];
         System.arraycopy(hits.scoreDocs, 0, slice, 0, topN);
         hits = new TopDocs(hits.totalHits, slice);
-        hits = rescorer.rescore(searcher, hits, topN);
+        hits = rescorer.rescore(searcher, hits);
         assertEquals(topN, hits.scoreDocs.length);
         for (int i = topN - 1, j = 0; i >= 0; i--, j++) {
           if (log.isInfoEnabled()) {

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -112,8 +112,12 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
 
       mainDocs.scoreDocs = reRankScoreDocs;
 
-      TopDocs rescoredDocs = reRankQueryRescorer
-          .rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
+      final TopDocs rescoredDocs;
+      if (reRankQueryRescorer instanceof ReRankRescorer) {
+        rescoredDocs = ((ReRankRescorer) reRankQueryRescorer).rescore(searcher, mainDocs);
+      } else {
+        rescoredDocs = reRankQueryRescorer.rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
+      }
 
       //Lower howMany to return if we've collected fewer documents.
       howMany = Math.min(howMany, mainScoreDocs.length);

--- a/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
@@ -42,9 +42,11 @@ public abstract class ReRankRescorer extends Rescorer {
 
   /**
    * Throws an {@link UnsupportedOperationException} exception.
-   * Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be <code>final</code>.
    */
-  final public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
+  @Deprecated
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
       throws IOException
   {
     throw new UnsupportedOperationException();

--- a/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
@@ -42,11 +42,9 @@ public abstract class ReRankRescorer extends Rescorer {
 
   /**
    * Throws an {@link UnsupportedOperationException} exception.
-   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
-   * From Solr 9.1.0 onwards this method will be <code>final</code>.
+   * Use {@link #rescore(IndexSearcher, TopDocs)} instead.
    */
-  @Deprecated
-  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
+  final public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
       throws IOException
   {
     throw new UnsupportedOperationException();

--- a/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankRescorer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.io.IOException;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Rescorer;
+import org.apache.lucene.search.TopDocs;
+
+/**
+ * This class is a variant of Lucene's {@link Rescorer} class for use by the
+ * {@link ReRankCollector} to rescore all results in a {@link TopDocs} object
+ * from an original query.
+ */
+public abstract class ReRankRescorer extends Rescorer {
+
+  /**
+   * Rescore an initial first-pass {@link TopDocs}.
+   *
+   * @param searcher {@link IndexSearcher} used to produce the first pass topDocs
+   * @param firstPassTopDocs Hits from the first pass search that are to be rescored.
+   *     It's very important that these hits were produced by the provided searcher;
+   *     otherwise the doc IDs will not match!
+   */
+  public abstract TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs)
+      throws IOException;
+
+  /**
+   * Throws an {@link UnsupportedOperationException} exception.
+   * @deprecated Use {@link #rescore(IndexSearcher, TopDocs)} instead.
+   * From Solr 9.1.0 onwards this method will be <code>final</code>.
+   */
+  @Deprecated
+  public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
+      throws IOException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+}


### PR DESCRIPTION
_(Keeping this PR as "draft" whilst the "keep or not keep" discussion in SOLR-15873 is underway and also because this PR includes the #470 changes.)_

https://issues.apache.org/jira/browse/SOLR-15873

The Lucene `Rescorer.rescore` API signature takes three arguments: `rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)`

The Solr `ReRankCollector` caps the number of documents that are passed to the `rescore` method so that `topN == firstPassTopDocs.scoreDocs.length` is always the case.

This pull request introduces a `ReRankRescorer` class for the specific `ReRankCollector` use case i.e. a two arguments API signature variant `rescore(IndexSearcher searcher, TopDocs firstPassTopDocs)` with non-support of the three argument variant.

Then the `LTR[Interleaving]Rescorer` logic can then be simplified by making use of the `topN == firstPassTopDocs.scoreDocs.length` condition.

Existing `LTR[Interleaving]Rescorer` APIs that support `topN != firstPassTopDocs.scoreDocs.length` are retained with `@deprecated` annotation for backwards compatibility and with the intention to remove them in the next or a subsequent Solr version.