### PR TITLE
SOLR-15956: Docs for building a Docker image from the TGZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ For more info on building an image, run:
 
 `./gradlew helpDocker`
 
+Docker images can also be built from the Solr binary distribution (i.e. `solr-<version>.tgz`).
+Please refer to the [Solr Docker README](solr/docker/README.md) for more information.
+
 ### Running Solr on Kubernetes
 
 Solr has official support for running on Kubernetes, in the official Docker image.

--- a/solr/README.md
+++ b/solr/README.md
@@ -156,8 +156,8 @@ prometheus-exporter/
   Contains a separate application to monitor Solr instances and export Prometheus metrics
 
 docker/
-  Contains a docker file to build a Docker image using the source binary distribution.
-  docker/scripts contains scripts that the docker image uses to manage Solr.
+  Contains a Dockerfile to build a Docker image using the source or binary distribution.
+  `docker/scripts` contains scripts that the Docker image uses to manage Solr.
   Refer to the README.md for instructions on how to build an image.
 
 docs/index.html

--- a/solr/README.md
+++ b/solr/README.md
@@ -158,6 +158,7 @@ prometheus-exporter/
 docker/
   Contains a docker file to build a Docker image using the source binary distribution.
   docker/scripts contains scripts that the docker image uses to manage Solr.
+  Refer to the README for instructions on how to build an image.
 
 docs/index.html
   A link to the online version of Apache Solr Javadoc API documentation and Tutorial

--- a/solr/README.md
+++ b/solr/README.md
@@ -158,7 +158,7 @@ prometheus-exporter/
 docker/
   Contains a docker file to build a Docker image using the source binary distribution.
   docker/scripts contains scripts that the docker image uses to manage Solr.
-  Refer to the README for instructions on how to build an image.
+  Refer to the README.md for instructions on how to build an image.
 
 docs/index.html
   A link to the online version of Apache Solr Javadoc API documentation and Tutorial

--- a/solr/docker/README.md
+++ b/solr/docker/README.md
@@ -21,7 +21,7 @@ Solr Docker
 This Solr docker module creates both a local Docker image from the source as well as the official Solr Dockerfile.
 This allows for local images to be completely compatible with the official Solr images available on DockerHub.
 
