### PR TITLE
The SVN URL lacks a '-' when deleting previous RC from staging svn

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -246,7 +246,7 @@ def maybe_remove_rc_from_svn():
                  logfile="svn_rm.log",
                  tee=True,
                  vars={
-                     'dist_folder': """solr-{{ release_version }}-RC{{ rc_number }}-rev{{ build_rc.git_rev | default("<git_rev>", True) }}""",
+                     'dist_folder': """solr-{{ release_version }}-RC{{ rc_number }}-rev-{{ build_rc.git_rev | default("<git_rev>", True) }}""",
                      'dist_url': "{{ dist_url_base }}/{{ dist_folder }}"
                  }
              )],


### PR DESCRIPTION
Error msg from wizard:
```
Running 'svn -m "Remove cancelled Solr 9.0.0 RC4" rm https://dist.apache.org/repos/dist/dev/solr/solr-9.0.0-RC4-revd6e36d590896755ca962c6d2ddedf78ca4f463cc' in folder '/Users/janhoy/.solr-releases/9.0.0/solr'
Output of command will be printed (logfile=/Users/janhoy/.solr-releases/9.0.0/RC4/logs/_svn_rm.log)
svn: E160013: URL 'https://dist.apache.org/repos/dist/dev/solr/solr-9.0.0-RC4-revd6e36d590896755ca962c6d2ddedf78ca4f463cc' does not exist
```
