### PR TITLE
Update branch_9_0 changelog

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -8,8 +8,6 @@ https://github.com/apache/solr/blob/main/solr/solr-ref-guide/modules/upgrade-not
 
 New Features
 ---------------------
-* SOLR-14789: Migrate docker image creation from docker-solr repo to solr/docker. (Houston Putman, Martijn Koster, Tim Potter, David Smiley, janhoy, Mike Drob)
-
 * SOLR-14440: Introduce new Certificate Authentication Plugin to load Principal from certificate subject. (Mike Drob)
 
 * SOLR-13528 Rate Limiting in Solr (Atri Sharma, Mike Drob)
@@ -18,29 +16,26 @@ New Features
   Improve support for arbitrary container-level plugins. Add ClusterSingleton
   support for plugins that require only one active instance in the cluster. (ab, noble)
 
-* SOLR-14613: Autoscaling replacement using placement plugins (ilan, ab, noble)
-
-* SOLR-15019: Replica placement API needs a way to fetch existing replica metrics. (ab, ilan)
+* SOLR-14613, SOLR-15019: Autoscaling replacement using placement plugins (ilan, ab, noble)
 
 * SOLR-15055: Re-implement 'withCollection'. This also adds the placement plugin support
   for rejecting replica / collection deletions that would violate placement constraints. (ab, ilan)
+
+* SOLR-15130: Support for per-collection replica placement node sets, a.k.a "node type"
+  placements. (ab, ilan)
 
 * SOLR-8138: Simple UI for issuing SQL queries (Michael Suzuki via Eric Pugh)
 
 * SOLR-14787: Payload check query parser now supports inequalities. (Kevin Watters, Gus Heck)
 
-* SOLR-15130: Support for per-collection replica placement node sets, a.k.a "node type"
-  placements. (ab, ilan)
-
-* SOLR-15164: Implement Task Management Interface (Atri Sharma, with extensive review and perf testing by Anshum Gupta, Mike Drob and Houston Putman)
+* SOLR-15164: Implement Task Management Interface
+  (Atri Sharma, with extensive review and perf testing by Anshum Gupta, Mike Drob and Houston Putman)
 
 * SOLR-15300: Report collection and shard "health" state in CLUSTERSTATUS response. (ab, janhoy)
 
 * SOLR-15423: JWTAuthPlugin now supports separate config for what SSL certs to trust when talking to IdPs (janhoy)
 
-* SOLR-15613: Enforce error-prone checks to catch all URLEqualsHashCode violations and use java.net.URI instead (Collins Abanda)
-
-* SOLR-15694: Node roles (Ishan Chattopadhyaya, noble)
+* SOLR-15694: Node roles framework, allowing restriction of certain nodes to certain tasks (Ishan Chattopadhyaya, noble)
 
 * SOLR-15197: Support temporal graph queries with DAY and WEEKDAY windows (Joel Bernstein)
 
@@ -52,8 +47,6 @@ New Features
 
 * SOLR-14660: Move HDFS support to a new HDFS module (Istvan Farkas, Kevin Risden)
 
-* SOLR-16040: Fix split packages in hdfs module (Kevin Risden)
-
 * SOLR-13989: Move Hadoop Authentication support to a new hadoop-auth module (Kevin Risden)
 
 * SOLR-15904: Move SQL support to new sql module (Kevin Risden)
@@ -64,7 +57,7 @@ Improvements
 
 * SOLR-14223: PKI Auth can bootstrap from existing key files instead of creating new keys on startup (Mike Drob)
 
-* SOLR-15153: Collection selector drop down does not sort collections (Edward Ribeiro)
+* SOLR-15153: Admin UI: Collection selector drop down does not sort collections (Edward Ribeiro)
 
 * SOLR-11725: Use corrected sample formula for computing stdDev and variance in JSON aggregations
   (hossman, Munendra S N, yonik)
@@ -75,13 +68,14 @@ Improvements
 
 * SOLR-10814: Add short-name feature to RuleBasedAuthz plugin (Mike Drob, Hrishikesh Gadre)
 
-* SOLR-7683 Introduce support to identify Solr internal request types (Atri Sharma, Hrishikesh Gadre)
+* SOLR-7683: Introduce support to identify Solr internal request types (Atri Sharma, Hrishikesh Gadre)
 
 * SOLR-14799: JWT authentication plugin only requires "sub" claim when principalClaim=sub. (Erik Hatcher)
 
 * SOLR-14878: Report solr.xml's coreRootDirectory property via System Settings API, when set (Alexandre Rafalovitch)
 
-* SOLR-14880: Support coreRootDirectory setting when create new cores from command line, in standalone mode (Alexandre Rafalovitch)
+* SOLR-14880: Support coreRootDirectory setting when create new cores from command line, in standalone mode
+  (Alexandre Rafalovitch)
 
 * SOLR-14926, SOLR-14926, SOLR-13506: Modernize and clean up search results clustering module. This issue upgrades
   the clustering module to the new Carrot2 4.x line, dropping several CVE-prone dependencies along the way.
@@ -90,27 +84,14 @@ Improvements
   properly regardless of the mode (standalone, distributed). The API has been stripped of ancient, unused, interfaces
   and simplified. (Dawid Weiss)
 
-* SOLR-14972: Prometheus: Change default port of prometheus exporter to 8989
-  because it clashed with default embedded zookeeper port (janhoy)
-
-* SOLR-14001: Docker: Removed /var/solr initialization from the Dockerfile; depend on init_var_solr.sh instead.
-  This leads to more consistent behavior no matter how /var/solr is mounted.
-  * init_var_solr.sh is now invoked by docker-entrypoint.sh; not in a bunch of other places.
-  * as before, you can set NO_INIT_VAR_SOLR=1 to short-circuit this.
-  * init_var_solr.sh no longer echo's anything.  For verbosity, set VERBOSE=yes.
-  (David Smiley)
-
-* SOLR-14957: Docker, Prometheus: Add Prometheus Exporter to docker PATH. Fix classpath issues.
-  (Houston Putman)
-
-* SOLR-14949: Docker: Ability to customize the FROM image when building.
-  (Houston Putman)
+* SOLR-14972: Prometheus: Change default port of prometheus exporter to 8989 because it clashed with default
+  embedded zookeeper port (janhoy)
 
 * SOLR-15011: /admin/logging handler will now propagate setLevel (log threshold) to all nodes
