### PR TITLE
SOLR-15856: Fix Lucene bug in facet prefix

### DIFF
--- a/solr/core/src/java/org/apache/solr/request/DocValuesFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/DocValuesFacets.java
@@ -103,7 +103,7 @@ public class DocValuesFacets {
     }
     
     int startTermIndex, endTermIndex;
-    if (prefix!=null) {
+    if (prefix!=null && si.getValueCount() > 0) {
       startTermIndex = (int) si.lookupTerm(prefixRef.get());
       if (startTermIndex<0) startTermIndex=-startTermIndex-1;
       prefixRef.append(UnicodeUtil.BIG_TERM);

--- a/solr/core/src/test/org/apache/solr/TestRandomDVFaceting.java
+++ b/solr/core/src/test/org/apache/solr/TestRandomDVFaceting.java
@@ -254,10 +254,6 @@ public class TestRandomDVFaceting extends SolrTestCaseJ4 {
       List<String> responses = new ArrayList<>(methods.size());
       for (String method : methods) {
         if (method.equals("dv")) {
-          // SOLR-16051: Remove this if-statement when Solr begins to use Lucene 9.1
-          if (params.get("facet.prefix", "").length() > 5) {
-            continue;
-          }
           params.set("facet.field", "{!key="+facet_field+"}"+facet_field+"_dv");
           params.set("facet.method",(String) null);
         } else {

--- a/solr/core/src/test/org/apache/solr/TestRandomDVFaceting.java
+++ b/solr/core/src/test/org/apache/solr/TestRandomDVFaceting.java
@@ -254,6 +254,10 @@ public class TestRandomDVFaceting extends SolrTestCaseJ4 {
       List<String> responses = new ArrayList<>(methods.size());
       for (String method : methods) {
         if (method.equals("dv")) {
+          // SOLR-16051: Remove this if-statement when Solr begins to use Lucene 9.1
+          if (params.get("facet.prefix", "").length() > 5) {
+            continue;
+          }
           params.set("facet.field", "{!key="+facet_field+"}"+facet_field+"_dv");
           params.set("facet.method",(String) null);
         } else {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15856

This is a fix until we can upgrade to Lucene 9.1. Though there is really no need to remove it down the line.

Some example seeds to test this out: (Useful to make sure the lucene upgrade solves this, when that happens)

```
gradlew test --tests TestRandomDVFaceting.testRandomFaceting -Dtests.seed=BEA0B40F548BF849 -Dtests.multiplier=2 -Dtests.slow=true -Dtests.locale=fr-MC -Dtests.timezone=Brazil/Acre -Dtests.asserts=true -Dtests.file.encoding=UTF-8

gradlew test --tests TestRandomDVFaceting.testRandomFaceting -Dtests.seed=93F6DBA02159A430 -Dtests.multiplier=2 -Dtests.slow=true -Dtests.locale=os-RU -Dtests.timezone=Pacific/Kwajalein -Dtests.asserts=true -Dtests.file.encoding=UTF-8

gradlew test --tests TestRandomDVFaceting.testRandomFaceting -Dtests.seed=90C562820BCF5DB2 -Dtests.multiplier=3 -Dtests.slow=true -Dtests.locale=pl-PL -Dtests.timezone=Europe/Belfast -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```