### PR TITLE
QueryRateLimiter should not error on empty input

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -47,7 +47,7 @@ public class QueryRateLimiter extends RequestRateLimiter {
     RateLimiterConfig rateLimiterConfig = getRateLimiterConfig();
     byte[] configInput = Utils.toJSON(properties.get(RL_CONFIG_KEY));
 
-    if (configInput == null) {
+    if (configInput == null || configInput.length == 0) {
       return;
     }
 

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -19,6 +19,7 @@ package org.apache.solr.servlet;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class RateLimitManager implements ClusterPropertiesListener {
       try {
         queryRateLimiter.processConfigChange(properties);
       } catch (IOException e) {
-        throw new RuntimeException("Encountered IOException: " + e.getMessage());
+        throw new UncheckedIOException(e);
       }
     }
 


### PR DESCRIPTION
Discovered this while viewing the output of `MiniSolrCloudClusterTest.testErrorsInStartup`