### PR TITLE
SOLR-15936 Reduce unnecessary startup logging, such as SSL warnings when SSL not in use 

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -555,6 +555,8 @@ and each individual module's jar will be included in its directory's lib/ folder
 
 * SOLR-15957: Add port and scraping information to Solr Prometheus startup logging. (Houston Putman)
 
+* SOLR-15936: Reduce unnecessary startup logging, such as SSL warnings when SSL not in use (janhoy)
+
 * SOLR-15777: Forbid useDocValuesAsStored for ICUCollationField (warn for luceneMatchVersion < 9.0.0). (Michael Gibney)
 
 Bug Fixes

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -659,7 +659,7 @@ public class SolrXmlConfig {
     // if there's an MBean server running but there was no JMX reporter then add a default one
     MBeanServer mBeanServer = JmxUtil.findFirstMBeanServer();
     if (mBeanServer != null && !hasJmxReporter) {
-      log.info("MBean server found: {}, but no JMX reporters were configured - adding default JMX reporter.", mBeanServer);
+      log.debug("MBean server found: {}, but no JMX reporters were configured - adding default JMX reporter.", mBeanServer);
       Map<String,Object> attributes = new HashMap<>();
       attributes.put("name", "default");
       attributes.put("class", SolrJmxReporter.class.getName());

--- a/solr/core/src/java/org/apache/solr/metrics/reporters/SolrJmxReporter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/reporters/SolrJmxReporter.java
@@ -108,7 +108,7 @@ public class SolrJmxReporter extends FilteringSolrMetricReporter {
                           .build();
     reporter.start();
     started = true;
-    log.info("JMX monitoring for '{}' (registry '{}') enabled at server: {}", fullDomain, registryName, mBeanServer);
+    log.debug("JMX monitoring for '{}' (registry '{}') enabled at server: {}", fullDomain, registryName, mBeanServer);
   }
 
   /**
@@ -123,7 +123,7 @@ public class SolrJmxReporter extends FilteringSolrMetricReporter {
    */
   @Override
   public synchronized void close() {
-    log.info("Closing reporter {} for registry {}/{}", this, registryName, registry);
+    log.debug("Closing reporter {} for registry {}/{}", this, registryName, registry);
     started = false;
     if (reporter != null) {
       reporter.close();

--- a/solr/server/resources/log4j2-console.xml
+++ b/solr/server/resources/log4j2-console.xml
@@ -33,6 +33,9 @@
     <!-- Use <AsyncLogger/<AsyncRoot and <Logger/<Root for asynchronous logging or synchonous logging respectively -->
     <AsyncLogger name="org.apache.zookeeper" level="WARN"/>
     <AsyncLogger name="org.apache.hadoop" level="WARN"/>
+    <AsyncLogger name="org.eclipse.jetty.deploy" level="warn"/>
+    <AsyncLogger name="org.eclipse.jetty.webapp" level="warn"/>
+    <AsyncLogger name="org.eclipse.jetty.server.session" level="warn"/>
 
     <AsyncRoot level="INFO">
       <AppenderRef ref="STDERR"/>

--- a/solr/server/resources/log4j2.xml
+++ b/solr/server/resources/log4j2.xml
@@ -74,6 +74,9 @@
     <AsyncLogger name="org.apache.solr.core.SolrCore.SlowRequest" level="info" additivity="false">
       <AppenderRef ref="SlowLogFile"/>
     </AsyncLogger>
+    <AsyncLogger name="org.eclipse.jetty.deploy" level="warn"/>
+    <AsyncLogger name="org.eclipse.jetty.webapp" level="warn"/>
+    <AsyncLogger name="org.eclipse.jetty.server.session" level="warn"/>
 
     <AsyncRoot level="info">
       <AppenderRef ref="MainLogFile"/>

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -58,7 +58,6 @@ import org.apache.solr.client.solrj.request.V2Request;
 import org.apache.solr.client.solrj.util.Cancellable;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.client.solrj.util.AsyncListener;
-import org.apache.solr.client.solrj.util.Constants;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.StringUtils;
 import org.apache.solr.common.params.CommonParams;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -205,12 +205,9 @@ public class Http2SolrClient extends SolrClient {
       sslEnabled = true;
     }
 
-    boolean sslOnJava8OrLower = sslEnabled && !Constants.JRE_IS_MINIMUM_JAVA9;
     HttpClientTransport transport;
-    if (builder.useHttp1_1 || sslOnJava8OrLower) {
-      if (sslOnJava8OrLower && !builder.useHttp1_1) {
-        log.warn("Create Http2SolrClient with HTTP/1.1 transport since Java 8 or lower versions does not support SSL + HTTP/2");
-      } else {
+    if (builder.useHttp1_1) {
+      if (log.isDebugEnabled()) {
         log.debug("Create Http2SolrClient with HTTP/1.1 transport");
       }
       transport = new HttpClientTransportOverHTTP(2);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15936

See JIRA issue for what log lines will be muted. Some Jetty packages are raised to WARN level. I kept the jetty logging related to Server startup.

@CaoManhDat: Check the `Http2SolrClient` changes. I detect ssl without instantiating `SslContextFactory`, and also removed dead code related to java8, which is not required as we now have minimum java 11 requirement.