### PR TITLE
SOLR-15983: change UpdateLog.RecoveryInfo.errors to AtomicInteger

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -176,7 +176,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
     public int adds;
     public int deletes;
     public int deleteByQuery;
-    public int errors;
+    public AtomicInteger errors = new AtomicInteger(0);
 
     public boolean failed;
 
@@ -460,7 +460,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
         return 0;
       } else if (state == State.APPLYING_BUFFERED) {
         // numRecords counts header as a record
-        return tlog.numRecords() - 1 - recoveryInfo.adds - recoveryInfo.deleteByQuery - recoveryInfo.deletes - recoveryInfo.errors;
+        return tlog.numRecords() - 1 - recoveryInfo.adds - recoveryInfo.deleteByQuery - recoveryInfo.deletes - recoveryInfo.errors.get();
       } else {
         return 0;
       }
@@ -1790,11 +1790,11 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
           SolrException.log(log, e);
           recoveryInfo.failed = true;
         } else {
-          recoveryInfo.errors++;
+          recoveryInfo.errors.incrementAndGet();
           SolrException.log(log, e);
         }
       } catch (Exception e) {
-        recoveryInfo.errors++;
+        recoveryInfo.errors.incrementAndGet();
         SolrException.log(log, e);
       } finally {
         // change the state while updates are still blocked to prevent races
@@ -1969,11 +1969,11 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
               // XXX should not happen?
             }
           } catch (ClassCastException cl) {
-            recoveryInfo.errors++;
+            recoveryInfo.errors.incrementAndGet();
             loglog.warn("REPLAY_ERR: Unexpected log entry or corrupt log.  Entry={}", o, cl);
             // would be caused by a corrupt transaction log
           } catch (Exception ex) {
-            recoveryInfo.errors++;
+            recoveryInfo.errors.incrementAndGet();
             loglog.warn("REPLAY_ERR: Exception replaying log", ex);
             // something wrong with the request?
           }
@@ -1992,7 +1992,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
           if (debug) log.debug("commit {}", cmd);
           uhandler.commit(cmd);          // this should cause a commit to be added to the incomplete log and avoid it being replayed again after a restart.
         } catch (IOException ex) {
-          recoveryInfo.errors++;
+          recoveryInfo.errors.incrementAndGet();
           loglog.error("Replay exception: final commit.", ex);
         }
 
@@ -2005,7 +2005,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
         try {
           proc.finish();
         } catch (IOException ex) {
-          recoveryInfo.errors++;
+          recoveryInfo.errors.incrementAndGet();
           loglog.error("Replay exception: finish()", ex);
         } finally {
           IOUtils.closeQuietly(proc);
@@ -2066,7 +2066,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
               proc.processDelete((DeleteUpdateCommand) cmd);
             }
           } catch (IOException e) {
-            recoveryInfo.errors++;
+            recoveryInfo.errors.incrementAndGet();
             loglog.warn("REPLAY_ERR: IOException reading log", e);
             // could be caused by an incomplete flush if recovering from log
           } catch (SolrException e) {
@@ -2074,8 +2074,8 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
               exceptionHolder.compareAndSet(null, e);
               return;
             }
-            recoveryInfo.errors++;
-            loglog.warn("REPLAY_ERR: IOException reading log", e);
+            recoveryInfo.errors.incrementAndGet();
+            loglog.warn("REPLAY_ERR: SolrException reading log", e);
           } finally {
             pendingTasks.decrementAndGet();
           }
@@ -2089,15 +2089,15 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
             proc.processDelete((DeleteUpdateCommand) cmd);
           }
         } catch (IOException e) {
-          recoveryInfo.errors++;
+          recoveryInfo.errors.incrementAndGet();
           loglog.warn("REPLAY_ERR: IOException replaying log", e);
           // could be caused by an incomplete flush if recovering from log
         } catch (SolrException e) {
           if (e.code() == ErrorCode.SERVICE_UNAVAILABLE.code) {
             throw e;
           }
-          recoveryInfo.errors++;
-          loglog.warn("REPLAY_ERR: IOException replaying log", e);
+          recoveryInfo.errors.incrementAndGet();
+          loglog.warn("REPLAY_ERR: SolrException replaying log", e);
         }
       }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15983

The errors counter can be incremented from multiple threads (though in practice hopefully that is unlikely!) and so use of an `AtomicInteger` instead of an `int` would communicate that more clearly, without impact of performance in the non-error code paths.

Noticed as part of the https://issues.apache.org/jira/browse/SOLR-15983 investigation, but it's not the root cause of the exception seen there.

Also fixing `s/IOException/SolrException` copy/paste in two warning log messages.