### PR TITLE
SOLR-15831: Refactor bin/solr and bin/solr.cmd to delegate args parsing and usage help to SolrCLI

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -424,29 +424,9 @@ function print_usage() {
     echo ""
     echo "  NOTE: To see if any Solr servers are running, do: solr status"
     echo ""
-  elif [ "$CMD" == "healthcheck" ]; then
-    echo ""
-    echo "Usage: solr healthcheck [-c collection] [-z zkHost] [-V]"
-    echo ""
-    echo "Can be run from remote (non-Solr) hosts, as long as a proper ZooKeeper connection is provided"
-    echo ""
-    echo "  -c <collection>  Collection to run healthcheck against."
-    echo ""
-    echo "  -z <zkHost>      Zookeeper connection string; unnecessary if ZK_HOST is defined in solr.in.sh;"
-    echo "                     otherwise, default is localhost:9983"
-    echo ""
-    echo "  -V               Enable more verbose output"
-    echo ""
-  elif [ "$CMD" == "status" ]; then
-    echo ""
-    echo "Usage: solr status"
-    echo ""
-    echo "  This command will show the status of all running Solr servers."
-    echo "  It can only detect those Solr servers running on the current host."
-    echo ""
   elif [ "$CMD" == "create" ]; then
     echo ""
-    echo "Usage: solr create [-c name] [-d confdir] [-n configName] [-shards #] [-replicationFactor #] [-p port] [-V]"
+    echo "Usage: solr create OPTIONS"
     echo ""
     echo "  Create a core or collection depending on whether Solr is running in standalone (core) or SolrCloud"
     echo "  mode (collection). In other words, this action detects which mode Solr is running in, and then takes"
@@ -457,90 +437,6 @@ function print_usage() {
     echo "       or"
     echo ""
     echo "    bin/solr create_collection -help"
-    echo ""
-  elif [ "$CMD" == "delete" ]; then
-    echo ""
-    echo "Usage: solr delete [-c name] [-deleteConfig true|false] [-p port] [-V]"
-    echo ""
-    echo "  Deletes a core or collection depending on whether Solr is running in standalone (core) or SolrCloud"
-    echo "  mode (collection). If you're deleting a collection in SolrCloud mode, the default behavior is to also"
-    echo "  delete the configuration directory from Zookeeper so long as it is not being used by another collection."
-    echo "  You can override this behavior by passing -deleteConfig false when running this command."
-    echo ""
-    echo "  Can be run on remote (non-Solr) hosts, as long as a valid SOLR_HOST is provided in solr.in.sh"
-    echo ""
-    echo "  -c <name>               Name of the core / collection to delete"
-    echo ""
-    echo "  -deleteConfig <boolean> Delete the configuration directory from Zookeeper; default is true"
-    echo ""
-    echo "  -p <port>               Port of a local Solr instance where you want to delete the core/collection"
-    echo "                            If not specified, the script will search the local system for a running"
-    echo "                            Solr instance and will use the port of the first server it finds."
-    echo ""
-    echo "  -V                      Enables more verbose output."
-    echo ""
-  elif [ "$CMD" == "create_core" ]; then
-    echo ""
-    echo "Usage: solr create_core [-c core] [-d confdir] [-p port] [-V]"
-    echo ""
-    echo "When a configSet is used, this can be run from remote (non-Solr) hosts.  If pointing at a non-configSet directory, this"
-    echo "must be run from the host that you wish to create the core on"
-    echo ""
-    echo "  -c <core>     Name of core to create"
-    echo ""
-    echo "  -d <confdir>  Configuration directory to copy when creating the new core, built-in options are:"
-    echo ""
-    echo "      _default: Minimal configuration, which supports enabling/disabling field-guessing support"
-    echo "      sample_techproducts_configs: Example configuration with many optional features enabled to"
-    echo "         demonstrate the full power of Solr"
-    echo ""
-    echo "      If not specified, default is: _default"
-    echo ""
-    echo "      Alternatively, you can pass the path to your own configuration directory instead of using"
-    echo "      one of the built-in configurations, such as: bin/solr create_core -c mycore -d /tmp/myconfig"
-    echo ""
-    echo "  -p <port>     Port of a local Solr instance where you want to create the new core"
-    echo "                  If not specified, the script will search the local system for a running"
-    echo "                  Solr instance and will use the port of the first server it finds."
-    echo ""
-    echo "  -V            Enable more verbose output."
-    echo ""
-  elif [ "$CMD" == "create_collection" ]; then
-    echo ""
-    echo "Usage: solr create_collection [-c collection] [-d confdir] [-n configName] [-shards #] [-replicationFactor #] [-p port] [-V]"
-    echo ""
-    echo "Can be run from remote (non-Solr) hosts, as long as a valid SOLR_HOST is provided in solr.in.sh"
-    echo "  -c <collection>         Name of collection to create"
-    echo ""
-    echo "  -d <confdir>            Configuration directory to copy when creating the new collection, built-in options are:"
-    echo ""
-    echo "      _default: Minimal configuration, which supports enabling/disabling field-guessing support"
-    echo "      sample_techproducts_configs: Example configuration with many optional features enabled to"
-    echo "         demonstrate the full power of Solr"
-    echo ""
-    echo "      If not specified, default is: _default"
-    echo ""
-    echo "      Alternatively, you can pass the path to your own configuration directory instead of using"
-    echo "      one of the built-in configurations, such as: bin/solr create_collection -c mycoll -d /tmp/myconfig"
-    echo ""
-    echo "      By default the script will upload the specified confdir directory into Zookeeper using the same"
-    echo "      name as the collection (-c) option. Alternatively, if you want to reuse an existing directory"
-    echo "      or create a confdir in Zookeeper that can be shared by multiple collections, use the -n option"
-    echo ""
-    echo "  -n <configName>         Name the configuration directory in Zookeeper; by default, the configuration"
-    echo "                            will be uploaded to Zookeeper using the collection name (-c), but if you want"
-    echo "                            to use an existing directory or override the name of the configuration in"
-    echo "                            Zookeeper, then use the -c option."
-    echo ""
-    echo "  -shards <#>             Number of shards to split the collection into; default is 1"
-    echo ""
-    echo "  -replicationFactor <#>  Number of copies of each document in the collection, default is 1 (no replication)"
-    echo ""
-    echo "  -p <port>               Port of a local Solr instance where you want to create the new collection"
-    echo "                            If not specified, the script will search the local system for a running"
-    echo "                            Solr instance and will use the port of the first server it finds."
-    echo ""
-    echo "  -V                      Enable more verbose output."
     echo ""
   elif [ "$CMD" == "zk" ]; then
     print_short_zk_usage ""
@@ -655,6 +551,8 @@ function print_usage() {
     echo ""
     echo "  -V                                     Enable more verbose output."
     echo ""
+  else
+    run_tool $CMD -help
   fi
 } # end print_usage
 
@@ -927,141 +825,25 @@ fi
 if [ "$SCRIPT_CMD" == "status" ]; then
   # hacky - the script hits this if the user passes additional args with the status command,
   # which is not supported but also not worth complaining about either
+  # TJP TODO
   get_info
   exit
 fi
 
-# assert tool
-if [ "$SCRIPT_CMD" == "assert" ]; then
-  run_tool assert $*
-  exit $?
-fi
-
-# run a healthcheck and exit if requested
-if [ "$SCRIPT_CMD" == "healthcheck" ]; then
-
-  VERBOSE=""
-
-  if [ $# -gt 0 ]; then
-    while true; do
-      case "$1" in
-          -c|-collection)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "Collection name is required when using the $1 option!"
-                exit 1
-              fi
-              HEALTHCHECK_COLLECTION="$2"
-              shift 2
-          ;;
-          -z|-zkhost|-zkHost)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "ZooKeeper connection string is required when using the $1 option!"
-                exit 1
-              fi
-              ZK_HOST="$2"
-              shift 2
-          ;;
-          -help|-usage)
-              print_usage "$SCRIPT_CMD"
-              exit 0
-          ;;
-          -V|--verbose)
-              VERBOSE="-verbose"
-              shift
-          ;;
-          --)
-              shift
-              break
-          ;;
-          *)
-              if [ "$1" != "" ]; then
-                print_usage "$SCRIPT_CMD" "Unrecognized or misplaced argument: $1!"
-                exit 1
-              else
-                break # out-of-args, stop looping
-              fi
-          ;;
-      esac
-    done
-  fi
-
-  if [ -z "$ZK_HOST" ]; then
-    ZK_HOST=localhost:9983
-  fi
-
-  if [ -z "$HEALTHCHECK_COLLECTION" ]; then
-    echo "collection parameter is required!"
-    print_usage "healthcheck"
-    exit 1
-  fi
-
-  run_tool healthcheck -zkHost "$ZK_HOST" -collection "$HEALTHCHECK_COLLECTION" $VERBOSE
-
-  exit $?
-fi
-
-if [[ "$SCRIPT_CMD" == "config" ]]; then
-  CONFIG_PARAMS=()
-
-  if [ $# -gt 0 ]; then
-    while true; do
-      case "$1" in
-          -z|-zkhost|-zkHost)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "ZooKeeper connection string is required when using the $1 option!"
-                exit 1
-              fi
-              ZK_HOST="$2"
-              shift 2
-          ;;
-          -s|-scheme)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "URL scheme is required when using the $1 option!"
-                exit 1
-              fi
-              SOLR_URL_SCHEME="$2"
-              shift 2
-          ;;
-          *)  # Pass through all other params
-              if [ "$1" != "" ]; then
-                CONFIG_PARAMS+=($1)
-                shift
-              else
-                break
-              fi
-          ;;
-      esac
-    done
-  fi
-  if [[ -n "$ZK_HOST" ]]; then
-    CONFIG_PARAMS+=("-z" "$ZK_HOST")
-  fi
-  if [[ -n "$SOLR_URL_SCHEME" ]]; then
-    CONFIG_PARAMS+=("-scheme" "$SOLR_URL_SCHEME")
-  fi
-  run_tool config "${CONFIG_PARAMS[@]}"
+if [[ "$SCRIPT_CMD" == "assert" || "$SCRIPT_CMD" == "healthcheck" || "$SCRIPT_CMD" == "config" || "$SCRIPT_CMD" == "export" || "$SCRIPT_CMD" == "api" ]]; then
+  run_tool $SCRIPT_CMD $*
   exit $?
 fi
 
 # create a core or collection
 if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CMD" == "create_collection" ]]; then
 
