### PR TITLE
SOLR-16127 Ordered Executor orphans locks

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/OrderedExecutor.java
+++ b/solr/core/src/java/org/apache/solr/util/OrderedExecutor.java
@@ -103,7 +103,14 @@ public class OrderedExecutor implements Executor {
         // myLock was successfully inserted
       }
       // won the lock
-      sizeSemaphore.acquire();
+      try {
+        sizeSemaphore.acquire();
+      } catch (InterruptedException e) {
+        if (t != null) {
+          map.remove(t).countDown();
+        }
+        throw e;
+      }
     }
 
     public void remove(T t) {

--- a/solr/core/src/test/org/apache/solr/util/OrderedExecutorTest.java
+++ b/solr/core/src/test/org/apache/solr/util/OrderedExecutorTest.java
@@ -267,8 +267,7 @@ public class OrderedExecutorTest extends SolrTestCase {
       t.join();
 
       // Release the first thread
-      assertFalse(
-          "Did not expect task #2 to complete", taskTwoFinished.await(0, TimeUnit.NANOSECONDS));
+      assertFalse("Did not expect task #2 to complete", taskTwoFinished.await(0, TimeUnit.SECONDS));
       blockingLatch.countDown();
 
       // Tasks without a lock can safely execute again


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16127

I'm not sure if the changes in #776 will fix this or not, but this is a test that fails with the current code.