### PR TITLE
Script to scaffold a new contrib module

### DIFF
--- a/dev-tools/scripts/README.md
+++ b/dev-tools/scripts/README.md
@@ -155,18 +155,18 @@ and prints a regular expression that will match all of them
       --json         Output as json
       --token TOKEN  Github access token in case you query too often anonymously
 
-### addContrib.py
+### scaffoldNewModule.py
 
 Scaffold a new contrib module and include it into the build. It will set up the folders
 and all for you, so the only thing you need to do is add classes, tests and test-data.
 
-    usage: addContrib.py [-h] name full_name description
+    usage: scaffoldNewModule.py [-h] name full_name description
     
-    Scaffold new contrib module
+    Scaffold new contrib module into solr/contrib/<name>
     
     positional arguments:
         name         code-name/id, e.g. my-module
-        full_name    Readable name, e.g. My Modle
+        full_name    Readable name, e.g. "My Module"
         description  Short description for docs
     
     optional arguments:

--- a/dev-tools/scripts/README.md
+++ b/dev-tools/scripts/README.md
@@ -155,6 +155,25 @@ and prints a regular expression that will match all of them
       --json         Output as json
       --token TOKEN  Github access token in case you query too often anonymously
 
+### addContrib.py
+
+Scaffold a new contrib module and include it into the build. It will set up the folders
+and all for you, so the only thing you need to do is add classes, tests and test-data.
+
+    usage: addContrib.py [-h] name full_name description
+    
+    Scaffold new contrib module
+    
+    positional arguments:
+        name         code-name/id, e.g. my-module
+        full_name    Readable name, e.g. My Modle
+        description  Short description for docs
+    
+    optional arguments:
+     -h, --help   show this help message and exit
+
+    Example: ./addContrib.py foo "My Contrib" "Very Useful Contrib module here"
+
 ### gitignore-gen.sh
 
 TBD

--- a/dev-tools/scripts/addContrib.py
+++ b/dev-tools/scripts/addContrib.py
@@ -88,13 +88,6 @@ def get_build_gradle(description):
 
 description = '%s'
 
-configurations.all {
-  exclude group: 'log4j', module: 'log4j'
-  exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-  exclude group: 'org.apache.yetus', module: 'audience-annotations'
-  // be conservative on what's added here.  Affects *all* configs, including internal ones.
-}
-
 dependencies {
   implementation project(':solr:core')
   implementation 'org.slf4j:slf4j-api'

--- a/dev-tools/scripts/addContrib.py
+++ b/dev-tools/scripts/addContrib.py
@@ -51,72 +51,71 @@ def read_config():
 
 
 def get_readme_skel(conrib_name):
-  return dedent('''Apache Solr %s
-=====================================
-
-Introduction
-------------
-TBD
-
-Getting Started
----------------
-TBD
-''' % conrib_name)
+  return dedent('''\
+  Apache Solr %s
+  =====================================
+  
+  Introduction
+  ------------
+  TBD
+  
+  Getting Started
+  ---------------
+  TBD
+  ''' % conrib_name)
 
 def get_license_header():
-  return '''/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-'''
+  return dedent('''\
+  /*
+   * Licensed to the Apache Software Foundation (ASF) under one or more
+   * contributor license agreements.  See the NOTICE file distributed with
+   * this work for additional information regarding copyright ownership.
+   * The ASF licenses this file to You under the Apache License, Version 2.0
+   * (the "License"); you may not use this file except in compliance with
+   * the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */''')
 
 def get_build_gradle(description):
-  return dedent('''apply plugin: 'java-library'
-
-description = '%s'
-
-dependencies {
-  implementation project(':solr:core')
-  implementation 'org.slf4j:slf4j-api'
+  return dedent('''\
+  apply plugin: 'java-library'
   
-  testImplementation project(':solr:test-framework')
-}
-''' % description)
+  description = '%s'
+  
+  dependencies {
+   implementation project(':solr:core')
+   
+   testImplementation project(':solr:test-framework')
+  }''' % description)
 
 def get_overview_tpl(name):
-  return dedent('''<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-     http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-<html>
-<body>
-Apache Solr Search Server: %s
-</body>
-</html>
-''' % name)
+  return dedent('''\
+  <!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+  <html>
+  <body>
+  Apache Solr Search Server: %s
+  </body>
+  </html>''' % name)
 
 def scaffold_folder(contrib_name, contrib_full_name, contrib_folder, contrib_description):
   print("\nScaffolding folder %s" % contrib_folder)
