### PR TITLE
SOLR-15902: Do not set maximum Solr version on test package

### DIFF
--- a/solr/core/src/test-files/solr/question-answer-repository/repository.json
+++ b/solr/core/src/test-files/solr/question-answer-repository/repository.json
@@ -13,7 +13,7 @@
           }
         ],
         "manifest": {
-          "version-constraint": "8 - 9",
+          "version-constraint": ">8",
           "plugins": [
             {
               "name": "request-handler",

--- a/solr/core/src/test/org/apache/solr/cloud/PackageManagerCLITest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/PackageManagerCLITest.java
@@ -20,7 +20,6 @@ package org.apache.solr.cloud;
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.core.TestSolrConfigHandler;
 import org.apache.solr.util.LogLevel;

--- a/solr/core/src/test/org/apache/solr/cloud/PackageManagerCLITest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/PackageManagerCLITest.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @LogLevel("org.apache=INFO")
-@LuceneTestCase.AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-15902")
 public class PackageManagerCLITest extends SolrCloudTestCase {
 
   // Note for those who want to modify the jar files used in the packages used in this test:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15902

This fixes the bug where newer versions of Solr (10.0.0) cause the `PackageManagerCLITest.testPackageManager` test to fail.

We can deal with the random jar issue separately.