### PR TITLE
SOLR-16046: fix thread leaks from non-blocking ZooKeeper.close()

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ConnectionManager.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ConnectionManager.java
@@ -210,7 +210,7 @@ public class ConnectionManager implements Watcher {
 
                 private void closeKeeper(ZooKeeper keeper) {
                   try {
-                    keeper.close();
+                    SolrZkClient.closeAsync(keeper);
                   } catch (InterruptedException e) {
                     // Restore the interrupted status
                     Thread.currentThread().interrupt();

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DefaultConnectionStrategy.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DefaultConnectionStrategy.java
@@ -40,7 +40,7 @@ public class DefaultConnectionStrategy extends ZkClientConnectionStrategy {
       success = true;
     } finally {
       if (!success) {
-        zk.close();
+        SolrZkClient.closeAsync(zk);
       }
     }
   }
@@ -64,7 +64,7 @@ public class DefaultConnectionStrategy extends ZkClientConnectionStrategy {
     } finally {
       if (!success) {
         try {
-          zk.close();
+          SolrZkClient.closeAsync(zk);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }


### PR DESCRIPTION
See: [SOLR-16046](https://issues.apache.org/jira/browse/SOLR-16046)