### PR TITLE
SOLR-16091 Wait for all nodes to register plugins in test

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/ContainerPluginsRegistry.java
+++ b/solr/core/src/java/org/apache/solr/api/ContainerPluginsRegistry.java
@@ -87,8 +87,6 @@ public class ContainerPluginsRegistry implements ClusterPropertiesListener, MapW
     refresh();
     Phaser localPhaser = phaser; // volatile read
     if (localPhaser != null) {
-      assert localPhaser.getRegisteredParties() == 1;
-      // we should be the only ones registered, so this will advance phase each time
       localPhaser.arrive();
     }
     return false;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16091

Tests were still failing after previous set of changes, but we can make the test wait for all nodes to trigger the onChange phaser, rather than a single overseer.

@sigram I can't add you as a reviewer, but would appreciate you looking as well.