### PR TITLE
[RefGuide] Fix github link on learning-to-rank.adoc page

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
@@ -472,7 +472,7 @@ Read more about model evolution in the <<LTR Lifecycle>> section of this page.
 
 === Training Example
 
-Example training data and a demo `train_and_upload_demo_model.py` script can be found in the `solr/modules/ltr/example` folder in the https://gitbox.apache.org/repos/asf?p=solr.git;a=tree;f=solr/modules/ltr/example[Apache lucene-solr Git repository] (mirrored on https://github.com/apache/lucene-solr/tree/releases/lucene-solr/{solr-full-version}/solr/modules/ltr/example[github.com]).
+Example training data and a demo `train_and_upload_demo_model.py` script can be found in the `solr/modules/ltr/example` folder in the https://gitbox.apache.org/repos/asf?p=solr.git;a=tree;f=solr/modules/ltr/example[Apache Solr Git repository] (mirrored on https://github.com/apache/solr/tree/releases/solr/{solr-full-version}/solr/modules/ltr/example[github.com]).
 This example folder is not shipped in the Solr binary release.
 
 == Installation of LTR


### PR DESCRIPTION
Once we tag the 9.0.0 release I **believe** that this will be the correct link (won't work right yet)