-  CREATE_NUM_SHARDS=1
-  CREATE_REPFACT=1
   FORCE=false
-  VERBOSE=""
 
+  declare -a TOOL_PARAMS
   if [ $# -gt 0 ]; then
     while true; do
       case "$1" in
-          -c|-core|-collection)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "name is required when using the $1 option!"
-                exit 1
-              fi
-              CREATE_NAME="$2"
-              shift 2
-          ;;
           -n|-confname)
               if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
                 print_usage "$SCRIPT_CMD" "Configuration name is required when using the $1 option!"
@@ -1078,22 +860,6 @@ if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CM
               CREATE_CONFDIR="$2"
               shift 2
           ;;
-          -s|-shards)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "Shard count is required when using the $1 option!"
-                exit 1
-              fi
-              CREATE_NUM_SHARDS="$2"
-              shift 2
-          ;;
-          -rf|-replicationFactor)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "Replication factor is required when using the $1 option!"
-                exit 1
-              fi
-              CREATE_REPFACT="$2"
-              shift 2
-          ;;
           -p|-port)
               if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
                 print_usage "$SCRIPT_CMD" "Solr port is required when using the $1 option!"
@@ -1101,10 +867,6 @@ if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CM
               fi
               CREATE_PORT="$2"
               shift 2
