### PR TITLE
SOLR-15957: Add information to Prometheus Exporter startup logging

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -543,7 +543,7 @@ and each individual module's jar will be included in its directory's lib/ folder
 
 * SOLR-15954: Move the Prometheus Exporter from "solr/modules/prometheus-exporter" to "solr/prometheus-exporter". (Houston Putman)
 
-* SOLR-15957: Add port and scrapping information to Solr Prometheus startup logging. (Houston Putman)
+* SOLR-15957: Add port and scraping information to Solr Prometheus startup logging. (Houston Putman)
 
 Bug Fixes
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -543,6 +543,8 @@ and each individual module's jar will be included in its directory's lib/ folder
 
 * SOLR-15954: Move the Prometheus Exporter from "solr/modules/prometheus-exporter" to "solr/prometheus-exporter". (Houston Putman)
 
+* SOLR-15957: Add port and scrapping information to Solr Prometheus startup logging. (Houston Putman)
+
 Bug Fixes
 ---------------------
 * SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrExporter.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrExporter.java
@@ -193,16 +193,17 @@ public class SolrExporter {
         log.error("Must provide either {} or {}", ARG_BASE_URL_FLAGS, ARG_ZK_HOST_FLAGS);
       }
 
+      int port = res.getInt(ARG_PORT_DEST);
       SolrExporter solrExporter = new SolrExporter(
-          res.getInt(ARG_PORT_DEST),
+          port,
           res.getInt(ARG_NUM_THREADS_DEST),
           res.getInt(ARG_SCRAPE_INTERVAL_DEST),
           scrapeConfiguration,
           loadMetricsConfiguration(res.getString(ARG_CONFIG_DEST)));
 
-      log.info("Starting Solr Prometheus Exporting");
+      log.info("Starting Solr Prometheus Exporting on port {}", port);
       solrExporter.start();
-      log.info("Solr Prometheus Exporter is running");
+      log.info("Solr Prometheus Exporter is running. Collecting metrics for {}", scrapeConfiguration);
     } catch (IOException e) {
       log.error("Failed to start Solr Prometheus Exporter: ", e);
     } catch (ArgumentParserException e) {

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrScrapeConfiguration.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrScrapeConfiguration.java
@@ -56,4 +56,15 @@ public class SolrScrapeConfiguration {
     return new SolrScrapeConfiguration(ConnectionType.STANDALONE, null, solrHost);
   }
 
+  @Override
+  public String toString() {
+    if (type == ConnectionType.CLOUD) {
+      return "Solr Cloud ZK: " + zookeeperConnectionString;
+    } else if (type == ConnectionType.STANDALONE) {
+      return "Solr Node: " + solrHost;
+    } else {
+      return "None";
+    }
+  }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15957

New startup logs look like:

```
INFO  - 2022-01-27 15:55:39.177; org.apache.solr.prometheus.exporter.SolrExporter; Starting Solr Prometheus Exporting on port 8989
INFO  - 2022-01-27 15:55:39.197; org.apache.solr.prometheus.collector.SchedulerMetricsCollector; Beginning metrics collection
INFO  - 2022-01-27 15:55:39.289; org.apache.solr.prometheus.exporter.SolrExporter; Solr Prometheus Exporter is running. Collecting metrics for Solr Node: http://solr-host:8983/solr
```