### PR TITLE
New release wizard build failures step

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -289,6 +289,13 @@ groups:
     title: Select JIRA issues to be included
     description: Set the appropriate "Fix Version" in JIRA for the issues that should be included in the release.
   - !Todo
+    id: fix_build_failures
+    title: Look into common build failures
+    description: |
+      Look over recent build results sent to the builds@lucene.apache.org list and try to address any recurring
+      failures. It's best to fix common failures now, so they don't pop up later and interfere with release smoke
+      testing. Build email archives are available at https://lists.apache.org/list.html?builds@lucene.apache.org.
+  - !Todo
     id: decide_branch_date
     title: Decide the date for branching
     types:
@@ -299,7 +306,7 @@ groups:
       name: branch_date
   - !Todo
     id: decide_freeze_length
-    title: Decide the lenght of feature freeze
+    title: Decide the length of feature freeze
     types:
     - major
     - minor

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -292,9 +292,10 @@ groups:
     id: fix_build_failures
     title: Look into common build failures
     description: |
-      Look over recent build results sent to the builds@lucene.apache.org list and try to address any recurring
+      Look over recent build results sent to the builds@solr.apache.org list and try to address any recurring
       failures. It's best to fix common failures now, so they don't pop up later and interfere with release smoke
-      testing. Build email archives are available at https://lists.apache.org/list.html?builds@lucene.apache.org.
+      testing. Build email archives are available at https://lists.apache.org/list.html?builds@solr.apache.org.
+      You can also find failure statistics at http://fucit.org/solr-jenkins-reports/
   - !Todo
     id: decide_branch_date
     title: Decide the date for branching


### PR DESCRIPTION
Cherry-picked from Lucene https://github.com/apache/lucene/pull/789

@jtibshirani I don't know if you are aware of the http://fucit.org/solr-jenkins-reports/ site, I added it to the Solr wizard since it is a nice tool to quickly spot failed tests. It also covers Lucene Jenkins, but I'm not sure if it is as useful for Lucene as for Solr, since Solr has a bigger problem with unstable tests.