### PR TITLE
Index only latest version to avoid confusing search results

### DIFF
--- a/solr/solr-ref-guide/playbook.template.yml
+++ b/solr/solr-ref-guide/playbook.template.yml
@@ -52,5 +52,5 @@ runtime:
   fetch: true
 antora:
   extensions:
-    - '@antora/lunr-extension'
+    - require: '@antora/lunr-extension'
       index_latest_only: true

--- a/solr/solr-ref-guide/playbook.template.yml
+++ b/solr/solr-ref-guide/playbook.template.yml
@@ -53,3 +53,4 @@ runtime:
 antora:
   extensions:
     - '@antora/lunr-extension'
+      index_latest_only: true


### PR DESCRIPTION
By default all versions of the guide are indexed in Lunr. This gets confusing when 9.1, 9.2, 9.3 etc are in, so this PR enables a config option to only include latest version in the index.

I have not tested this yet, so don't know what will happen when e.g. the 9.1 guide is in beta version, if it all search results will then link to the beta guide. That would perhaps not be what we want, though it would be for a short period only..