-when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
+  when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 
 * SOLR-15100: Make the ConfigSetService pluggable/configurable via <string name="configSetService" /> in solr.xml
- (baisui)
+  (baisui)
 
 * SOLR-15185: Various optimizations to the {!hash} QParser, typically used by the parallel()
   streaming expression.  The hash algorithm changed.  (David Smiley)
@@ -122,15 +103,12 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-15161: Don't encourage users to hack JSON response mimetype by documenting in examples how to
   specify wt=json use mimetype of text/plain.  (Eric Pugh)
 
-* SOLR-15203: remove deprecated parameter name jwkUrl in favour of jwksUrl for the JWK Url. (Eric Pugh)
-
-* SOLR-15276: V2 API call to look up async request status restful style of "/cluster/command-status/1000" instead of "/cluster/command-status?requestid=1000". (Eric Pugh)
+* SOLR-15276: V2 API call to look up async request status restful style of "/cluster/command-status/1000" instead
+  of "/cluster/command-status?requestid=1000". (Eric Pugh)
 
 * SOLR-15274: The QueryElevationComponent now supports loading elevation file changes on commits.
   This doesn't work in SolrCloud (but may someday).  QEC no longer supports a config file in
   the data dir. (David Smiley)
-
-* SOLR-15322: Solr releases now contain everything needed to build runable docker images (Houston Putman, hossman)
 
 * SOLR-14185: Added DocSet.iterator(LeafReaderContext) and some related changes that may add
   a minor performance boost to some cases (e.g. interval facets).  Reduced need for Filter.java.
@@ -140,34 +118,37 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 
 * SOLR-15340: Rename shardsWhitelist and extract AllowListUrlChecker to use it more broadly. (Bruno Roustant)
 
-* SOLR-14790: Docker: Move Solr Docker image documentation to the ref guide. (Houston Putman)
+* SOLR-15414: Use ConfigSet API instead of Zookeeper data node to list out configsets available in Solr Admin UI.
+  (Nazerke Seidan via Eric Pugh)
 
-* SOLR-15335: Docker: Solr has capability to build functionally-identical local and official Docker image. (hossman, Houston Putman)
-
-* SOLR-15414: Use ConfigSet API instead of Zookeeper data node to list out configsets available in Solr Admin UI. (Nazerke Seidan via Eric Pugh)
-
-* SOLR-15421: ConfigSet API also checks for solrconfig.xml when checking the existence of a configset (Andras Salamon via David Smiley)
+* SOLR-15421: ConfigSet API also checks for solrconfig.xml when checking the existence of a configset
+  (Andras Salamon via David Smiley)
 
 * SOLR-15392: Distributed Tracing request span operation names are now composed of a command/verb
   and a templated path.  The collection or core name is now in the db.instance tag.
   (David Smiley)
 
-* SOLR-15453: Update the content security policy in Jetty to allow image requests from local host and prevent security errors on the client side. (MarcusSorealheis via Houston Putman)
+* SOLR-15453: Update the content security policy in Jetty to allow image requests from local host and prevent security
+  errors on the client side. (MarcusSorealheis via Houston Putman)
 
-* SOLR-15362: Let core and collection dropdowns in Admin UI float wide to see entire core or collection name.  (Matthias Krepp, Eric Pugh)
+* SOLR-15362: Let core and collection dropdowns in Admin UI float wide to see entire core or collection name.
+  (Matthias Krepp, Eric Pugh)
 
 * SOLR-15044: When indexing nested docs via JSON, it is no longer necessary to provide child doc IDs.
   This was already working for XML & "javabin"/SolrJ.  Previously, omitting the ID would be confused
   for a partial/atomic update.  (David Smiley)
 
-* SOLR-10887: Migrate "managed-schema" file naming to "managed-schema.xml" file name, with a fallback to the legacy "managed-schema".  (Eric Pugh, David Smiley)
+* SOLR-10887: Migrate "managed-schema" file naming to "managed-schema.xml" file name, with a fallback to the legacy
+  "managed-schema".  (Eric Pugh, David Smiley)
 
-* SOLR-15630: Logging MDC values no longer include a hardcoded prefix, allowing custom logging configurations access to the plain values.
-  The default log4j2.xml PatternLayout has been updated to ensure the values are formatted with the existing prefixes. (hossman)
+* SOLR-15630: Logging MDC values no longer include a hardcoded prefix, allowing custom logging configurations access to
+  the plain values. The default log4j2.xml PatternLayout has been updated to ensure the values are formatted with the
+  existing prefixes. (hossman)
 
-* SOLR-15650: Choosing lucene defType in Solr Admin now is passed explicitly through UI, not relying on default solrconfig.xml behavior.  (Eric Pugh)
+* SOLR-15650: Choosing lucene defType in Solr Admin now is passed explicitly through UI, not relying on default
+  solrconfig.xml behavior.  (Eric Pugh)
 
-* SOL4-12848: SolrJ and the server can now recognize some standard Java system properties like
+* SOLR-12848: SolrJ and the server can now recognize some standard Java system properties like
   for an HTTP proxy.  This is only for the Apache HttpClient based SolrJ communication, not Jetty.
   (Shawn Heisey, David Smiley)
 
