### PR TITLE
SOLR-16088 De-couple Http2SolrClient from org.apache.http

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -313,6 +313,8 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 
 * SOLR-15982: Add end time value to backup response, standardize backup response key names and date formats (Artem Abeleshev, Christine Poerschke, Houston Putman)
 
+* SOLR-16088: De-couple Http2SolrClient and ContentStreamBase from org.apache.http (janhoy)
+
 Build
 ---------------------
 * LUCENE-9077 LUCENE-9433: Support Gradle build, remove Ant support from trunk (Dawid Weiss, Erick Erickson, Uwe Schindler et.al.)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -719,7 +719,7 @@ public class Http2SolrClient extends SolrClient {
       switch (httpStatus) {
         case HttpStatus.OK_200:
         case HttpStatus.BAD_REQUEST_400:
-        case HttpStatus.CONFLICT_409: // 409
+        case HttpStatus.CONFLICT_409:
           break;
         case HttpStatus.MOVED_PERMANENTLY_301:
         case HttpStatus.MOVED_TEMPORARILY_302:

--- a/solr/solrj/src/java/org/apache/solr/common/EmptyEntityResolver.java
+++ b/solr/solrj/src/java/org/apache/solr/common/EmptyEntityResolver.java
@@ -21,7 +21,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLResolver;
-import org.apache.http.impl.io.EmptyInputStream;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 
@@ -41,7 +40,7 @@ public final class EmptyEntityResolver {
       new EntityResolver() {
         @Override
         public InputSource resolveEntity(String publicId, String systemId) {
-          return new InputSource(EmptyInputStream.INSTANCE);
+          return new InputSource(InputStream.nullInputStream());
         }
       };
 
@@ -50,7 +49,7 @@ public final class EmptyEntityResolver {
         @Override
         public InputStream resolveEntity(
             String publicId, String systemId, String baseURI, String namespace) {
-          return EmptyInputStream.INSTANCE;
+          return InputStream.nullInputStream();
         }
       };
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/ContentStreamBase.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ContentStreamBase.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Predicate;
 import java.util.zip.GZIPInputStream;
-import org.apache.http.entity.ContentType;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
 
@@ -47,10 +46,15 @@ public abstract class ContentStreamBase implements ContentStream {
 
   public static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
   private static final String TEXT_CSV = "text/csv";
+  public static final String TEXT_XML = "text/xml";
+  public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+  public static final String APPLICATION_GZIP = "application/gzip";
+  public static final String APPLICATION_XML = "application/xml";
+  public static final String APPLICATION_JSON = "application/json";
   private static final List<String> UNHELPFUL_TYPES =
       Arrays.asList(
-          ContentType.APPLICATION_OCTET_STREAM.getMimeType(),
-          "application/gzip",
+          APPLICATION_OCTET_STREAM,
+          APPLICATION_GZIP,
           "content/unknown");
   private static final List<String> XML_SUF = Arrays.asList(".xml", ".xml.gz", ".xml.gzip");
   private static final List<String> JSON_SUF = Arrays.asList(".json", ".json.gz", ".json.gzip");
@@ -80,9 +84,9 @@ public abstract class ContentStreamBase implements ContentStream {
       Predicate<String> endsWith = suffix -> name.toLowerCase(Locale.ROOT).endsWith(suffix);
 
       if (XML_SUF.stream().anyMatch(endsWith)) {
-        type = ContentType.APPLICATION_XML.getMimeType();
+        type = APPLICATION_XML;
       } else if (JSON_SUF.stream().anyMatch(endsWith)) {
-        type = ContentType.APPLICATION_JSON.getMimeType();
+        type = APPLICATION_JSON;
       } else if (CSV_SUF.stream().anyMatch(endsWith)) {
         type = TEXT_CSV;
       } else {
@@ -102,9 +106,9 @@ public abstract class ContentStreamBase implements ContentStream {
         data = stream.read();
       }
       if ((char) data == '<') {
-        type = ContentType.APPLICATION_XML.getMimeType();
+        type = APPLICATION_XML;
       } else if ((char) data == '{') {
-        type = ContentType.APPLICATION_JSON.getMimeType();
+        type = APPLICATION_JSON;
       }
     } catch (Exception ex) {
       // This code just eats, the exception and leaves
@@ -230,9 +234,9 @@ public abstract class ContentStreamBase implements ContentStream {
                     || str.charAt(i + 1) == '*')) // single line or multi-line comment
             || (ch == '{' || ch == '[') // start of JSON object
         ) {
-          detectedContentType = "application/json";
+          detectedContentType = APPLICATION_JSON;
         } else if (ch == '<') {
-          detectedContentType = "text/xml";
+          detectedContentType = TEXT_XML;
         }
         break;
       }

--- a/solr/solrj/src/java/org/apache/solr/common/util/ContentStreamBase.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ContentStreamBase.java
@@ -52,10 +52,7 @@ public abstract class ContentStreamBase implements ContentStream {
   public static final String APPLICATION_XML = "application/xml";
   public static final String APPLICATION_JSON = "application/json";
   private static final List<String> UNHELPFUL_TYPES =
-      Arrays.asList(
-          APPLICATION_OCTET_STREAM,
-          APPLICATION_GZIP,
-          "content/unknown");
+      Arrays.asList(APPLICATION_OCTET_STREAM, APPLICATION_GZIP, "content/unknown");
   private static final List<String> XML_SUF = Arrays.asList(".xml", ".xml.gz", ".xml.gzip");
   private static final List<String> JSON_SUF = Arrays.asList(".json", ".json.gz", ".json.gzip");
   private static final List<String> CSV_SUF = Arrays.asList(".csv", ".csv.gz", ".csv.gzip");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16088

A baby step towards getting rid of Apache Http client in solrj, removing it from three classes where it is not needed.

I was hoping that we could perhaps make the "default" solr-solr-core NOT suck in Apache Http client, only the Jetty-client, so that to use the old `HttpSolrClient` classes you'd have to add e.g. `org.apache.solr:solr-solrj-apache-http`.