### PR TITLE
Utils.fromJSONResource should take a ClassLoader

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
@@ -174,7 +174,7 @@ public class ConfigOverlay implements MapSerializable {
   //The path maps to the xml xpath and value of 1 means it is a tag with a string value and value
   // of 0 means it is an attribute with string value
 
-  private static Map<?, ?> editable_prop_map = (Map<?, ?>) Utils.fromJSONResource("EditableSolrConfigAttributes.json");
+  private static Map<?, ?> editable_prop_map = (Map<?, ?>) Utils.fromJSONResource(ConfigOverlay.class.getClassLoader(), "EditableSolrConfigAttributes.json");
 
   public static boolean isEditableProp(String path, boolean isXpath, List<String> hierarchy) {
     return !(checkEditable(path, isXpath, hierarchy) == null);

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3218,7 +3218,7 @@ public final class SolrCore implements SolrInfoBean, Closeable {
 
     static {
       @SuppressWarnings("unchecked")
-      Map<String,?> implicitPluginsInfo = (Map<String,?>) Utils.fromJSONResource("ImplicitPlugins.json");
+      Map<String,?> implicitPluginsInfo = (Map<String,?>) Utils.fromJSONResource(SolrCore.class.getClassLoader(), "ImplicitPlugins.json");
       @SuppressWarnings("unchecked")
       Map<String, Map<String,Object>> requestHandlers = (Map<String, Map<String, Object>>) implicitPluginsInfo.get(SolrRequestHandler.TYPE);
 

--- a/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerConcurrent.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerConcurrent.java
@@ -55,7 +55,7 @@ public class TestSolrConfigHandlerConcurrent extends AbstractFullDistribZkTestBa
 
   @Test
   public void test() throws Exception {
-    Map<?, ?> editable_prop_map = (Map<?, ?>) Utils.fromJSONResource("EditableSolrConfigAttributes.json");
+    Map<?, ?> editable_prop_map = (Map<?, ?>) Utils.fromJSONResource(getClass().getClassLoader(), "EditableSolrConfigAttributes.json");
     Map<?, ?> caches = (Map<?, ?>) editable_prop_map.get("query");
 
     setupRestTestHarnesses();

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -402,8 +402,8 @@ public class Utils {
     }
   }
 
-  public static Object fromJSONResource(String resourceName) {
-    final URL resource = Utils.class.getClassLoader().getResource(resourceName);
+  public static Object fromJSONResource(ClassLoader loader, String resourceName) {
+    final URL resource = loader.getResource(resourceName);
     if (null == resource) {
       throw new IllegalArgumentException("invalid resource name: " + resourceName);
     }


### PR DESCRIPTION
Not a bug necessarily but is better because it's presumptuous to assume the classloader of Utils (SolrJ)

It's really only used internally.  While debugging something, I was suspicious this could have been a problem so I changed it.  It wasn't the problem I was hunting down but nonetheless I think this change makes sense.