### PR TITLE
SOLR-16205: Simplify v2 API span-population logic

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
+++ b/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
@@ -423,13 +423,7 @@ public class V2HttpCall extends HttpSolrCall {
     }
 
     // Get the templatize-ed path, ex: "/c/{collection}"
-    String path;
-    if (api instanceof AnnotatedApi) {
-      // ideal scenario; eventually everything might be AnnotatedApi?
-      path = ((AnnotatedApi) api).getEndPoint().path()[0]; // consider first to be primary
-    } else {
-      path = computeEndpointPath();
-    }
+    final String path = computeEndpointPath();
 
     String verb = null;
     // if this api has commands ...

--- a/solr/core/src/test/org/apache/solr/util/tracing/TestDistributedTracing.java
+++ b/solr/core/src/test/org/apache/solr/util/tracing/TestDistributedTracing.java
@@ -152,12 +152,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
         .build()
         .process(cloudClient);
     finishedSpans = getAndClearSpans();
-    // TODO See SOLR-16205.  A quirk in the way that span operationNames are generated causes
-    // core-level v2 endpoints
-    //  implemented using AnnotatedApi to produce spans lacking the full url (ie.
-    // /c/{collection}/update/json).  This test
-    //  will need updated to assert against the "full url" when SOLR-16205 is fixed.
-    assertEquals("post:/update/json", finishedSpans.get(0).operationName());
+    assertEquals("post:/c/{collection}/update/json", finishedSpans.get(0).operationName());
     assertDbInstanceColl(finishedSpans.get(0));
 
     final V2Response v2Response =


### PR DESCRIPTION
# Description

Prior to this commit, V2HttpCall populated the "operationName" of
tracing spans differently depending on whether the API was implemented
as an AnnotatedApi or not.  A special code path for AnnotatedApi's had
the operationName come primarily from the path value specified on the
@Endpoint annotation.

This works well for AnnotatedApis registered at the CoreContainer level,
but actually produces the wrong path for AnnotatedApis registered on
individual cores.

# Solution

This commit removes this optimized code path, so that
per-core AnnotatedApis produce spans consistent with everything else.

# Tests

Relying primarily on existing tests in TestDistributedTracing.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
