### PR TITLE
SOLR-16164: ConfigSet API returns error if untrusted user creates from _default configset

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -779,6 +779,8 @@ Bug Fixes
 
 * SOLR-16143: SolrConfig ResourceProvider can miss updates from ZooKeeper (Mike Drob)
 
+* SOLR-16164: ConfigSet API returns error if untrusted user creates from _default configset (Eric Pugh, Kevin Risden)
+
 ==================  8.11.2 ==================
 
 Bug Fixes

--- a/solr/core/src/java/org/apache/solr/cloud/ZkConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkConfigSetService.java
@@ -21,7 +21,6 @@ import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -233,15 +232,10 @@ public class ZkConfigSetService extends ConfigSetService {
   @Override
   public Map<String, Object> getConfigMetadata(String configName) throws IOException {
     try {
-
-      byte[] bytedata = zkClient.getData(CONFIGS_ZKNODE + "/" + configName, null, null, true);
-      if (bytedata == null) return new HashMap<>();
-
       @SuppressWarnings("unchecked")
       Map<String, Object> data =
           (Map<String, Object>)
-              Utils.fromJSON(bytedata);
-      if (data == null) return new HashMap<>();
+              Utils.fromJSON(zkClient.getData(CONFIGS_ZKNODE + "/" + configName, null, null, true));
       return data;
     } catch (KeeperException | InterruptedException e) {
       throw new IOException("Error getting config metadata", SolrZkClient.checkInterrupted(e));

--- a/solr/core/src/java/org/apache/solr/cloud/ZkConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkConfigSetService.java
@@ -233,10 +233,14 @@ public class ZkConfigSetService extends ConfigSetService {
   @Override
   public Map<String, Object> getConfigMetadata(String configName) throws IOException {
     try {
+
+      byte[] bytedata = zkClient.getData(CONFIGS_ZKNODE + "/" + configName, null, null, true);
+      if (bytedata == null) return new HashMap<>();
+
       @SuppressWarnings("unchecked")
       Map<String, Object> data =
           (Map<String, Object>)
-              Utils.fromJSON(zkClient.getData(CONFIGS_ZKNODE + "/" + configName, null, null, true));
+              Utils.fromJSON(bytedata);
       if (data == null) return new HashMap<>();
       return data;
     } catch (KeeperException | InterruptedException e) {

--- a/solr/core/src/java/org/apache/solr/core/ConfigSetProperties.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigSetProperties.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.core;
 
-import static org.apache.solr.common.util.Utils.fromJSON;
-
 import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
@@ -26,6 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +72,7 @@ public class ConfigSetProperties {
 
   public static NamedList<Object> readFromInputStream(InputStreamReader reader) {
     try {
-      Object object = fromJSON(reader);
+      Object object = Utils.fromJSON(reader);
       if (!(object instanceof Map)) {
         final String objectClass = object == null ? "null" : object.getClass().getName();
         throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/core/RequestParams.java
+++ b/solr/core/src/java/org/apache/solr/core/RequestParams.java
@@ -16,10 +16,6 @@
  */
 package org.apache.solr.core;
 
-import static java.util.Collections.singletonMap;
-import static org.apache.solr.common.util.Utils.fromJSON;
-import static org.apache.solr.common.util.Utils.getDeepCopy;
-
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,7 +63,7 @@ public class RequestParams implements MapSerializable {
 
   @SuppressWarnings({"rawtypes"})
   public static ParamSet createParamSet(Map map, Long version) {
-    Map copy = getDeepCopy(map, 3);
+    Map copy = Utils.getDeepCopy(map, 3);
     @SuppressWarnings("unchecked")
     Map<String, Long> meta = (Map<String, Long>) copy.remove("");
     if (meta == null && version != null) {
@@ -132,7 +128,7 @@ public class RequestParams implements MapSerializable {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   public RequestParams setParams(String name, ParamSet paramSet) {
-    Map deepCopy = getDeepCopy(data, 3);
+    Map deepCopy = Utils.getDeepCopy(data, 3);
     Map p = (Map) deepCopy.get(NAME);
     if (p == null) deepCopy.put(NAME, p = new LinkedHashMap<>());
     if (paramSet == null) p.remove(name);
@@ -192,7 +188,7 @@ public class RequestParams implements MapSerializable {
         log.info("conf resource {} loaded . version : {} ", name, version);
       }
       try {
-        Map<?, ?> m = (Map<?, ?>) fromJSON(in);
+        Map<?, ?> m = (Map<?, ?>) Utils.fromJSON(in);
         return new Object[] {m, version};
       } catch (Exception e) {
         throw new SolrException(
@@ -253,10 +249,10 @@ public class RequestParams implements MapSerializable {
     public ParamSet update(@SuppressWarnings({"rawtypes"}) Map map) {
       ParamSet p = createParamSet(map, null);
       return new ParamSet(
-          mergeMaps(getDeepCopy(defaults, 2), p.defaults),
-          mergeMaps(getDeepCopy(invariants, 2), p.invariants),
-          mergeMaps(getDeepCopy(appends, 2), p.appends),
-          mergeMaps(getDeepCopy(meta, 2), singletonMap("v", getVersion() + 1)));
+          mergeMaps(Utils.getDeepCopy(defaults, 2), p.defaults),
+          mergeMaps(Utils.getDeepCopy(invariants, 2), p.invariants),
+          mergeMaps(Utils.getDeepCopy(appends, 2), p.appends),
+          mergeMaps(Utils.getDeepCopy(meta, 2), Collections.singletonMap("v", getVersion() + 1)));
     }
 
     private static <K, V> Map<K, V> mergeMaps(Map<K, V> m1, Map<K, V> m2) {

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -18,7 +18,6 @@ package org.apache.solr.core;
 
 import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.common.params.CommonParams.PATH;
-import static org.apache.solr.common.util.Utils.fromJSON;
 import static org.apache.solr.core.ConfigOverlay.ZNODEVER;
 import static org.apache.solr.core.SolrConfig.PluginOpts.LAZY;
 import static org.apache.solr.core.SolrConfig.PluginOpts.MULTI_OK;
@@ -600,7 +599,7 @@ public class SolrConfig implements MapSerializable {
         log.debug("Config overlay loaded. version : {} ", version);
       }
       @SuppressWarnings("unchecked")
-      Map<String, Object> m = (Map<String, Object>) fromJSON(in);
+      Map<String, Object> m = (Map<String, Object>) Utils.fromJSON(in);
       return new ConfigOverlay(m, version);
     } catch (Exception e) {
       throw new SolrException(ErrorCode.SERVER_ERROR, "Error reading config overlay", e);

--- a/solr/core/src/java/org/apache/solr/rest/RestManager.java
+++ b/solr/core/src/java/org/apache/solr/rest/RestManager.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.rest;
 
-import static org.apache.solr.common.util.Utils.fromJSON;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
@@ -44,6 +42,7 @@ import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -388,7 +387,7 @@ public class RestManager {
       Iterator<ContentStream> iter = req.getContentStreams().iterator();
       if (iter.hasNext()) {
         try (Reader reader = iter.next().getReader()) {
-          return fromJSON(reader);
+          return Utils.fromJSON(reader);
         } catch (IOException ioExc) {
           throw new SolrException(ErrorCode.SERVER_ERROR, ioExc);
         }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Aliases.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Aliases.java
@@ -95,12 +95,7 @@ public class Aliases {
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static Aliases fromJSON(byte[] bytes, int zNodeVersion) {
-    Map<String, Map> aliasMap;
-    if (bytes == null || bytes.length == 0) {
-      aliasMap = Collections.emptyMap();
-    } else {
-      aliasMap = (Map<String, Map>) Utils.fromJSON(bytes);
-    }
+    Map<String, Map> aliasMap = (Map<String, Map>) Utils.fromJSON(bytes);
 
     @SuppressWarnings({"rawtypes"})
     Map colAliases = aliasMap.getOrDefault(COLLECTION, Collections.emptyMap());

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -18,7 +18,6 @@ package org.apache.solr.common.cloud;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySortedSet;
-import static org.apache.solr.common.util.Utils.fromJSON;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
@@ -441,7 +440,7 @@ public class ZkStateReader implements SolrCloseable {
               cd.data =
                   pair.first() == null || pair.first().length == 0
                       ? emptyMap()
-                      : Utils.getDeepCopy((Map) fromJSON(pair.first()), 4, false);
+                      : Utils.getDeepCopy((Map) Utils.fromJSON(pair.first()), 4, false);
               cd.version = pair.second() == null ? -1 : pair.second().getVersion();
               securityData = cd;
               securityNodeListener.run();

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -302,10 +302,16 @@ public class Utils {
   }
 
   public static Object fromJSON(byte[] utf8) {
+    if (utf8 == null || utf8.length == 0) {
+      return Collections.emptyMap();
+    }
     return fromJSON(utf8, 0, utf8.length);
   }
 
   public static Object fromJSON(byte[] utf8, int offset, int length) {
+    if (utf8 == null || utf8.length == 0) {
+      return Collections.emptyMap();
+    }
     // convert directly from bytes to chars
     // and parse directly from that instead of going through
     // intermediate strings or readers

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -302,6 +302,8 @@ public class Utils {
   }
 
   public static Object fromJSON(byte[] utf8) {
+    // Need below check in both fromJSON methods since
+    // utf8.length returns a NPE without this check.
     if (utf8 == null || utf8.length == 0) {
       return Collections.emptyMap();
     }
@@ -309,7 +311,7 @@ public class Utils {
   }
 
   public static Object fromJSON(byte[] utf8, int offset, int length) {
-    if (utf8 == null || utf8.length == 0) {
+    if (utf8 == null || utf8.length == 0 || length == 0) {
       return Collections.emptyMap();
     }
     // convert directly from bytes to chars


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16164

# Description

A draft fix for a NPE that happens when there is no metadata on a node.

# Solution
Update Utils.fromJSON to handle the null case. 

# Tests
Test added to `TestConfigSetsAPI` to check for base configset create case without authentication.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
