### PR TITLE
Forbid 'String.matches(String)' API.

### DIFF
--- a/gradle/validation/forbidden-apis/java.solr.txt
+++ b/gradle/validation/forbidden-apis/java.solr.txt
@@ -18,3 +18,5 @@ java.lang.Thread#<init>()
 java.lang.Thread#<init>(java.lang.Runnable)
 java.lang.Thread#<init>(java.lang.ThreadGroup,java.lang.Runnable)
 
+@defaultMessage Prefer Pattern.compile(someRegEx).matcher(someInput).matches()
+java.lang.String#matches(java.lang.String)

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/RoutedAlias.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/RoutedAlias.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.RoutedAliasTypes;
 import org.apache.solr.cloud.ZkController;
@@ -185,8 +186,9 @@ public abstract class RoutedAlias {
   }
 
   private static Map<String, String> selectForIndex(int i, Map<String, String> original) {
+    final Pattern pattern = Pattern.compile("(((?!^router\\.).)*$|(^router\\." + i + ".*$))");
     return original.entrySet().stream()
-        .filter(e -> e.getKey().matches("(((?!^router\\.).)*$|(^router\\." + i + ".*$))"))
+        .filter(e -> pattern.matcher(e.getKey()).matches())
         .map(
             e ->
                 new SimpleEntry<>(

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
@@ -53,6 +54,8 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
 
   protected static final String INDEX_W_TIMESTAMP_REGEX =
       "index\\.[0-9]{17}"; // see SnapShooter.DATE_FMT
+  protected static final Pattern INDEX_W_TIMESTAMP_REGEX_PATTERN =
+      Pattern.compile(INDEX_W_TIMESTAMP_REGEX);
 
   // May be set by sub classes as data root, in which case getDataHome will use it as base.
   // Absolute.
@@ -357,7 +360,8 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
                 String fileName = file.getName();
                 return file.isDirectory()
                     && !file.equals(currentIndexDir)
-                    && (fileName.equals("index") || fileName.matches(INDEX_W_TIMESTAMP_REGEX));
+                    && (fileName.equals("index")
+                        || INDEX_W_TIMESTAMP_REGEX_PATTERN.matcher(fileName).matches());
               }
             });
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/AdminHandlersProxy.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/AdminHandlersProxy.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -53,6 +54,7 @@ import org.slf4j.LoggerFactory;
 public class AdminHandlersProxy {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final String PARAM_NODES = "nodes";
+  private static final Pattern PARAM_NODES_PATTERN = Pattern.compile("^[^/:]+:\\d+_[\\w/]+$");
 
   // Proxy this request to a different remote node if 'node' parameter is provided
   public static boolean maybeProxyToNodes(
@@ -81,7 +83,7 @@ public class AdminHandlersProxy {
     } else {
       nodes = new HashSet<>(Arrays.asList(nodeNames.split(",")));
       for (String nodeName : nodes) {
-        if (!nodeName.matches("^[^/:]+:\\d+_[\\w/]+$")) {
+        if (!PARAM_NODES_PATTERN.matcher(nodeName).matches()) {
           throw new SolrException(
               SolrException.ErrorCode.BAD_REQUEST,
               "Parameter " + PARAM_NODES + " has wrong format");

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageUtils.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageUtils.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.IOUtils;
@@ -255,15 +256,15 @@ public class PackageUtils {
   }
 
   public static String[] validateCollections(String collections[]) {
-    String collectionNameRegex = "^[a-zA-Z0-9_-]*$";
+    Pattern collectionNameRegexPattern = Pattern.compile("^[a-zA-Z0-9_-]*$");
     for (String c : collections) {
-      if (c.matches(collectionNameRegex) == false) {
+      if (collectionNameRegexPattern.matcher(c).matches() == false) {
         throw new SolrException(
             ErrorCode.BAD_REQUEST,
             "Invalid collection name: "
                 + c
                 + ". Didn't match the pattern: '"
-                + collectionNameRegex
+                + collectionNameRegexPattern
                 + "'");
       }
     }

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -44,6 +44,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import org.apache.http.HttpHeaders;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.util.tracing.HttpServletCarrier;
@@ -96,6 +97,7 @@ public abstract class ServletUtils {
 
           return new ServletInputStreamWrapper(super.getInputStream()) {
             @Override
+            @SuppressForbidden(reason = "String.matches(String) use in assert only")
             public void close() {
               // even though we skip closes, we let local tests know not to close so that a full
               // understanding can take place
@@ -133,6 +135,7 @@ public abstract class ServletUtils {
 
           return new ServletOutputStreamWrapper(super.getOutputStream()) {
             @Override
+            @SuppressForbidden(reason = "String.matches(String) use in assert only")
             public void close() {
               // even though we skip closes, we let local tests know not to close so that a full
               // understanding can take place

--- a/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
+++ b/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
@@ -627,7 +627,7 @@ public class HdfsDirectoryFactory extends CachingDirectoryFactory
                         fs.getFileStatus(path).isDirectory()
                             && !path.equals(currentIndexDirPath)
                             && (pathName.equals("index")
-                                || pathName.matches(INDEX_W_TIMESTAMP_REGEX));
+                                || INDEX_W_TIMESTAMP_REGEX_PATTERN.matcher(pathName).matches());
                   } catch (IOException e) {
                     log.error(
                         "Error checking if path {} is an old index directory, caused by: {}",

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.xml.xpath.XPathExpressionException;
 import org.apache.commons.io.IOUtils;
@@ -2980,7 +2981,8 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    */
   public static String randomXmlUsableUnicodeString() {
     String result = TestUtil.randomRealisticUnicodeString(random());
-    if (result.matches(".*\\p{InSpecials}.*")) {
+    Pattern specialPattern = Pattern.compile(".*\\p{InSpecials}.*");
+    if (specialPattern.matcher(result).matches()) {
       result = TestUtil.randomSimpleString(random());
     }
     return result;

--- a/solr/test-framework/src/java/org/apache/solr/util/RestTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/RestTestBase.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.regex.Pattern;
 import javax.xml.xpath.XPathExpressionException;
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.SolrJettyTestBase;
@@ -114,7 +115,8 @@ public abstract class RestTestBase extends SolrJettyTestBase {
         query = request.substring(queryStartPos + 1);
         path = request.substring(0, queryStartPos);
       }
-      if (!query.matches(".*wt=schema\\.xml.*")) { // don't overwrite wt=schema.xml
+      final Pattern WT_SCHEMA_XML_PATTERN = Pattern.compile(".*wt=schema\\.xml.*");
+      if (!WT_SCHEMA_XML_PATTERN.matcher(query).matches()) { // don't overwrite wt=schema.xml
         query = setParam(query, "wt", "xml");
       }
       request = path + '?' + setParam(query, "indent", "on");


### PR DESCRIPTION
In favour of reusable compiled patterns.

No JIRA issue as yet.