@@ -180,13 +161,11 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-11623: Every request handler in Solr now implements PermissionNameProvider to explicitly decide on what security
   permissions are required to access the handler (janhoy, Hrishikesh Gadre, David Smiley)
 
-* SOLR-15608: Remove deprecated methods, classes and constructors from solrj clients (janhoy)
-
 * SOLR-15705: A delete-by-id command is forwarded to all shards when using the CompositeId router with a router field
   and the route is missing from the command. (Michael Kosten via Christine Poerschke, David Smiley, Eric Pugh)
 
-* SOLR-15790: SearchHandler now includes the `rid` value in the Logging MDC for the duration of the request, allowing custom logging
-  configurations to include it. (hossman)
+* SOLR-15790: SearchHandler now includes the `rid` value in the Logging MDC for the duration of the request, allowing
+  custom logging configurations to include it. (hossman)
 
 * SOLR-15785: Custom node request handlers/endpoints that weren't in packages can now be located in JARs in solr-home/lib,
   not just WEB-INF/lib. (Nazerke Seidan, David Smiley)
@@ -194,26 +173,26 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-15376: Accept "Long" values for CollectionAdminRequest.CreateTimeRoutedAlias.setMaxFutureMs
   to support durations greater than ~ 25 days. (Nahian-Al Hasan, Gus Heck, Christine Poerschke)
 
-* SOLR-15427: Nested docs: [child limit=...] now defaults to -1 which is interpreted as unlimited.
-  (David Smiley)
-  
+* SOLR-15427: Nested docs: [child limit=...] now defaults to -1 which is interpreted as unlimited. (David Smiley)
+
 * SOLR-15786: Add the "films" example to SolrCLI via -e films parameter. (Eric Pugh)
 
-* SOLR-15834: Films example readme needs updating, including useParams support for multiple algorithms.  (Eric Pugh) 
+* SOLR-15834: Films example readme needs updating, including useParams support for multiple algorithms.  (Eric Pugh)
 
-* SOLR-15824 Improved Query Screen handling of raw query parameters.  (Betul Ince via Tim Potter, Eric Pugh)
+* SOLR-15824: Improved Query Screen handling of raw query parameters.  (Betul Ince via Tim Potter, Eric Pugh)
 
-* SOLR-15803: Compute concurrent replica assignment requests together, using the shared context to better distribute replicas. (Houston Putman)
+* SOLR-15803: Compute concurrent replica assignment requests together, using the shared context to better distribute
+  replicas. (Houston Putman)
 
 * SOLR-15213: Atomic updates: "add" now uses add-or-replace logic for child documents.  They can
   also themselves be atomic updates.  (James Ashbourne, Endika Posadas via David Smiley)
 
-* SOLR-10321: highlighting (hl.method=unified): When there are no highlights for a field, don't
+* SOLR-10321: Highlighting (hl.method=unified): When there are no highlights for a field, don't
   return the field in the response at all.  (David Smiley)
 
 * SOLR-15890: Add a limit to the Admin SQL panel if one is not included in the stmt (Joel Bernstein)
 
-* SOLR-15887: Remove <jmx/> from shipped solrconfig.xm. (Eric Pugh)
+* SOLR-15887: Remove <jmx/> from shipped solrconfig.xml. (Eric Pugh)
 
 * SOLR-14608: Faster sorting for the /export handler (Joel Bernstein)
 
@@ -244,7 +223,8 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 
 * SOLR-11905: New Admin UI Query screen input boxes for JSON query and facet DSL (janhoy)
 
-* SOLR-15556: Migrate the Ref Guide to be built with Antora, enabling many new features (Cassandra Targett, Houston Putman, Mike Drob)
+* SOLR-15556: Migrate the Ref Guide to be built with Antora, enabling many new features
+  (Cassandra Targett, Houston Putman, Mike Drob)
 
 * SOLR-15965: Use better signatures for the PKI Authentication plugin. (Mike Drob)
 
@@ -266,8 +246,6 @@ Build
 * LUCENE-9411: Fail complation on warnings, 9x gradle-only (Erick Erickson, Dawid Weiss)
   Deserves mention here as well as Lucene CHANGES.txt since it affects both.
 
-* LUCENE-10104, SOLR-15631: Upgrade forbiddenapis to version 3.2.  (Uwe Schindler)
-
 * SOLR-13671: Remove check for bare "var" declarations in validate-source-patterns (Erick Erickson, Alex Bulygin, janhoy)
 
 * SOLR-14857: Add optional gradle property to run docker tests in parallel (hossman, Houston Putman)
@@ -282,6 +260,9 @@ Build
 
 * SOLR-15603: Add an option to activate Gradle build cache, build task cleanups (Alexis Tual, Dawid Weiss)
 
+* SOLR-15613: Enforce error-prone checks to catch all URLEqualsHashCode violations and use java.net.URI instead
+  (Collins Abanda)
+
 * SOLR-15670: Introduce Gradle parameter to skip ref-guide tasks (Houston Putman, Dawid Weiss)
 
 * SOLR-15984: Ensure all used dependencies are declared (Kevin Risden)
@@ -291,6 +272,89 @@ Build
 * SOLR-15992: Globally forbid and exclude known bad dependencies (Kevin Risden)
 
 * SOLR-12228: Move bin-test scripts to packaging project and create gradle task for running them. (Mike Drob)
