### PR TITLE
SOLR-16118 Bring back NOTICE and LICENSE files in source-jar and javadoc-jar files

### DIFF
--- a/gradle/java/jar-manifest.gradle
+++ b/gradle/java/jar-manifest.gradle
@@ -27,7 +27,6 @@ subprojects {
     // Apply the manifest to any JAR or WAR file created by any project,
     // excluding those explicitly listed.
     tasks.withType(Jar)
-            .matching { t -> !["sourcesJar", "javadocJar"].contains(t.name) }
             .configureEach { task ->
                 // Compute git status once on the root project prior to assembling manifest.
                 dependsOn ":gitStatus"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16118

I don't know why these were explicitly excluded in the first place, but the smoke tester explicitly checks for these in all jar files, and all our historic maven source and javadoc artifacts have had them.

Have not had time to dig up whether it is an absolute ASF policy, but doing this change to keep it as have been.