### PR TITLE
SOLR-16138: Throw when streaming and all cores are down

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -102,6 +102,8 @@ Improvements
 
 * SOLR-17058: Add 'distrib.statsCache' parameter to disable distributed stats requests at query time. (Wei Wang, Mikhail Khludnev)
 
+* SOLR-16138: Throw a exception when issuing a streaming expression and all cores are down instead of returning 0 documents. (Antoine Bursaux via Eric Pugh)
+
 Optimizations
 ---------------------
 * SOLR-17144: Close searcherExecutor thread per core after 1 minute (Pierre Salagnac, Christine Poerschke)

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/BadClusterTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/BadClusterTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.solrj.io.stream;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
+import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.MultiMapSolrParams;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+*  Tests behaviors of CloudSolrStream when the cluster is behaving badly.
+**/
+
+@SolrTestCaseJ4.SuppressSSL
+@LuceneTestCase.SuppressCodecs({"Lucene3x", "Lucene40","Lucene41","Lucene42","Lucene45"})
+public class BadClusterTest extends SolrCloudTestCase {
+
+  private static final String collection = "streams";
+  private static final String id = "id";
+
+  private static final StreamFactory streamFactory = new StreamFactory()
+      .withFunctionName("search", CloudSolrStream.class);
+
+  private static String zkHost;
+
+  @BeforeClass
+  public static void configureCluster() throws Exception {
+    configureCluster(1)
+        .addConfig("conf", getFile("solrj").toPath().resolve("solr").resolve("configsets").resolve("streaming").resolve("conf"))
+        .configure();
+
+    CollectionAdminRequest.createCollection(collection, "conf", 1, 1)
+        .process(cluster.getSolrClient());
+    cluster.waitForActiveCollection(collection, 1, 1);
+
+    zkHost = cluster.getZkServer().getZkAddress();
+    streamFactory.withCollectionZkHost(collection, zkHost);
+  }
+
+  // test order is important because the cluster progressively gets worse, but it is only created once in BeforeClass as in other tests
+  // ordering can not be strictly enforced with JUnit annotations because of parallel executions, so we have this aggregated test instead
+  @Test
+  public void testBadCluster() throws Exception {
+    testEmptyCollection();
+    testAllNodesDown();
+    testClusterShutdown();
+  }
+
+  private void testEmptyCollection() throws Exception {
+    CloudSolrStream stream = new CloudSolrStream(buildSearchExpression(), streamFactory);
+    assertEquals(0, getTuples(stream).size());
+  }
+
+  private void testAllNodesDown() throws Exception {
+
+    CloudSolrStream stream = new CloudSolrStream(buildSearchExpression(), streamFactory);
+    cluster.expireZkSession(cluster.getReplicaJetty(getReplicas().get(0)));
+
+    try {
+      getTuples(stream);
+      fail("Expected IOException");
+    } catch (IOException ioe) {
+    }
+  }
+
+  private void testClusterShutdown() throws Exception {
+
+    CloudSolrStream stream = new CloudSolrStream(buildSearchExpression(), streamFactory);
+    cluster.shutdown();
+
+    try {
+      getTuples(stream);
+      fail("Expected IOException: SolrException: TimeoutException");
+    } catch (IOException ioe) {
+      SolrException se = (SolrException) ioe.getCause();
+      TimeoutException te = (TimeoutException) se.getCause();
+      assertNotNull(te);
+    }
+  }
+
+  private StreamExpression buildSearchExpression() {
+    StreamExpression expression = new StreamExpression("search");
+    expression.addParameter(collection);
+    expression.addParameter(new StreamExpressionNamedParameter(CommonParams.Q, "*:*"));
+    expression.addParameter(new StreamExpressionNamedParameter(CommonParams.FL, id));
+    expression.addParameter(new StreamExpressionNamedParameter(CommonParams.SORT, id + " asc"));
+    return expression;
+  }
+
+  private List<Replica> getReplicas() throws IOException {
+    return TupleStream.getReplicas(zkHost, collection, null, new MultiMapSolrParams(Map.of()));
+  }
+
+  private List<Tuple> getTuples(TupleStream tupleStream) throws IOException {
+    tupleStream.open();
+    List<Tuple> tuples = new ArrayList<>();
+    for(;;) {
+      Tuple t = tupleStream.read();
+      if(t.EOF) {
+        break;
+      } else {
+        tuples.add(t);
+      }
+    }
+    tupleStream.close();
+    return tuples;
+  }
+}

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/BadClusterTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/BadClusterTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
@@ -36,26 +35,29 @@ import org.apache.solr.common.params.MultiMapSolrParams;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
-*  Tests behaviors of CloudSolrStream when the cluster is behaving badly.
-**/
-
+/** Tests behaviors of CloudSolrStream when the cluster is behaving badly. */
 @SolrTestCaseJ4.SuppressSSL