+
+Docker
+----------------------
+* SOLR-14789: Migrate docker image creation from docker-solr repo to solr/docker.
+  (Houston Putman, Martijn Koster, Tim Potter, David Smiley, janhoy, Mike Drob)
+
+* SOLR-14790: Docker: Move Solr Docker image documentation to the ref guide. (Houston Putman)
+
+* SOLR-15322: Solr releases now contain everything needed to build runnable docker images (Houston Putman, hossman)
+
+* SOLR-15949: Docker: the official image now uses Java 17 provided by Eclipse Temurin.  Formerly it was Java 11 from OpenJDK.
+  (janhoy, David Smiley)
+
+* SOLR-15891: The Solr Docker image uses the default file permissions from the tarball artifact (Houston Putman, janhoy)
+
+* SOLR-14001: Docker: Removed /var/solr initialization from the Dockerfile; depend on init_var_solr.sh instead.
+  This leads to more consistent behavior no matter how /var/solr is mounted.
+  * init_var_solr.sh is now invoked by docker-entrypoint.sh; not in a bunch of other places.
+  * as before, you can set NO_INIT_VAR_SOLR=1 to short-circuit this.
+  * init_var_solr.sh no longer echo's anything.  For verbosity, set VERBOSE=yes.
+  (David Smiley)
+
+* SOLR-14957: Docker, Prometheus: Add Prometheus Exporter to docker PATH. Fix classpath issues.
+  (Houston Putman)
+
+* SOLR-14949: Docker: Ability to customize the FROM image when building.
+  (Houston Putman)
+
+* SOLR-15335: Docker: Solr has capability to build functionally-identical local and official Docker image.
+  (hossman, Houston Putman)
+
+Deprecation Removals
+----------------------
+* SOLR-15203: JWT Auth plugin: Remove deprecated parameter name jwkUrl in favour of jwksUrl for the JWK Url. (Eric Pugh)
+
+* SOLR-15608: Remove deprecated methods, classes and constructors from solrj clients (janhoy)
+
+* SOLR-14272: Remove autoReplicaFailoverBadNodeExpiration and autoReplicaFailoverWorkLoopDelay for 9.0 as it was
+  deprecated in 7.1 (Anshum Gupta)
+
+* SOLR-14197: SolrResourceLoader: remove deprecated methods and do other improvements. (David Smiley)
+
+* SOLR-9909: The deprecated SolrjNamedThreadFactory has been removed. Use SolrNamedThreadFactory instead.
+  (Andras Salamon, shalin)
+
+* SOLR-14783: Remove Data Import Handler (DIH), previously deprecated (Alexandre Rafalovitch)
+
+* SOLR-14035: Remove deprecated preferLocalShards=true support in favour of the shards.preference=replica.location:local
+  alternative. (Alex Bulygin via Christine Poerschke)
+
+* SOLR-14934: Remove redundant deprecated "solr.solr.home" logic (hossman)
+
+* SOLR-14034: Remove deprecated min_rf references (Tim Dillon)
+
+* SOLR-13893: Remove support to read BlobRepository's max jar size from deprecated `runtme.lib.size` system property
+  (Erick Erickson, Kesharee Nandan Vishwakarma, Munendra S N)
+
+* SOLR-12720: Remove support for `autoReplicaFailoverWaitAfterExpiration`. (marcussorealheis, shalin)
+
+* SOLR-12823: Remove /clusterstate.json support, including support for collections created with stateFormat=1,
+  as well as support for Collection API MIGRATESTATEFORMAT action and support for the legacyCloud flag (Ilan Ginzburg).
+
+* SOLR-12847: Remove support for maxShardsPerNode. (ab)
+
+* SOLR-14244: Remove ReplicaInfo. (ab)
+
+* SOLR-14654: Remove plugin loading from .system collection (noble)
+
+* SOLR-14944: Remove the "spins" metrics - support for detection of spinning disks has been
+  removed in LUCENE-9576. (ab)
+
+* SOLR-15341: Remove indexHeapUsageBytes info from /admin/segments and /admin/luke because it's no
+  longer available in Lucene -- LUCENE-9387. (janhoy, David Smiley)
+
+* SOLR-15416: Remove metrics history collection (and MetricsHistoryHandler). (ab)
+
+* SOLR-13138: Remove deprecated LegacyBM25SimilarityFactory class. (Christine Poerschke, janhoy)
+
+* SOLR-15716: Remove deprecated SolrException.ignorePatterns and related code (hossman)
+
+* SOLR-12336: Remove Filter, SolrFilter and SolrConstantScoreQuery. Filter no longer has a need to exist due to multiple
+  JIRA issues, implemented by a number of issues. With Filter going away, there is no longer need for
+  SolrConstantScoreQuery. (Collins Abanda, Mike Drob, Tim Potter, David Smiley, Michael Gibney)
 
 Other Changes
 ----------------------
@@ -320,20 +384,10 @@ Other Changes
 * SOLR-14256: Remove HashDocSet; add DocSet.getBits() instead.  DocSet is now strictly immutable and ascending order.
   It's now locked-down to external extension; only 2 impls exist.  (David Smiley)
 
-* SOLR-14197: SolrResourceLoader: remove deprecated methods and do other improvements. (David Smiley)
-
 * SOLR-14012: Return long value for unique and hll aggregations irrespective of shard count (Munendra S N, hossman)
 
 * SOLR-14322: AbstractFullDistribZkTestBase.waitForRecoveriesToFinish now takes a timeout and time unit instead of
   assuming that we are passed value in seconds. (Mike Drob)
-
-* SOLR-13893: Remove support to read BlobRepository's max jar size from deprecated `runtme.lib.size` system property
-  (Erick Erickson, Kesharee Nandan Vishwakarma, Munendra S N)
-
-* SOLR-12720: Remove support for `autoReplicaFailoverWaitAfterExpiration`. (marcussorealheis, shalin)
-
-* SOLR-9909: The deprecated SolrjNamedThreadFactory has been removed. Use SolrNamedThreadFactory instead.
-  (Andras Salamon, shalin)
 
 * SOLR-14420: AuthenticationPlugin.authenticate accepts HttpServletRequest instead of ServletRequest. (Mike Drob)
 
@@ -346,22 +400,8 @@ Other Changes
   If you have security concerns or other reasons to disable the Admin UI, you can modify `SOLR_ADMIN_UI_DISABLED`
   `solr.in.sh`/`solr.in.cmd` at start. (marcussorealheis)
 
