### PR TITLE
Mention uniqueKey requirement for highlighting

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/highlighting.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/highlighting.adoc
@@ -28,7 +28,7 @@ Nonetheless, highlighting is very simple to use.
 == Usage
 
 === Common Highlighter Parameters
-You only need to set the `hl` and often `hl.fl` parameters to get results.
+You only need to set the `hl` and often `hl.fl` parameters to get results (assuming there's a `uniqueKey` defined in your xref:indexing-guide:schema-elements.adoc[schema]).
 The following table documents these and some other supported parameters.
 Note that many highlighting parameters support per-field overrides, such as: `f._title_txt_.hl.snippets`.
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/highlighting.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/highlighting.adoc
@@ -27,8 +27,10 @@ Nonetheless, highlighting is very simple to use.
 
 == Usage
 
+Highlighting requires that you have a `uniqueKey` defined in your xref:indexing-guide:schema-elements.adoc[schema].
+
 === Common Highlighter Parameters
-You only need to set the `hl` and often `hl.fl` parameters to get results (assuming there's a `uniqueKey` defined in your xref:indexing-guide:schema-elements.adoc[schema]).
+You need to set the `hl` and often `hl.fl` parameters to enable highlighting results to be returned.
 The following table documents these and some other supported parameters.
 Note that many highlighting parameters support per-field overrides, such as: `f._title_txt_.hl.snippets`.
 


### PR DESCRIPTION
This one is hard to catch because there's no error if you set `hl=on` and there's no `uniqueKey`. You just don't see a `highlighting` element in the response.

I didn't think a Jira is required for this small change. I did test my changes with `./gradlew buildLocalSite` so the link to the schema page works.