### PR TITLE
SOLR-15789: Explain that atomic update "inc" can take negative and fractional values

### DIFF
--- a/solr/solr-ref-guide/src/partial-document-updates.adoc
+++ b/solr/solr-ref-guide/src/partial-document-updates.adoc
@@ -37,7 +37,7 @@ Solr supports several modifiers that atomically update values of a document.
 This allows updating only specific fields, which can help speed indexing processes in an environment where speed of index additions is critical to the application.
 
 To use atomic updates, add a modifier to the field that needs to be updated.
-The content can be updated, added to, or incrementally increased if the field has a numeric type.
+The content can be updated, added to, or, if the field has a numeric type, incrementally increased or decreased.
 
 `set`::
 Set or replace the field value(s) with the specified value(s), or remove the values if 'null' or empty list is specified as the new value.
@@ -61,8 +61,8 @@ Removes all occurrences of the specified regex from a multiValued field.
 May be specified as a single value, or as a list.
 
 `inc`::
-Increments a numeric value by a specific amount.
-Must be specified as a single numeric value.
+Increments or decrements a numeric field's value by a specific amount, specified as a single integer or float.
+Postive amounts increment the field's value, and negative decrement.
 
 === Field Storage
 
@@ -101,7 +101,7 @@ And we apply the following update command:
 ----
 {"id":"mydoc",
  "price":{"set":99},
- "popularity":{"inc":20},
+ "popularity":{"inc":-7},
  "categories":{"add":["toys","games"]},
  "sub_categories":{"add-distinct":"under_10"},
  "promo_ids":{"remove":"a123x"},
@@ -115,7 +115,7 @@ The resulting document in our collection will be:
 ----
 {"id":"mydoc",
  "price":99,
- "popularity":62,
+ "popularity":35,
  "categories":["kids","toys","games"],
  "sub_categories":["under_5","under_10"],
  "tags":["buy_now","clearance"]
@@ -249,15 +249,15 @@ An atomic update operation is performed using this In-Place approach only when t
 * copy targets of updated fields, if any, are also non-indexed, non-stored single valued numeric docValues fields.
 
 To use in-place updates, add a modifier to the field that needs to be updated.
-The content can be updated or incrementally increased.
+The content can be updated or incremented/decremented.
 
 `set`::
 Set or replace the field value(s) with the specified value(s).
 May be specified as a single value.
 
 `inc`::
-Increments a numeric value by a specific amount.
-Must be specified as a single numeric value.
+Increments or decrements a numeric field's value by a specific amount, specified as a single integer or float.
+Postive amounts increment the field's value, and negative decrement.
 
 [TIP]
 ====


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15789

# Description

Explicitly state that the "inc" amounts in atomic updates can be negative or fractional. As written now, a reader may think that fields can only be incremented, as in Redis's INCRBY command.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