-* SOLR-14486: Autoscaling simulation framework no longer creates /clusterstate.json (format 1),
-  instead it creates individual per-collection /state.json files (format 2). (ab)
-
-* SOLR-12823: Remove /clusterstate.json support, including support for collections created with stateFormat=1,
-  as well as support for Collection API MIGRATESTATEFORMAT action and support for the legacyCloud flag (Ilan Ginzburg).
-
-* SOLR-12847: Remove support for maxShardsPerNode. (ab)
-
-* SOLR-14244: Remove ReplicaInfo. (ab)
-
-* SOLR-14654: Remove plugin loading from .system collection (for 9.0) (noble)
-
 * SOLR-14702: All references to "master" and "slave" replaced with "leader" and "follower" (MarcusSorealheis,
   Erick Erickson, Tomás Fernández Löbbe)
-
-* SOLR-14783: Remove Data Import Handler (DIH), previously deprecated (Alexandre Rafalovitch)
 
 * SOLR-14846: Backup/Restore classes no longer take Optional method parameters and will accept nulls instead. (Mike Drob)
 
@@ -378,16 +418,8 @@ Other Changes
 
 * SOLR-14930: Removed rule based replica placement (noble)
 
-* SOLR-14944: Remove the "spins" metrics - support for detection of spinning disks has been
-  removed in LUCENE-9576. (ab)
-
 * SOLR-14912: Clean up solr-extraction module to produce solr-extraction-* jar
   (instead of solr-cell-*). (Dawid Weiss)
-
-* SOLR-14035: Remove deprecated preferLocalShards=true support in favour of the shards.preference=replica.location:local alternative.
-  (Alex Bulygin via Christine Poerschke)
-
-* SOLR-14934: Remove redundent deprecated "solr.solr.home" logic (hossman)
 
 * SOLR-14915: Prometheus: Reduced dependencies from Solr server down to just SolrJ.  Don't add WEB-INF/lib.
   * Can run via gradle, "gradlew run"
@@ -395,19 +427,14 @@ Other Changes
   * Was missing some dependencies in lib/; now has all except SolrJ & logging.
   (David Smiley, Houston Putman)
 
-* SOLR-14789: Docker: Migrate docker image creation from docker-solr repo to solr/docker.
-  (Houston Putman, Martijn Koster, Tim Potter, David Smiley, janhoy, Mike Drob)
-
 * SOLR-15016: Replica placement plugins should use container plugins API / configs. (ab, ilan)
-
-* SOLR-14034: Remove deprecated min_rf references (Tim Dillon)
 
 * SOLR-14297: Replace commons-codec Base64 with JDK8 Base64 (Andras Salamon via Houston Putman)
 
 * SOLR-15113: Do not attempt to start Solr server when embedded ZK fails (Mike Drob)
 
-* SOLR-14067: StatelessScriptUpdateProcessorFactory moved to it's own /module/scripting/ package instead
- of shipping as part of Solr due to security concerns.  Renamed to ScriptUpdateProcessorFactory for simpler name. (Eric Pugh)
+* SOLR-14067: StatelessScriptUpdateProcessorFactory moved to it's own /module/scripting/ package instead of shipping as
+  part of Solr due to security concerns.  Renamed to ScriptUpdateProcessorFactory for simpler name. (Eric Pugh)
 
 * SOLR-15118: Switch /v2/collections APIs over to the now-preferred annotated-POJO implementation approach (Jason Gerlowski)
 
@@ -428,10 +455,8 @@ Other Changes
 
 * SOLR-15280: Fixed misleading error message in HdfsDirectoryFactory (Andras Salamon via janhoy)
 
-* SOLR-15341: Remove indexHeapUsageBytes info from /admin/segments and /admin/luke because it's no
-  longer available in Lucene -- LUCENE-9387. (janhoy, David Smiley)
-
-* SOLR-15146: Allow Collection API and Config Set API to be done in a distributed fashion without going through Overseer (Ilan Ginzburg)
+* SOLR-15146: Allow Collection API and Config Set API to be done in a distributed fashion without going through Overseer
+  (Ilan Ginzburg)
 
 * SOLR-15356: "mergeindexes" should not use UninvertingReader (FieldCache). (David Smiley)
 
@@ -455,11 +480,10 @@ Other Changes
 
 * SOLR-15409: Upgrade to Zookeeper 3.7.0 (Mike Drob)
 
-* SOLR-15416: Remove metrics history collection (and MetricsHistoryHandler). (ab)
-
 * SOLR-15439: Upgrade jose4j library used for JWT authentication processing, to v0.7.7 (janhoy)
 
-* SOLR-15385, SOLR-15535: Address many rawtypes warnings, resulting in several modified signatures in the public API. (Mike Drob, David Smiley, Christine Poerschke)
+* SOLR-15385, SOLR-15535: Address many rawtypes warnings, resulting in several modified signatures in the public API.
+  (Mike Drob, David Smiley, Christine Poerschke)
 
 * SOLR-15470: The binary distribution no longer contains test-framework jars (janhoy)
 
@@ -469,30 +493,30 @@ Other Changes
   collections/collectionName into its state.json.  For many-collection clusters, this is an
   optimization when the cluster status is fetched.  (Nazerke Seidan, David Smiley)
 
-* SOLR-15517: Remove unnecessary no-op implementation of SolrCoreAware in ExpandComponent and TermVectorComponent. (Christine Poerschke)
+* SOLR-15517: Remove unnecessary no-op implementation of SolrCoreAware in ExpandComponent and TermVectorComponent.
+  (Christine Poerschke)
 
 * SOLR-15309: Add missing IntelliJ IDEA entries to the .gitignore file (Pushkar Raste via Anshum Gupta)
 
