### PR TITLE
SOLR-16168: Spellcheck NPE if invalid dictionary name is provided

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -65,6 +65,8 @@ Bug Fixes
 
 * SOLR-13044: Fix NPE during core close racing with index replication check.  (David Smiley, hossman)
 
+* SOLR-16168: Spellcheck NPE if invalid dictionary name is provided (Kevin Risden)
+
 Other Changes
 ---------------------
 * SOLR-15897: Remove <jmx/> from all unit test solrconfig.xml files. (Eric Pugh)

--- a/solr/core/src/java/org/apache/solr/handler/component/SpellCheckComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SpellCheckComponent.java
@@ -131,23 +131,23 @@ public class SpellCheckComponent extends SearchComponent implements SolrCoreAwar
       return;
     }
     boolean shardRequest = "true".equals(params.get(ShardParams.IS_SHARD));
-    String q = params.get(SPELLCHECK_Q);
-    SolrSpellChecker spellChecker = getSpellChecker(params);
-    Collection<Token> tokens = null;
 
-    if (q != null) {
-      // we have a spell check param, tokenize it with the query analyzer applicable for this
-      // spellchecker
-      tokens = getTokens(q, spellChecker.getQueryAnalyzer());
-    } else {
-      q = rb.getQueryString();
-      if (q == null) {
-        q = params.get(CommonParams.Q);
+    SolrSpellChecker spellChecker = getSpellChecker(params);
+    if (spellChecker != null) {
+      Collection<Token> tokens;
+      String q = params.get(SPELLCHECK_Q);
+      if (q != null) {
+        // we have a spell check param, tokenize it with the query analyzer applicable for this
+        // spellchecker
+        tokens = getTokens(q, spellChecker.getQueryAnalyzer());
+      } else {
+        q = rb.getQueryString();
+        if (q == null) {
+          q = params.get(CommonParams.Q);
+        }
+        tokens = queryConverter.convert(q);
       }
-      tokens = queryConverter.convert(q);
-    }
-    if (tokens != null && tokens.isEmpty() == false) {
-      if (spellChecker != null) {
+      if (tokens != null && tokens.isEmpty() == false) {
         int count = params.getInt(SPELLCHECK_COUNT, 1);
         boolean onlyMorePopular =
             params.getBool(SPELLCHECK_ONLY_MORE_POPULAR, DEFAULT_ONLY_MORE_POPULAR);
@@ -215,13 +215,12 @@ public class SpellCheckComponent extends SearchComponent implements SolrCoreAwar
         }
 
         rb.rsp.add("spellcheck", response);
-
-      } else {
-        throw new SolrException(
-            SolrException.ErrorCode.NOT_FOUND,
-            "Specified dictionaries do not exist: "
-                + getDictionaryNameAsSingleString(getDictionaryNames(params)));
       }
+    } else {
+      throw new SolrException(
+          SolrException.ErrorCode.NOT_FOUND,
+          "Specified dictionaries do not exist: "
+              + getDictionaryNameAsSingleString(getDictionaryNames(params)));
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/component/SpellCheckComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SpellCheckComponentTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.lucene.util.LuceneTestCase.SuppressTempFileChecks;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SpellingParams;
@@ -287,6 +288,43 @@ public class SpellCheckComponentTest extends SolrTestCaseJ4 {
             "foo"),
         "/spellcheck/suggestions/bar=={'numFound':1, 'startOffset':0, 'endOffset':1, 'suggestion':['foo']}",
         "/spellcheck/suggestions/foo=={'numFound':1, 'startOffset':2, 'endOffset':3, 'suggestion':['bar']}");
+  }
+
+  @Test
+  public void testInvalidDictionary() throws Exception {
+    assertQEx(
+        "Invalid specified dictionary should throw exception",
+        "Specified dictionaries do not exist: INVALID",
+        req(
+            "json.nl",
+            "map",
+            "qt",
+            rh,
+            SpellCheckComponent.COMPONENT_NAME,
+            "true",
+            "q",
+            "documemt",
+            SpellingParams.SPELLCHECK_DICT,
+            "INVALID"),
+        SolrException.ErrorCode.NOT_FOUND);
+
+    assertQEx(
+        "Invalid specified dictionary should throw exception",
+        "Specified dictionaries do not exist: INVALID2",
+        req(
+            "json.nl",
+            "map",
+            "qt",
+            rh,
+            SpellCheckComponent.COMPONENT_NAME,
+            "true",
+            "q",
+            "test",
+            SpellingParams.SPELLCHECK_Q,
+            "documemt",
+            SpellingParams.SPELLCHECK_DICT,
+            "INVALID2"),
+        SolrException.ErrorCode.NOT_FOUND);
   }
 
   @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16168

# Description

If a user provides `spellcheck.q` and an invalid `spellcheck.dictionary` there is an NPE.

# Solution

This throws an exception with a helpful error message instead of the NPE. It moves the spellcheck null check up in the processing.

# Tests

Added tests for both when `spellcheck.q` is specified and when `spellcheck.q` isn't specified with an invalid `spellcheck.dictionary` value.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
