### PR TITLE
Make 'latest' remain in URL instead of `9_0`

### DIFF
--- a/solr/solr-ref-guide/playbook.template.yml
+++ b/solr/solr-ref-guide/playbook.template.yml
@@ -21,7 +21,7 @@ urls:
   latest_version_segment: latest
 # This does not work unless the redirect_facility below is set to
 # something other than the default 'static'
-  latest_version_segment_strategy: redirect:from
+  latest_version_segment_strategy: redirect:to
 # If this is set to 'httpd', antora will create a .htaccess file with all redirects, including 'latest'.
 # Default is 'static' which produces index.html at the root.
 # See https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/


### PR DESCRIPTION
Spinoff from #77 - do not rewrite `latest` to `9_0`, but opposite, so that people are encouraged to sharing `latest` links.
Note that it will still be possible to share an explicit link to 9.0 version, that will be sure to route to the 9.0 guide. Just that the 'default' will be `latest` when working with the latest version.

This may perhaps also help in boosting the PageRank of `latest` links in search engines?
