### PR TITLE
(core) Leader election declares unused IOExceptions

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ElectionContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ElectionContext.java
@@ -17,7 +17,6 @@
 package org.apache.solr.cloud;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkNodeProps;
@@ -66,7 +65,7 @@ public abstract class ElectionContext implements Closeable {
   }
 
   abstract void runLeaderProcess(boolean weAreReplacement, int pauseBeforeStartMs)
-      throws KeeperException, InterruptedException, IOException;
+      throws KeeperException, InterruptedException;
 
   public void checkIfIamLeaderFired() {}
 

--- a/solr/core/src/java/org/apache/solr/cloud/LeaderElector.java
+++ b/solr/core/src/java/org/apache/solr/cloud/LeaderElector.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -96,7 +95,7 @@ public class LeaderElector {
    * @param replacement has someone else been the leader already?
    */
   private void checkIfIamLeader(final ElectionContext context, boolean replacement)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     context.checkIfIamLeaderFired();
     // get all other numbers...
     final String holdElectionPath = context.electionPath + ELECTION_NODE;
@@ -171,7 +170,7 @@ public class LeaderElector {
   }
 
   protected void runIamLeaderProcess(final ElectionContext context, boolean weAreReplacement)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     context.runLeaderProcess(weAreReplacement, 0);
   }
 
@@ -214,7 +213,7 @@ public class LeaderElector {
   }
 
   public int joinElection(ElectionContext context, boolean replacement)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     return joinElection(context, replacement, false);
   }
 
@@ -227,7 +226,7 @@ public class LeaderElector {
    * @return sequential node number
    */
   public int joinElection(ElectionContext context, boolean replacement, boolean joinAtHead)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     context.joinedElectionFired();
 
     final String shardsElectZkPath = context.electionPath + LeaderElector.ELECTION_NODE;
@@ -382,7 +381,7 @@ public class LeaderElector {
   }
 
   void retryElection(ElectionContext context, boolean joinAtHead)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     ElectionWatcher watcher = this.watcher;
     ElectionContext ctx = context.copy();
     if (electionContexts != null) {

--- a/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContext.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.concurrent.Future;
@@ -98,7 +97,7 @@ final class ShardLeaderElectionContext extends ShardLeaderElectionContextBase {
    */
   @Override
   void runLeaderProcess(boolean weAreReplacement, int pauseBeforeStart)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     String coreName = leaderProps.getStr(ZkStateReader.CORE_NAME_PROP);
     ActionThrottle lt;
     try (SolrCore core = cc.getCore(coreName)) {
@@ -533,8 +532,7 @@ final class ShardLeaderElectionContext extends ShardLeaderElectionContextBase {
     return false;
   }
 
-  private void rejoinLeaderElection(SolrCore core)
-      throws InterruptedException, KeeperException, IOException {
+  private void rejoinLeaderElection(SolrCore core) throws InterruptedException, KeeperException {
     // remove our ephemeral and re join the election
     if (cc.isShutDown()) {
       log.debug("Not rejoining election because CoreContainer is closed");

--- a/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContextBase.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContextBase.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.cloud;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -122,7 +121,7 @@ class ShardLeaderElectionContextBase extends ElectionContext {
 
   @Override
   void runLeaderProcess(boolean weAreReplacement, int pauseBeforeStartMs)
-      throws KeeperException, InterruptedException, IOException {
+      throws KeeperException, InterruptedException {
     // register as leader - if an ephemeral is already there, wait to see if it goes away
 
     String parent = ZkMaintenanceUtils.getZkParent(leaderPath);

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -800,7 +800,7 @@ public class ZkController implements Closeable {
         try {
           log.warn("Leader {} met tragic exception, give up its leadership", key);
           elector.retryElection(context, false);
-        } catch (KeeperException | InterruptedException | IOException e) {
+        } catch (KeeperException | InterruptedException e) {
           SolrZkClient.checkInterrupted(e);
           log.error("Met exception on give up leadership for {}", key, e);
         }

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
@@ -101,7 +101,7 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
 
     @Override
     void runLeaderProcess(boolean weAreReplacement, int pauseBeforeStartMs)
-        throws KeeperException, InterruptedException, IOException {
+        throws KeeperException, InterruptedException {
       super.runLeaderProcess(weAreReplacement, pauseBeforeStartMs);
       if (runLeaderDelay > 0) {
         log.info("Sleeping for {}ms to simulate leadership takeover delay", runLeaderDelay);


### PR DESCRIPTION
Minor change - no JIRA issue

Removes declared IOException from method signatures where it could never be thrown.