### PR TITLE
SOLR-16019 Supress SSL for the test, fix other test failures

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
+++ b/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
@@ -69,6 +69,7 @@ public class V2HttpCall extends HttpSolrCall {
   }
 
   protected void init() throws Exception {
+    queryParams = SolrRequestParsers.parseQueryString(req.getQueryString());
     String path = this.path;
     final String fullPath = path = path.substring(7);//strip off '/____v2'
     try {

--- a/solr/core/src/test/org/apache/solr/servlet/HttpSolrCallCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/HttpSolrCallCloudTest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.cloud.AbstractDistribZkTestBase;
@@ -37,6 +38,7 @@ import org.eclipse.jetty.server.Response;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+@SolrTestCaseJ4.SuppressSSL
 public class HttpSolrCallCloudTest extends SolrCloudTestCase {
   private static final String COLLECTION = "collection1";
   private static final int NUM_SHARD = 3;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16019

* Addresses test failures due to randomized SSL in `org.apache.solr.servlet.HttpSolrCallCloudTest.testWrongUtf8InQ`
* Addresses test failures in `org.apache.solr.handler.V2ApiIntegrationTest`
