### PR TITLE
SOLR-16196: Use Solr KEYS in official Dockerfile

### DIFF
--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -26,20 +26,14 @@
 #-#
 #-#
 
-# add symlink to /opt/solr, remove what we don't want.
-# Remove the Dockerfile because it might not represent the dockerfile that was used to generate the image.
-RUN set -ex; \
-  (cd /opt; ln -s solr-*/ solr); \
-  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile;
-
-LABEL maintainer="The Apache Solr Project"
-LABEL url="https://solr.apache.org"
-LABEL repository="https://github.com/apache/solr"
-
-RUN set -ex; \
-    apt-get update; \
-    apt-get -y install acl dirmngr lsof procps wget netcat gosu tini jattach; \
-    rm -rf /var/lib/apt/lists/*;
+LABEL org.opencontainers.image.title="Apache Solr"
+LABEL org.opencontainers.image.description="Apache Solr is the popular, blazing-fast, open source search platform built on Apache Lucene."
+LABEL org.opencontainers.image.authors="The Apache Solr Project"
+LABEL org.opencontainers.image.url="https://solr.apache.org"
+LABEL org.opencontainers.image.source="https://github.com/apache/solr"
+LABEL org.opencontainers.image.documentation="https://solr.apache.org/guide/"
+LABEL org.opencontainers.image.version="${SOLR_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
@@ -57,6 +51,12 @@ RUN set -ex; \
   groupadd -r --gid "$SOLR_GID" "$SOLR_GROUP"; \
   useradd -r --uid "$SOLR_UID" --gid "$SOLR_GID" "$SOLR_USER"
 
+# add symlink to /opt/solr, remove what we don't want.
+# Remove the Dockerfile because it might not represent the dockerfile that was used to generate the image.
+RUN set -ex; \
+  (cd /opt; ln -s solr-*/ solr); \
+  rm -Rf /opt/solr/docs /opt/solr/docker/Dockerfile;
+
 RUN set -ex; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d; \
   cp /opt/solr/bin/solr.in.sh /etc/default/solr.in.sh; \
@@ -67,6 +67,11 @@ RUN set -ex; \
   chown -R "$SOLR_USER:0" /var/solr; \
   ln -s /opt/solr/modules /opt/solr/contrib; \
   ln -s /opt/solr/prometheus-exporter /opt/solr/modules/prometheus-exporter;
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get -y install acl dirmngr lsof procps wget netcat gosu tini jattach; \
+    rm -rf /var/lib/apt/lists/*;
 
 VOLUME /var/solr
 EXPOSE 8983

--- a/solr/docker/templates/Dockerfile.official.header.template
+++ b/solr/docker/templates/Dockerfile.official.header.template
@@ -22,7 +22,6 @@
 FROM _REPLACE_BASE_IMAGE_
 
 # TODO: remove things that exist solely for downstream specialization since Dockerfile.local now exists for that
-# TODO: replace 3rd party keyservers with official Apache Solr KEYS url
 
 ARG SOLR_VERSION="_REPLACE_SOLR_VERSION_"
 ARG SOLR_SHA512="_REPLACE_SOLR_TGZ_SHA_"
@@ -44,26 +43,22 @@ ARG SOLR_ARCHIVE_URL="https://archive.apache.org/dist/solr/solr/$SOLR_VERSION/so
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install wget gpg; \
+  apt-get -y install wget gpg dirmngr; \
   rm -rf /var/lib/apt/lists/*; \
   export GNUPGHOME="/tmp/gnupg_home"; \
   mkdir -p "$GNUPGHOME"; \
   chmod 700 "$GNUPGHOME"; \
   echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf"; \
-  for key in $SOLR_KEYS; do \
-    found=''; \
-    for server in \
-      pgp.mit.edu \
-      keyserver.ubuntu.com \
-      hkp://keyserver.ubuntu.com:80 \
-    ; do \
-      echo "  trying $server for $key"; \
-      gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
-      gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
-    done; \
-    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
-  done; \
-  MAX_REDIRECTS=2; \
+  if [ -n "$SOLR_KEYS" ]; then \
+    # Install all Solr GPG Keys to start
+    wget -nv "https://downloads.apache.org/solr/KEYS" -O- | \
+      gpg --import --key-origin 'url,https://downloads.apache.org/solr/KEYS'; \
+    # Save just the release key
+    release_keys="$(gpg --export -a ${SOLR_KEYS})"; \
+    rm -rf "$GNUPGHOME"/*; \
+    echo "${release_keys}" | gpg --import; \
+  fi; \
+  MAX_REDIRECTS=3; \
   if [ -n "$SOLR_DOWNLOAD_URL" ]; then \
     # If a custom URL is defined, we download from non-ASF mirror URL and allow more redirects and skip GPG step
     # This takes effect only if the SOLR_DOWNLOAD_URL build-arg is specified, typically in downstream Dockerfiles

--- a/solr/docker/templates/Dockerfile.official.header.template
+++ b/solr/docker/templates/Dockerfile.official.header.template
@@ -52,11 +52,11 @@ RUN set -ex; \
   if [ -n "$SOLR_KEYS" ]; then \
     # Install all Solr GPG Keys to start
     wget -nv "https://downloads.apache.org/solr/KEYS" -O- | \
-      gpg --import --key-origin 'url,https://downloads.apache.org/solr/KEYS'; \
+      gpg --batch --import --key-origin 'url,https://downloads.apache.org/solr/KEYS'; \
     # Save just the release key
-    release_keys="$(gpg --export -a ${SOLR_KEYS})"; \
+    release_keys="$(gpg --batch --export -a ${SOLR_KEYS})"; \
     rm -rf "$GNUPGHOME"/*; \
-    echo "${release_keys}" | gpg --import; \
+    echo "${release_keys}" | gpg --batch --import; \
   fi; \
   MAX_REDIRECTS=3; \
   if [ -n "$SOLR_DOWNLOAD_URL" ]; then \


### PR DESCRIPTION
Also address other issues required by official images team for the 9.0.0 image.

https://issues.apache.org/jira/browse/SOLR-16196

Mirroring the changes made in: https://github.com/apache/solr-docker/pull/4

These changes are in response to feedback on: https://github.com/docker-library/official-images/pull/12406

Will wait to merge until the 9.0.0 image has been released, to capture any other changes.