-* SOLR-15428: Integrate the OpenJDK JMH micro benchmark framework for micro benchmarks and performance comparisons and investigation.
-  (Mark Miller)
+* SOLR-15428: Integrate the OpenJDK JMH micro benchmark framework for micro benchmarks and performance comparisons
+  and investigation. (Mark Miller)
 
 * SOLR-15111: Use JDK8 Base64 instead of own implementation (Andras Salamon via janhoy)
 
-* SOLR-15612: Remove unecessary https8 jetty module (Houston Putman)
+* SOLR-15612: Remove unnecessary https8 jetty module (Houston Putman)
 
-* SOLR-15606: Rename (deprecated) Insanity.java to NumericHidingLeafReader.java adjusting callers to match. (Christine Poerschke)
+* SOLR-15606: Rename (deprecated) Insanity.java to NumericHidingLeafReader.java adjusting callers to match.
+  (Christine Poerschke)
 
-* SOLR-13138: Remove deprecated LegacyBM25SimilarityFactory class. (Christine Poerschke, janhoy)
-
-* SOLR-15480: Make Tuple copy constructor, clone and merge consistent w.r.t. markers (EOF, EXCEPTION), field names and labels. (John Durham, Mike Drob, Christine Poerschke)
+* SOLR-15480: Make Tuple copy constructor, clone and merge consistent w.r.t. markers (EOF, EXCEPTION), field names
+  and labels. (John Durham, Mike Drob, Christine Poerschke)
 
 * SOLR-15692: Fix parsing of -zkHost flag for the bin/solr commands (janhoy)
 
 * SOLR-15455: Facilitate joint Solr/Lucene development via local dependency substitution (Dawid Weiss, Michael Gibney)
 
-* SOLR-15716: Remove deprecated SolrException.ignorePatterns and related code (hossman)
-
-* SOLR-15699: Removal of the (unused since 5.0) "updateHandler/indexWriter/closeWaitsForMerges" solrconfig.xml element. (Christine Poerschke)
+* SOLR-15699: Removal of the (unused since 5.0) "updateHandler/indexWriter/closeWaitsForMerges" solrconfig.xml element.
+  (Christine Poerschke)
 
 * SOLR-15728: Remove dead, unused log rotation code from SolrCLI (janhoy)
 
@@ -500,16 +524,17 @@ Other Changes
 
 * SOLR-15784: Remove SolrJ dependency on commons-io. (Mike Drob)
 
-* SOLR-15808: [Docker] The jattach tool is now installed with apt (janhoy)
-
 * SOLR-15809: Get rid of blacklist/whitelist terminology
   JWTAuthPlugin parameter 'algWhitelist' is now 'algAllowlist'
-  Environment variables SOLR_IP_WHITELIST and SOLR_IP_BLACKLIST are no longer supported, but replaced with SOLR_IP_ALLOWLIST and SOLR_IP_DENYLIST.
-  (janhoy)
+  Environment variables SOLR_IP_WHITELIST and SOLR_IP_BLACKLIST are no longer supported, but replaced with
+  SOLR_IP_ALLOWLIST and SOLR_IP_DENYLIST. (janhoy)
 
-* SOLR-15807: New LogListener class for tests to use to make assertions about what Log messages should or should not be produced by a test (hossman)
+* SOLR-15807: New LogListener class for tests to use to make assertions about what Log messages should or should not
+  be produced by a test (hossman)
 
-* SOLR-15907: Move JWT Authenticaion plugin to module 'jwt-auth' (janhoy)
+* SOLR-14660: Move HDFS support to a new HDFS module (Istvan Farkas, Kevin Risden)
+
+* SOLR-15907: Move JWT Authentication plugin to module 'jwt-auth' (janhoy)
 
 * SOLR-15845: Add a new SolrVersion class to manage Solr's version independently from the Lucene version we consume (janhoy)
 
@@ -524,20 +549,23 @@ Other Changes
 * SOLR-14142: Jetty's RequestLog is enabled by default. If you don't want these logs, you can disable
   via SOLR_REQUESTLOG_ENABLED=false.  (rmuir, janhoy)
 
-* SOLR-15924: Remove lucene-libs from module packaging. The lucene libraries will be included in lib/ with all other dependencies. (Houston Putman)
+* SOLR-15924: Remove lucene-libs from module packaging. The lucene libraries will be included in lib/ with all
+  other dependencies. (Houston Putman)
 
 * SOLR-15934: CloseHook is now an interface with default method implementations instead of an abstract class. (Mike Drob)
 
 * SOLR-15953: Remove unused LTRThreadModule.preClose CloseHook logic. (Christine Poerschke)
 
-* SOLR-15916: Remove dist/ from the binary release. The solr-core and solrj jars will be included in the server WEB-INF/lib directory,
-and each individual module's jar will be included in its directory's lib/ folder. (Houston Putman)
+* SOLR-15916: Remove dist/ from the binary release. The solr-core and solrj jars will be included in the server
+  WEB-INF/lib directory, and each individual module's jar will be included in its directory's lib/ folder. (Houston Putman)
 
-* SOLR-15917: "Contrib Modules" have been renamed to "Modules" and have been moved from "contrib/" to "modules/". (Houston Putman)
+* SOLR-15917: "Contrib Modules" have been renamed to "Modules" and have been moved from "contrib/" to "modules/".
+  (Houston Putman)
 
 * SOLR-15632: Upgrade to Caffeine Cache 3.0.5 (Mike Drob)
 
-* SOLR-15954: Move the Prometheus Exporter from "solr/modules/prometheus-exporter" to "solr/prometheus-exporter". (Houston Putman)
+* SOLR-15954: Move the Prometheus Exporter from "solr/modules/prometheus-exporter" to "solr/prometheus-exporter".
+  (Houston Putman)
 
 * SOLR-15957: Add port and scraping information to Solr Prometheus startup logging. (Houston Putman)
 
