### PR TITLE
Update github PR link to use the new solr repo

### DIFF
--- a/gradle/documentation/changes-to-html/changes2html.pl
+++ b/gradle/documentation/changes-to-html/changes2html.pl
@@ -25,7 +25,7 @@ use strict;
 use warnings;
 
 my $jira_url_prefix = 'http://issues.apache.org/jira/browse/';
-my $github_pull_request_prefix = 'https://github.com/apache/lucene-solr/pull/';
+my $github_pull_request_prefix = 'https://github.com/apache/solr/pull/';
 my $month_regex = &setup_month_regex;
 my %month_nums = &setup_month_nums;
 my %lucene_bugzilla_jira_map = &setup_lucene_bugzilla_jira_map;
@@ -575,6 +575,9 @@ for my $rel (@releases) {
       $item =~ s{((?:(?:(?:github|gh)\s+)?pull\s+request\s*(?:\#?\s*)?|gh-)(\d+))}
                 {<a href="${github_pull_request_prefix}$2">$1</a>}gi;
       # Link "LUCENE_CHANGES.txt" to Lucene's same-release Changes.html
+      # TODO: We can no longer rely on this since Solr may have a different Lucene version
+      # But it will still work for pre-9.0 changes, and from 9.0 we can instead provide
+      # full links.
       if ($product eq 'SOLR') {
         $item =~ s[(LUCENE_CHANGES.txt)]
                   [<a href="${lucene_javadoc_url}changes/Changes.html">$1</a>]g;

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -5198,7 +5198,7 @@ Versions of Major Components
 ---------------------
 Apache Tika 1.16
 Carrot2 3.15.0
-Velocity 1.7 and Velocity  and Velocity Tools 2.0
+Velocity 1.7 and Velocity Tools 2.0
 Apache UIMA 2.3.1
 Apache ZooKeeper 3.4.10
 Jetty 9.3.20.v20170531

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -5198,7 +5198,7 @@ Versions of Major Components
 ---------------------
 Apache Tika 1.16
 Carrot2 3.15.0
-Velocity 1.7 and Velocity Tools 2.0
+Velocity 1.7 and Velocity  and Velocity Tools 2.0
 Apache UIMA 2.3.1
 Apache ZooKeeper 3.4.10
 Jetty 9.3.20.v20170531
@@ -12389,7 +12389,7 @@ Other Changes
 
 * SOLR-6448: Add SolrJ support for all current Collection API calls. (Anshum Gupta)
 
-* Fixed a typo in various solrconfig.xml files.  (sdumitriu - pull request #120)
+* Fixed a typo in various solrconfig.xml files.  (sdumitriu)
 
 * SOLR-6895: SolrServer classes are renamed to *SolrClient.  The existing
   classes still exist, but are deprecated. (Alan Woodward, Erik Hatcher)
@@ -14000,7 +14000,7 @@ Other Changes
   (Karl Wright via Shawn Heisey)
 
 * SOLR-2794: change the default of hl.phraseLimit to 5000.
-  (Michael Della Bitta via Robert Muir, Koji, zarni - pull request #11)
+  (Michael Della Bitta via Robert Muir, Koji, zarni)
 
 * SOLR-5632: Improve response message for reloading a non-existent core.
   (Anshum Gupta via Mark Miller)


### PR DESCRIPTION
When we convert CHANGES.txt to Changes.html, we support adding href links to text like "Pull Request #123". I counted and we only use it like 2 times, and both of those were incorrect, so I removed them.

NB: Perhaps we should allow a pattern like this as well, so you can add PRs to CHANGES without a JIRA:

```
* #794 Fix a bug
```

I.e. in addition to the pattern `((?:(?:(?:github|gh)\s+)?pull\s+request\s*(?:\#?\s*)?|gh-)(\d+))` also support `^\*\s+\#\d{1..4}`.