### PR TITLE
SOLR-16215 Escape query characters in Solr SQL Array UDF functions

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -821,6 +821,8 @@ Bug Fixes
 * SOLR-16199: Improve query syntax construction for SQL LIKE clause with phrases and wildcards
   (Kiran Chitturi, Aroop Ganguly, Amrit Sarkar via Timothy Potter)
 
+* SOLR-16215: Escape query characters in Solr SQL Array UDF functions (Kiran Chitturi via Timothy Potter)
+
 ==================  8.11.1 ==================
 
 Bug Fixes

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -169,7 +169,7 @@ class SolrFilter extends Filter implements SolrRel {
       if (valuesNode instanceof RexLiteral) {
         String literal = toSolrLiteral(fieldName, (RexLiteral) valuesNode);
         if (!StringUtils.isEmpty(literal)) {
-          return fieldName + ":\"" + literal + "\"";
+          return fieldName + ":\"" + ClientUtils.escapeQueryChars(literal.trim()) + "\"";
         } else {
           return null;
         }
@@ -179,7 +179,7 @@ class SolrFilter extends Filter implements SolrRel {
             valuesRexCall.getOperands().stream()
                 .map(op -> toSolrLiteral(fieldName, (RexLiteral) op))
                 .filter(value -> !StringUtils.isEmpty(value))
-                .map(value -> "\"" + value.trim() + "\"")
+                .map(value -> "\"" + ClientUtils.escapeQueryChars(value.trim()) + "\"")
                 .collect(Collectors.joining(" " + booleanOperator + " "));
         return fieldName + ":(" + valuesString + ")";
       }

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -3375,12 +3375,18 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults(
         "select id, stringxmv from $ALIAS WHERE array_contains_any(pdoublexmv, (1.5, 2.5))", 3);
     expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(longs, (1, 3))", 3);
-    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"a\"', '\"e\"'))", 0);
-    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"a\"'))", 0);
-    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"f\"'))", 1);
-    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('g\"h'))", 1);
     expectResults(
-            "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e', '\"f\"'))", 3);
+        "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"a\"', '\"e\"'))",
+        0);
+    expectResults(
+        "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"a\"'))", 0);
+    expectResults(
+        "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"f\"'))", 1);
+    expectResults(
+        "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('g\"h'))", 1);
+    expectResults(
+        "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e', '\"f\"'))",
+        3);
 
     expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a'))", 2);
     expectResults(

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -3342,7 +3342,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stringxmv",
             "e",
             "stringxmv",
-            "f",
+            "\"f\"",
+            "stringxmv",
+            "g\"h",
             "stringxmv",
             "a",
             "pdoublexmv",
@@ -3373,6 +3375,13 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults(
         "select id, stringxmv from $ALIAS WHERE array_contains_any(pdoublexmv, (1.5, 2.5))", 3);
     expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(longs, (1, 3))", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"a\"', '\"e\"'))", 0);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"a\"'))", 0);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('\"f\"'))", 1);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('g\"h'))", 1);
+    expectResults(
+            "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e', '\"f\"'))", 3);
+
     expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a'))", 2);
     expectResults(
         "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'b', 'c'))", 3);
@@ -3380,7 +3389,5 @@ public class TestSQLHandler extends SolrCloudTestCase {
         "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'c'))", 3);
     expectResults(
         "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e'))", 3);
-    expectResults(
-        "select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e', 'f'))", 3);
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16215

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

* Query characters are currently not escaped inside values in array udf functions 

# Solution

* Escape the query characters in translation

# Tests

* Unit tests added

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
