### PR TITLE
Add the .gradletasknamecache file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ lucene/
 
 # Ignore gradle wrapper
 gradle/wrapper/gradle-wrapper.jar
+.gradletasknamecache


### PR DESCRIPTION
This file has recently started popping up as changed. I think it should be ignored, as it causes e.g. `gradlew check -x tests` to fail with "not clean checkout"