### PR TITLE
SOLR-15916: Remove dist from distribution.

### DIFF
--- a/gradle/solr/packaging.gradle
+++ b/gradle/solr/packaging.gradle
@@ -80,6 +80,10 @@ configure(allprojects.findAll {project -> project.path.startsWith(":solr:contrib
         into "lib"
       })
 
+      from (tasks.jar, {
+        into "lib"
+      })
+
       from ({
         def projectLibs = configurations.runtimeLibs.copyRecursive { dep ->
           (dep instanceof org.gradle.api.artifacts.ProjectDependency)

--- a/solr/README.md
+++ b/solr/README.md
@@ -141,18 +141,26 @@ server/
   configuration and documents to index. Please see: bin/solr start -help
   for more information about starting a Solr server.
 
+bin/
+   Scripts to startup, manage and interact with Solr instances.
+
 example/
   Contains example documents and an alternative Solr home
   directory containing various examples.
 
-dist/solr-<component>-XX.jar
-  The Apache Solr libraries.  To compile Apache Solr Plugins,
-  one or more of these will be required.  The core library is
-  required at a minimum. (see https://solr.apache.org/guide/solr-plugins.html
-  for more information).
+contrib/
+  Contains modules to extend the functionality of Solr.
+  Libraries for these modules can be found under contrib/*/lib
+
+docker/
+  Contains a docker file to build a Docker image using the source binary distribution.
+  docker/scripts contains scripts that the docker image uses to manage Solr.
 
 docs/index.html
   A link to the online version of Apache Solr Javadoc API documentation and Tutorial
+
+licenses/
+  Licenses, notice files and signatures for Solr dependencies.
 ```
 
 Instructions for Building Apache Solr from Source

--- a/solr/bin/postlogs
+++ b/solr/bin/postlogs
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -30,4 +31,8 @@
 #
 ############################################################################################
 
-java -classpath dist/*:dist/solrj-lib/*: org.apache.solr.util.SolrLogPostTool $1 $2
+
+SOLR_TIP=`dirname "$THIS_SCRIPT"`/..
+SOLR_TIP=`cd "$SOLR_TIP"; pwd`
+
+java -classpath "$SOLR_TIP/server/lib/ext/*:$SOLR_TIP/server/solr-webapp/webapp/WEB-INF/lib/*" org.apache.solr.util.SolrLogPostTool $1 $2

--- a/solr/contrib/analysis-extras/README.md
+++ b/solr/contrib/analysis-extras/README.md
@@ -9,7 +9,7 @@ analyzers for Chinese and Polish, and integration with
 OpenNLP for multilingual tokenization, part-of-speech tagging
 lemmatization, phrase chunking, and named-entity recognition.
 
-Each of the jars below relies upon including `/dist/solr-analysis-extras-X.Y.jar`
+Each of the jars below relies upon including `/contrib/analysis-extras/lib/solr-analysis-extras-X.Y.Z.jar`
 in the `solrconfig.xml`
 
 * ICU relies upon `lucene-libs/lucene-analyzers-icu-X.Y.jar`

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter
@@ -73,16 +73,7 @@ then
   REPO="$BASEDIR"/lib
 fi
 
-CLASSPATH=$CLASSPATH_PREFIX:"$BASEDIR/conf":"$REPO/*":"$BASEDIR/../../dist/solrj-lib/*"
-for JAR in $(find "$BASEDIR"/../../dist -name 'solr-solrj-*.jar')
-do
-  CLASSPATH="$CLASSPATH":"$JAR"
-done
-for JAR in $(find "$BASEDIR"/../../dist -name 'solr-prometheus-exporter-*.jar')
-do
-  CLASSPATH="$CLASSPATH":"$JAR"
-done
-CLASSPATH="$CLASSPATH":"$BASEDIR/../../server/solr-webapp/webapp/WEB-INF/lib/*":"$BASEDIR/../../server/lib/ext/*"
+CLASSPATH=$CLASSPATH_PREFIX:"$BASEDIR/conf":"$REPO/*":"$BASEDIR/../../server/solr-webapp/webapp/WEB-INF/lib/*":"$BASEDIR/../../server/lib/ext/*"
 
 # Memory settings
 JAVA_MEM_OPTS=

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter.cmd
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter.cmd
@@ -71,7 +71,7 @@ if "%JAVACMD%"=="" set JAVACMD=java
 
 if "%REPO%"=="" set REPO=%BASEDIR%\lib
 
-set CLASSPATH=%REPO%\*;%BASEDIR%\conf;%BASEDIR%\..\..\dist\solrj-lib\*;%BASEDIR%\..\..\dist\*;%BASEDIR%\..\..\server\lib\ext\*
+set CLASSPATH=%REPO%\*;%BASEDIR%\conf;%BASEDIR%\..\..\server\lib\ext\*;%BASEDIR%\..\..\server\solr-webapp\webapp\WEB-INF\lib\*
 
 @REM Convert Environment Variables to Command Line Options
 set EXPORTER_ARGS=

--- a/solr/core/src/test-files/solr/configsets/upload/with-lib-directive/solrconfig.xml
+++ b/solr/core/src/test-files/solr/configsets/upload/with-lib-directive/solrconfig.xml
@@ -37,7 +37,7 @@
 
   <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
 
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/ltr/lib/" regex=".*\.jar" />
 
   <requestHandler name="/select" class="solr.SearchHandler">
     <lst name="defaults">

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -29,7 +29,7 @@
 # add symlink to /opt/solr, remove what we don't want
 RUN set -ex; \
   (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs /opt/solr/dist/solr-solrj-*.jar /opt/solr/dist/solrj-lib /opt/solr/dist/solr-core-*.jar;
+  rm -Rf /opt/solr/docs;
 
 LABEL maintainer="The Apache Solr Project"
 LABEL url="https://solr.apache.org"

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -31,10 +31,6 @@ ext {
 }
 
 configurations {
-  distSolr {
-    transitive = false
-  }
-  distSolrj
   contrib
   example
   server
@@ -51,8 +47,6 @@ artifacts {
 }
 
 dependencies {
-  distSolrj project(":solr:solrj")
-
   [":solr:contrib:analysis-extras",
    ":solr:contrib:analytics",
    ":solr:contrib:extraction",
@@ -65,13 +59,8 @@ dependencies {
    ":solr:contrib:s3-repository",
    ":solr:contrib:scripting"
   ].each { contribName ->
-    distSolr project(contribName)
     contrib  project(path: contribName, configuration: "packaging")
   }
-
-  distSolr project(":solr:core")
-  distSolr project(":solr:server")
-  distSolr project(":solr:solrj")
 
   example project(path: ":solr:example", configuration: "packaging")
   server project(path: ":solr:server", configuration: "packaging")
@@ -104,14 +93,6 @@ distributions {
 
       from(configurations.contrib, {
         into "contrib"
-      })
-
-      from(configurations.distSolr, {
-        into "dist"
-      })
-
-      from(configurations.distSolrj - configurations.distSolr, {
-        into "dist/solrj-lib"
       })
 
       from(configurations.example, {

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -72,7 +72,7 @@
        The example below can be used to load a solr-contrib along
        with their external dependencies.
     -->
-    <!-- <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" /> -->
+    <!-- <lib dir="${solr.install.dir:../../../..}/contrib/ltr/lib" regex=".*\.jar" /> -->
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -73,17 +73,14 @@
        with their external dependencies.
     -->
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-extraction-\d.*\.jar" />
 
   <lib dir="${solr.install.dir:../../../..}/contrib/clustering/lib/" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-clustering-\d.*\.jar" />
 
   <lib dir="${solr.install.dir:../../../..}/contrib/langid/lib/" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-langid-\d.*\.jar" />
 
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/ltr/lib/" regex=".*\.jar" />
 
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-scripting-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/scripting/lib/" regex=".*\.jar" />
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged

--- a/solr/solr-ref-guide/src/analytics.adoc
+++ b/solr/solr-ref-guide/src/analytics.adoc
@@ -34,7 +34,7 @@ The Analytics Handler should not be used by users to submit analytics requests.
 
 To use the Analytics Component, the first step is to install this contrib module's plugins into Solr -- see the <<solr-plugins.adoc#installing-plugins,Solr Plugins>> section on how to do this.
 Note: Method with `<lib/>` directive doesn't work.
-Instead copy `${solr.install.dir}/dist/solr-analytics-x.x.x.jar` to `${solr.install.dir}/server/solr-webapp/webapp/WEB-INF/lib/`, as described in the <<libs.adoc#lib-directories,lib directories documentation>>.
+Instead copy `${solr.install.dir}/contrib/analytics/lib/solr-analytics-x.x.x.jar` to `${solr.install.dir}/server/solr-webapp/webapp/WEB-INF/lib/`, as described in the <<libs.adoc#lib-directories,lib directories documentation>>.
 
 Next you need to register the request handler and search component.
 Add the following lines to `solrconfig.xml`, near the defintions for other request handlers:

--- a/solr/solr-ref-guide/src/docker-networking.adoc
+++ b/solr/solr-ref-guide/src/docker-networking.adoc
@@ -205,7 +205,7 @@ To load data, and see it was split over shards:
 [source,bash]
 ----
 docker exec -it --user=solr zksolr1 bin/post -c my_collection1 example/exampledocs/manufacturers.xml
-# /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -classpath /opt/solr/dist/solr-core-9.0.0.jar -Dauto=yes -Dc=my_collection1 -Ddata=files org.apache.solr.util.SimplePostTool example/exampledocs/manufacturers.xml
+# /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -classpath /opt/solr/server/lib/ext/*:/opt/solr/server/solr-webapp/webapp/WEB-INF/lib/* -Dauto=yes -Dc=my_collection1 -Ddata=files org.apache.solr.util.SimplePostTool example/exampledocs/manufacturers.xml
 # SimplePostTool version 9.0.0
 # Posting files to [base] url http://localhost:8983/solr/my_collection1/update...
 # Entering auto mode. File endings considered are xml,json,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,ots,rtf,htm,html,txt,log

--- a/solr/solr-ref-guide/src/indexing-with-tika.adoc
+++ b/solr/solr-ref-guide/src/indexing-with-tika.adoc
@@ -412,7 +412,6 @@ If it is not already configured, you will need to configure `solrconfig.xml` to 
 [source,xml]
 ----
   <lib dir="${solr.install.dir:../../..}/contrib/extraction/lib" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../..}/dist/" regex="solr-cell-\d.*\.jar" />
 ----
 
 You can then configure the `ExtractingRequestHandler` in `solrconfig.xml`.

--- a/solr/solr-ref-guide/src/indexing-with-update-handlers.adoc
+++ b/solr/solr-ref-guide/src/indexing-with-update-handlers.adoc
@@ -277,7 +277,7 @@ The status field will be non-zero in case of failure.
 The Scripting contrib module provides a separate XSLT Update Request Handler that allows you to index any arbitrary XML by using the `<tr>` parameter to apply an https://en.wikipedia.org/wiki/XSLT[XSL transformation].
 You must have an XSLT stylesheet in the `conf/xslt` directory of your <<config-sets.adoc#,configset>> that can transform the incoming data to the expected `<add><doc/></add>` format, and use the `tr` parameter to specify the name of that stylesheet.
 
-Learn more about adding the `dist/solr-scripting-*.jar` file into Solr's <<libs.adoc#lib-directories,Lib Directories>>.
+Learn more about adding the `contrib/scripting/lib/solr-scripting-*.jar` file into Solr's <<libs.adoc#lib-directories,Lib Directories>>.
 
 === tr Parameter
 

--- a/solr/solr-ref-guide/src/installing-solr.adoc
+++ b/solr/solr-ref-guide/src/installing-solr.adoc
@@ -93,9 +93,6 @@ It is described in more detail in the section <<taking-solr-to-production.adoc#,
 contrib/::
 Solr's `contrib` directory includes add-on plugins for specialized features of Solr.
 
-dist/::
-The `dist` directory contains the main Solr .jar files.
-
 docs/::
 The `docs` directory includes a link to online Javadocs for Solr.
 
@@ -109,7 +106,7 @@ The `licenses` directory includes all of the licenses for 3rd party libraries us
 server/::
 This directory is where the heart of the Solr application resides.
 A README in this directory provides a detailed overview, but here are some highlights:
-* Solr's Admin UI (`server/solr-webapp`)
+* Solr's Admin UI & JAR files (`server/solr-webapp`)
 * Jetty libraries (`server/lib`)
 * Log files (`server/logs`) and log configurations (`server/resources`).
 See the section <<configuring-logging.adoc#,Configuring Logging>> for more details on how to customize Solr's default logging.

--- a/solr/solr-ref-guide/src/jdbc-dbvisualizer.adoc
+++ b/solr/solr-ref-guide/src/jdbc-dbvisualizer.adoc
@@ -22,8 +22,8 @@ For DbVisualizer, you will need to create a new driver for Solr using the DbVisu
 This will add several SolrJ client .jars to the DbVisualizer classpath.
 The files required are:
 
-* all .jars found in `$SOLR_HOME/dist/solrj-lib`
-* the SolrJ .jar found at `$SOLR_HOME/dist/solr-solrj-<version>.jar`
+* all .jars found in `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/\*` and `$SOLR_HOME/server/lib/ext/*`
+* the SolrJ .jar found at `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/solr-solrj-<version>.jar`
 
 Once the driver has been created, you can create a connection to Solr with the connection string format outlined in the generic section and use the SQL Commander to issue queries.
 
@@ -54,8 +54,8 @@ image::images/jdbc-dbvisualizer/dbvisualizer_solrjdbc_3.png[image,width=532,heig
 
 The driver files to be added are:
 
-* all .jars in `$SOLR_HOME/dist/solrj-lib`
-* the SolrJ .jar found in `$SOLR_HOME/dist/solr-solrj-<version>.jar`
+* all .jars found in `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/\*` and `$SOLR_HOME/server/lib/ext/*`
+* the SolrJ .jar found at `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/solr-solrj-<version>.jar`
 
 image::images/jdbc-dbvisualizer/dbvisualizer_solrjdbc_4.png[image,width=535,height=400]
 

--- a/solr/solr-ref-guide/src/jdbc-python-jython.adoc
+++ b/solr/solr-ref-guide/src/jdbc-python-jython.adoc
@@ -34,7 +34,7 @@ The CLASSPATH variable must be configured to contain the `solr-solrj` jar and th
 
 pip install JayDeBeApi
 
-export CLASSPATH="$(echo $(ls /opt/solr/dist/solr-solrj* /opt/solr/dist/solrj-lib/*) | tr ' ' ':')"
+export CLASSPATH="/opt/solr/server/lib/ext/*:/opt/solr/server/solr-webapp/webapp/WEB-INF/lib/*"
 
 python solr_jaydebeapi.py
 ----
@@ -74,7 +74,7 @@ The CLASSPATH variable must be configured to contain the solr-solrj jar and the 
 #!/usr/bin/env bash
 # Java and Jython must already be installed
 
-export CLASSPATH="$(echo $(ls /opt/solr/dist/solr-solrj* /opt/solr/dist/solrj-lib/*) | tr ' ' ':')"
+export CLASSPATH="/opt/solr/server/lib/ext/*:/opt/solr/server/solr-webapp/webapp/WEB-INF/lib/*"
 
 jython [solr_java_native.py | solr_zxjdbc.py]
 ----

--- a/solr/solr-ref-guide/src/jdbc-r.adoc
+++ b/solr/solr-ref-guide/src/jdbc-r.adoc
@@ -38,7 +38,7 @@ Rscript solr_rjdbc.R
 
 library("RJDBC")
 
-solrCP <- c(list.files('/opt/solr/dist/solrj-lib', full.names=TRUE), list.files('/opt/solr/dist', pattern='solrj', full.names=TRUE, recursive = TRUE))
+solrCP <- c(list.files('/opt/solr/server/lib/ext/', list.files('/opt/solr/server/solr-webapp/webapp/WEB-INF/lib/', full.names=TRUE, recursive = TRUE))
 
 drv <- JDBC("org.apache.solr.client.solrj.io.sql.DriverImpl",
            solrCP,

--- a/solr/solr-ref-guide/src/jdbc-squirrel.adoc
+++ b/solr/solr-ref-guide/src/jdbc-squirrel.adoc
@@ -22,8 +22,8 @@ To configure this, you will need to create a new driver for Solr.
 This will add several SolrJ client .jars to the SQuirreL SQL classpath.
 The files required are:
 
-* all .jars found in `$SOLR_HOME/dist/solrj-libs`
-* the SolrJ .jar found at `$SOLR_HOME/dist/solr-solrj-<version>.jar`
+* all .jars found in `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/\*` and `$SOLR_HOME/server/lib/ext/*`
+* the SolrJ .jar found at `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/solr-solrj-<version>.jar`
 
 Once the driver has been created, you can create a connection to Solr with the connection string format outlined in the generic section and use the editor to issue queries.
 

--- a/solr/solr-ref-guide/src/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/src/learning-to-rank.adoc
@@ -477,7 +477,7 @@ This example folder is not shipped in the Solr binary release.
 
 == Installation of LTR
 
-The ltr contrib module requires the `dist/solr-ltr-*.jar` JARs.
+The ltr contrib module requires the `contrib/ltr/lib/solr-ltr-*.jar` JARs.
 
 == LTR Configuration
 
@@ -490,7 +490,7 @@ Note that by default paths are relative to the Solr core so they may need adjust
 +
 [source,xml]
 ----
-<lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" />
+<lib dir="${solr.install.dir:../../../..}/contrib/ltr/lib/" regex=".*\.jar" />
 ----
 
 * Declaration of the `ltr` query parser.

--- a/solr/solr-ref-guide/src/libs.adoc
+++ b/solr/solr-ref-guide/src/libs.adoc
@@ -39,6 +39,8 @@ Create this adjacent to the `conf/` directory; it's not present by default.
 Certain plugins or add-ons to plugins require placement here.
 They will document themselves to say so.
 
+* `<solr_install>/server/lib/ext`: The `.jar` files used for the Solr server as well as Solr Core/SolrJ.
+
 Solr incorporates Jetty for providing HTTP server functionality.
 Jetty has some directories that contain `.jar` files for itself and its own plugins / modules or JVM level plugins (e.g., loggers).
 Solr plugins won't work in these locations.
@@ -64,13 +66,10 @@ These examples show how to load contrib modules into Solr:
 [source,xml]
 ----
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-extraction-\d.*\.jar" />
 
   <lib dir="${solr.install.dir:../../../..}/contrib/clustering/lib/" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-clustering-\d.*\.jar" />
 
   <lib dir="${solr.install.dir:../../../..}/contrib/langid/lib/" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-langid-\d.*\.jar" />
 
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/ltr/lib/" regex=".*\.jar" />
 ----

--- a/solr/solr-ref-guide/src/response-writers.adoc
+++ b/solr/solr-ref-guide/src/response-writers.adoc
@@ -412,7 +412,6 @@ You can run these commands from your `$SOLR_INSTALL` directory:
 [source,bash]
 ----
 cp contrib/extraction/lib/*.jar server/solr-webapp/webapp/WEB-INF/lib/
-cp dist/solr-extraction-*.jar server/solr-webapp/webapp/WEB-INF/lib/
 ----
 
 Once the libraries are in place, you can add `wt=xlsx` to your request, and results will be returned as an XLSX sheet.

--- a/solr/solr-ref-guide/src/result-clustering.adoc
+++ b/solr/solr-ref-guide/src/result-clustering.adoc
@@ -213,14 +213,13 @@ The score of the other topics group is zero.
 
 == Installation
 
-The clustering contrib extension requires `dist/solr-clustering-*.jar` and all JARs under `contrib/clustering/lib`.
+The clustering contrib extension requires all JARs under `contrib/clustering/lib`.
 
 You can include the required contrib JARs in `solrconfig.xml` as shown below (by default paths are relative to the Solr core so they may need adjustments to your configuration, or an explicit specification of the `$solr.install.dir`):
 
 [source,xml]
 ----
 <lib dir="${solr.install.dir:../../..}/contrib/clustering/lib/" regex=".*\.jar" />
-<lib dir="${solr.install.dir:../../..}/dist/" regex="solr-clustering-\d.*\.jar" />
 ----
 
 == Configuration

--- a/solr/solr-ref-guide/src/script-update-processor.adoc
+++ b/solr/solr-ref-guide/src/script-update-processor.adoc
@@ -35,7 +35,7 @@ The scripting update processor lives in the contrib module `/contrib/scripting`,
 Java 11 and previous versions come with a JavaScript engine called Nashorn, but Java 12 will require you to add your own JavaScript engine.
 Other supported scripting engines like JRuby, Jython, Groovy, all require you to add JAR files.
 
-Learn more about adding the `dist/solr-scripting-*.jar` file, and any other needed JAR files (depending on your scripting engine) into Solr's <<libs.adoc#lib-directories,Lib Directories>>.
+Learn more about adding the `contrib/scripting/lib/solr-scripting-*.jar` file, and any other needed JAR files (depending on your scripting engine) into Solr's <<libs.adoc#lib-directories,Lib Directories>>.
 
 == Configuration
 

--- a/solr/solr-ref-guide/src/solrj.adoc
+++ b/solr/solr-ref-guide/src/solrj.adoc
@@ -65,16 +65,16 @@ To compile code manually that uses SolrJ, use a `javac` command similar to:
 
 [source,bash,subs="attributes"]
 ----
-javac -cp .:$SOLR_HOME/dist/solr-solrj-{solr-docs-version}.0.jar ...
+javac -cp .:$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/solr-solrj-{solr-docs-version}.0.jar ...
 ----
 
 At runtime, you need a few of SolrJ's dependencies, in addition to SolrJ itself.
-For convenience, these dependencies are made available in the `dist/solrj-lib` directory.
+In the Solr distribution these dependencies are not separated from Solr's dependencies, so you must include all.
 Run your project with a classpath like:
 
 [source,bash,subs="attributes"]
 ----
-java -cp .:$SOLR_HOME/dist/solrj-lib/*:$SOLR_HOME/dist/solr-solrj-{solr-docs-version}.0.jar ...
+java -cp .:$SOLR_HOME/server/lib/ext:$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/* ...
 ----
 
 If you are worried about the SolrJ libraries expanding the size of your client application, you can use a code obfuscator like http://proguard.sourceforge.net/[ProGuard] to remove APIs that you are not using.

--- a/solr/solr-ref-guide/src/sql-query.adoc
+++ b/solr/solr-ref-guide/src/sql-query.adoc
@@ -551,8 +551,8 @@ This Guide contains documentation to configure the following tools and clients:
 
 For most Java-based clients, the following jars will need to be placed on the client classpath:
 
-* all .jars found in `$SOLR_HOME/dist/solrj-libs`
-* the SolrJ .jar found at `$SOLR_HOME/dist/solr-solrj-<version>.jar`
+* all .jars found in `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/\*` and `$SOLR_HOME/server/lib/ext/*`
+* the SolrJ .jar found at `$SOLR_HOME/server/solr-webapp/webapp/WEB-INF/lib/solr-solrj-<version>.jar`
 
 If you are using Maven, the `org.apache.solr.solr-solrj` artifact contains the required jars.
 

--- a/solr/solr-ref-guide/src/tutorial-films.adoc
+++ b/solr/solr-ref-guide/src/tutorial-films.adoc
@@ -244,7 +244,7 @@ Each command will produce output similar to the below seen while indexing JSON:
 [source,bash,subs="verbatim,attributes"]
 ----
 $ ./bin/post -c films example/films/films.json
-/bin/java -classpath /solr-{solr-docs-version}.0/dist/solr-core-{solr-docs-version}.0.jar -Dauto=yes -Dc=films -Ddata=files org.apache.solr.util.SimplePostTool example/films/films.json
+/bin/java -classpath /solr-{solr-docs-version}.0/server/solr-webapp/webapp/WEB-INF/lib/solr-core-{solr-docs-version}.0.jar -Dauto=yes -Dc=films -Ddata=files org.apache.solr.util.SimplePostTool example/films/films.json
 SimplePostTool version 5.0.0
 Posting files to [base] url http://localhost:8983/solr/films/update...
 Entering auto mode. File endings considered are xml,json,jsonl,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,ots,rtf,htm,html,txt,log


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15916

Contrib module jars are now moved under `contrib/<module>/lib`.

The only real loss here is that you have to load all solr dependency jars when just using SolrJ (not through maven or gradle). It seems like there is a lot of documentation around using the jdbc stuff with it, but I'm not sure this is a great loss.