### PR TITLE
SOLR-15852: Smoketester fixes for maven artifact comparison

### DIFF
--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -828,7 +828,8 @@ def checkIdenticalMavenArtifacts(distFiles, artifacts, version):
     if reJarWar.search(artifact):
       artifactFilename = os.path.basename(artifact)
       if artifactFilename in ['solr-test-framework-%s.jar' % version]:
-        print('      Skipping artifact %s as it should not be in the binary distribution' % artifactFilename)
+        if artifactFilename in distFilenames:
+          raise RuntimeError('      solr-test-framework should not be present in solr binary distribution' % artifact)
         continue
       if artifactFilename not in distFilenames:
         raise RuntimeError('      Maven artifact %s is not present in solr binary distribution' % artifact)

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -622,12 +622,12 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
 
     validateCmd = './gradlew --no-daemon check -p solr/documentation'
     print('    run "%s"' % validateCmd)
-    #java.run_java11(validateCmd, '%s/validate.log' % unpackPath)
+    java.run_java11(validateCmd, '%s/validate.log' % unpackPath)
 
     print("    run tests w/ Java 11 and testArgs='%s'..." % testArgs)
-    #java.run_java11('./gradlew --no-daemon test %s' % testArgs, '%s/test.log' % unpackPath)
+    java.run_java11('./gradlew --no-daemon test %s' % testArgs, '%s/test.log' % unpackPath)
     print("    run integration tests w/ Java 11")
-    #java.run_java11('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest.log' % unpackPath)
+    java.run_java11('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest.log' % unpackPath)
     print("    build binary release w/ Java 11")
     java.run_java11('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/compile.log' % unpackPath)
     testSolrExample("%s/solr/packaging/build/dev" % unpackPath, java.java11_home, True)

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -424,7 +424,7 @@ def versionToTuple(version, name):
 
 reUnixPath = re.compile(r'\b[a-zA-Z_]+=(?:"(?:\\"|[^"])*"' + '|(?:\\\\.|[^"\'\\s])*' + r"|'(?:\\'|[^'])*')" \
                         + r'|(/(?:\\.|[^"\'\s])*)' \
-                        + r'|("/(?:\\.|[^"])*")'   \
+                        + r'|("/(?:\\.|[^"])*")' \
                         + r"|('/(?:\\.|[^'])*')")
 
 
@@ -622,26 +622,27 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
 
     validateCmd = './gradlew --no-daemon check -p solr/documentation'
     print('    run "%s"' % validateCmd)
-    java.run_java11(validateCmd, '%s/validate.log' % unpackPath)
+    #java.run_java11(validateCmd, '%s/validate.log' % unpackPath)
 
     print("    run tests w/ Java 11 and testArgs='%s'..." % testArgs)
-    java.run_java11('./gradlew --no-daemon test %s' % testArgs, '%s/test.log' % unpackPath)
-    print("    compile jars w/ Java 11")
-    java.run_java11('./gradlew --no-daemon jar -Dversion.release=%s' % version, '%s/compile.log' % unpackPath)
-    print("    run interation tests w/ Java 11")
-    java.run_java11('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest.log' % unpackPath)
-    testSolrExample(unpackPath, java.java11_home, True)
+    #java.run_java11('./gradlew --no-daemon test %s' % testArgs, '%s/test.log' % unpackPath)
+    print("    run integration tests w/ Java 11")
+    #java.run_java11('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest.log' % unpackPath)
+    print("    build binary release w/ Java 11")
+    java.run_java11('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/compile.log' % unpackPath)
+    testSolrExample("%s/solr/packaging/build/dev" % unpackPath, java.java11_home, True)
 
     if java.run_java17:
       print("    run tests w/ Java 17 and testArgs='%s'..." % testArgs)
-      java.run_java17('./gradlew --no-daemon test %s' % testArgs, '%s/test.log' % unpackPath)
-      print("    compile jars w/ Java 17")
-      java.run_java17('./gradlew --no-daemon jar -Dversion.release=%s' % version, '%s/compile.log' % unpackPath)
-      print("    run interation tests w/ Java 17")
-      java.run_java17('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest.log' % unpackPath)
-      testSolrExample(unpackPath, java.java17_home, True)
+      java.run_java17('./gradlew --no-daemon clean test %s' % testArgs, '%s/test-java17.log' % unpackPath)
+      print("    run integration tests w/ Java 17")
+      java.run_java17('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest-java17.log' % unpackPath)
+      print("    build binary release w/ Java 17")
+      java.run_java17('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/compile-java17.log' % unpackPath)
+      testSolrExample("%s/solr/packaging/build/dev" % unpackPath, java.java17_home, True)
 
   else:
+    # Binary tarball
     checkAllJARs(os.getcwd(), gitRevision, version)
 
     print('    copying unpacked distribution for Java 11 ...')
@@ -699,18 +700,14 @@ def readSolrOutput(p, startupEvent, failureEvent, logFile):
     f.close()
 
 def is_port_in_use(port):
-    import socket
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('localhost', port)) == 0
+  import socket
+  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    return s.connect_ex(('localhost', port)) == 0
 
 def testSolrExample(unpackPath, javaPath, isSrc):
   # test solr using some examples it comes with
   logFile = '%s/solr-example.log' % unpackPath
-  if isSrc:
-    os.chdir(unpackPath+'/solr')
-    subprocess.call(['chmod','+x',unpackPath+'/solr/bin/solr', unpackPath+'/solr/bin/solr.cmd', unpackPath+'/solr/bin/solr.in.cmd'])
-  else:
-    os.chdir(unpackPath)
+  os.chdir(unpackPath)
 
   print('      start Solr instance (log=%s)...' % logFile)
   env = {}
@@ -720,12 +717,12 @@ def testSolrExample(unpackPath, javaPath, isSrc):
 
   # Stop Solr running on port 8983 (in case a previous run didn't shutdown cleanly)
   try:
-      if not cygwin:
-        subprocess.call(['bin/solr','stop','-p','8983'])
-      else:
-        subprocess.call('env "PATH=`cygpath -S -w`:$PATH" bin/solr.cmd stop -p 8983', shell=True)
+    if not cygwin:
+      subprocess.call(['bin/solr','stop','-p','8983'])
+    else:
+      subprocess.call('env "PATH=`cygpath -S -w`:$PATH" bin/solr.cmd stop -p 8983', shell=True)
   except:
-      print('      Stop failed due to: '+sys.exc_info()[0])
+    print('      Stop failed due to: '+sys.exc_info()[0])
 
   print('      Running techproducts example on port 8983 from %s' % unpackPath)
   try:
@@ -752,20 +749,14 @@ def testSolrExample(unpackPath, javaPath, isSrc):
   finally:
     # Stop server:
     print('      stop server using: bin/solr stop -p 8983')
-    if isSrc:
-      os.chdir(unpackPath+'/solr')
-    else:
-      os.chdir(unpackPath)
+    os.chdir(unpackPath)
 
     if not cygwin:
       subprocess.call(['bin/solr','stop','-p','8983'])
     else:
       subprocess.call('env "PATH=`cygpath -S -w`:$PATH" bin/solr.cmd stop -p 8983', shell=True)
 
-  if isSrc:
-    os.chdir(unpackPath+'/solr')
-  else:
-    os.chdir(unpackPath)
+  os.chdir(unpackPath)
 
 
 def removeTrailingZeros(version):
@@ -775,7 +766,7 @@ def removeTrailingZeros(version):
 def checkMaven(baseURL, tmpDir, gitRevision, version, isSigned, keysFile):
   print('    download artifacts')
   artifacts = []
-  artifactsURL = '%s/solr/maven/org/apache/solr/' % baseURL
+  artifactsURL = '%s/maven/org/apache/solr/' % baseURL
   targetDir = '%s/maven/org/apache/solr' % tmpDir
   if not os.path.exists(targetDir):
     os.makedirs(targetDir)
@@ -836,12 +827,15 @@ def checkIdenticalMavenArtifacts(distFiles, artifacts, version):
   for artifact in artifacts:
     if reJarWar.search(artifact):
       artifactFilename = os.path.basename(artifact)
+      if artifactFilename in ['solr-test-framework-%s.jar' % version]:
+        print('      Skipping artifact %s as it should not be in the binary distribution' % artifactFilename)
+        continue
       if artifactFilename not in distFilenames:
