### PR TITLE
warn about unused UnifiedSolrHighlighter configuration

### DIFF
--- a/solr/core/src/java/org/apache/solr/highlight/UnifiedSolrHighlighter.java
+++ b/solr/core/src/java/org/apache/solr/highlight/UnifiedSolrHighlighter.java
@@ -17,6 +17,7 @@
 package org.apache.solr.highlight;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.text.BreakIterator;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,6 +54,8 @@ import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SolrReturnFields;
 import org.apache.solr.util.RTimerTree;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Highlighter impl that uses {@link UnifiedHighlighter}
@@ -132,10 +135,16 @@ import org.apache.solr.util.plugin.PluginInfoInitialized;
  */
 public class UnifiedSolrHighlighter extends SolrHighlighter implements PluginInfoInitialized {
 
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   protected static final String SNIPPET_SEPARATOR = "\u0000";
 
   @Override
-  public void init(PluginInfo info) {}
+  public void init(PluginInfo info) {
+    for (PluginInfo child : info.children) {
+      log.warn("unused configuration: {}", child);
+    }
+  }
 
   @Override
   public NamedList<Object> doHighlighting(

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-highlight.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-highlight.xml
@@ -34,7 +34,7 @@
   <requestHandler name="/select" class="solr.SearchHandler"/>
 
   <searchComponent class="solr.HighlightComponent" name="highlight">
-    <highlighting class="org.apache.solr.highlight.DummyHighlighter">
+    <highlighting class="${solr.highlighting:org.apache.solr.highlight.DummyHighlighter}">
       <!-- Configure the standard fragmenter -->
       <fragmenter name="gap" class="org.apache.solr.highlight.GapFragmenter" default="true">
         <lst name="defaults">

--- a/solr/core/src/test/org/apache/solr/highlight/HighlighterConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/highlight/HighlighterConfigTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.handler.component.HighlightComponent;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,10 +30,20 @@ import org.slf4j.LoggerFactory;
 public class HighlighterConfigTest extends SolrTestCaseJ4 {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static boolean useUnified;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    useUnified = random().nextBoolean();
+    if (useUnified) {
+      System.setProperty("solr.highlighting", UnifiedSolrHighlighter.class.getName());
+    }
     initCore("solrconfig-highlight.xml", "schema.xml");
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    System.clearProperty("solr.highlighting");
   }
 
   @Override
@@ -53,6 +64,10 @@ public class HighlighterConfigTest extends SolrTestCaseJ4 {
     SolrHighlighter highlighter = getHighlighter();
     log.info("highlighter");
 
+    if (useUnified) {
+      assertTrue(highlighter instanceof UnifiedSolrHighlighter);
+      return;
+    }
     assertTrue(highlighter instanceof DummyHighlighter);
 
     // check to see that doHighlight is called from the DummyHighlighter


### PR DESCRIPTION
No JIRA issue as yet but would create one if this seem useful.

The default config has a comment

```
<!-- note: the hl.method=unified highlighter is not configured here; it's completely configured
    via parameters.  The below configuration supports hl.method=original and fastVector. -->
```

i.e. https://github.com/apache/solr/blob/branch_9_0/solr/server/solr/configsets/_default/conf/solrconfig.xml#L849-L850 but it still could be useful to flag unused configuration in the logs?