### PR TITLE
Fix escaping in playbook/antora templates: Use single quotes and escape all single quotes by duplicating them

### DIFF
--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -27,6 +27,14 @@ def officialSiteIncludePrerelease = propertyOrEnvOrDefault("refguide.official.in
 
 def buildLocalUI = propertyOrEnvOrDefault("refguide.buildLocalUI", "SOLR_REF_GUIDE_BUILD_LOCAL_UI", "false").toBoolean()
 
+// This escapes strings inside YAML templates
+// WARNING: Strings in YAML must use single quotes for this to work correctly!
+// Double quotes in YAML can't be used as this requires more complicated
+// escaping, see spec: https://yaml.org/spec/1.2.2/#732-single-quoted-style
+def escapeYamlSingleQuotesString(props) {
+  return props.collectEntries{k, v -> [k, v.toString().replace("'","''")]}
+}
+
 // Attach building the ref guide to standard convention tasks. This
 // can be optionally turned off (see SOLR-15670).
 if (propertyOrEnvOrDefault('refguide.include', 'SOLR_REF_GUIDE_INCLUDE', "true").toBoolean()) {
@@ -109,7 +117,7 @@ task buildLocalAntoraYaml {
             }
             into project.ext.antoraConfigBuildDir
 
-            expand(props)
+            expand(escapeYamlSingleQuotesString(props))
         }
     }
     inputs.properties(props)
@@ -136,7 +144,7 @@ task buildLocalAntoraPlaybookYaml(type: Copy) {
         'site_dir'           : "./" + file(project.ext.siteStagingDir).relativePath(file(project.ext.siteDir)),
     ]
 
-    expand(props)
+    expand(escapeYamlSingleQuotesString(props))
     inputs.properties(props)
 }
 
@@ -168,7 +176,7 @@ task buildOfficialAntoraPlaybookYaml(type: Copy) {
         'site_dir'           : "./" + file(project.ext.playbooksDir).relativePath(file(project.ext.siteDir)),
     ]
 
-    expand(props)
+    expand(escapeYamlSingleQuotesString(props))
     inputs.properties(props)
 }
 

--- a/solr/solr-ref-guide/playbook.template.yml
+++ b/solr/solr-ref-guide/playbook.template.yml
@@ -10,23 +10,23 @@ urls:
 # If this is set to 'httpd', antora will create a .htaccess file with all redirects, including 'latest'.
 # Default is 'static' which produces index.html at the root.
 # See https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
-  redirect_facility: ${redirect_facility}
+  redirect_facility: '${redirect_facility}'
 content:
   # The URL for "Edit this page" links will always go to 'main' in Github
   edit_url: '{web_url}/tree/main/{path}'
   sources:
-  - url: "${source_url}"
-    branches: ${source_branches}
-    start_path: "${start_path}"
+  - url: '${source_url}'
+    branches: '${source_branches}'
+    start_path: '${start_path}'
 
 ui:
   bundle:
-    url: "https://nightlies.apache.org/solr/draft-guides/ui-bundle.zip"
+    url: 'https://nightlies.apache.org/solr/draft-guides/ui-bundle.zip'
     snapshot: true
-  supplemental_files: "${supplemental_files}"
+  supplemental_files: '${supplemental_files}'
 output:
   clean: true
-  dir: "${site_dir}"
+  dir: '${site_dir}'
 asciidoc:
   attributes:
     stem:


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SOLR-15556?focusedCommentId=17491611&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17491611