-        raise RuntimeError('Maven artifact %s is not present in solr binary distribution' % artifact)
+        raise RuntimeError('      Maven artifact %s is not present in solr binary distribution' % artifact)
       else:
         identical = filecmp.cmp(artifact, distFilenames[artifactFilename], shallow=False)
         if not identical:
-          raise RuntimeError('Maven artifact %s is not identical to %s in solr binary distribution'
+          raise RuntimeError('      Maven artifact %s is not identical to %s in solr binary distribution'
                 % (artifact, distFilenames[artifactFilename]))
 
 
@@ -1090,11 +1084,10 @@ def main():
 def smokeTest(java, baseURL, gitRevision, version, tmpDir, isSigned, local_keys, testArgs, downloadOnly=False):
   startTime = datetime.datetime.now()
 
-  # Tests annotated @Nightly are more resource-intensive but often cover
-  # important code paths. They're disabled by default to preserve a good
-  # developer experience, but we enable them for smoke tests where we want good
-  # coverage. Still we disable @BadApple tests
-  testArgs = '-Dtests.nightly=true -Dtests.badapples=false %s' % testArgs
+  # Avoid @Nightly and @Badapple tests as they are slow and buggy
+  # Instead verify that the recent Jenkins tests pass
+  print('NOTE: Not running @Nightly or @BadApple tests. Please verify that recent Jenkins runs have passed.')
+  testArgs = '-Dtests.nightly=false -Dtests.badapples=false %s' % testArgs
 
   if FORCE_CLEAN:
     if os.path.exists(tmpDir):

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -700,9 +700,9 @@ def readSolrOutput(p, startupEvent, failureEvent, logFile):
     f.close()
 
 def is_port_in_use(port):
-  import socket
-  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-    return s.connect_ex(('localhost', port)) == 0
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(('localhost', port)) == 0
 
 def testSolrExample(unpackPath, javaPath, isSrc):
   # test solr using some examples it comes with
@@ -717,12 +717,12 @@ def testSolrExample(unpackPath, javaPath, isSrc):
 
   # Stop Solr running on port 8983 (in case a previous run didn't shutdown cleanly)
   try:
-    if not cygwin:
-      subprocess.call(['bin/solr','stop','-p','8983'])
-    else:
-      subprocess.call('env "PATH=`cygpath -S -w`:$PATH" bin/solr.cmd stop -p 8983', shell=True)
+      if not cygwin:
+        subprocess.call(['bin/solr','stop','-p','8983'])
+      else:
+        subprocess.call('env "PATH=`cygpath -S -w`:$PATH" bin/solr.cmd stop -p 8983', shell=True)
   except:
-    print('      Stop failed due to: '+sys.exc_info()[0])
+     print('      Stop failed due to: '+sys.exc_info()[0])
 
   print('      Running techproducts example on port 8983 from %s' % unpackPath)
   try:

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -629,7 +629,7 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
     print("    run integration tests w/ Java 11")
     java.run_java11('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest.log' % unpackPath)
     print("    build binary release w/ Java 11")
-    java.run_java11('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/compile.log' % unpackPath)
+    java.run_java11('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/assemble.log' % unpackPath)
     testSolrExample("%s/solr/packaging/build/dev" % unpackPath, java.java11_home, True)
 
     if java.run_java17:
@@ -638,7 +638,7 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
       print("    run integration tests w/ Java 17")
       java.run_java17('./gradlew --no-daemon integrationTest -Dversion.release=%s' % version, '%s/itest-java17.log' % unpackPath)
       print("    build binary release w/ Java 17")
-      java.run_java17('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/compile-java17.log' % unpackPath)
+      java.run_java17('./gradlew --no-daemon dev -Dversion.release=%s' % version, '%s/assemble-java17.log' % unpackPath)
       testSolrExample("%s/solr/packaging/build/dev" % unpackPath, java.java17_home, True)
 
   else:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15852

Smoketester fixes for 9.0 RC1
* Test of source tarball is now done on the `gradlew dev` output folder instead of inside source unpack where jars are missing
* Unique log-file names for java17 testing
* Do not require `solr-test-framework-x.x.x.jar` to be in binary release even if it a maven artifact
* Do not run `@Nighlty` tests in the smoketester, instead print a message to check recent Jenkins runs