### PR TITLE
Implement check for null scorer in DocSetQuery to simplify TestFilteredDocIdSet.testNullDocIdSet

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/DocSetQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSetQuery.java
@@ -40,7 +40,7 @@ class DocSetQuery extends Query implements DocSetProducer{
     private final DocSet docSet;
 
     DocSetQuery(DocSet docSet) {
-        this.docSet = docSet;
+        this.docSet = Objects.requireNonNull(docSet);
     }
 
     @Override
@@ -64,7 +64,7 @@ class DocSetQuery extends Query implements DocSetProducer{
 
     @Override
     public int hashCode() {
-        return classHash() * 31 + (docSet != null ? docSet.hashCode() : 0);
+        return classHash() * 31 + docSet.hashCode();
     }
 
     /**
@@ -81,9 +81,6 @@ class DocSetQuery extends Query implements DocSetProducer{
         return new ConstantScoreWeight(this, boost) {
             @Override
             public Scorer scorer(LeafReaderContext context) {
-                if (docSet == null) {
-                    return null;
-                }
                 DocIdSetIterator disi = docSet.iterator(context);
                 if (disi == null) {
                     return null;

--- a/solr/core/src/test/org/apache/solr/search/TestFilteredDocIdSet.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFilteredDocIdSet.java
@@ -131,26 +131,7 @@ public class TestFilteredDocIdSet extends SolrTestCase {
     Assert.assertEquals(1, searcher.search(new MatchAllDocsQuery(), 10).totalHits.value);
     
     // Now search w/ a Query which returns a null Scorer
-    DocSetQuery f = new DocSetQuery(null) {
-
-      @Override
-      public String toString(String s) {
-        return "nullDocIdSetFilter";
-      }
-
-      @Override
-      public void visit(QueryVisitor queryVisitor) {}
-
-      @Override
-      public boolean equals(Object o) {
-        return o == this;
-      }
-
-      @Override
-      public int hashCode() {
-        return System.identityHashCode(this);
-      }
-    };
+    DocSetQuery f = new DocSetQuery(DocSet.empty());
 
     Query filtered = new BooleanQuery.Builder()
         .add(new MatchAllDocsQuery(), Occur.MUST)


### PR DESCRIPTION
This is a follow-up improvement to the creation of DocSetQuery, reference https://issues.apache.org/jira/browse/SOLR-15257

In the overriden Scorer in `DocSetQuery.createWeight` we do not currently impose a null check on `docSet`. Implementing a null check on `scorer` here could simplify some of the implementations in `TestFilteredDocIdSet`.

This PR also investigates at what seems to be an unnecessary redundancy in `TestFilteredDocIdSet`, i.e `testNullDocIdSet` seemingly functions the same as `testNullIteratorFilteredDocIdSet`, therefore potentially rendering `testNullIteratorFilteredDocIdSet` pointless as is. 

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
