### PR TITLE
SOLR-14858: Add docker test for the prometheus exporter

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -467,6 +467,9 @@ Other Changes
 
 * SOLR-15845: Add a new SolrVersion class to manage Solr's version independently from the Lucene version we consume (janhoy)
 
+* SOLR-14858: Add the server WEB-INF/lib directory to the classpath for the solr-exporter script. Will allow the script
+  to work when the dist/solrj-lib jars are missing in the Docker image. (Houston Putman)
+
 Bug Fixes
 ---------------------
 * SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter
@@ -86,6 +86,10 @@ for JAR in $(find "$BASEDIR"/../../dist -name 'solr-solrj-*.jar')
 do
   CLASSPATH="$CLASSPATH":"$JAR"
 done
+for JAR in $(find "$BASEDIR"/../../server/solr-webapp/webapp/WEB-INF/lib/ -name '*.jar')
+do
+  CLASSPATH="$CLASSPATH":"$JAR"
+done
 for JAR in $(find "$BASEDIR"/../../dist -name 'solr-prometheus-exporter-*.jar')
 do
   CLASSPATH="$CLASSPATH":"$JAR"

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter
@@ -73,20 +73,8 @@ then
   REPO="$BASEDIR"/lib
 fi
 
-CLASSPATH=$CLASSPATH_PREFIX:$BASEDIR/conf
-for JAR in $(find "$REPO" -name '*.jar')
-do
-  CLASSPATH="$CLASSPATH":"$JAR"
-done
-for JAR in $(find "$BASEDIR"/../../dist/solrj-lib -name '*.jar')
-do
-  CLASSPATH="$CLASSPATH":"$JAR"
-done
+CLASSPATH=$CLASSPATH_PREFIX:"$BASEDIR/conf":"$REPO/*":"$BASEDIR/../../dist/solrj-lib/*"
 for JAR in $(find "$BASEDIR"/../../dist -name 'solr-solrj-*.jar')
-do
-  CLASSPATH="$CLASSPATH":"$JAR"
-done
-for JAR in $(find "$BASEDIR"/../../server/solr-webapp/webapp/WEB-INF/lib/ -name '*.jar')
 do
   CLASSPATH="$CLASSPATH":"$JAR"
 done
@@ -94,10 +82,7 @@ for JAR in $(find "$BASEDIR"/../../dist -name 'solr-prometheus-exporter-*.jar')
 do
   CLASSPATH="$CLASSPATH":"$JAR"
 done
-for JAR in $(find "$BASEDIR"/../../server/lib/ext -name '*.jar')
-do
-  CLASSPATH="$CLASSPATH":"$JAR"
-done
+CLASSPATH="$CLASSPATH":"$BASEDIR/../../server/solr-webapp/webapp/WEB-INF/lib/*":"$BASEDIR/../../server/lib/ext/*"
 
 # Memory settings
 JAVA_MEM_OPTS=

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -502,8 +502,8 @@ abstract class TestDockerImageTask extends DefaultTask {
         environment "TEST_DIR", testCaseDir
         environment "BUILD_DIR", testCaseBuildDir
 
-        standardOutput new FileOutputStream("${testCaseWorkDir}/test.std.out")
-        errorOutput new FileOutputStream("${testCaseWorkDir}/test.err.out")
+        //standardOutput new FileOutputStream("${testCaseWorkDir}/test.std.out")
+        //errorOutput new FileOutputStream("${testCaseWorkDir}/test.err.out")
 
         commandLine "bash", "${testCaseDir}/test.sh", getParameters().getImageId().get()
       }

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -502,8 +502,8 @@ abstract class TestDockerImageTask extends DefaultTask {
         environment "TEST_DIR", testCaseDir
         environment "BUILD_DIR", testCaseBuildDir
 
-        //standardOutput new FileOutputStream("${testCaseWorkDir}/test.std.out")
-        //errorOutput new FileOutputStream("${testCaseWorkDir}/test.err.out")
+        standardOutput new FileOutputStream("${testCaseWorkDir}/test.std.out")
+        errorOutput new FileOutputStream("${testCaseWorkDir}/test.err.out")
 
         commandLine "bash", "${testCaseDir}/test.sh", getParameters().getImageId().get()
       }

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -26,12 +26,10 @@
 #-#
 #-#
 
