### PR TITLE
Attempt to detect remote if not specified

### DIFF
--- a/dev-tools/scripts/cherrypick.sh
+++ b/dev-tools/scripts/cherrypick.sh
@@ -196,11 +196,15 @@ for BRANCH in "${BRANCHES[@]}"; do
       LOG "WARN" "Cannot auto push if tests are disabled"
       exit 1
     fi
+    if [[ -z "$REMOTE" ]]; then
+      LOG "WARN" "Remote not specified, attempting to auto detect"
+      REMOTE=$(git config --get "branch.$BRANCH.remote")
+    fi
     LOG "INFO" "Pushing changes to $REMOTE/$BRANCH"
     # shellcheck disable=SC2086
     $GIT_COMMAND push $REMOTE $BRANCH
     if [ $? -gt 0 ]; then
-      LOG "WARN" "PUSH to $REMOTE/$BRANCH failed, please clean up an proceed manually"
+      LOG "WARN" "PUSH to $REMOTE/$BRANCH failed, please clean up and proceed manually"
       exit 2
     fi
     LOG "INFO" "Pushed $BRANCH to remote. Cherry-pick complete."


### PR DESCRIPTION
Running cherrypick.sh with `-p` but without `-r` caused a local failure for me. Running it without `-r` previously had always worked even for the pulls because I have upstream tracking branches set up.