### PR TITLE
ReleaseWizard: Add git pull for the 'gradlew documentation' todo

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -628,6 +628,14 @@ groups:
         cmd: git checkout {{ release_branch }}
         stdout: true
       - !Command
+        cmd: git clean -df && git checkout -- .
+        comment: Make sure checkout is clean and up to date
+        logfile: git_clean.log
+        tee: true
+      - !Command
+        cmd: git pull --ff-only
+        tee: true
+      - !Command
         cmd: "{{ gradle_cmd }} documentation"
     post_description: Check that the task passed. If it failed, commit fixes for the failures before proceeding.
   - !Todo


### PR DESCRIPTION
This is the first test done before building the release artifacts from release branch, so it should make sure the local branch is up to date with remote.

Discovered during 9.0 release. Tested locally.