### PR TITLE
Ref-Guide: Fix dangling double-euqals-signs

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/core-discovery.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/core-discovery.adoc
@@ -32,7 +32,6 @@ Any `core.properties` file in any directory of your Solr installation (or in a d
 The `core.properties` file is a simple Java Properties file where each line is just a key=value pair, e.g., `name=core1`.
 Notice that no quotes are required.
 
-==
 A minimal `core.properties` file looks like the example below.
 However, it can also be empty, see information on placement of `core.properties` below.
 


### PR DESCRIPTION
Look at https://solr.apache.org/guide/solr/9_0/configuration-guide/core-discovery.html and you see the equal signs are mal-placed. And I don't think it was meant to be a new paragraph, so removing.