### PR TITLE
Simplify rm statement, make sure deletion works, remove redundant solr-core jar

### DIFF
--- a/solr/bin/post
+++ b/solr/bin/post
@@ -52,7 +52,7 @@ fi
 
 # ===== post specific code
 
-TOOL_JAR=("$SOLR_TIP/dist"/solr-core-*.jar)
+TOOL_JAR=("$SOLR_TIP/server/solr-webapp/webapp/WEB-INF/lib"/solr-core-*.jar)
 
 function print_usage() {
   echo ""

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -30,7 +30,7 @@
 #  TODO; arguably these permissions should have been set correctly previously in the TAR
 RUN set -ex; \
   (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile* /opt/solr/dist/solr-solrj-*.jar /opt/solr/dist/solrj-lib; \
+  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile* /opt/solr/dist/solr-solrj-*.jar /opt/solr/dist/solrj-lib /opt/solr/dist/solr-core-*.jar; \
   find /opt/solr/ -type d -print0 | xargs -0 chmod 0755; \
   find /opt/solr/ -type f -print0 | xargs -0 chmod 0644; \
   chmod -R 0755 /opt/solr/docker/scripts /opt/solr/bin /opt/solr/contrib/prometheus-exporter/bin/solr-exporter /opt/solr/server/scripts/cloud-scripts

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -30,7 +30,7 @@
 #  TODO; arguably these permissions should have been set correctly previously in the TAR
 RUN set -ex; \
   (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile* /opt/solr/dist/{solr-solrj-*.jar,solrj-lib}; \
+  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile* /opt/solr/dist/solr-solrj-*.jar /opt/solr/dist/solrj-lib; \
   find /opt/solr/ -type d -print0 | xargs -0 chmod 0755; \
   find /opt/solr/ -type f -print0 | xargs -0 chmod 0644; \
   chmod -R 0755 /opt/solr/docker/scripts /opt/solr/bin /opt/solr/contrib/prometheus-exporter/bin/solr-exporter /opt/solr/server/scripts/cloud-scripts


### PR DESCRIPTION
Inspired by https://github.com/docker-solr/docker-solr/pull/405

Make sure the rm statement works, and also delete redundant `solr-core-*.jar` from dist folder.