### PR TITLE
SOLR-12336: DocSetQuery can have 1 score

### DIFF
--- a/solr/core/src/java/org/apache/solr/query/FilterQuery.java
+++ b/solr/core/src/java/org/apache/solr/query/FilterQuery.java
@@ -19,6 +19,7 @@ package org.apache.solr.query;
 import java.io.IOException;
 
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -30,6 +31,11 @@ import org.apache.solr.search.DocSet;
 import org.apache.solr.search.ExtendedQueryBase;
 import org.apache.solr.search.SolrIndexSearcher;
 
+/**
+ * A filtered query wrapped around another query
+ * similar to {@link org.apache.lucene.search.BooleanClause.Occur#FILTER} -- it scores as 0.
+ * Moreover, it will use Solr's filter cache.
+ */
 public class FilterQuery extends ExtendedQueryBase {
   protected final Query q;
 
@@ -68,7 +74,7 @@ public class FilterQuery extends ExtendedQueryBase {
 
   @Override
   public void visit(QueryVisitor visitor) {
-    q.visit(visitor);
+    q.visit(visitor.getSubVisitor(BooleanClause.Occur.FILTER, this));
   }
 
   @Override
@@ -87,13 +93,15 @@ public class FilterQuery extends ExtendedQueryBase {
 
     if (!(searcher instanceof SolrIndexSearcher)) {
       // delete-by-query won't have SolrIndexSearcher
-      return new ConstantScoreQuery(q).createWeight(searcher, scoreMode, 1f);
+      // note: CSQ has some optimizations so we wrap it even though unnecessary given 0 boost
+      return new ConstantScoreQuery(q).createWeight(searcher, scoreMode, 0f);
     }
 
     SolrIndexSearcher solrSearcher = (SolrIndexSearcher)searcher;
     DocSet docs = solrSearcher.getDocSet(q);
     // reqInfo.addCloseHook(docs);  // needed for off-heap refcounting
 
-    return docs.makeQuery().createWeight(searcher, scoreMode, 1f);
+    // note: DocSet.makeQuery is basically a CSQ
+    return docs.makeQuery().createWeight(searcher, scoreMode, 0f);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/DocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSet.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.FixedBitSet;
 /**
  * An immutable ordered set of Lucene Document Ids.
  * It's similar to a Lucene {@link org.apache.lucene.search.DocIdSet}.
+ * Solr never puts a deleted document into a DocSet.
  *
  * <p>
  * WARNING: Any DocSet returned from SolrIndexSearcher should <b>not</b> be modified as it may have been retrieved from
@@ -118,10 +119,8 @@ public abstract class DocSet implements Accountable, Cloneable /* extends Collec
   }
 
   /**
-   * Returns a constant scoring Query for use in Lucene search methods, assuming this DocSet
-   * was generated from the top-level MultiReader that the Lucene search
-   * methods will be invoked with. DocSets, and thus this query, do not
-   * match deleted docs.
+   * Returns a Query matching these documents with a score of 1.
+   * Note that DocSets do not refer to deleted docs.
    */
   public abstract Query makeQuery();
 

--- a/solr/core/src/java/org/apache/solr/search/DocSetQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSetQuery.java
@@ -36,11 +36,10 @@ import java.util.Objects;
  * @see DocSet#makeQuery()
  * @since 9.0
  */
-public class DocSetQuery extends Query implements DocSetProducer{
+class DocSetQuery extends Query implements DocSetProducer{
     private final DocSet docSet;
 
-    public DocSetQuery(DocSet docSet) {
-        super();
+    DocSetQuery(DocSet docSet) {
         this.docSet = docSet;
     }
 

--- a/solr/core/src/java/org/apache/solr/search/DocSetQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSetQuery.java
@@ -31,9 +31,10 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * A class that accesses Queries based on a DocSet
+ * A Query based on a {@link DocSet}.  The un-boosted score is always 1.
  *
- * Refer SOLR-15257
+ * @see DocSet#makeQuery()
+ * @since 9.0
  */
 public class DocSetQuery extends Query implements DocSetProducer{
     private final DocSet docSet;
@@ -78,11 +79,9 @@ public class DocSetQuery extends Query implements DocSetProducer{
 
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-        //This should probably use the provided boost as scorer. However, that causes
-        // TestSolrQueryParser.testFilter to fail.
-        return new ConstantScoreWeight(this, 0) {
+        return new ConstantScoreWeight(this, boost) {
             @Override
-            public Scorer scorer(LeafReaderContext context) throws IOException {
+            public Scorer scorer(LeafReaderContext context) {
                 DocIdSetIterator disi = docSet.iterator(context);
                 if (disi == null) {
                     return null;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -944,7 +944,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    */
   public static class ProcessedFilter {
     public DocSet answer; // maybe null. Sometimes we have a docSet answer that represents the complete answer / result.
-    public Query filter; // maybe null
+    public Query filter; // maybe null.  Scoring is irrelevant / unspecified.
     public DelegatingCollector postFilter; // maybe null
   }
 
@@ -2075,12 +2075,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       return a == absQ ? b.intersectionSize(positiveA) : b.andNotSize(positiveA);
     } else {
       // If there isn't a cache, then do a single filtered query
-      // NOTE: we cannot use FilteredQuery, because BitDocSet assumes it will never
-      // have deleted documents, but UninvertedField's doNegative has sets with deleted docs
       TotalHitCountCollector collector = new TotalHitCountCollector();
       BooleanQuery.Builder bq = new BooleanQuery.Builder();
       bq.add(QueryUtils.makeQueryable(a), Occur.MUST);
-      bq.add(new ConstantScoreQuery(b.makeQuery()), Occur.MUST);
+      bq.add(b.makeQuery(), Occur.MUST);
       super.search(bq.build(), collector);
       return collector.getTotalHits();
     }

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -311,7 +311,5 @@ Example has been provided in `sample_techproducts_configs` to override content-t
 * SOLR-15124: Removed three core level admin API endpoints because they are already registered at the node level
 where they really belong: /admin/threads, /admin/properties, /admin/logging
 
-* SOLR-12336: Remove Filter, SolrFilter and SolrConstantScoreQuery
-
 * SOLR-15949: Docker: the official image now uses Java 17 provided by Eclipse Temurin.  Formerly it was Java 11 from OpenJDK.
 (janhoy, David Smiley)


### PR DESCRIPTION
... and some misc adjustments

https://issues.apache.org/jira/browse/SOLR-12336

Mostly; instead of making DocSetQuery score as 0, make FilteredQuery do that.  Since FilteredQuery wraps DocSetQuery, there's no difference for FilteredQuery.  DocSetQuery is more internal.  It's users don't see to care about the score any way.