@@ -127,6 +126,7 @@ def scaffold_folder(contrib_name, contrib_full_name, contrib_folder, contrib_des
   build = os.path.join(contrib_folder, 'build.gradle')
   with open(build, 'w') as fp:
     fp.write (get_license_header())
+    fp.write('\n\n')
     fp.write (get_build_gradle(contrib_description))
   src_java_folder = os.path.join(contrib_folder, 'src', 'java')
   os.makedirs(src_java_folder)

--- a/dev-tools/scripts/addContrib.py
+++ b/dev-tools/scripts/addContrib.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+sys.path.append(os.path.dirname(__file__))
+from scriptutil import *
+
+import argparse
+import re
+from textwrap import dedent
+
+def update_build(file_path, search_re, replace_line):
+  print('adding contrib into %s' % file_path)
+  matcher = re.compile(search_re)
+
+  def edit(buffer, match, line):
+    if replace_line in line:
+      return None
+    match = matcher.search(line)
+    if match is not None:
+      buffer.append(replace_line)
+    buffer.append(line)
+    return match is not None
+
+  changed = update_file(file_path, matcher, edit)
+  print('done' if changed else 'uptodate')
+
+
+def read_config():
+  parser = argparse.ArgumentParser(description='Scaffold new contrib module')
+  parser.add_argument("name")
+  parser.add_argument("full_name")
+  parser.add_argument("description")
+  newconf = parser.parse_args()
+  return newconf
+
+
+def get_readme_skel(conrib_name):
+  return dedent('''Apache Solr %s
+=====================================
+
+Introduction
+------------
+TBD
+
+Getting Started
+---------------
+TBD
+''' % conrib_name)
+
+def get_license_header():
+  return '''/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'''
+
+def get_build_gradle(description):
+  return dedent('''apply plugin: 'java-library'
+
+description = '%s'
+
+configurations.all {
+  exclude group: 'log4j', module: 'log4j'
+  exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+  exclude group: 'org.apache.yetus', module: 'audience-annotations'
+  // be conservative on what's added here.  Affects *all* configs, including internal ones.
+}
+
+dependencies {
+  implementation project(':solr:core')
+  implementation 'org.slf4j:slf4j-api'
+  
+  testImplementation project(':solr:test-framework')
+}
+''' % description)
+
+def get_overview_tpl(name):
+  return dedent('''<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html>
+<body>
+Apache Solr Search Server: %s
+</body>
+</html>
+''' % name)
+
+def scaffold_folder(contrib_name, contrib_full_name, contrib_folder, contrib_description):
+  print("\nScaffolding folder %s" % contrib_folder)
+  os.makedirs(contrib_folder)
+  readme = os.path.join(contrib_folder, 'README.md')
+  with open(readme, 'w') as fp:
+    fp.write(get_readme_skel(contrib_full_name))
+  build = os.path.join(contrib_folder, 'build.gradle')
+  with open(build, 'w') as fp:
+    fp.write (get_license_header())
+    fp.write (get_build_gradle(contrib_description))
+  src_java_folder = os.path.join(contrib_folder, 'src', 'java')
+  os.makedirs(src_java_folder)
+  overview = os.path.join(src_java_folder, 'overview.html')
+  with open(overview, 'w') as fp:
+    fp.write (get_overview_tpl(contrib_full_name))
+
+  os.makedirs(os.path.join(contrib_folder, 'src', 'resources'))
+  os.makedirs(os.path.join(contrib_folder, 'src', 'test-files'))
+  os.makedirs(os.path.join(contrib_folder, 'src', 'test'))
+
+  update_build(os.path.join('solr', 'packaging', 'build.gradle'),
+               r':solr:contrib:extraction',
+               '   ":solr:contrib:%s",\n' % contrib_name)
+  update_build(os.path.join('gradle', 'maven', 'defaults-maven.gradle'),
+               r':solr:contrib:extraction',
+               '        ":solr:contrib:%s",\n' % contrib_name)
+  update_build(os.path.join('settings.gradle'),
+               r'include "solr:contrib:extraction"',
+               'include "solr:contrib:%s"\n' % contrib_name)
+
+def main():
+  conf = read_config()
+  contrib_name = conf.name
+
+  contrib_folder = os.path.join('solr', 'contrib', contrib_name)
+  scaffold_folder(contrib_name, conf.full_name, contrib_folder, conf.description)
+
+
+if __name__ == '__main__':
+  try:
+    main()
+  except KeyboardInterrupt:
+    print('\nReceived Ctrl-C, exiting early')

--- a/dev-tools/scripts/scaffoldNewModule.py
+++ b/dev-tools/scripts/scaffoldNewModule.py
@@ -25,7 +25,7 @@ import re
 from textwrap import dedent
 
 def update_build(file_path, search_re, replace_line):
-  print('adding contrib into %s' % file_path)
+  print('adding new module into %s' % file_path)
   matcher = re.compile(search_re)
 
   def edit(buffer, match, line):
@@ -42,10 +42,10 @@ def update_build(file_path, search_re, replace_line):
 
 
 def read_config():
-  parser = argparse.ArgumentParser(description='Scaffold new contrib module')
-  parser.add_argument("name")
-  parser.add_argument("full_name")
-  parser.add_argument("description")
+  parser = argparse.ArgumentParser(description='Scaffold new contrib module into solr/contrib/<name>')
+  parser.add_argument("name", help='short-name, e.g. my-module')
+  parser.add_argument("full_name", help='Readable name, e.g. "My Module"')
+  parser.add_argument("description", help='Short description for docs, max one line')
   newconf = parser.parse_args()
   return newconf
 
@@ -117,43 +117,43 @@ def get_overview_tpl(name):
   </body>
   </html>''' % name)
 
-def scaffold_folder(contrib_name, contrib_full_name, contrib_folder, contrib_description):
-  print("\nScaffolding folder %s" % contrib_folder)
-  os.makedirs(contrib_folder)
-  readme = os.path.join(contrib_folder, 'README.md')
+def scaffold_folder(module_name, module_full_name, module_folder, module_description):
+  print("\nScaffolding folder %s" % module_folder)
+  os.makedirs(module_folder)
+  readme = os.path.join(module_folder, 'README.md')
   with open(readme, 'w') as fp:
-    fp.write(get_readme_skel(contrib_full_name))
-  build = os.path.join(contrib_folder, 'build.gradle')
+    fp.write(get_readme_skel(module_full_name))
+  build = os.path.join(module_folder, 'build.gradle')
   with open(build, 'w') as fp:
     fp.write (get_license_header())
     fp.write('\n\n')
-    fp.write (get_build_gradle(contrib_description))
-  src_java_folder = os.path.join(contrib_folder, 'src', 'java')
+    fp.write (get_build_gradle(module_description))
+  src_java_folder = os.path.join(module_folder, 'src', 'java')
   os.makedirs(src_java_folder)
   overview = os.path.join(src_java_folder, 'overview.html')
   with open(overview, 'w') as fp:
-    fp.write (get_overview_tpl(contrib_full_name))
+    fp.write (get_overview_tpl(module_full_name))
 
-  os.makedirs(os.path.join(contrib_folder, 'src', 'resources'))
-  os.makedirs(os.path.join(contrib_folder, 'src', 'test-files'))
-  os.makedirs(os.path.join(contrib_folder, 'src', 'test'))
+  os.makedirs(os.path.join(module_folder, 'src', 'resources'))
+  os.makedirs(os.path.join(module_folder, 'src', 'test-files'))
+  os.makedirs(os.path.join(module_folder, 'src', 'test'))
 
   update_build(os.path.join('solr', 'packaging', 'build.gradle'),
                r':solr:contrib:extraction',
-               '   ":solr:contrib:%s",\n' % contrib_name)
+               '   ":solr:contrib:%s",\n' % module_name)
   update_build(os.path.join('gradle', 'maven', 'defaults-maven.gradle'),
                r':solr:contrib:extraction',
-               '        ":solr:contrib:%s",\n' % contrib_name)
+               '        ":solr:contrib:%s",\n' % module_name)
   update_build(os.path.join('settings.gradle'),
                r'include "solr:contrib:extraction"',
-               'include "solr:contrib:%s"\n' % contrib_name)
+               'include "solr:contrib:%s"\n' % module_name)
 
 def main():
   conf = read_config()
-  contrib_name = conf.name
+  module_name = conf.name
 
-  contrib_folder = os.path.join('solr', 'contrib', contrib_name)
-  scaffold_folder(contrib_name, conf.full_name, contrib_folder, conf.description)
+  module_folder = os.path.join('solr', 'contrib', module_name)
+  scaffold_folder(module_name, conf.full_name, module_folder, conf.description)
 
 
 if __name__ == '__main__':

--- a/dev-tools/scripts/scaffoldNewModule.py
+++ b/dev-tools/scripts/scaffoldNewModule.py
@@ -147,6 +147,8 @@ def scaffold_folder(module_name, module_full_name, module_folder, module_descrip
   update_build(os.path.join('settings.gradle'),
                r'include "solr:contrib:extraction"',
                'include "solr:contrib:%s"\n' % module_name)
+  print("Adding new files to git")
+  run("git add %s" % module_folder)
 
 def main():
   conf = read_config()


### PR DESCRIPTION
Adding a new contrib required wiring contrib-name into several gradle files, and they all need a README and a `build.gradle`. So here is a py script to scaffold a new contrib and wire it into the build. See usage in README.

Perhaps such a tool can propell the effort to lift stuff out from core into contribs. A nice detail is that solr-operator has 1st class support for adding contribs by name. I wonder if we could add such shortcut to `bin/solr` as well, e.g. `bin/solr start -c -Dcontribs=analysis-extras,langid,clustering` and the script will automatically add them to global path.