### PR TITLE
Add the new minor version (e.g. 9.1) also to main branch

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -435,7 +435,7 @@ groups:
       Make sure to follow the manual instructions printed by the script.
   - !Todo
     id: add_version_minor
-    title: Add a new minor version on stable branch
+    title: Add a new minor version on stable and unstable branches
     types:
     - major
     - minor
@@ -444,10 +444,20 @@ groups:
       next_version: "{{ release_version_major }}.{{ release_version_minor + 1 }}.0"
     commands: !Commands
       root_folder: '{{ git_checkout_folder }}'
-      commands_text: Run these commands to add the new minor version {{ next_version }} to the stable branch
+      commands_text: Run these commands to add the new minor version {{ next_version }} to the stable and unstable branches
       commands:
       - !Command
         cmd: git checkout {{ stable_branch }}
+        tee: true
+      - !Command
+        cmd: python3 -u dev-tools/scripts/addVersion.py {{ next_version }}
+        tee: true
+      - !Command
+        comment: Make sure the edits done by `addVersion.py` are ok, then push
+        cmd: git add -u .  && git commit -m "Add next minor version {{ next_version }}"  && git push
+        logfile: commit-stable.log
+      - !Command
+        cmd: git checkout main
         tee: true
       - !Command
         cmd: python3 -u dev-tools/scripts/addVersion.py {{ next_version }}

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -460,6 +460,9 @@ groups:
         cmd: git checkout main
         tee: true
       - !Command
+        cmd: git pull --ff-only
+        tee: true
+      - !Command
         cmd: python3 -u dev-tools/scripts/addVersion.py {{ next_version }}
         tee: true
       - !Command


### PR DESCRIPTION
Just discovered that the releaseWizard, after branching `branch_9_0`, adds version 9.1 to `branch_9x` (including CHANGES.txt), but it does not add v 9.1 to main branch. This is wrong, as there should be a 9.1 changes section also on main branch now.

I added it manually and committed. But this is the change I believe is ncessary to the wizard to automate this in the future. I find it strage that this has not been discovered before, so I'm starting to question whether I am overlooking something obvious here? Please review.