### PR TITLE
SOLR-16048: Examine Tika dependencies that brought in javax classes

### DIFF
--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -203,8 +203,10 @@ def checkAllJARs(topDir, gitRevision, version):
     
     for file in files:
       if file.lower().endswith('.jar'):
-        if ((normRoot.endswith('/test-framework/lib') and file.startswith('jersey-'))
-            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('xml-apis-'))):
+        if ((normRoot.endswith('/modules/extraction/lib') and file.startswith('jakarta.activation-'))
+            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('jakarta.annotation-api-'))
+            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('jakarta.xml.bind-api-'))
+            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('unit-api-'))):
           print('      **WARNING**: skipping check of %s/%s: it has javax.* classes' % (root, file))
           continue
         fullPath = '%s/%s' % (root, file)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16048

* jakarta.annotation-api  - this should be allowed so exclusion in smokeTestRelease
* jakarta.activation - this should be allowed so exclusion in smokeTestRelease
* jakarta.xml.bind-api - this should be allowed so exclusion in smokeTestRelease
* unit-api - this should be allowed so exclusion in smokeTestRelease
* removed jersey and xml-api exclusion since they aren't dependencies
  anymore