-          ;;
-          -V|--verbose)
-              VERBOSE="-verbose"
-              shift
           ;;
           -force)
               FORCE=true
@@ -1119,11 +881,16 @@ if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CM
               break
           ;;
           *)
-              if [ "$1" != "" ]; then
-                print_usage "$SCRIPT_CMD" "Unrecognized or misplaced argument: $1!"
-                exit 1
+              if [ "$1" == "" ]; then
+                break
+              fi
+
+              if [[ -z "$2" ]]; then
+                TOOL_PARAMS=("${TOOL_PARAMS[@]}" "$1")
+                shift
               else
-                break # out-of-args, stop looping
+                TOOL_PARAMS=("${TOOL_PARAMS[@]}" "$1" "$2")
+                shift 2
               fi
           ;;
       esac
@@ -1140,12 +907,6 @@ if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CM
     exit 1
   fi
 
-  if [ -z "$CREATE_NAME" ]; then
-    echo "Name (-c) argument is required!"
-    print_usage "$SCRIPT_CMD"
-    exit 1
-  fi
-
   if [ -z "$CREATE_PORT" ]; then
     for ID in `ps auxww | grep java | grep start\.jar | awk '{print $2}' | sort -r`
       do
@@ -1158,13 +919,13 @@ if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CM
   fi
 
   if [ -z "$CREATE_PORT" ]; then
