### PR TITLE
Link to PDF-guides in dropdown

### DIFF
--- a/solr/solr-ref-guide/ui-src/partials/nav-explore.hbs
+++ b/solr/solr-ref-guide/ui-src/partials/nav-explore.hbs
@@ -90,6 +90,10 @@
       </li>
       <li class="version">
         <a href="https://solr.apache.org/guide/6_6">6.6</a>
+      </li>
+      <li class="version">
+        <a href="http://archive.apache.org/dist/lucene/solr/ref-guide/">Older</a>
+      </li>
     </ul>
   </li>
   <!-- Solr Additions - End -->


### PR DESCRIPTION
Add a link to PDF guides in the "old guides" section for completeness.