### PR TITLE
SOLR-16169: IndexBasedSpellChecker with empty spellcheck.q results in NegativeArraySizeException

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -67,6 +67,8 @@ Bug Fixes
 
 * SOLR-16168: Spellcheck NPE if invalid dictionary name is provided (Kevin Risden)
 
+* SOLR-16169: IndexBasedSpellChecker with empty spellcheck.q results in NegativeArraySizeException (Kevin Risden)
+
 Other Changes
 ---------------------
 * SOLR-15897: Remove <jmx/> from all unit test solrconfig.xml files. (Eric Pugh)

--- a/solr/core/src/java/org/apache/solr/spelling/AbstractLuceneSpellChecker.java
+++ b/solr/core/src/java/org/apache/solr/spelling/AbstractLuceneSpellChecker.java
@@ -141,6 +141,10 @@ public abstract class AbstractLuceneSpellChecker extends SolrSpellChecker {
 
     int count = Math.max(options.count, AbstractLuceneSpellChecker.DEFAULT_SUGGESTION_COUNT);
     for (Token token : options.tokens) {
+      if (token.length() == 0) {
+        result.add(token, Collections.emptyList());
+        continue;
+      }
       String tokenText = new String(token.buffer(), 0, token.length());
       term = new Term(field, tokenText);
       int docFreq = 0;

--- a/solr/core/src/java/org/apache/solr/spelling/DirectSolrSpellChecker.java
+++ b/solr/core/src/java/org/apache/solr/spelling/DirectSolrSpellChecker.java
@@ -186,6 +186,10 @@ public class DirectSolrSpellChecker extends SolrSpellChecker {
         (options.accuracy == Float.MIN_VALUE) ? checker.getAccuracy() : options.accuracy;
 
     for (Token token : options.tokens) {
+      if (token.length() == 0) {
+        result.add(token, Collections.emptyList());
+        continue;
+      }
       String tokenText = token.toString();
       Term term = new Term(field, tokenText);
       int freq = options.reader.docFreq(term);

--- a/solr/core/src/test/org/apache/solr/spelling/DirectSolrSpellCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/DirectSolrSpellCheckerTest.java
@@ -17,6 +17,7 @@
 package org.apache.solr.spelling;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.lucene.util.LuceneTestCase.SuppressTempFileChecks;
 import org.apache.solr.SolrTestCaseJ4;
@@ -70,7 +71,7 @@ public class DirectSolrSpellCheckerTest extends SolrTestCaseJ4 {
               SpellingOptions spellOpts = new SpellingOptions(tokens, searcher.getIndexReader());
               SpellingResult result = checker.getSuggestions(spellOpts);
               assertNotNull("result shouldn't be null", result);
-              Map<String, Integer> suggestions = result.get(tokens.iterator().next());
+              Map<String, Integer> suggestions = result.get(spellOpts.tokens.iterator().next());
               assertFalse("suggestions shouldn't be empty", suggestions.isEmpty());
               Map.Entry<String, Integer> entry = suggestions.entrySet().iterator().next();
               assertEquals("foo", entry.getKey());
@@ -80,6 +81,14 @@ public class DirectSolrSpellCheckerTest extends SolrTestCaseJ4 {
 
               // check that 'super' is *not* corrected
               spellOpts.tokens = queryConverter.convert("super");
+              result = checker.getSuggestions(spellOpts);
+              assertNotNull("result shouldn't be null", result);
+              suggestions = result.get(spellOpts.tokens.iterator().next());
+              assertNotNull("suggestions shouldn't be null", suggestions);
+              assertTrue("suggestions should be empty", suggestions.isEmpty());
+
+              // Check empty token due to spellcheck.q = ""
+              spellOpts.tokens = Collections.singletonList(new Token("", 0, 0));
               result = checker.getSuggestions(spellOpts);
               assertNotNull("result shouldn't be null", result);
               suggestions = result.get(spellOpts.tokens.iterator().next());
@@ -138,7 +147,7 @@ public class DirectSolrSpellCheckerTest extends SolrTestCaseJ4 {
               SpellingOptions spellOpts = new SpellingOptions(tokens, searcher.getIndexReader());
               SpellingResult result = checker.getSuggestions(spellOpts);
               assertNotNull("result shouldn't be null", result);
-              Map<String, Integer> suggestions = result.get(tokens.iterator().next());
+              Map<String, Integer> suggestions = result.get(spellOpts.tokens.iterator().next());
               assertNotNull("suggestions shouldn't be null", suggestions);
 
               if (limitQueryLength) {

--- a/solr/core/src/test/org/apache/solr/spelling/FileBasedSpellCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/FileBasedSpellCheckerTest.java
@@ -18,6 +18,7 @@ package org.apache.solr.spelling;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressTempFileChecks;
@@ -80,8 +81,8 @@ public class FileBasedSpellCheckerTest extends SolrTestCaseJ4 {
               Collection<Token> tokens = queryConverter.convert("fob");
               SpellingOptions spellOpts = new SpellingOptions(tokens, searcher.getIndexReader());
               SpellingResult result = checker.getSuggestions(spellOpts);
-              assertTrue("result is null and it shouldn't be", result != null);
-              Map<String, Integer> suggestions = result.get(tokens.iterator().next());
+              assertNotNull("result shouldn't be null", result);
+              Map<String, Integer> suggestions = result.get(spellOpts.tokens.iterator().next());
               Map.Entry<String, Integer> entry = suggestions.entrySet().iterator().next();
               assertTrue(
                   entry.getKey() + " is not equal to " + "foo",
@@ -92,9 +93,18 @@ public class FileBasedSpellCheckerTest extends SolrTestCaseJ4 {
 
               spellOpts.tokens = queryConverter.convert("super");
               result = checker.getSuggestions(spellOpts);
-              assertTrue("result is null and it shouldn't be", result != null);
-              suggestions = result.get(tokens.iterator().next());
-              assertTrue("suggestions is not null and it should be", suggestions == null);
+              assertNotNull("result shouldn't be null", result);
+              suggestions = result.get(spellOpts.tokens.iterator().next());
+              assertNotNull("suggestions shouldn't be null", suggestions);
+              assertTrue("suggestions should be empty", suggestions.isEmpty());
+
+              // Check empty token due to spellcheck.q = ""
+              spellOpts.tokens = Collections.singletonList(new Token("", 0, 0));
+              result = checker.getSuggestions(spellOpts);
+              assertNotNull("result shouldn't be null", result);
+              suggestions = result.get(spellOpts.tokens.iterator().next());
+              assertNotNull("suggestions shouldn't be null", suggestions);
+              assertTrue("suggestions should be empty", suggestions.isEmpty());
               return null;
             });
   }
@@ -125,7 +135,7 @@ public class FileBasedSpellCheckerTest extends SolrTestCaseJ4 {
               SpellingResult result = checker.getSuggestions(spellOpts);
               assertTrue("result is null and it shouldn't be", result != null);
               // should be lowercased, b/c we are using a lowercasing analyzer
-              Map<String, Integer> suggestions = result.get(tokens.iterator().next());
+              Map<String, Integer> suggestions = result.get(spellOpts.tokens.iterator().next());
               assertTrue(
                   "suggestions Size: " + suggestions.size() + " is not: " + 1,
                   suggestions.size() == 1);
@@ -140,9 +150,10 @@ public class FileBasedSpellCheckerTest extends SolrTestCaseJ4 {
               // test something not in the spell checker
               spellOpts.tokens = queryConverter.convert("super");
               result = checker.getSuggestions(spellOpts);
-              assertTrue("result is null and it shouldn't be", result != null);
-              suggestions = result.get(tokens.iterator().next());
-              assertTrue("suggestions is not null and it should be", suggestions == null);
+              assertNotNull("result shouldn't be null", result);
+              suggestions = result.get(spellOpts.tokens.iterator().next());
+              assertNotNull("suggestions shouldn't be null", suggestions);
+              assertTrue("suggestions should be empty", suggestions.isEmpty());
               return null;
             });
   }
@@ -172,9 +183,9 @@ public class FileBasedSpellCheckerTest extends SolrTestCaseJ4 {
               Collection<Token> tokens = queryConverter.convert("solar");
               SpellingOptions spellOpts = new SpellingOptions(tokens, searcher.getIndexReader());
               SpellingResult result = checker.getSuggestions(spellOpts);
-              assertTrue("result is null and it shouldn't be", result != null);
+              assertNotNull("result shouldn't be null", result);
               // should be lowercased, b/c we are using a lowercasing analyzer
-              Map<String, Integer> suggestions = result.get(tokens.iterator().next());
+              Map<String, Integer> suggestions = result.get(spellOpts.tokens.iterator().next());
               assertTrue(
                   "suggestions Size: " + suggestions.size() + " is not: " + 1,
                   suggestions.size() == 1);
@@ -188,9 +199,10 @@ public class FileBasedSpellCheckerTest extends SolrTestCaseJ4 {
 
               spellOpts.tokens = queryConverter.convert("super");
               result = checker.getSuggestions(spellOpts);
-              assertTrue("result is null and it shouldn't be", result != null);
+              assertNotNull("result shouldn't be null", result);
               suggestions = result.get(spellOpts.tokens.iterator().next());
-              assertTrue("suggestions size should be 0", suggestions.size() == 0);
+              assertNotNull("suggestions shouldn't be null", suggestions);
+              assertTrue("suggestions should be empty", suggestions.isEmpty());
               return null;
             });
   }

--- a/solr/core/src/test/org/apache/solr/spelling/IndexBasedSpellCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/IndexBasedSpellCheckerTest.java
@@ -18,6 +18,7 @@ package org.apache.solr.spelling;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Map;
@@ -188,6 +189,14 @@ public class IndexBasedSpellCheckerTest extends SolrTestCaseJ4 {
               assertTrue(
                   entry.getValue() + " does not equal: " + SpellingResult.NO_FREQUENCY_INFO,
                   entry.getValue() == SpellingResult.NO_FREQUENCY_INFO);
+
+              // Check empty token due to spellcheck.q = ""
+              spellOpts.tokens = Collections.singletonList(new Token("", 0, 0));
+              result = checker.getSuggestions(spellOpts);
+              assertNotNull(result);
+              suggestions = result.get(spellOpts.tokens.iterator().next());
+              assertNotNull(suggestions);
+              assertTrue("suggestions should be empty", suggestions.isEmpty());
               return null;
             });
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16169

# Description

An empty `spellcheck.q` parameter results in `NegativeArraySizeException` from Lucene. 

# Solution

https://issues.apache.org/jira/browse/LUCENE-10533 is fixing the root cause, but we can add protection in Solr as well. This skips doing a spell check if the token is empty.

# Tests

Adds tests to explicitly check if spellcheck tokens are empty and short circuits if it is.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