-@LuceneTestCase.SuppressCodecs({"Lucene3x", "Lucene40","Lucene41","Lucene42","Lucene45"})
 public class BadClusterTest extends SolrCloudTestCase {
 
   private static final String collection = "streams";
   private static final String id = "id";
 
-  private static final StreamFactory streamFactory = new StreamFactory()
-      .withFunctionName("search", CloudSolrStream.class);
+  private static final StreamFactory streamFactory =
+      new StreamFactory().withFunctionName("search", CloudSolrStream.class);
 
   private static String zkHost;
 
   @BeforeClass
   public static void configureCluster() throws Exception {
     configureCluster(1)
-        .addConfig("conf", getFile("solrj").toPath().resolve("solr").resolve("configsets").resolve("streaming").resolve("conf"))
+        .addConfig(
+            "conf",
+            getFile("solrj")
+                .toPath()
+                .resolve("solr")
+                .resolve("configsets")
+                .resolve("streaming")
+                .resolve("conf"))
         .configure();
 
     CollectionAdminRequest.createCollection(collection, "conf", 1, 1)
@@ -66,8 +68,10 @@ public class BadClusterTest extends SolrCloudTestCase {
     streamFactory.withCollectionZkHost(collection, zkHost);
   }
 
-  // test order is important because the cluster progressively gets worse, but it is only created once in BeforeClass as in other tests
-  // ordering can not be strictly enforced with JUnit annotations because of parallel executions, so we have this aggregated test instead
+  // test order is important because the cluster progressively gets worse, but it is only created
+  // once in BeforeClass as in other tests
+  // ordering can not be strictly enforced with JUnit annotations because of parallel executions, so
+  // we have this aggregated test instead
   @Test
   public void testBadCluster() throws Exception {
     testEmptyCollection();
@@ -123,9 +127,9 @@ public class BadClusterTest extends SolrCloudTestCase {
   private List<Tuple> getTuples(TupleStream tupleStream) throws IOException {
     tupleStream.open();
     List<Tuple> tuples = new ArrayList<>();
-    for(;;) {
+    for (; ; ) {
       Tuple t = tupleStream.read();
-      if(t.EOF) {
+      if (t.EOF) {
         break;
       } else {
         tuples.add(t);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16138

# Description

When reading from a `CloudSolrStream`, if all Solr cores are down, we receive an empty stream (EOF from the first `read()` operation).

Instead, an exception should be thrown to represent that the Solr cluster is unreachable, even if the ZooKeeper cluster itself is reachable.

# Solution

Throw `IOException` in `CloudSolrStream.open()` when all shards or replicas are unavailable.

# Tests

I added a set of three tests to validate behaviors on badly behaving clusters. These tests are in their own suite, for reasons explained in the comments: we progressively damage the cluster, so it can not be run along "normal" tests.

Tests 1 (empty collection) and 3 (cluster shutdown) were already working as expected, but I left them in for completeness.

Test 2 (all nodes down) demonstrates the issue explained in Jira. On the current version of Solr, `getTuples(stream)` on line 89 would successfully return an empty list. With the changes made in this PR, it throws `IOException`, which the test asserts.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- ~~[ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)~~
