### PR TITLE
SOLR-16210: skip Antora task for lift builds

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -8,3 +8,5 @@ ignoreFiles = '''
 **/*.min.js
 solr/webapp/web/libs/*.js
 '''
+build = "./gradlew clean assemble -x test -x buildLocalAntoraSite"
+

--- a/.lift.toml
+++ b/.lift.toml
@@ -8,5 +8,5 @@ ignoreFiles = '''
 **/*.min.js
 solr/webapp/web/libs/*.js
 '''
-build = "./gradlew clean assemble -x test -x buildLocalAntoraSite"
+build = "./gradlew jar"
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16210

# Description

The antora site task is failing when trying to compile solr to prepare for lift static analysis. This prevents some tools from being able to produce results.

# Solution

This will skip the antora task which was failing during the lift
build process by adding a line of configuration to the .lift.toml file

# Tests

There should be no noticeable changes to the behavior of solr its self, but more lift results should be available and, under the tool results panel you should see that Infer ran successfully

![image](https://user-images.githubusercontent.com/1688763/170068251-4596489b-6280-46a9-a364-69eb51849c52.png)

*Note: As a result lift may claim this pr introduces new issues :-)*