-In order to build/test/tag your Docker images using local Solr source code, please refer to `./gradlew helpDocker`
+In order to build/test/tag your Docker images using local Solr source code, please refer to `./gradlew helpDocker` in a git checkout or a source-release download.
 
 Please refer to the [Solr Reference Guide](https://solr.apache.org/guide/solr-in-docker.html) for information on using the Solr Docker image.
 

--- a/solr/docker/README.md
+++ b/solr/docker/README.md
@@ -1,0 +1,49 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+Solr Docker
+----
+
+This Solr docker module creates both a local Docker image from the source as well as the official Solr Dockerfile.
+This allows for local images to be completely compatible with the official Solr images available on DockerHub.
+
+In order to build/test/tag your Docker images using local Solr source code, please refer to `./gradlew helpDocker`
+
+Please refer to the [Solr Reference Guide](https://solr.apache.org/guide/solr-in-docker.html) for information on using the Solr Docker image.
+
+Building from the Solr Binary Distribution
+----
+
+Officially-compliant Docker images can be built directly from the Solr binary distribution (i.e. `solr-<version>.tgz`).
+A Dockerfile is included in the binary distribution, under `solr-<version>/docker/Dockerfile`, and is the same one used when building a docker image via Gradle.
+
+To build the Docker image, pass the Solr TGZ as the Docker context and provide the path of the Dockerfile.
+Note, that Docker will accept either a URL or a local TGZ file, but each require slightly different syntax.
+Therefore custom Solr releases or official releases can be used to create custom Solr images.
+
+```bash
+docker build -f solr-X.Y.Z/docker/Dockerfile - < solr-X.Y.Z.tgz
+docker build -f solr-X.Y.Z/docker/Dockerfile https://www.apache.org/dyn/closer.lua/solr/X.Y.Z/solr-X.Y.Z.tgz
+```
+
+When building the image, Solr accepts arguments for customization. Currently only one argument is accepted:
+
+- `BASE_IMAGE`: Change the base java image for Solr. This can be used to change java versions, jvms, etc.
+
+```bash
+docker build --build-arg BASE_IMAGE=custom/jdk:17-slim -f solr-X.Y.Z/docker/Dockerfile https://www.apache.org/dyn/closer.lua/solr/X.Y.Z/solr-X.Y.Z.tgz
+```

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -106,9 +106,13 @@ task assemblePackaging(type: Sync) {
 
   from(projectDir, {
     include "scripts/**"
+    include "README.md"
   })
   from(dockerfilesDirPath, {
     include 'Dockerfile.local'
+    rename {
+      'Dockerfile'
+    }
   })
   into packagingDir
 }
@@ -127,7 +131,7 @@ task dockerBuild(dependsOn: configurations.solrTgz) {
     exec {
       standardInput = configurations.solrTgz.singleFile.newDataInputStream()
       commandLine "docker", "build",
-              "-f", "solr-${version}/docker/Dockerfile.local",
+              "-f", "solr-${version}/docker/Dockerfile",
               "--iidfile", imageIdFile,
               "--build-arg", "BASE_IMAGE=${inputs.properties.baseDockerImage}",
               "-"
@@ -173,7 +177,7 @@ task dockerTag(dependsOn: tasks.dockerBuild) {
 
 task testDocker(type: TestDockerImageTask, dependsOn: tasks.dockerBuild) {
   group = 'Docker'
-  description = 'Test Solr docker image built from Dockerfile.local'
+  description = 'Test Solr docker image built from the local Dockerfile'
 
   idFile = tasks.dockerBuild.outputs.files.singleFile
   outputDir = file("$buildDir/test-results")
@@ -436,7 +440,7 @@ task testBuildDockerfileOfficial(type: Copy) {
 }
 
 task testDockerfileOfficial(type: TestDockerImageTask, dependsOn: configurations.dockerOfficialSmokeCheckImage) {
-  description = 'Smoke Test Solr docker image built from Dockerfile.official'
+  description = 'Smoke Test Solr docker image built from the official Dockerfile'
 
   idFile = file(imageIdFileOfficial)
   outputDir = file("$smokeTestOfficial/test-results")

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -26,10 +26,11 @@
 #-#
 #-#
 
-# add symlink to /opt/solr, remove what we don't want
+# add symlink to /opt/solr, remove what we don't want.
+# Remove the Dockerfile because it might not represent the dockerfile that was used to generate the image.
 RUN set -ex; \
   (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs;
+  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile;
 
 LABEL maintainer="The Apache Solr Project"
 LABEL url="https://solr.apache.org"

--- a/solr/prometheus-exporter/README.md
+++ b/solr/prometheus-exporter/README.md
@@ -7,3 +7,17 @@ Apache Solr Prometheus Exporter (solr-exporter) provides a way for you to expose
 
 For information on how to get started with solr-exporter please see:
  * [Solr Reference Guide's section on Monitoring Solr with Prometheus and Grafana](https://solr.apache.org/guide/monitoring-with-prometheus-and-grafana.html)
+
+# Docker
+
+The Solr Prometheus Exporter can be run via the official or local Solr docker image.
+Please refer to the `docker` directory's `README.md` for information on building the image
+and the [Solr Reference Guide](https://solr.apache.org/guide/solr-in-docker.html) for information on using the image.
+
+The `solr-exporter` script is available on the path by default in the Docker image, so the Prometheus Exporter can be run using:
+
+```bash
+docker run <image> solr-exporter
+```
+
+The environment variables and command line arguments that the Prometheus Exporter accepts can be used the same way in the Docker image.

--- a/solr/solr-ref-guide/src/installing-solr.adoc
+++ b/solr/solr-ref-guide/src/installing-solr.adoc
@@ -101,6 +101,8 @@ See the <<monitoring-with-prometheus-and-grafana.adoc#,documentation>> for more 
 docker/::
 This contains a Dockerfile to build a Docker image from the binary distribution, that is compatible with the official image.
 This directory also contains the scripts needed when using Solr inside the Docker image, under the `scripts/` directory.
+The `README.md` in this directory describes how custom Solr Docker images can be built using this binary distribution.
+Refer to the <<solr-in-docker.adoc#,Running Solr in Docker>> page for information on using a Solr docker image.
 
 docs/::
 The `docs` directory includes a link to online Javadocs for Solr.

--- a/solr/solr-ref-guide/src/installing-solr.adoc
+++ b/solr/solr-ref-guide/src/installing-solr.adoc
@@ -102,7 +102,7 @@ docker/::
 This contains a Dockerfile to build a Docker image from the binary distribution, that is compatible with the official image.
 This directory also contains the scripts needed when using Solr inside the Docker image, under the `scripts/` directory.
 The `README.md` in this directory describes how custom Solr Docker images can be built using this binary distribution.
-Refer to the <<solr-in-docker.adoc#,Running Solr in Docker>> page for information on using a Solr docker image.
+Refer to the <<solr-in-docker.adoc#,Running Solr in Docker>> page for information on using a Solr Docker image.
 
 docs/::
 The `docs` directory includes a link to online Javadocs for Solr.

--- a/solr/solr-ref-guide/src/solr-in-docker.adoc
+++ b/solr/solr-ref-guide/src/solr-in-docker.adoc
@@ -22,7 +22,6 @@
 
 Instructions below apply to `solr:8.0.0` and above.
 
-
 See the https://hub.docker.com/_/solr?tab=tags[Docker Hub page] for a full list of tags and architectures available.
 
 === Running Solr with host-mounted directories


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15956

Note I have also renamed `solr-<version>/docker/Dockerfile.local` to `solr-<version>/docker/Dockerfile` in the distribution, as I don't think there would be any confusion there and it is just cleaner. It's completely compatible with the official Docker image, just uses the binary distribution instead of downloading official releases.

As a last non-doc change, I added back in the logic to remove the Dockerfile from the Docker image. This is because without this logic, the official docker image would contain the _local_ Dockerfile, which doesn't particularly make sense. Easier to just remove it as it doesn't provide value.

Will mention both above changes in the JIRA.