### PR TITLE
SOLR-16016 Refactoring RestTestBase and JSONTestUtil

### DIFF
--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
@@ -17,6 +17,7 @@
 package org.apache.solr.ltr;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.nio.file.Files;
@@ -258,20 +259,31 @@ public class TestRerankBase extends RestTestBase {
     return sb.toString();
   }
 
+  /** Load a feature from the test fstore and verify that it succeeded */
   protected static void loadFeature(String name, String type, String params)
-      throws Exception {
-    final String feature = getFeatureInJson(name, type, "test", params);
-    log.info("loading feauture \n{} ", feature);
-    assertJPut(ManagedFeatureStore.REST_END_POINT, feature,
-        "/responseHeader/status==0");
+      throws IOException {
+    loadFeature(name, type, "test", params, 0);
   }
 
+  /** Load a feature and expect a given status code (i.e. testing for failure) */
+  protected static void loadFeature(String name, String type, String params, int responseCode)
+      throws IOException {
+    loadFeature(name, type, "test", params, responseCode);
+  }
+
+  /** Load a feature from a custom fstore and verify that it succeeded */
   protected static void loadFeature(String name, String type, String fstore,
       String params) throws Exception {
+    loadFeature(name, type, fstore, params, 0);
+  }
+
+  /** Load a feature from a custom fstore and expect a given status code (i.e. testing for failure) */
+  protected static void loadFeature(String name, String type, String fstore,
+                                    String params, int responseCode) throws IOException {
     final String feature = getFeatureInJson(name, type, fstore, params);
     log.info("loading feauture \n{} ", feature);
     assertJPut(ManagedFeatureStore.REST_END_POINT, feature,
-        "/responseHeader/status==0");
+        "/responseHeader/status==" + responseCode);
   }
 
   protected static void loadModel(String name, String type, String[] features,

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestValueFeature.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestValueFeature.java
@@ -48,23 +48,11 @@ public class TestValueFeature extends TestRerankBase {
   }
 
   @Test
-  public void testValueFeatureWithEmptyValue() throws Exception {
-    final RuntimeException expectedException =
-        new RuntimeException("mismatch: '0'!='500' @ responseHeader/status");
-    RuntimeException e = expectThrows(RuntimeException.class, () -> {
-      loadFeature("c2", ValueFeature.class.getName(), "{\"value\":\"\"}");
-    });
-    assertEquals(expectedException.toString(), e.toString());
-  }
-
-  @Test
-  public void testValueFeatureWithWhitespaceValue() throws Exception {
-    final RuntimeException expectedException =
-        new RuntimeException("mismatch: '0'!='500' @ responseHeader/status");
-    RuntimeException e = expectThrows(RuntimeException.class, () -> {
-      loadFeature("c2", ValueFeature.class.getName(), "{\"value\":\" \"}");
-    });
-    assertEquals(expectedException.toString(), e.toString());
+  public void testValueFeaturesWithBadValues() throws Exception {
+    // Empty Value
+    loadFeature("c2", ValueFeature.class.getName(), "{\"value\":\"\"}", 500);
+    // Whitespace Value
+    loadFeature("c2", ValueFeature.class.getName(), "{\"value\":\" \"}", 500);
   }
 
   @Test

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/response/transform/TestInterleavingTransformer.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/response/transform/TestInterleavingTransformer.java
@@ -261,17 +261,8 @@ public class TestInterleavingTransformer extends TestRerankBase {
     int[] nullFeatureVectorIndexes = new int[]{1, 2, 4};
     for (int index : nullFeatureVectorIndexes) {
       TeamDraftInterleaving.setRANDOM(new Random(10101010));
-      String[] nullFeatureVectorTests = new String[1];
-      try {
-        nullFeatureVectorTests[0] = "/response/docs/[" + index + "]/features==";
-        assertJQ("/query" + query.toQueryString(), nullFeatureVectorTests);
-      } catch (Exception e) {
-        assertEquals("Path not found: /response/docs/[" + index + "]/features", e.getMessage());
-        continue;
-      }
-
+      assertJQ("/query" + query.toQueryString(), "!/response/docs/[" + index + "]/features==");
     }
-
   }
 
 }

--- a/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
@@ -614,23 +614,18 @@ public abstract class SolrParams implements Serializable, MapWriter, Iterable<Ma
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder(128);
-    try {
-      boolean first=true;
-      for (final Iterator<String> it = getParameterNamesIterator(); it.hasNext();) {
-        final String name = it.next();
-        for (String val : getParams(name)) {
-          if (!first) sb.append('&');
-          first=false;
-          StrUtils.partialURLEncodeVal(sb, name);
-          sb.append('=');
-          StrUtils.partialURLEncodeVal(sb, val);
-        }
+    boolean first = true;
+    for (final Iterator<String> it = getParameterNamesIterator(); it.hasNext();) {
+      final String name = it.next();
+      for (String val : getParams(name)) {
+        if (!first) sb.append('&');
+        first = false;
+        StrUtils.partialURLEncodeVal(sb, name);
+        sb.append('=');
+        StrUtils.partialURLEncodeVal(sb, val);
       }
-      return sb.toString();
-    } catch (IOException e) {
-      // impossible!
-      throw new AssertionError(e);
     }
+    return sb.toString();
   }
 
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.common.util;
 
-import java.io.IOException;
 import java.nio.CharBuffer;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -309,7 +308,7 @@ public class StrUtils {
    * Characters with a numeric value less than 32 are encoded.
    * &amp;,=,%,+,space are encoded.
    */
-  public static void partialURLEncodeVal(Appendable dest, String val) throws IOException {
+  public static void partialURLEncodeVal(StringBuilder dest, String val) {
     for (int i = 0; i < val.length(); i++) {
       char ch = val.charAt(i);
       if (ch < 32) {

--- a/solr/test-framework/src/java/org/apache/solr/JSONTestUtil.java
+++ b/solr/test-framework/src/java/org/apache/solr/JSONTestUtil.java
@@ -39,7 +39,7 @@ public class JSONTestUtil {
    * @see #DEFAULT_DELTA
    * @see #match(String,String,double)
    */
-  public static String match(String input, String pathAndExpected) throws Exception {
+  public static String match(String input, String pathAndExpected) throws IOException {
     return match(input, pathAndExpected, DEFAULT_DELTA);
   }
 
@@ -48,7 +48,7 @@ public class JSONTestUtil {
    * @see #DEFAULT_DELTA
    * @see #match(String,String,String,double)
    */
-  public static String match(String path, String input, String expected) throws Exception {
+  public static String match(String path, String input, String expected) throws IOException {
     return match(path, input, expected, DEFAULT_DELTA);
   }
 
@@ -57,16 +57,16 @@ public class JSONTestUtil {
    * @see #DEFAULT_DELTA
    * @see #matchObj(String,Object,Object,double)
    */
-  public static String matchObj(String path, Object input, Object expected) throws Exception {
+  public static String matchObj(String path, Object input, Object expected) throws IOException {
     return matchObj(path,input,expected, DEFAULT_DELTA);
   }
 
   /**
    * @param input JSON Structure to parse and test against
    * @param pathAndExpected JSON path expression + '==' + expected value
-   * @param delta tollerance allowed in comparing float/double values
+   * @param delta tolerance allowed in comparing float/double values
    */
-  public static String match(String input, String pathAndExpected, double delta) throws Exception {
+  public static String match(String input, String pathAndExpected, double delta) throws IOException {
     int pos = pathAndExpected.indexOf("==");
     String path = pos>=0 ? pathAndExpected.substring(0,pos) : null;
     String expected = pos>=0 ? pathAndExpected.substring(pos+2) : pathAndExpected;
@@ -76,9 +76,9 @@ public class JSONTestUtil {
   /**
    * @param input Object structure to parse and test against
    * @param pathAndExpected JSON path expression + '==' + expected value
-   * @param delta tollerance allowed in comparing float/double values
+   * @param delta tolerance allowed in comparing float/double values
    */
-  public static String matchObj(Object input, String pathAndExpected, double delta) throws Exception {
+  public static String matchObj(Object input, String pathAndExpected, double delta) throws IOException {
     int pos = pathAndExpected.indexOf("==");
     String path = pos>=0 ? pathAndExpected.substring(0,pos) : null;
     String expected = pos>=0 ? pathAndExpected.substring(pos+2) : pathAndExpected;
@@ -90,9 +90,9 @@ public class JSONTestUtil {
    * @param path JSON path expression
    * @param input JSON Structure to parse and test against
    * @param expected expected value of path
-   * @param delta tollerance allowed in comparing float/double values
+   * @param delta tolerance allowed in comparing float/double values
    */
-  public static String match(String path, String input, String expected, double delta) throws Exception {
+  public static String match(String path, String input, String expected, double delta) throws IOException {
     Object inputObj = failRepeatedKeys ? new NoDupsObjectBuilder(new JSONParser(input)).getVal() : ObjectBuilder.fromJSON(input);
     Object expectObj = failRepeatedKeys ? new NoDupsObjectBuilder(new JSONParser(expected)).getVal() : ObjectBuilder.fromJSON(expected);
     return matchObj(path, inputObj, expectObj, delta);
@@ -117,14 +117,15 @@ public class JSONTestUtil {
    * @param path JSON path expression
    * @param input JSON Structure
    * @param expected expected JSON Object
-   * @param delta tollerance allowed in comparing float/double values
+   * @param delta tolerance allowed in comparing float/double values
+   * @return the error message from the match, or null if match was good
    */
   public static String matchObj(String path, Object input, Object expected, double delta) {
     CollectionTester tester = new CollectionTester(input,delta);
     boolean reversed = path.startsWith("!");
     String positivePath = reversed ? path.substring(1) : path;
     if (!tester.seek(positivePath) ^ reversed) {
-      return "Path not found: " + path;
+      return "Path " + (reversed ? "" : "not ") + "found: " + path;
     }
     if (expected != null && (!tester.match(expected) ^ reversed)) {
       return tester.err + " @ " + tester.getPath();

--- a/solr/test-framework/src/java/org/apache/solr/util/RestTestHarness.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/RestTestHarness.java
@@ -101,13 +101,13 @@ public class RestTestHarness extends BaseTestHarness implements Closeable {
    *
    * @param request the URL path and optional query params
    * @return The response to the query
-   * @exception Exception any exception in the response.
+   * @exception IOException any exception in the response.
    */
-  public String query(String request) throws Exception {
+  public String query(String request) throws IOException {
     return getResponse(new HttpGet(getBaseURL() + request));
   }
 
-  public String adminQuery(String request) throws Exception {
+  public String adminQuery(String request) throws IOException {
     return getResponse(new HttpGet(getAdminURL() + request));
   }
 


### PR DESCRIPTION
Pull duplicate setup code into common methods
Narrow thrown exception type declarations
Fix a few spelling errors
Have test results lead to fail() instead of exception

I was motivated to make these changes while viewing the output of the proposed patch on SOLR-15333

Not sure if this is significant enough changes to warrant a JIRA issue or not.