### PR TITLE
Add Github Action to test all affected modules

### DIFF
--- a/.github/workflows/solr-affected-tests.yml
+++ b/.github/workflows/solr-affected-tests.yml
@@ -1,12 +1,9 @@
-name: SolrJ Tests
+name: Affected Module Tests
 
 on:
   pull_request:
     branches:
       - 'main'
-    paths:
-      - '.github/workflows/solrj-test.yml'
-      - 'solr/solrj/**'
 
 jobs:
   test:
@@ -29,11 +26,11 @@ jobs:
       with:
         path: |
           ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-solrj-${{ hashFiles('versions.lock') }}
+        key: ${{ runner.os }}-gradle-solr-tests-affected-${{ hashFiles('versions.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-solrj-
+          ${{ runner.os }}-gradle-solr-tests-affected--
           ${{ runner.os }}-gradle-
     - name: Initialize gradle settings
       run: ./gradlew localSettings
-    - name: Test the SolrJ Package
-      run: ./gradlew solr:solrj:test
+    - name: Test modules affected by this PR
+      run: ./gradlew runAffectedUnitTests -Paffected_module_detector.enable

--- a/.github/workflows/solr-affected-tests.yml
+++ b/.github/workflows/solr-affected-tests.yml
@@ -32,5 +32,7 @@ jobs:
           ${{ runner.os }}-gradle-
     - name: Initialize gradle settings
       run: ./gradlew localSettings
+    - name: Fetch the main branch
+      run: git fetch origin main:main
     - name: Test modules affected by this PR
       run: ./gradlew runAffectedUnitTests -Paffected_module_detector.enable

--- a/.github/workflows/solr-affected-tests.yml
+++ b/.github/workflows/solr-affected-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run SolrJ Tests
+    name: Run Tests for Affected Modules
 
     runs-on: ubuntu-latest
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,15 @@
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.3"
+  }
+}
+
 plugins {
   id "base"
   id "com.palantir.consistent-versions" version "2.0.0"
@@ -174,6 +183,7 @@ apply from: file('gradle/testing/slowest-tests-at-end.gradle')
 apply from: file('gradle/testing/failed-tests-at-end.gradle')
 apply from: file('gradle/testing/profiling.gradle')
 apply from: file('gradle/testing/beasting.gradle')
+apply from: file('gradle/testing/affected-tests.gradle')
 apply from: file('gradle/help.gradle')
 
 // Configures development for joint Lucene/ Solr composite build.

--- a/gradle/testing/affected-tests.gradle
+++ b/gradle/testing/affected-tests.gradle
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "com.dropbox.affectedmoduledetector"
+
+affectedModuleDetector {
+  baseDir = "${project.rootDir}"
+  specifiedBranch = 'main'
+  compareFrom = "SpecifiedBranchCommit" //default is PreviousCommit
+  excludedModules = [
+      ":solr:core",
+      ":solr:test-framework"
+  ]
+}
+
+allprojects {project ->
+  plugins.withType(JavaPlugin) {
+    configure(project) {
+      affectedTestConfiguration {
+        jvmTestTask = "test"
+      }
+    }
+  }
+}

--- a/solr/modules/s3-repository/src/java/org/apache/solr/s3/S3BackupRepository.java
+++ b/solr/modules/s3-repository/src/java/org/apache/solr/s3/S3BackupRepository.java
@@ -79,7 +79,7 @@ public class S3BackupRepository implements BackupRepository {
   @Override
   public URI createURI(String location) {
     if (StringUtils.isEmpty(location)) {
-      throw new IllegalArgumentException("cannot create URI with an empty location");
+      throw new IllegalArgumentException("Cannot create URI with an empty location");
     }
 
     URI result;


### PR DESCRIPTION
So I am really just testing around here. Now that we have a lot of functionality (and tests) split out into modules, it would be great if we could test the only the modules that are affected by a PR (Excluding solr-core for now).

This is pretty straightforward using the Dropbox Gradle plugin, but this does not work as well when running locally because the latest `main` commit might not actually be in the git history of the current branch (if it was forked from an earlier commit). This works well in github actions, however, because github will always merge the branch before running tests.

Still need to add docs here, and there are other issues that stem from this, such as core has a dependency on `modules/analysis-extras`, because of two tests. This means that if we change `analysis-extras`, it counts solr-core as an affected module, and thus wants to run the tests of every module except for SolrJ, since they depend on solr-core. If we move the ICUCollation field out of those tests and into analysis-extras tests, then this dependency won't exist anymore. Same for the recently created SQL Module, but that has a fix coming in the future anyways.