### PR TITLE
SOLR-16195: Correct task-mgmt API paths in ref-guide

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/task-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/task-management.adoc
@@ -29,36 +29,131 @@ Task management interface supports the following types of operations:
 . Cancel a specific task.
 . Query the status of a specific task.
 
+
+
 == Listing All Active Cancellable Tasks
 To list all the active cancellable tasks currently running, please use the following syntax:
 
-`\http://localhost:8983/solr/tasks/list`
+[.dynamic-tabs]
+--
+[example.tab-pane#v1listalltasks]
+====
+[.tab-label]*V1 API*
+
+[source,bash]
+----
+curl -X GET "http://localhost:8983/solr/collectionName/tasks/list"
+----
+====
+
+[example.tab-pane#v2listalltasks]
+====
+[.tab-label]*V2 API*
+
+[source,bash]
+----
+curl -X GET "http://localhost:8983/v2/collections/collName/tasks/list"
+----
+====
+--
 
 === Sample Response
 
-`{responseHeader={status=0, QTime=11370}, taskList={0=q=*%3A*&canCancel=true&queryUUID=0&_stateVer_=collection1%3A4&wt=javabin&version=2, 5=q=*%3A*&canCancel=true&queryUUID=5&_stateVer_=collection1%3A4&wt=javabin&version=2, 7=q=*%3A*&canCancel=true&queryUUID=7&_stateVer_=collection1%3A4&wt=javabin&version=2}`
+----
+{
+  "responseHeader":{
+    "status":0,
+    "QTime":16},
+  "taskList":[
+    "0,"q=weight_i:[0+TO+200]&canCancel=true&queryUUID=0",
+    "5","q=weight_i:[0+TO+200]&canCancel=true&queryUUID=5",
+    "4bcd27bb-0792-4512-a699-532fa7878bd3","q=weight_i:[0+TO+200]&canCancel=true"]}
+----
 
 == Cancelling An Active Cancellable Task
 To cancel an active task, please use the following syntax:
 
-`\http://localhost:8983/solr/tasks/cancel?queryUUID=foobar`
+[.dynamic-tabs]
+--
+[example.tab-pane#v1cancelalltasks]
+====
+[.tab-label]*V1 API*
+
+[source,bash]
+----
+curl -X GET "http://localhost:8983/solr/collectionName/tasks/cancel?queryUUID=5"
+----
+====
+
+[example.tab-pane#v2cancelalltasks]
+====
+[.tab-label]*V2 API*
+
+[source,bash]
+----
+curl -X GET "http://localhost:8983/v2/collections/collName/tasks/cancel?queryUUID=5"
+----
+====
+--
 
 === Sample Response
 ==== If the task UUID was found and successfully cancelled:
 
-`{responseHeader={status=0, QTime=39}, status=Query with queryID 85 cancelled successfully}`
+----
+{
+  "responseHeader":{
+    "status":0,
+    "QTime":26},
+  "status":"Query with queryID 5 cancelled successfully",
+  "responseCode":200}
+----
 
 ==== If the task UUID was not found
 
-`{responseHeader={status=0, QTime=39}, status=Query with queryID 85 not found}`
+----
+{
+  "responseHeader":{
+    "status":0,
+    "QTime":24},
+  "status":"Query with queryID 5 not found",
+  "responseCode":404}
+----
 
 == Check Status of a Specific Task
 To check the status of a specific task, please use the following syntax:
 
-`\http://localhost:8983/solr/tasks/list?taskUUID=foobar`
+[.dynamic-tabs]
+--
+[example.tab-pane#v1checksingletask]
+====
+[.tab-label]*V1 API*
+
+[source,bash]
+----
+curl -X GET "http://localhost:8983/solr/collectionName/tasks/list?taskUUID=5"
+----
+====
+
+[example.tab-pane#v2checksingletask]
+====
+[.tab-label]*V2 API*
+
+[source,bash]
+----
+curl -X GET "http://localhost:8983/v2/collections/collName/tasks/list?taskUUID=5"
+----
+====
+--
 
 === taskUUID Parameter
 `taskUUID` parameter can be used to specify a task UUID whose status can be checked.
 
 === Sample Response
-`{responseHeader={status=0, QTime=6128}, taskStatus=foobar:true}`
+
+----
+{
+  "responseHeader":{
+    "status":0,
+    "QTime":16},
+  "taskStatus":"id:5, status: active"}
+----


### PR DESCRIPTION
# Description

The "task management" page in the ref-guide had accidentally omitted the collection-name path segment from its API examples.

# Solution

This commit corrects the API examples, as well as adding v2 examples while we're at id.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
