### PR TITLE
SOLR-16042: Fix TestSolrCloudWithKerberosAlt.testBasics failure due to minikdc locale

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -608,6 +608,8 @@ and each individual module's jar will be included in its directory's lib/ folder
 
 * SOLR-15989: Upgrade to Tika 1.28.1 (Kevin Risden)
 
+* SOLR-16042: Fix TestSolrCloudWithKerberosAlt.testBasics failure due to minikdc locale (Kevin Risden)
+
 Bug Fixes
 ---------------------
 * SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosTestServices.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosTestServices.java
@@ -198,10 +198,10 @@ public class KerberosTestServices {
    * These Locales don't generate dates that are compatible with Hadoop MiniKdc. See LocaleTest.java
    * and https://issues.apache.org/jira/browse/DIRKRB-753
    */
-  private static final List<String> incompatibleLanguagesWithMiniKdc =
+  static final List<String> incompatibleLanguagesWithMiniKdc =
       Arrays.asList(
           "mzn", "ps", "mr", "uz", "ks", "bn", "my", "sd", "pa", "ar", "th", "dz", "ja", "ne",
-          "ckb", "fa", "lrc", "ur", "ig");
+          "ckb", "fa", "lrc", "ur", "ig", "sat", "mni", "sa", "as");
 
   public static class Builder {
     private File kdcWorkDir;

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosUtils.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosUtils.java
@@ -70,6 +70,7 @@ public class KerberosUtils {
     Files.writeString(jaasFile, jaas);
     System.setProperty("java.security.auth.login.config", jaasFile.toString());
     System.setProperty("solr.kerberos.jaas.appname", appName);
+    System.setProperty("solr.kerberos.cookie.domain", "127.0.0.1");
 
     System.setProperty("solr.kerberos.principal", solrServerPrincipal);
     System.setProperty("solr.kerberos.keytab", keytabFile.getAbsolutePath());
@@ -80,6 +81,11 @@ public class KerberosUtils {
             + "\nRULE:[2:$2@$0](.*EXAMPLE.COM)s/@.*//"
             + "\nDEFAULT");
 
+    // more debugging, if needed
+    // System.setProperty("sun.security.jgss.debug", "true");
+    // System.setProperty("sun.security.krb5.debug", "true");
+    // System.setProperty("sun.security.jgss.debug", "true");
+    // System.setProperty("java.security.debug", "logincontext,policy,scl,gssloginconfig");
     return tmp;
   }
 
@@ -90,11 +96,20 @@ public class KerberosUtils {
    * @param kerberosTestServices An instance of Hadoop mini-kdc
    */
   public static void cleanupMiniKdc(KerberosTestServices kerberosTestServices) {
+    System.clearProperty("solr.jaas.debug");
     System.clearProperty("java.security.auth.login.config");
+    System.clearProperty("solr.kerberos.jaas.appname");
+    System.clearProperty("solr.kerberos.cookie.domain");
     System.clearProperty("solr.kerberos.principal");
     System.clearProperty("solr.kerberos.keytab");
     System.clearProperty("solr.kerberos.name.rules");
-    System.clearProperty("solr.jaas.debug");
+
+    // more debugging, if needed
+    System.clearProperty("sun.security.jgss.debug");
+    System.clearProperty("sun.security.krb5.debug");
+    System.clearProperty("sun.security.jgss.debug");
+    System.clearProperty("java.security.debug");
+
     if (kerberosTestServices != null) {
       kerberosTestServices.stop();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16042

* Simplifies `TestSolrCloudWithKerberosAlt` to use `KerberosUtils#setupMiniKdc`
* Make sure `KerberosUtils#cleanupMiniKdc` actually clears all system properties it sets
* Adds assertion to `LocaleTest` to confirm that `KerberosTestServices#incompatibleLanguagesWithMiniKdc` has proper list of languages to ignore
* Adds missing languages to `KerberosTestServices#incompatibleLanguagesWithMiniKdc`