@@ -582,7 +610,8 @@ and each individual module's jar will be included in its directory's lib/ folder
 
 Bug Fixes
 ---------------------
-* SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status (Fa Ming).
+* SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status
+  (Fa Ming).
 
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution
   of Collection API tasks competing for a lock (Ilan Ginzburg).
@@ -597,11 +626,13 @@ Bug Fixes
 
 * SOLR-15410: Always use -Xverbosegclog for OpenJ9.  (Colvin Cowie via Eric Pugh)
 
-* SOLR-15653: Fix collection creation race that assumes a local clusterstate when the collection has only just been created. (Mark Miller)
+* SOLR-15653: Fix collection creation race that assumes a local clusterstate when the collection has only just been
+  created. (Mark Miller)
 
 * SOLR-10529: Solr UI Health Check enable/disable ping Button doesn't work (Oscar Wang via janhoy)
 
-* SOLR-15783: Prevent Logging MDC values from leaking between request threads, and set 'trace_id' in MDC as soon as it's available (hossman)
+* SOLR-15783: Prevent Logging MDC values from leaking between request threads, and set 'trace_id' in MDC as soon as it's
+  available (hossman)
 
 * SOLR-14781: Removed many unused classes that accumulated over the years. (Bence Szabo, David Smiley)
 
@@ -609,26 +640,24 @@ Bug Fixes
 
 * SOLR-15854: Let RealtimeGet component support negative filters (Tomás Fernández Löbbe)
 
-* SOLR-15501: GCSBackupRepository no longer strictly requires a pointer to a service account JSON file, allowing users running within GCP
-              to take advantage of it's "Workload Identity" and other role-based access feature. (Jacek Kikiewicz, Martin Stocker
-              via Jason Gerlowski)
+* SOLR-15501: GCSBackupRepository no longer strictly requires a pointer to a service account JSON file, allowing users
+  running within GCP to take advantage of it's "Workload Identity" and other role-based access feature.
+  (Jacek Kikiewicz, Martin Stocker via Jason Gerlowski)
 
 * SOLR-15919: Replace File with Path for many ZK operations (Mike Drob)
 
-
 * SOLR-15259: hl.fragAlignRatio now defaults to 0.33 to be faster and maybe looks nicer. (David Smiley)
-
-* SOLR-15842: Async response for backups now correctly aggregates and returns information (Houston Putman, Artem Abeleshev, Christine Poerschke)
-
-* hl.method=postings highlighter, deprecated in 7.0
 
 * SOLR-15944: The Tagger's JSON response format now always uses an object/map to represent each tag instead of an
   array, which didn't make sense. (David Smiley)
 
+* SOLR-15842: Async response for backups now correctly aggregates and returns information
+  (Houston Putman, Artem Abeleshev, Christine Poerschke)
+
 * SOLR-14595: Consistent overrequest across different facet methods for `sort:index` JSON Facet field (Michael Gibney, hossman)
 
 * SOLR-15961: Fix bug in PKIAuthenticationPlugin that can cause a request to fail with 401 Unauthorized instead
- of re-fetching expired remote keys from other nodes. (Tomás Fernández Löbbe)
+  of re-fetching expired remote keys from other nodes. (Tomás Fernández Löbbe)
 
 * SOLR-15968: Hide annoying WARN log from bin/solr zk command (janhoy, Mike Drob)
 
@@ -643,6 +672,8 @@ Bug Fixes
 * SOLR-16090: Better error message when JWT auth SIGNATURE_INVALID during token parsing (janhoy)
 
 * SOLR-15333: Reduced spurious warn logging by AbstractSpatialPrefixTreeFieldType field properties (Steffen Moldenhauer, David Smiley, Mike Drob)
+
+* SOLR-15405: Make HDFS handle little endian LUCENE-9047 (Kevin Risden)
 
 * SOLR-16009: Force Calcite's Rel simplify config flag to false to avoid erasing filters that are meaningful to Solr,
   but look like nonsense to Calcite, such as AND'd filters on the same multi-valued field (Timothy Potter, Kiran Chitturi)

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -62,7 +62,7 @@ Improvements
 * SOLR-11725: Use corrected sample formula for computing stdDev and variance in JSON aggregations
   (hossman, Munendra S N, yonik)
 
-* SOLR-14387: SolrClient.getById() will escape comma separater within ids (Markus Schuch via Mike Drob)
+* SOLR-14387: SolrClient.getById() will escape comma separator within ids (Markus Schuch via Mike Drob)
 
 * SOLR-15327: Fix typos in the code base (Edward Ribeiro via Eric Pugh)
 
@@ -74,7 +74,7 @@ Improvements
 
 * SOLR-14878: Report solr.xml's coreRootDirectory property via System Settings API, when set (Alexandre Rafalovitch)
 
-* SOLR-14880: Support coreRootDirectory setting when create new cores from command line, in standalone mode
+* SOLR-14880: Support coreRootDirectory setting when creating new cores from command line in standalone mode
   (Alexandre Rafalovitch)
 
 * SOLR-14926, SOLR-14926, SOLR-13506: Modernize and clean up search results clustering module. This issue upgrades
@@ -248,7 +248,7 @@ Build
 ---------------------
 * LUCENE-9077 LUCENE-9433: Support Gradle build, remove Ant support from trunk (Dawid Weiss, Erick Erickson, Uwe Schindler et.al.)
 
-* LUCENE-9411: Fail complation on warnings, 9x gradle-only (Erick Erickson, Dawid Weiss)
+* LUCENE-9411: Fail compilation on warnings, 9x gradle-only (Erick Erickson, Dawid Weiss)
   Deserves mention here as well as Lucene CHANGES.txt since it affects both.
 
 * SOLR-13671: Remove check for bare "var" declarations in validate-source-patterns (Erick Erickson, Alex Bulygin, janhoy)
