### PR TITLE
SOLR-13044: fix searcher/core close sequence

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1009,7 +1009,6 @@ public class IndexFetcher {
   }
 
   private void openNewSearcherAndUpdateCommitPoint() throws IOException {
-    RefCounted<SolrIndexSearcher> searcher = null;
     IndexCommit commitPoint;
     // must get the latest solrCore object because the one we have might be closed because of a
     // reload
@@ -1020,18 +1019,20 @@ public class IndexFetcher {
       }
       @SuppressWarnings("unchecked")
       Future<Void>[] waitSearcher = (Future<Void>[]) Array.newInstance(Future.class, 1);
-      searcher = core.getSearcher(true, true, waitSearcher, true);
-      if (waitSearcher[0] != null) {
-        try {
-          waitSearcher[0].get();
-        } catch (InterruptedException | ExecutionException e) {
-          SolrException.log(log, e);
+      RefCounted<SolrIndexSearcher> searcher = core.getSearcher(true, true, waitSearcher, true);
+      try {
+        if (waitSearcher[0] != null) {
+          try {
+            waitSearcher[0].get();
+          } catch (InterruptedException | ExecutionException e) {
+            SolrException.log(log, e);
+          }
         }
-      }
-      commitPoint = searcher.get().getIndexReader().getIndexCommit();
-    } finally {
-      if (searcher != null) {
-        searcher.decref();
+        commitPoint = searcher.get().getIndexReader().getIndexCommit();
+      } finally {
+        if (searcher != null) {
+          searcher.decref();
+        }
       }
     }
 


### PR DESCRIPTION
Fixing a bug in previous PR for this issue as pointed out by @magibney https://github.com/apache/solr/pull/794#issuecomment-1105477466

It'd be nice if RefCounted was Autocloseable