### PR TITLE
SOLR-16022: Enforce special character requirements on passwords with length less than 15

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -719,6 +719,8 @@ Bug Fixes
 * SOLR-16009: Force Calcite's Rel simplify config flag to false to avoid erasing filters that are meaningful to Solr,
   but look like nonsense to Calcite, such as AND'd filters on the same multi-valued field (Timothy Potter, Kiran Chitturi)
 
+* SOLR-16022: Enforce special character requirements on passwords with length less than 15 (Timothy Potter)
+
 ==================  8.11.1 ==================
 
 Bug Fixes

--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -412,8 +412,8 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
       return false;
     }
 
-    if (!password.match(strongPasswordRegex)) {
-      $scope.validationError = "Password not strong enough! Must contain at least one lowercase letter, one uppercase letter, one digit, and one of these special characters: !@#$%^&*_-[]()";
+    if (password.length < 15 && !password.match(strongPasswordRegex)) {
+      $scope.validationError = "Password not strong enough! Must have length >= 15 or contain at least one lowercase letter, one uppercase letter, one digit, and one of these special characters: !@#$%^&*_-[]()";
       return false;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-SOLR-16022

# Description

One liner (well actually 2 but who's counting)! No regex enforcement for passwords with length >= 15

# Tests

Manually tested in browser, created user with password 123456789012345 (passes) and 12345678901234 (fails)

