### PR TITLE
SOLR-16043: Fix HDFS tests - "Command processor" thread leak

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -616,6 +616,8 @@ and each individual module's jar will be included in its directory's lib/ folder
 
 * SOLR-16042: Fix TestSolrCloudWithKerberosAlt.testBasics failure due to minikdc locale (Kevin Risden)
 
+* SOLR-16043: Fix HDFS tests - "Command processor" thread leak (Mike Drob, Kevin Risden)
+
 Bug Fixes
 ---------------------
 * SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).

--- a/solr/modules/hdfs/src/test/org/apache/solr/hdfs/cloud/HdfsTestUtil.java
+++ b/solr/modules/hdfs/src/test/org/apache/solr/hdfs/cloud/HdfsTestUtil.java
@@ -205,7 +205,7 @@ public class HdfsTestUtil {
       System.setProperty("tests.hdfs.numdatanodes", "1");
     }
 
-    int dataNodes = Integer.getInteger("tests.hdfs.numdatanodes", 2);
+    int dataNodes = Integer.getInteger("tests.hdfs.numdatanodes", 1);
     final MiniDFSCluster.Builder dfsClusterBuilder =
         new MiniDFSCluster.Builder(conf).numDataNodes(dataNodes).format(true);
     if (haTesting) {
@@ -331,15 +331,13 @@ public class HdfsTestUtil {
           }
         }
         try {
-          dfsCluster.getDataNodes().forEach(dataNode -> dataNode.shutdown());
-          dfsCluster.shutdownNameNodes();
           dfsCluster.shutdown(true);
         } catch (Error e) {
           // Added in SOLR-7134
           // Rarely, this can fail to either a NullPointerException
           // or a class not found exception. The later may fixable
           // by adding test dependencies.
-          log.warn("Exception shutting down dfsCluster", e);
+          log.error("Exception shutting down dfsCluster", e);
         }
       }
     } finally {

--- a/solr/modules/hdfs/src/test/org/apache/solr/hdfs/util/BadHdfsThreadsFilter.java
+++ b/solr/modules/hdfs/src/test/org/apache/solr/hdfs/util/BadHdfsThreadsFilter.java
@@ -42,6 +42,8 @@ public class BadHdfsThreadsFilter implements ThreadFilter {
       return true;
     } else if (name.startsWith("nioEventLoopGroup")) {
       return true; // netty threads waiting for a web server stop confirm that won't happen
+    } else if (name.startsWith("Command processor")) { // SOLR-16043 and HDFS-14997
+      return true;
     }
 
     return false;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16043

Simplifies HDFS tests by:
* defaulting to 1 datanode instead of 2
* Calling only dfsCluster.shutdown(true);
  * DataNode::shutdown should only be called from the offerService thread, otherwise deadlock might occur

This passes - but I couldn't readily reproduce the failure from SOLR-16043 on demand.
```
./gradlew test --tests "*hdfs*" --tests "*Hdfs*" --tests "*HDFS*" --tests "*Hadoop*" -Ptests.jvms=4 -Ptests.jvmargs=-XX:TieredStopAtLevel=1 -Ptests.nightly=true -Ptests.awaitsfix=false -Ptests.badapples=false -Ptests.file.encoding=UTF-8
```