@@ -434,7 +434,7 @@ Other Changes
 
 * SOLR-15016: Replica placement plugins should use container plugins API / configs. (ab, ilan)
 
-* SOLR-14297: Replace commons-codec Base64 with JDK8 Base64 (Andras Salamon via Houston Putman)
+* SOLR-14297: Replace commons-codec Base64 with JDK11 Base64 (Andras Salamon via Houston Putman)
 
 * SOLR-15113: Do not attempt to start Solr server when embedded ZK fails (Mike Drob)
 
@@ -506,7 +506,7 @@ Other Changes
 * SOLR-15428: Integrate the OpenJDK JMH micro benchmark framework for micro benchmarks and performance comparisons
   and investigation. (Mark Miller)
 
-* SOLR-15111: Use JDK8 Base64 instead of own implementation (Andras Salamon via janhoy)
+* SOLR-15111: Use JDK11 Base64 instead of own implementation (Andras Salamon via janhoy)
 
 * SOLR-15612: Remove unnecessary https8 jetty module (Houston Putman)
 
@@ -517,8 +517,6 @@ Other Changes
   and labels. (John Durham, Mike Drob, Christine Poerschke)
 
 * SOLR-15692: Fix parsing of -zkHost flag for the bin/solr commands (janhoy)
-
-* SOLR-15455: Facilitate joint Solr/Lucene development via local dependency substitution (Dawid Weiss, Michael Gibney)
 
 * SOLR-15699: Removal of the (unused since 5.0) "updateHandler/indexWriter/closeWaitsForMerges" solrconfig.xml element.
   (Christine Poerschke)
@@ -587,9 +585,6 @@ Other Changes
 * SOLR-15064: Atomic/partial updates to nested documents now _require_ the `\_root_` field to
   clearly show the document isn't a root document.  Solr 8 would fallback on the `\_route_` param but no longer.
   (David Smiley)
-
-* SOLR-15949: Docker: the official image now uses Java 17 provided by Eclipse Temurin.  Formerly it was Java 11 from OpenJDK.
-  (janhoy, David Smiley)
 
 * SOLR-15943: Simplify HDFS cache to account for LUCENE-10366 / LUCENE-10376 (Kevin Risden)
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -618,8 +618,6 @@ Bug Fixes
 
 * SOLR-15162: Allow readOnly parameter to be used with v2 modify collection command (Eric Pugh)
 
-* SOLR-15317: Correctly handle user principals with whitespace in PKIAuthPlugin (Dominik Dresel, Mike Drob)
-
 * SOLR-15334: Return error response when failing auth in PKIAuthPlugin (Mike Drob)
 
 * SOLR-15449: Edismax sow incorrectly affect mm parameter in multi field search (Alessandro Benedetti, Michael Gibney, David Smiley)

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -230,6 +230,7 @@ Improvements
 
 * SOLR-15982: Add end time value to backup response, standardize backup response key names and date formats (Artem Abeleshev, Christine Poerschke, Houston Putman)
 
+<<<<<<< HEAD
 * SOLR-14401: Metrics: Only SearchHandler and subclasses have "local" metrics now.
   It's now tracked as if it's another handler with a "[shard]" suffix, e.g. "/select[shard]".
   There are no longer ".distrib." named metrics; all metrics are assumed to be such except
@@ -238,6 +239,10 @@ Improvements
   (David Smiley)
 
 * SOLR-16088: De-couple Http2SolrClient and ContentStreamBase from org.apache.http (janhoy)
+=======
+* SOLR-15286: A brand new follower in the legacy mode should wait to replicate index before reporting
+  healthy (Pushkar Raste, Anshum Gupta)
+>>>>>>> 9fb40b57b97 (SOLR-15286: Add missing changelog entry)
 
 Build
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -230,7 +230,6 @@ Improvements
 
 * SOLR-15982: Add end time value to backup response, standardize backup response key names and date formats (Artem Abeleshev, Christine Poerschke, Houston Putman)
 
-<<<<<<< HEAD
 * SOLR-14401: Metrics: Only SearchHandler and subclasses have "local" metrics now.
   It's now tracked as if it's another handler with a "[shard]" suffix, e.g. "/select[shard]".
   There are no longer ".distrib." named metrics; all metrics are assumed to be such except
@@ -239,10 +238,9 @@ Improvements
   (David Smiley)
 
 * SOLR-16088: De-couple Http2SolrClient and ContentStreamBase from org.apache.http (janhoy)
-=======
+
 * SOLR-15286: A brand new follower in the legacy mode should wait to replicate index before reporting
   healthy (Pushkar Raste, Anshum Gupta)
->>>>>>> 9fb40b57b97 (SOLR-15286: Add missing changelog entry)
 
 Build
 ---------------------


### PR DESCRIPTION
This contains changes from https://github.com/apache/solr/pull/643 and https://github.com/apache/solr/pull/647
I'll be moving things around a bit more and consolidating this. I have some draft changes but should be ready to go tomorrow.

Changes from Jan's PR:
* Long lines split
* Moved [SOLR-15405](https://issues.apache.org/jira/browse/SOLR-15405) from 8.11.2 section to 9.0 section
* Removed 8.11.2 section from branch_9_0 (will re-add after 8.11.2 release)
* New "Docker" sub-heading since we have so many docker related changes
* New "Deprecation removals" sub-heading. Moved (most) removal JIRAs there
* Fixed some typos
* Remove [SOLR-15631](https://issues.apache.org/jira/browse/SOLR-15631) from 9.0 since it was in 8.11.0
* Removed [SOLR-15222 ](https://issues.apache.org/jira/browse/SOLR-15222)and [SOLR-14486 ](https://issues.apache.org/jira/browse/SOLR-14486)from 9.0 section since they are obsoleted by later commits

The intention here is to merge these updates into branch_9_0 and then take those changes to main and branch_9x.