### PR TITLE
Symlink contrib to modules for 9.x

### DIFF
--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -64,7 +64,8 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chmod 0664 /etc/default/solr.in.sh; \
   mkdir -p -m0770 /var/solr; \
-  chown -R "$SOLR_USER:0" /var/solr;
+  chown -R "$SOLR_USER:0" /var/solr; \
+  ln -s /opt/solr/modules /opt/solr/contrib;
 
 VOLUME /var/solr
 EXPOSE 8983

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -65,7 +65,8 @@ RUN set -ex; \
   chmod 0664 /etc/default/solr.in.sh; \
   mkdir -p -m0770 /var/solr; \
   chown -R "$SOLR_USER:0" /var/solr; \
-  ln -s /opt/solr/modules /opt/solr/contrib;
+  ln -s /opt/solr/modules /opt/solr/contrib; \
+  ln -s /opt/solr/prometheus-exporter /opt/solr/modules/prometheus-exporter;
 
 VOLUME /var/solr
 EXPOSE 8983


### PR DESCRIPTION
I got this idea, that adding a symlink from `modules` to `contrib` in 9.x images, we'd get some degree of back-compat for free. If someone expects `/opt/solr/contrib/extracting/lib/*.jar` then that would actually work with the 9.x image. Not sure about solr-operator @HoustonPutman, perhaps this is enough for v0.5 to handle 9.x? Just a quick thought, have not tested, may be that other changes precludes this from being useful at all :) 