### PR TITLE
SOLR-15974: Remove Calcite's ENUMERABLE_AGGREGATE_RULE as Solr only supports push-down for LogicalAggregate

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -644,6 +644,8 @@ Bug Fixes
 * SOLR-14569: Configuring a shardHandlerFactory on the /select requestHandler results in HTTP 401 when searching on alias
   in secured Solr. (Isabelle Giguere, Jason Gerlowski, Anshum Gupta, Mark Mark Miller)
 
+* SOLR-15974: Remove Calcite's ENUMERABLE_AGGREGATE_RULE as Solr only supports push-down for LogicalAggregate (Timothy Potter)
+
 ==================  8.11.1 ==================
 
 Bug Fixes

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -644,7 +644,7 @@ Bug Fixes
 * SOLR-14569: Configuring a shardHandlerFactory on the /select requestHandler results in HTTP 401 when searching on alias
   in secured Solr. (Isabelle Giguere, Jason Gerlowski, Anshum Gupta, Mark Mark Miller)
 
-* SOLR-15974: Remove Calcite's ENUMERABLE_AGGREGATE_RULE as Solr only supports push-down for LogicalAggregate (Timothy Potter)
+* SOLR-15974: Remove Calcite's ENUMERABLE_AGGREGATE_RULE as Solr only supports push-down for LogicalAggregate (Timothy Potter, Kiran Chitturi)
 
 ==================  8.11.1 ==================
 

--- a/solr/core/src/java/org/apache/solr/handler/sql/SolrTableScan.java
+++ b/solr/core/src/java/org/apache/solr/handler/sql/SolrTableScan.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.handler.sql;
 
+import org.apache.calcite.adapter.enumerable.EnumerableRules;
 import org.apache.calcite.plan.*;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
@@ -74,6 +75,8 @@ class SolrTableScan extends TableScan implements SolrRel {
       planner.addRule(rule);
     }
 
+    // Solr's impl only supports LogicalAggregate, so don't let Calcite convert LogicalAggregate's to Enumerable (SOLR-15974)
+    planner.removeRule(EnumerableRules.ENUMERABLE_AGGREGATE_RULE);
     planner.removeRule(CoreRules.FILTER_REDUCE_EXPRESSIONS); // prevent AND NOT from being reduced away, see SOLR-15461
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -1494,6 +1494,14 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assertTrue(maxf == null);
     assertTrue(avgf == null);
 
+    // test bunch of where predicates
+    sParams = mapParams(CommonParams.QT, "/sql",
+        "stmt", "select count(*), sum(a_i), min(a_i), max(a_i), cast(avg(1.0 * a_i) as float), sum(a_f), " +
+            "min(a_f), max(a_f), avg(a_f) from collection1 where id = 2 AND a_s='hello0' AND a_i=2 AND a_f=2");
+
+
+    tuples = getTuples(sParams, baseUrl);
+    assert (tuples.size() == 1);
   }
 
   @Test
@@ -2502,9 +2510,11 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "4", "a_s", "world-4", "b_s", "foo", "a_i", "3", "d_s", "b")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
+    expectResults("SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (id='1')", 1);
+    expectResults("SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1')", 1);
     expectResults("SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo')", 1);
     expectResults("SELECT COUNT(1) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo')", 1);
-    expectResults("SELECT COUNT(1) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo') AND (d_s='x')", 1);
+    expectResults("SELECT COUNT(1) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo') AND (a_s='hello-1')", 1);
     expectResults("SELECT COUNT(*) as QUERY_COUNT, max(id) as max_id FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo')", 1);
     expectResults("SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo') HAVING COUNT(*) > 0", 1);
   }

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -2492,4 +2492,20 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // just a bunch of OR's that end up matching all docs
     expectResults("SELECT id FROM $ALIAS WHERE a_s <> 'hello-1' OR a_i <> 2 OR d_s <> 'x' ORDER BY id ASC LIMIT 10", 4);
   }
+
+  @Test
+  public void testCountWithManyFilters() throws Exception {
+    new UpdateRequest()
+        .add("id", "1", "a_s", "hello-1", "b_s", "foo", "c_s", "bar", "d_s", "x")
+        .add("id", "2", "a_s", "world-2", "b_s", "foo", "a_i", "2", "d_s", "a")
+        .add("id", "3", "a_s", "hello-3", "b_s", "foo", "c_s", "bar", "d_s", "x")
+        .add("id", "4", "a_s", "world-4", "b_s", "foo", "a_i", "3", "d_s", "b")
+        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    expectResults("SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo')", 1);
+    expectResults("SELECT COUNT(1) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo')", 1);
+    expectResults("SELECT COUNT(1) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo') AND (d_s='x')", 1);
+    expectResults("SELECT COUNT(*) as QUERY_COUNT, max(id) as max_id FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo')", 1);
+    expectResults("SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo') HAVING COUNT(*) > 0", 1);
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15974

Disable the `EnumerableRules.ENUMERABLE_AGGREGATE_RULE` optimization so that Solr only deals with LogicalAggregate. I looked into adding another rule for EnumerableAggregate but it seemed like we don't need this optimization from Calcite since we're pushing down into Solr's agg engine anyway, we don't need a bunch of optimizations in the Calcite layer.