### PR TITLE
SOLR-16227 Use local params value syntax for phrase queries 

### DIFF
--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -364,7 +365,7 @@ class SolrFilter extends Filter implements SolrRel {
         if (hasMultipleTerms && (terms.contains("*") || terms.contains("?"))) {
           String quotedTerms = "\\\"" + terms.substring(1, terms.length() - 1) + "\\\"";
           String query = pair.getKey() + ":" + quotedTerms;
-          return String.format("{!complexphrase v=\"%s\"}", query);
+          return String.format(Locale.ROOT, "{!complexphrase v=\"%s\"}", query);
         }
       } // else treat as an embedded Solr query and pass-through
 

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -362,8 +362,8 @@ class SolrFilter extends Filter implements SolrRel {
         // but that expects the terms wrapped in double-quotes, not parens
         boolean hasMultipleTerms = terms.split("\\s+").length > 1;
         if (hasMultipleTerms && (terms.contains("*") || terms.contains("?"))) {
-          String quotedTerms = "\"" + terms.substring(1, terms.length() - 1) + "\"";
-          return "{!complexphrase}" + pair.getKey() + ":" + quotedTerms;
+          String quotedTerms = "\\\"" + terms.substring(1, terms.length() - 1) + "\\\"";
+          return String.format("{!complexphrase v=\"%s\"}", pair.getKey() + ":" + quotedTerms);
         }
       } // else treat as an embedded Solr query and pass-through
 

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -363,7 +363,8 @@ class SolrFilter extends Filter implements SolrRel {
         boolean hasMultipleTerms = terms.split("\\s+").length > 1;
         if (hasMultipleTerms && (terms.contains("*") || terms.contains("?"))) {
           String quotedTerms = "\\\"" + terms.substring(1, terms.length() - 1) + "\\\"";
-          return String.format("{!complexphrase v=\"%s\"}", pair.getKey() + ":" + quotedTerms);
+          String query = pair.getKey() + ":" + quotedTerms;
+          return String.format("{!complexphrase v=\"%s\"}", query);
         }
       } // else treat as an embedded Solr query and pass-through
 

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -363,9 +363,9 @@ class SolrFilter extends Filter implements SolrRel {
         // but that expects the terms wrapped in double-quotes, not parens
         boolean hasMultipleTerms = terms.split("\\s+").length > 1;
         if (hasMultipleTerms && (terms.contains("*") || terms.contains("?"))) {
-          String quotedTerms = "\\\"" + terms.substring(1, terms.length() - 1) + "\\\"";
-          String query = pair.getKey() + ":" + quotedTerms;
-          return String.format(Locale.ROOT, "{!complexphrase v=\"%s\"}", query);
+          String quotedTerms = "\"" + terms.substring(1, terms.length() - 1) + "\"";
+          String query = ClientUtils.encodeLocalParamVal(pair.getKey() + ":" + quotedTerms);
+          return String.format(Locale.ROOT, "{!complexphrase v=%s}", query);
         }
       } // else treat as an embedded Solr query and pass-through
 

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2553,7 +2553,8 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '(\"dog pig\"~5)'", 2);
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'jumped over'", 8);
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'quick brown fox'", 5);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'quick brow%'", 5);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'quick brow%' AND b_s LIKE 'foo*'", 3);
     expectResults("SELECT b_s FROM $ALIAS WHERE b_s LIKE 'foo*'", 5);
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '*og'", 8);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16227 

# Description
parse query that has multiple terms fails when it formatted like this `({!complexphrase}name:"Sample Temp*" AND cluster_id:aws*)`

# Solution

Format the complex phrase like `{!complexphrase v="name:\"Sample Temp*\""}` so that the parsing works

# Tests

Added unit tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
