### PR TITLE
SOLR-15605: Fix duplicate jars in prometheus-exporter

### DIFF
--- a/solr/modules/prometheus-exporter/build.gradle
+++ b/solr/modules/prometheus-exporter/build.gradle
@@ -69,22 +69,4 @@ assemblePackaging {
     include "bin/**"
     include "conf/**"
   })
-  // Add all libs except those provided by SolrJ & Logging
-  from ({
-    def externalLibs = configurations.runtimeLibs.copyRecursive { dep ->
-      if (dep instanceof org.gradle.api.artifacts.ProjectDependency) {
-        return !dep.dependencyProject.path.startsWith(":solr")
-      } else {
-        return true
-      }
-    }
-    return externalLibs - project(':solr:server').configurations.getByName('libExt')
-  }, {
-    into "lib"
-  })
-
-  // TODO: SOLR-15605 this copy spec has duplicate jars and this fails by default in gradle7
-  duplicatesStrategy = 'warn'
-
-  into deps
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15605

The duplicate jars existed because the `lib` generating logic was duplicated in `solr/modules/prometheus-exporter/build.gradle` and `gradle/solr/packaging.gradle`. The `gradle/solr/packaging.gradle` logic was correct, however the `solr/modules/prometheus-exporter/build.gradle` logic did not remove jars from solrj/solr-core, so there were duplicates left.

There's no reason to duplicate this logic in the first place, so removing the section fixes the build.