### PR TITLE
SOLR-15780: Document v2 API as "experimental"

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -713,6 +713,9 @@ Other Changes
 
 * SOLR-16101: Add empty constructor for SolrInputDocument (Anshum Gupta)
 
+* SOLR-15780: The v2 API is now treated as "experimental".  It may change in backwards-incompatible ways in subsequent releases
+  as it expands to cover additional functionality and prepares to supplant the v1 API. (Jason Gerlowski)
+
 Bug Fixes
 ---------------------
 * SOLR-15849: Fix the connection reset problem caused by the incorrect use of 4LW with \n when monitoring zooKeeper status

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/v2-api.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/v2-api.adoc
@@ -19,9 +19,11 @@
 [[top-v2-api]]
 The v2 API is a modernized self-documenting API interface covering most current Solr APIs.
 It is anticipated that once the v2 API reaches full coverage, and Solr-internal API usages like SolrJ and the Admin UI have been converted from the old API to the v2 API, the old API will eventually be retired.
+Today, the two API styles coexist, and all the old APIs will continue to work without any change.
+You can disable all v2 API endpoints if desired by starting your servers with this system property: `-Ddisable.v2.api=true`.
 
-For now the two API styles will coexist, and all the old APIs will continue to work without any change.
-You can disable all v2 API endpoints by starting your servers with this system property: `-Ddisable.v2.api=true`.
+NOTE: The v2 API is classified as "experimental".
+It may change in backwards-incompatible ways as it evolves to cover additional functionality.
 
 The old API and the v2 API differ in three principle ways:
 


### PR DESCRIPTION
# Description

The community decided recently that the v2 API should be treated as
"experimental", and exempt from strict adherence to
backwards-compatibility requirements.  But there's no mention of this
designation in our ref-guide or other docs.

# Solution

This commit updates the v2-api.adoc page in the ref guide to include
a caveat/warning about this, along with a corresponding note in
CHANGES.txt.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