-# remove what we don't want; ensure permissions are right
-# In the header templates, all solr files/directories are set to 0644 permissions, so we need to update that.
-#  TODO; arguably these permissions should have been set correctly previously in the TAR
+# add symlink to /opt/solr, remove what we don't want
 RUN set -ex; \
   (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs /opt/solr/dist/solr-solrj-*.jar /opt/solr/dist/solrj-lib /opt/solr/dist/solr-core-*.jar;
+  rm -Rf /opt/solr/docs;
 
 LABEL maintainer="The Apache Solr Project"
 LABEL url="https://solr.apache.org"

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -29,7 +29,7 @@
 # add symlink to /opt/solr, remove what we don't want
 RUN set -ex; \
   (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs;
+  rm -Rf /opt/solr/docs /opt/solr/dist/solr-solrj-*.jar /opt/solr/dist/solrj-lib /opt/solr/dist/solr-core-*.jar;
 
 LABEL maintainer="The Apache Solr Project"
 LABEL url="https://solr.apache.org"

--- a/solr/docker/tests/cases/prometheus-exporter/test.sh
+++ b/solr/docker/tests/cases/prometheus-exporter/test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+TEST_DIR="${TEST_DIR:-$(dirname -- "${BASH_SOURCE[0]}")}"
+source "${TEST_DIR}/../../shared.sh"
+
+container_cleanup "${container_name}-solr"
+
+echo "Running $container_name"
+docker run --name "${container_name}-solr" -d "$tag" "solr-demo"
+
+wait_for_container_and_solr "${container_name}-solr"
+
+solr_ip=$(docker inspect --format="{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "${container_name}-solr")
+
+docker run --name "$container_name" --add-host "solr-host:${solr_ip}" -d \
+  -p "127.0.0.1:8989:8989" \
+  --env "PORT=8989" \
+  --env "SOLR_URL=http://solr-host:8983/solr" \
+  --env "SCRAPE_INTERVAL=1" \
+  "$tag" "solr-exporter"
+
+echo "Submitting Solr query"
+docker exec --user=solr "${container_name}-solr" wget -q -O - 'http://localhost:8983/solr/demo/select?q=id%3Adell' > /dev/null
+
+sleep 2
+
+echo "Checking prometheus data"
+data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8989/metrics')
+
+if ! grep -E -q 'solr_metrics_core_query_local_count{category="QUERY",searchHandler="/select",core="demo",base_url="http://solr-host:8983/solr",} 2.0' <<<"$data"; then
+  echo "Test $TEST_NAME $tag failed; did not find correct data"
+  echo "$data"
+  exit 1
+fi
+
+container_cleanup "${container_name}-solr"
+container_cleanup "$container_name"
+
+echo "Test $TEST_NAME $tag succeeded"

--- a/solr/docker/tests/cases/prometheus-exporter/test.sh
+++ b/solr/docker/tests/cases/prometheus-exporter/test.sh
@@ -41,7 +41,7 @@ docker exec --user=solr "${container_name}-solr" wget -q -O - 'http://localhost:
 echo "Checking prometheus data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8989/metrics')
 
-if ! grep -E -q 'solr_metrics_core_query_local_count{category="QUERY",searchHandler="/select",core="demo",base_url="http://solr-host:8983/solr",} \d+.0' <<<"$data"; then
+if ! grep -E -q 'solr_metrics_core_query_local_count{category="QUERY",searchHandler="/select",core="demo",base_url="http://solr-host:8983/solr",} [0-9]+.0' <<<"$data"; then
   echo "Test $TEST_NAME $tag failed; did not find correct data"
   echo "$data"
   exit 1

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -100,7 +100,7 @@ function wait_for_server_started {
     local container_status
     container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
     if [[ $container_status == 'exited' ]]; then
-      echo "container exited"
+      docker logs "$container_name"
       exit 1
     fi
 

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -51,6 +51,25 @@ function wait_for_container_and_solr {
   sleep 4
 }
 
+function wait_for_container_and_solr_exporter {
+  local container_name
+  container_name=$1
+  wait_for_server_started "$container_name" 0 'org.apache.solr.prometheus.exporter.SolrExporter; Solr Prometheus Exporter is running'
+
+  printf '\nWaiting for Solr Prometheus Exporter...\n'
+  local status
+  status=$(docker exec --env SOLR_PORT=8989 "$container_name" wait-for-solr.sh --max-attempts 15 --wait-seconds 1)
+#  echo "Got status from Solr Prometheus Exporter: $status"
+  if ! grep -E -i -q 'Solr is running' <<<"$status"; then
+    echo "Solr Prometheus Exporter did not start"
+    container_cleanup "$container_name"
+    exit 1
+  else
+    echo "Solr Prometheus Exporter is running"
+  fi
+  sleep 4
+}
+
 function wait_for_server_started {
   local container_name
   container_name=$1
@@ -58,6 +77,11 @@ function wait_for_server_started {
   sleep_time=5
   if [ -n "${2:-}" ]; then
     sleep_time=$2
+  fi
+  local log_grep
+  log_grep='(o\.e\.j\.s\.Server Started|Started SocketConnector)'
+  if [ -n "${3:-}" ]; then
+    log_grep=$3
   fi
   echo "Waiting for container start: $container_name"
   local TIMEOUT_SECONDS
@@ -68,7 +92,7 @@ function wait_for_server_started {
   log="${BUILD_DIR}/${container_name}.log"
   while true; do
     docker logs "$container_name" > "${log}" 2>&1
-    if grep -E -q '(o\.e\.j\.s\.Server Started|Started SocketConnector)' "${log}" ; then
+    if grep -E -q "${log_grep}" "${log}" ; then
       docker logs "$container_name"
       break
     fi


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14858

This finally adds docker testing for the prometheus-exporter contrib.

I also had to remove the jar-removing from the Dockerfile, because the prometheus-exporter relies on `solrj-lib` as well as `solr-solrj-*.jar`. Will see what I can do in the `solr-exporter` script, to use the other locations of these jars.