### PR TITLE
Use full gpg fingerprint when building official dockerfile

### DIFF
--- a/dev-tools/scripts/README.md
+++ b/dev-tools/scripts/README.md
@@ -72,25 +72,33 @@ of the other tools in this folder.
 
 ### buildAndPushRelease.py
 
-    usage: buildAndPushRelease.py [-h] [--no-prepare] [--local-keys PATH]
-                                  [--push-local PATH] [--sign KEYID]
-                                  [--rc-num NUM] [--root PATH] [--logfile PATH]
+    usage: buildAndPushRelease.py [-h] [--no-prepare] [--local-keys PATH] [--push-local PATH] [--sign FINGERPRINT]
+    [--sign-method-gradle] [--gpg-pass-noprompt] [--gpg-home PATH] [--rc-num NUM]
+    [--root PATH] [--logfile PATH] [--dev-mode]
     
     Utility to build, push, and test a release.
     
     optional arguments:
-      -h, --help         show this help message and exit
-      --no-prepare       Use the already built release in the provided checkout
-      --local-keys PATH  Uses local KEYS file to validate presence of RM's gpg key
-      --push-local PATH  Push the release to the local path
-      --sign KEYID       Sign the release with the given gpg key
-      --rc-num NUM       Release Candidate number. Default: 1
-      --root PATH        Root of Git working tree for solr. Default: "."
-                         (the current directory)
-      --logfile PATH     Specify log file path (default /tmp/release.log)
+    -h, --help            show this help message and exit
+    --no-prepare          Use the already built release in the provided checkout
+    --local-keys PATH     Uses local KEYS file to validate presence of RM's gpg key
+    --push-local PATH     Push the release to the local path
+    --sign FINGERPRINT    Sign the release with the given gpg key. This must be the full GPG fingerprint, not just the
+                          last 8 characters.
+    --sign-method-gradle  Use Gradle built-in GPG signing instead of gpg command for signing artifacts. This may require
+    --gpg-secring argument if your keychain cannot be resolved automatically.
+    --gpg-pass-noprompt   Do not prompt for gpg passphrase. For the default gnupg method, this means your gpg-agent needs
+                          a non-TTY pin-entry program. For gradle signing method, passphrase must be provided in
+                          gradle.properties or by env.var/sysprop. See ./gradlew helpPublishing for more info
+    --gpg-home PATH       Path to gpg home containing your secring.gpg Optional, will use $HOME/.gnupg/secring.gpg by
+                          default
+    --rc-num NUM          Release Candidate number. Default: 1
+    --root PATH           Root of Git working tree for solr. Default: "." (the current directory)
+    --logfile PATH        Specify log file path (default /tmp/release.log)
+    --dev-mode            Enable development mode, which disables some strict checks
     
     Example usage for a Release Manager:
-    python3 -u dev-tools/scripts/buildAndPushRelease.py --push-local /tmp/releases/6.0.1 --sign 6E68DA61 --rc-num 1
+    python3 -u dev-tools/scripts/buildAndPushRelease.py --push-local /tmp/releases/6.0.1 --sign 3782CBB60147010B330523DD26FBCC7836BF353A --rc-num 1
 
 ### addVersion.py
 

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -241,7 +241,7 @@ def read_version(path): # pylint: disable=unused-argument
 def parse_config():
   epilogue = textwrap.dedent('''
     Example usage for a Release Manager:
-    python3 -u dev-tools/scripts/buildAndPushRelease.py --push-local /tmp/releases/6.0.1 --sign 6E68DA61 --rc-num 1
+    python3 -u dev-tools/scripts/buildAndPushRelease.py --push-local /tmp/releases/6.0.1 --sign 3782CBB60147010B330523DD26FBCC7836BF353A --rc-num 1
   ''')
   description = 'Utility to build, push, and test a release.'
   parser = argparse.ArgumentParser(description=description, epilog=epilogue,
@@ -252,8 +252,8 @@ def parse_config():
                       help='Uses local KEYS file to validate presence of RM\'s gpg key')
   parser.add_argument('--push-local', metavar='PATH',
                       help='Push the release to the local path')
-  parser.add_argument('--sign', metavar='KEYID',
-                      help='Sign the release with the given gpg key')
+  parser.add_argument('--sign', metavar='FINGERPRINT',
+                      help='Sign the release with the given gpg key. This must be the full GPG fingerprint, not just the last 8 characters.')
   parser.add_argument('--sign-method-gradle', dest='sign_method_gradle', default=False, action='store_true',
                       help='Use Gradle built-in GPG signing instead of gpg command for signing artifacts. '
                       ' This may require --gpg-secring argument if your keychain cannot be resolved automatically.')

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -734,7 +734,7 @@ groups:
         cmd: git pull --ff-only
         tee: true
       - !Command
-        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }}  --sign {{ gpg_key | default("<gpg_key_id>", True) }}{% if gpg.use_gradle %}  --sign-method-gradle{% endif %}{% if not gpg.prompt_pass %}  --gpg-pass-noprompt{% endif %}
+        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }}  --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }}{% if gpg.use_gradle %}  --sign-method-gradle{% endif %}{% if not gpg.prompt_pass %}  --gpg-pass-noprompt{% endif %}
         comment: "Using {% if gpg.use_gradle %}gradle{% else %}gpg command{% endif %} for signing.{% if gpg.prompt_pass %} Remember to type your GPG pass-phrase at the prompt!{% endif %}"
         logfile: build_rc.log
         tee: true


### PR DESCRIPTION
Also fixing a small issue in the release wizard (the `gpg_key` needed to be prepended by `gpg.` although it's the `gpg_fingerprint` now)