### PR TITLE
SOLR-16090 Better error message when JWT auth SIGNATURE_INVALID

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -690,6 +690,8 @@ Bug Fixes
 
 * SOLR-15983: Fix ClassCastException in UpdateLog$LogReplayer.doReplay. (Christine Poerschke, David Smiley)
 
+* SOLR-16090: Better error message when JWT auth SIGNATURE_INVALID during token parsing (janhoy)
+
 ==================  8.11.2 ==================
 
 Bug Fixes

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
@@ -405,24 +405,29 @@ public class JWTAuthPlugin extends AuthenticationPlugin
     String exceptionMessage =
         authResponse.getJwtException() != null ? authResponse.getJwtException().getMessage() : "";
     if (AuthCode.SIGNATURE_INVALID.equals(authResponse.getAuthCode())) {
-      String issuer = jwtConsumer.processToClaims(header).getIssuer();
-      if (issuer != null) {
-        Optional<JWTIssuerConfig> issuerConfig =
-            issuerConfigs.stream().filter(ic -> issuer.equals(ic.getIss())).findFirst();
-        if (issuerConfig.isPresent() && issuerConfig.get().usesHttpsJwk()) {
-          log.info(
-              "Signature validation failed for issuer {}. Refreshing JWKs from IdP before trying again: {}",
-              issuer,
-              exceptionMessage);
-          for (HttpsJwks httpsJwks : issuerConfig.get().getHttpsJwks()) {
-            httpsJwks.refresh();
+      String jwt = parseAuthorizationHeader(header);
+      try {
+        String issuer = jwtConsumer.processToClaims(jwt).getIssuer();
+        if (issuer != null) {
+          Optional<JWTIssuerConfig> issuerConfig =
+              issuerConfigs.stream().filter(ic -> issuer.equals(ic.getIss())).findFirst();
+          if (issuerConfig.isPresent() && issuerConfig.get().usesHttpsJwk()) {
+            log.info(
+                "Signature validation failed for issuer {}. Refreshing JWKs from IdP before trying again: {}",
+                issuer,
+                exceptionMessage);
+            for (HttpsJwks httpsJwks : issuerConfig.get().getHttpsJwks()) {
+              httpsJwks.refresh();
+            }
+            authResponse = authenticate(header); // Retry
+            exceptionMessage =
+                authResponse.getJwtException() != null
+                    ? authResponse.getJwtException().getMessage()
+                    : "";
           }
-          authResponse = authenticate(header); // Retry
-          exceptionMessage =
-              authResponse.getJwtException() != null
-                  ? authResponse.getJwtException().getMessage()
-                  : "";
         }
+      } catch (InvalidJwtException ex) {
+        /* ignored */
       }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16090

We don't have a test for `AuthCode.SIGNATURE_INVALID` yet, so please review the fix.