### PR TITLE
SOLR-16214: Fix refGuide usage of lunr

### DIFF
--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -148,7 +148,6 @@ task buildLocalAntoraPlaybookYaml(type: Copy) {
         'source_url'         : project.rootDir,
         'source_branches'    : "HEAD",
         'start_path'         : project.rootDir.relativePath(file(project.ext.siteStagingDir)),
-        'supplemental_files' : "${project.ext.nodeProjectDir}/node_modules/@antora/lunr-extension/supplemental_ui",
         'site_dir'           : "./" + file(project.ext.siteStagingDir).relativePath(file(project.ext.siteDir)),
     ]
 
@@ -180,7 +179,6 @@ task buildOfficialAntoraPlaybookYaml(type: Copy) {
         'source_url'         : "https://github.com/apache/solr.git",
         'source_branches'    : branches,
         'start_path'         : 'solr/solr-ref-guide',
-        'supplemental_files' : "${project.ext.nodeProjectDir}/node_modules/@antora/lunr-extension/supplemental_ui",
         'site_dir'           : "./" + file(project.ext.playbooksDir).relativePath(file(project.ext.siteDir)),
     ]
 

--- a/solr/solr-ref-guide/playbook.template.yml
+++ b/solr/solr-ref-guide/playbook.template.yml
@@ -38,7 +38,6 @@ ui:
   bundle:
     url: 'https://nightlies.apache.org/solr/solr-reference-guide-ui-bundle/ui-bundle.zip'
     snapshot: true
-  supplemental_files: '${supplemental_files}'
 output:
   clean: true
   dir: '${site_dir}'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16214

Remove the use of supplemental-ui, as it's no longer necessary with the lunr-extension.

For more information, see: https://gitlab.com/antora/antora-lunr-extension/-/issues/15