-    echo "Failed to determine the port of a local Solr instance, cannot create $CREATE_NAME!"
+    echo "Failed to determine the port of a local Solr instance, use the -p or -solrUrl options"
     exit 1
   fi
 
   if [[ "$CREATE_CONFDIR" == "_default" ]] && ([[ "$CREATE_CONFNAME" == "" ]] || [[ "$CREATE_CONFNAME" == "_default" ]]); then
     echo "WARNING: Using _default configset with data driven schema functionality. NOT RECOMMENDED for production use."
-    echo "         To turn off: bin/solr config -c $CREATE_NAME -p $CREATE_PORT -action set-user-property -property update.autoCreateFields -value false"
+    echo "         To turn off: bin/solr config -c <NAME> -p $CREATE_PORT -action set-user-property -property update.autoCreateFields -value false"
   fi
 
   if [[ $EUID -eq 0 ]] && [[ "$FORCE" == "false" ]] ; then
@@ -1172,19 +933,10 @@ if [[ "$SCRIPT_CMD" == "create" || "$SCRIPT_CMD" == "create_core" || "$SCRIPT_CM
     echo "         If you started Solr as root (not advisable either), force core creation by adding argument -force"
     exit 1
   fi
-  if [ "$SCRIPT_CMD" == "create_core" ]; then
-    run_tool create_core -name "$CREATE_NAME" -solrUrl "$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$CREATE_PORT/solr" \
-      -confdir "$CREATE_CONFDIR" -configsetsDir "$SOLR_TIP/server/solr/configsets" \
-      $VERBOSE
-    exit $?
-  else
-    run_tool "$SCRIPT_CMD" -name "$CREATE_NAME" -solrUrl "$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$CREATE_PORT/solr" \
-      -shards "$CREATE_NUM_SHARDS" -replicationFactor "$CREATE_REPFACT" \
-      -confname "$CREATE_CONFNAME" -confdir "$CREATE_CONFDIR" \
-      -configsetsDir "$SOLR_TIP/server/solr/configsets" \
-      $VERBOSE
-    exit $?
-  fi
+
+  run_tool "$SCRIPT_CMD" -solrUrl "$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$CREATE_PORT/solr" \
+    -n "$CREATE_CONFNAME" -d "$CREATE_CONFDIR" -configsetsDir "$SOLR_TIP/server/solr/configsets" "${TOOL_PARAMS[@]}"
+  exit $?
 fi
 
 # delete a core or collection
@@ -1421,12 +1173,6 @@ if [[ "$SCRIPT_CMD" == "zk" ]]; then
     ;;
   esac
 
-  exit $?
-fi
-
-
-if [[ "$SCRIPT_CMD" == "export" ]]; then
-  run_tool export $@
   exit $?
 fi
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15831

Start of some much needed clean-up of the bin/solr scripts! In this PR, I'm mainly removing usage information from the OS specific scripts (`bin/solr` and `bin\solr.cmd`) and instead delegating the usage output to the `SolrCLI` Java code. There's no reason to maintain command usage info in 3 places!
