### PR TITLE
SOLR-16053: Upgrade script dep versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,18 +82,6 @@ ext {
 
   minJavaVersion = JavaVersion.VERSION_11
 
-  // Declare script dependency versions outside of palantir's
-  // version unification control. These are not our main dependencies.
-  scriptDepVersions = [
-      "apache-rat": "0.11",
-      "commons-codec": "1.15",
-      "ecj": "3.19.0",
-      "javacc": "7.0.4",
-      "jflex": "1.7.0",
-      "jgit": "5.9.0.202009080501-r",
-      "flexmark": "0.61.24",
-  ]
-
   // Allow definiting external tool locations using system props.
   externalTool = { name ->
     def resolved = propertyOrDefault("${name}.exe", name as String)
@@ -112,6 +100,17 @@ ext {
     return luceneBaseVersion
   }
 }
+
+configurations {
+  groovy
+}
+
+dependencies {
+  // Use a newer groovy that doesn't have illegal reflective accesses.
+  groovy "org.codehaus.groovy:groovy-all:3.0.9"
+}
+
+apply from: file('buildSrc/scriptDepVersions.gradle')
 
 // Include smaller chunks configuring dedicated build areas.
 // Some of these intersect or add additional functionality.

--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -20,14 +20,12 @@
 // but are reused in buildSrc and across applied scripts.
 
 ext {
-  // TODO: Check if Solr needs all of these
   scriptDepVersions = [
-      "apache-rat": "0.11",
+      "apache-rat": "0.13",
       "commons-codec": "1.15",
-      "ecj": "3.27.0",
-      "flexmark": "0.61.24",
-      "javacc": "7.0.4",
-      "jflex": "1.8.2",
-      "jgit": "5.9.0.202009080501-r",
+      "ecj": "3.28.0",
+      "javacc": "7.0.10",
+      "jgit": "5.13.0.202109080827-r",
+      "flexmark": "0.64.0",
   ]
 }

--- a/gradle/generation/regenerate.gradle
+++ b/gradle/generation/regenerate.gradle
@@ -24,10 +24,11 @@ configure(rootProject) {
      */
     modifyFile = { File path, Function<String, String> modify ->
       Function<String, String> normalizeEols = { text -> text.replace("\r\n", "\n") }
-      modify = normalizeEols.andThen(modify).andThen(normalizeEols)
 
       String original = path.getText("UTF-8")
-      String modified = modify.apply(original)
+      String modified = normalizeEols.apply(original)
+      modified = modify.apply(modified)
+      modified = normalizeEols.apply(modified)
       if (!original.equals(modified)) {
         path.write(modified, "UTF-8")
       }

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -59,6 +59,10 @@ Other Changes
 
 * SOLR-15886: Remove deprecated showItems configuration value from solrconfig.xml files (Andy Lester via Eric Pugh)
 
+Build
+---------------------
+* SOLR-16053: Upgrade scriptDepVersions (Kevin Risden)
+
 ==================  9.0.0 ==================
 
 New Features

--- a/solr/core/src/java/org/apache/solr/handler/designer/SampleDocumentsLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SampleDocumentsLoader.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
-import org.apache.solr.handler.designer.SampleDocuments;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.schema.StrField;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;

--- a/solr/core/src/java/org/apache/solr/parser/ParseException.java
+++ b/solr/core/src/java/org/apache/solr/parser/ParseException.java
@@ -65,7 +65,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 
@@ -122,7 +122,9 @@ public class ParseException extends Exception {
       retval += " \"";
       tok = tok.next;
     }
-    retval += "\" at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn;
+    if (currentToken.next != null) {
+      retval += "\" at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn;
+    }
     retval += "." + EOL;
     
     

--- a/solr/core/src/java/org/apache/solr/parser/QueryParser.java
+++ b/solr/core/src/java/org/apache/solr/parser/QueryParser.java
@@ -672,33 +672,33 @@ if (splitOnWhitespace == false) {
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_4()) {
+    if (jj_3R_Clause_249_7_4()) {
     jj_scanpos = xsp;
-    if (jj_3R_5()) return true;
+    if (jj_3R_Clause_250_9_5()) return true;
     }
     return false;
   }
 
   private boolean jj_3_2()
  {
-    if (jj_3R_3()) return true;
+    if (jj_3R_MultiTerm_327_3_3()) return true;
     return false;
   }
 
-  private boolean jj_3R_5()
+  private boolean jj_3R_Clause_250_9_5()
  {
     if (jj_scan_token(STAR)) return true;
     if (jj_scan_token(COLON)) return true;
     return false;
   }
 
-  private boolean jj_3R_7()
+  private boolean jj_3R_MultiTerm_340_5_7()
  {
     if (jj_scan_token(TERM)) return true;
     return false;
   }
 
-  private boolean jj_3R_4()
+  private boolean jj_3R_Clause_249_7_4()
  {
     if (jj_scan_token(TERM)) return true;
     if (jj_scan_token(COLON)) return true;
@@ -707,27 +707,27 @@ if (splitOnWhitespace == false) {
 
   private boolean jj_3_1()
  {
-    if (jj_3R_3()) return true;
+    if (jj_3R_MultiTerm_327_3_3()) return true;
     return false;
   }
 
-  private boolean jj_3R_6()
+  private boolean jj_3R_MultiTerm_338_3_6()
  {
     return false;
   }
 
-  private boolean jj_3R_3()
+  private boolean jj_3R_MultiTerm_327_3_3()
  {
     if (jj_scan_token(TERM)) return true;
     jj_lookingAhead = true;
     jj_semLA = getToken(1).kind == TERM && allowedPostMultiTerm(getToken(2).kind);
     jj_lookingAhead = false;
-    if (!jj_semLA || jj_3R_6()) return true;
+    if (!jj_semLA || jj_3R_MultiTerm_338_3_6()) return true;
     Token xsp;
-    if (jj_3R_7()) return true;
+    if (jj_3R_MultiTerm_340_5_7()) return true;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_7()) { jj_scanpos = xsp; break; }
+      if (jj_3R_MultiTerm_340_5_7()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -828,8 +828,13 @@ if (splitOnWhitespace == false) {
   }
 
   @SuppressWarnings("serial")
-  static private final class LookaheadSuccess extends java.lang.Error { }
-  static final private LookaheadSuccess jj_ls = new LookaheadSuccess();
+  static private final class LookaheadSuccess extends java.lang.Error {
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+  static private final LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {
      if (jj_scanpos == jj_lastpos) {
        jj_la--;
@@ -959,7 +964,6 @@ if (splitOnWhitespace == false) {
      return new ParseException(token, exptokseq, tokenImage);
   }
 
-  private int trace_indent = 0;
   private boolean trace_enabled;
 
 /** Trace enabled. */

--- a/solr/core/src/java/org/apache/solr/parser/QueryParserTokenManager.java
+++ b/solr/core/src/java/org/apache/solr/parser/QueryParserTokenManager.java
@@ -17,6 +17,7 @@ package org.apache.solr.parser;
 
 
 /** Token Manager. */
+@SuppressWarnings ("unused")
 public class QueryParserTokenManager implements QueryParserConstants {
   int commentNestingDepth ;
 
@@ -1349,9 +1350,7 @@ protected Token jjFillToken()
    beginColumn = input_stream.getBeginColumn();
    endLine = input_stream.getEndLine();
    endColumn = input_stream.getEndColumn();
-   t = Token.newToken(jjmatchedKind);
-   t.kind = jjmatchedKind;
-   t.image = curTokenImage;
+   t = Token.newToken(jjmatchedKind, curTokenImage);
 
    t.beginLine = beginLine;
    t.endLine = endLine;

--- a/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
@@ -24,7 +24,6 @@ import org.apache.solr.CursorPagingTest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.LukeRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.cloud.ZkTestServer;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;

--- a/solr/core/src/test/org/apache/solr/handler/TestRequestId.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestRequestId.java
@@ -23,7 +23,6 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.util.LogListener;
 import org.apache.solr.SolrTestCaseJ4;
 

--- a/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
+++ b/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
@@ -31,7 +31,6 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.search.PostFilter;
 
 import org.junit.After;
 import org.junit.BeforeClass;

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -1305,7 +1305,7 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
 
   @Test
   /**
-   *  Test the @see {@link AtomicUpdateDocumentMerger#doInPlaceUpdateMerge(AddUpdateCommand,Set<String>)} 
+   *  Test the @see {@link AtomicUpdateDocumentMerger#doInPlaceUpdateMerge(AddUpdateCommand,Set)}
    *  method is working fine
    */
   public void testDoInPlaceUpdateMerge() throws Exception {

--- a/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
+++ b/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
@@ -60,7 +60,7 @@ public class UpdateLogTest extends SolrTestCaseJ4 {
 
   @Test
   /**
-   * @see org.apache.solr.update.UpdateLog#applyPartialUpdates(BytesRef,long,long,SolrDocumentBase)
+   * @see org.apache.solr.update.UpdateLog#applyPartialUpdates
    */
   public void testApplyPartialUpdatesOnMultipleInPlaceUpdatesInSequence() {    
     // Add a full update, two in-place updates and verify applying partial updates is working


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16053

Upgrades
* apache-rat 0.11 -> 0.13
* ecj 3.27.0 -> 3.28.0
* javacc 7.0.4 -> 7.0.10
* jgit 5.9.0.202009080501-r -> 5.13.0.202109080827-r
* flexmark 0.61.24 -> 0.64.0

Addresses
* LUCENE-10240: gradle regenerate fails on java 17
* ecj new findings
* regenerate based on new javacc
* Removes duplicate scriptDepVersions definition from build.gradle and uses buildSrc/scriptDepVersions.gradle