### PR TITLE
SOLR-16228: Audit how we refer to Solr Modules

### DIFF
--- a/dev-docs/plugins-modules-packages.adoc
+++ b/dev-docs/plugins-modules-packages.adoc
@@ -13,7 +13,7 @@ See ref guide page https://solr.apache.org/guide/solr-plugins.html[Solr Plugins]
 
 === Module
 
-Solr modules are addon Solr plugins that are not part of solr-core, but officially maintained
+Solr Modules are addon Solr plugins that are not part of solr-core, but officially maintained
 by the Solr project. They provide well-defined features such as the "extracting" module which lets
 users index rich text documents with Apache Tika. Modules were earlier known as "contribs".
 

--- a/gradle/validation/jar-checks.gradle
+++ b/gradle/validation/jar-checks.gradle
@@ -127,7 +127,7 @@ subprojects {
       while (!queue.isEmpty()) {
         def dep = queue.removeFirst()
 
-        // Skip any artifacts from other Solr modules (they will be resolved there).
+        // Skip any artifacts from other Solr Modules (they will be resolved there).
         if (dep.moduleGroup == "org.apache.solr") {
           continue
         }

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -69,7 +69,7 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The example below can be used to load a solr module along
+       The example below can be used to load a Solr Module along
        with their external dependencies.
     -->
     <!-- <lib dir="${solr.install.dir:../../../..}/modules/ltr/lib" regex=".*\.jar" /> -->

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -71,7 +71,7 @@
 
        The examples below can be used to load some Solr Modules along
        with their external dependencies as an alternative to using a
-       startup parameter to define the modules to load.  For more info
+       startup parameter to define the modules to load globally.  For more info
        see https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html.
     -->
   <lib dir="${solr.install.dir:../../../..}/modules/extraction/lib" regex=".*\.jar" />

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -69,8 +69,10 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The examples below can be used to load some solr modules along
-       with their external dependencies.
+       The examples below can be used to load some Solr Modules along
+       with their external dependencies as an alternative to using a
+       startup parameter to define the modules to load.  For more info
+       see https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html.
     -->
   <lib dir="${solr.install.dir:../../../..}/modules/extraction/lib" regex=".*\.jar" />
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
@@ -183,7 +183,7 @@ Note that specifying `sharedLib` will not remove `$SOLR_HOME/lib` from Solr's cl
 |Optional |Default: none
 |===
 +
-Takes a list of bundled xref:solr-modules.adoc[Solr Modules] to enable
+Takes a list of bundled xref:solr-modules.adoc[] to enable
 on startup. This way of adding modules will add them to the shared class loader, making them
 available to every collection in Solr, unlike `<lib>` tag in `solrconfig.xml` which is only
 for that one collection. Example value: `extracting,ltr`. See the

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
@@ -183,7 +183,7 @@ Note that specifying `sharedLib` will not remove `$SOLR_HOME/lib` from Solr's cl
 |Optional |Default: none
 |===
 +
-Takes a list of bundled xref:solr-modules.adoc[Solr Modules] to enabled
+Takes a list of bundled xref:solr-modules.adoc[Solr Modules] to enable
 on startup. This way of adding modules will add them to the shared class loader, making them
 available to every collection in Solr, unlike `<lib>` tag in `solrconfig.xml` which is only
 for that one collection. Example value: `extracting,ltr`. See the

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
@@ -183,9 +183,9 @@ Note that specifying `sharedLib` will not remove `$SOLR_HOME/lib` from Solr's cl
 |Optional |Default: none
 |===
 +
-Takes a list of bundled xref:solr-modules.adoc[solr modules] to add to Solr's class path
+Takes a list of bundled xref:solr-modules.adoc[Solr Modules] to enabled
 on startup. This way of adding modules will add them to the shared class loader, making them
-available for every collection in Solr, unlike `<lib>` tag in `solrconfig.xml` which is only
+available to every collection in Solr, unlike `<lib>` tag in `solrconfig.xml` which is only
 for that one collection. Example value: `extracting,ltr`. See the
 xref:solr-modules.adoc[Solr Modules] chapter for more details.
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/libs.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/libs.adoc
@@ -29,19 +29,18 @@ If there is overlap or inter-dependencies between libraries, then pay attention 
 There are several special places you can place Solr plugin `.jar` files:
 
 * `<solr_home>/lib/`: The `.jar` files placed here are available to all Solr cores running on the node, and to node level plugins referenced in `solr.xml` -- so basically everything.
-This directory is not present by default so create it.
+This directory is not present by default so you willl need to create it.
 See xref:deployment-guide:taking-solr-to-production.adoc[].
 
 * `<core_instance>/lib/`: In a user-managed cluster or a single-node installation, you may want to add plugins just for a specific Solr core.
-Create this adjacent to the `conf/` directory; it's not present by default.
+Create this adjacent to the `<core_instance>/conf/` directory; it's not present by default.
 
 * `<solr_install>/lib/`: The `.jar` files placed here are available to all Solr cores running on the node, and to node level plugins referenced in `solr.xml` -- so basically everything.
 Contrary to `<solr_home>/lib/`, this directory is always located in the install dir, so it can be used e.g. for custom
 Dockerfile to place custom plugin jars.
 
 * `<solr_install>/server/solr-webapp/webapp/WEB-INF/lib/`: The `.jar` files for Solr itself and it's dependencies live here.
-Certain plugins or add-ons to plugins require placement here.
-They will document themselves to say so.
+Certain plugins or add-ons to plugins require placement here, and they will have explicit documentation for this need.
 
 * `<solr_install>/server/lib/ext`: The `.jar` files used for the Solr server as well as Solr Core/SolrJ.
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/libs.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/libs.adoc
@@ -29,7 +29,7 @@ If there is overlap or inter-dependencies between libraries, then pay attention 
 There are several special places you can place Solr plugin `.jar` files:
 
 * `<solr_home>/lib/`: The `.jar` files placed here are available to all Solr cores running on the node, and to node level plugins referenced in `solr.xml` -- so basically everything.
-This directory is not present by default so you willl need to create it.
+This directory is not present by default so you will need to create it.
 See xref:deployment-guide:taking-solr-to-production.adoc[].
 
 * `<core_instance>/lib/`: In a user-managed cluster or a single-node installation, you may want to add plugins just for a specific Solr core.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/script-update-processor.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/script-update-processor.adoc
@@ -28,10 +28,15 @@ The script can be written in any scripting language supported by your JVM (such 
 WARNING: Being able to run a script of your choice as part of the indexing pipeline is a really powerful tool, that I sometimes call the _Get out of jail free_ card because you can solve some problems this way that you can't in any other way.
 However, you are introducing some potential security vulnerabilities.
 
-== Installing the ScriptingUpdateProcessor and Scripting Engines
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be added to the classpath before use
-by adding it to the list of modules via `solr.modules=scripting`.
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `scripting`.
+
+
+== Enababling the ScriptingUpdateProcessor and Scripting Engines
 
 Java 11 and previous versions come with a JavaScript engine called Nashorn, but Java 12 will require you to add your own JavaScript engine.
 Other supported scripting engines like JRuby, Jython, Groovy, all require you to add JAR files to Solr.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/script-update-processor.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/script-update-processor.adoc
@@ -31,9 +31,7 @@ However, you are introducing some potential security vulnerabilities.
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `scripting`.
+This is provided via the `scripting` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 
 == Enababling the ScriptingUpdateProcessor and Scripting Engines

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -32,8 +32,8 @@ The easiest way to enable a module is to list the modules you intend to use eith
 system property `solr.modules` or in the environment variable `SOLR_MODULES` (e.g. in `solr.in.sh`
 or `solr.in.cmd`). You can also add a `<str name="modules">` tag to your
 xref:configuration-guide:configuring-solr-xml.adoc[solr.xml]. The expected value is a comma separated list
-of module names, e.g. `SOLR_MODULES=extracting,ltr`. This will add
-them to the shared class loader, making them available to every collection in Solr.
+of module names, e.g. `SOLR_MODULES=extracting,ltr`. This will make the functionality of configured Modules
+available to every collection in Solr.
 
 You can also specify the modules to include when using the Solr CLI to start Solr:
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -42,8 +42,9 @@ You can also specify the modules to include when using the Solr CLI to start Sol
 bin/solr start -e techproducts -Dsolr.modules=scripting
 ----
 
-If you only wish to enable a module for a single collection, you may add `<lib>` tags to `solrconfig.xml`
-as explained in xref:configuration-guide:libs.adoc[Lib Directories].
+NOTE: If you only wish to enable a module for a single collection, you may add `<lib>` tags to `solrconfig.xml`
+as explained in xref:configuration-guide:libs.adoc[Lib Directories].   This technically isn't considered enabling
+a module, as you are instead just loading all the jars in the module's `lib/` folder, thus enabling all that module' plugins.
 
 Some modules may have been made available as packages for the xref:configuration-guide:package-manager.adoc[Package Manager],
 check by listing available packages.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -17,13 +17,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-Solr modules are addon Solr plugins that are not part of solr-core, but officially maintained
+Solr Modules are addon Solr plugins that are not part of solr-core, but officially maintained
 by the Solr project. They provide well-defined features such as the "extracting" module which lets
 users index rich text documents with Apache Tika. A single module can contain multiple Plugins.
 Modules were earlier known as "contribs".
 
-Each module produces a separate `.jar` file in the build, and additional dependencies required by
-each module are also packaged with the module. This helps keep the main core of Solr small and lean.
+Each module produces a separate `.jar` file in the build, and any additional dependencies required
+are also packaged with the module and therefore included for you. This helps keep the main core of Solr
+small and lean.
 
 == Installing a module
 
@@ -31,10 +32,10 @@ The easiest way to enable a module is to list the modules you intend to use eith
 system property `solr.modules` or in the environment variable `SOLR_MODULES` (e.g. in `solr.in.sh`
 or `solr.in.cmd`). You can also add a `<str name="modules">` tag to
 xref:configuration-guide:configuring-solr-xml.adoc[solr.xml]. The expected value is a comma separated list
-of module names, e.g. `SOLR_MODULES=extracting,ltr`. This way of adding modules will add
-them to the shared class loader, making them available for every collection in Solr.
+of module names, e.g. `SOLR_MODULES=extracting,ltr`. This will add
+them to the shared class loader, making them available to every collection in Solr.
 
-You can also specify the modules when using the Solr CLI to start Solr:
+You can also specify the modules to include when using the Solr CLI to start Solr:
 
 [source,bash]
 ----

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -43,8 +43,9 @@ bin/solr start -e techproducts -Dsolr.modules=scripting
 ----
 
 NOTE: If you only wish to enable a module for a single collection, you may add `<lib>` tags to `solrconfig.xml`
-as explained in xref:configuration-guide:libs.adoc[Lib Directories].   This technically isn't considered enabling
-a module, as you are instead just loading all the jars in the module's `lib/` folder, thus enabling all that module' plugins.
+as explained in xref:configuration-guide:libs.adoc[Lib Directories].
+Collection-level plugins will work if the module is enabled either per collection (`<lib>`) or for the whole Solr node.
+Cluster-level plugins will not work when using the `<lib>` option, they must be enabled for the entire Solr node, as described above.
 
 Some modules may have been made available as packages for the xref:configuration-guide:package-manager.adoc[Package Manager],
 check by listing available packages.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -22,15 +22,15 @@ by the Solr project. They provide well-defined features such as the "extracting"
 users index rich text documents with Apache Tika. A single module can contain multiple Plugins.
 Modules were earlier known as "contribs".
 
-Each module produces a separate `.jar` file in the build, and any additional dependencies required
-are also packaged with the module and therefore included for you. This helps keep the main core of Solr
-small and lean.
+Each module produces a separate `.jar` file in the build, packaged in the module's `lib/` directory.
+All additional dependencies required by the module, and not provided by Solr core, are also packaged there.
+This helps keep the main core of Solr small and lean.
 
 == Installing a module
 
 The easiest way to enable a module is to list the modules you intend to use either in the
 system property `solr.modules` or in the environment variable `SOLR_MODULES` (e.g. in `solr.in.sh`
-or `solr.in.cmd`). You can also add a `<str name="modules">` tag to
+or `solr.in.cmd`). You can also add a `<str name="modules">` tag to your
 xref:configuration-guide:configuring-solr-xml.adoc[solr.xml]. The expected value is a comma separated list
 of module names, e.g. `SOLR_MODULES=extracting,ltr`. This will add
 them to the shared class loader, making them available to every collection in Solr.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -42,7 +42,7 @@ You can also specify the modules to include when using the Solr CLI to start Sol
 bin/solr start -e techproducts -Dsolr.modules=scripting
 ----
 
-NOTE: If you only wish to enable a module for a single collection, you may add `<lib>` tags to `solrconfig.xml`
+NOTE: If you only wish to enable a module for certain collections, you may add `<lib>` tags to `solrconfig.xml` in applicable configset(s).
 as explained in xref:configuration-guide:libs.adoc[Lib Directories].
 Collection-level plugins will work if the module is enabled either per collection (`<lib>`) or for the whole Solr node.
 Cluster-level plugins will not work when using the `<lib>` option, they must be enabled for the entire Solr node, as described above.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-modules.adoc
@@ -45,7 +45,7 @@ bin/solr start -e techproducts -Dsolr.modules=scripting
 NOTE: If you only wish to enable a module for certain collections, you may add `<lib>` tags to `solrconfig.xml` in applicable configset(s).
 as explained in xref:configuration-guide:libs.adoc[Lib Directories].
 Collection-level plugins will work if the module is enabled either per collection (`<lib>`) or for the whole Solr node.
-Cluster-level plugins will not work when using the `<lib>` option, they must be enabled for the entire Solr node, as described above.
+Node-level plugins such as those specified in `solr.xml` will not work when using the `<lib>` option in `solrconfig.xml` because configsets configure collections, not the node.  They must be enabled for the entire Solr node, as described above.
 
 Some modules may have been made available as packages for the xref:configuration-guide:package-manager.adoc[Package Manager],
 check by listing available packages.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-plugins.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-plugins.adoc
@@ -47,7 +47,7 @@ Examples of these are xref:deployment-guide:authentication-and-authorization-plu
 == Installing Plugins ==
 
 Many plugins are built-in to Solr core and there is nothing to install.
-However some plugins require an installation step (or two if they are a Solr Module).
+However some plugins require installation step(s).
 Plugins are packaged into a Java jar file and may have other dependent jar files required to function.
 
 The next sections describe some installation options:

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-plugins.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-plugins.adoc
@@ -46,11 +46,11 @@ Examples of these are xref:deployment-guide:authentication-and-authorization-plu
 
 == Installing Plugins ==
 
-Most plugins are built-in to Solr core and there is nothing to install.
-The subject here is how to make the bundled modules and other plugins available to Solr.
-Plugins are packaged into a Java jar file and may have other dependent jar files to function.
+Many plugins are built-in to Solr core and there is nothing to install.
+However some plugins require an installation step (or two if they are a Solr Module).
+Plugins are packaged into a Java jar file and may have other dependent jar files required to function.
 
-The next sections describe some options:
+The next sections describe some installation options:
 
 ****
 // This tags the below list so it can be used in the parent page section list

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
@@ -404,8 +404,10 @@ An example configuration using this property can be found below.
 === HdfsBackupRepository
 
 Stores and retrieves backup files from HDFS directories.
-This is provided in the `hdfs` xref:configuration-guide:solr-modules.adoc[Solr Module].
-This plugin must first be xref:configuration-guide:solr-plugins.adoc#installing-plugins[installed] before using.
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `hdfs`.
 
 HdfsBackupRepository accepts the following configuration options:
 
@@ -464,8 +466,10 @@ An example configuration using these properties can be found below:
 === GCSBackupRepository
 
 Stores and retrieves backup files in a Google Cloud Storage ("GCS") bucket.
-This is provided in the `gcs-repository` xref:configuration-guide:solr-modules.adoc[Solr Module].
-This plugin must first be xref:configuration-guide:solr-plugins.adoc#installing-plugins[installed] before using.
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `gcs-repository`.
 
 GCSBackupRepository accepts the following options for overall configuration:
 
@@ -664,8 +668,10 @@ An example configuration using the overall and GCS-client properties can be seen
 === S3BackupRepository
 
 Stores and retrieves backup files in an Amazon S3 bucket.
-This is provided in the `s3-repository` xref:configuration-guide:solr-modules.adoc[Solr Module].
-This plugin must first be xref:configuration-guide:solr-plugins.adoc#installing-plugins[installed] before using.
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `s3-repository`.
 
 This plugin uses the https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html[default AWS credentials provider chain], so ensure that your credentials are set appropriately (e.g., via env var, or in `~/.aws/credentials`, etc.).
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
@@ -405,9 +405,7 @@ An example configuration using this property can be found below.
 
 Stores and retrieves backup files from HDFS directories.
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `hdfs`.
+This is provided via the `hdfs` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 HdfsBackupRepository accepts the following configuration options:
 
@@ -467,9 +465,7 @@ An example configuration using these properties can be found below:
 
 Stores and retrieves backup files in a Google Cloud Storage ("GCS") bucket.
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `gcs-repository`.
+This is provided via the `gcs-repository` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 GCSBackupRepository accepts the following options for overall configuration:
 
@@ -669,9 +665,7 @@ An example configuration using the overall and GCS-client properties can be seen
 
 Stores and retrieves backup files in an Amazon S3 bucket.
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `s3-repository`.
+This is provided via the `s3-repository` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 This plugin uses the https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html[default AWS credentials provider chain], so ensure that your credentials are set appropriately (e.g., via env var, or in `~/.aws/credentials`, etc.).
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/distributed-tracing.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/distributed-tracing.adoc
@@ -16,15 +16,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-Solr includes a general tracing framework based on OpenTracing that can be used to trace lifecycle of a request for performance monitoring.
+Solr includes a general tracing framework based on OpenTracing that can be used to trace the lifecycle of a request for performance monitoring.
 
-Tracing data can be configured to send to arbitrary backend like Jaeger, Zipkin, Datadog, etc.
+Tracing data can be configured to send to arbitrary backends like Jaeger, Zipkin, Datadog, etc.
 At the moment, only Jaeger is supported out of the box.
 
 A sampled distributed tracing query request on Jaeger looks like this:
 
 .Tracing of a Solr query
 image::distributed-tracing/query-request-tracing.png[]
+
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `jaegertracer-configurator`.
 
 == Configuring Tracer
 
@@ -51,7 +57,7 @@ https://docs.datadoghq.com/tracing/setup/java/[datadog-java-agent] uses Javaagen
 The `modules/jagertracer-configurator` provides a default implementation for setting up Jaeger Tracer.
 
 Add the solr-jaegertracer JAR file and the other JARs provided with this module to your Solr installation, ideally to each node.
-GSON is a dependency that is only used by Jaeger's "remote" sampler,
+https://github.com/google/gson[GSON] is a dependency that is only used by Jaeger's "remote" sampler,
 which is the default.  Solr doesn't distribute it, so you'll need to add GSON yourself or configure a different sampler.
 
 Then Jaeger tracer is configured in `solr.xml` like this:

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/distributed-tracing.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/distributed-tracing.adoc
@@ -28,9 +28,7 @@ image::distributed-tracing/query-request-tracing.png[]
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `jaegertracer-configurator`.
+This is provided via the `jaegertracer-configurator` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == Configuring Tracer
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/installing-solr.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/installing-solr.adoc
@@ -94,7 +94,8 @@ This script is used on *nix systems to install Solr as a service.
 It is described in more detail in the section xref:taking-solr-to-production.adoc[].
 
 modules/::
-Solr's `modules` directory includes 1st-party add-on plugins for specialized features of Solr.
+Solr's `modules` directory includes 1st-party add-ons for specialized features that enhance Solr.
+See the section xref:configuration-guide:solr-modules.adoc[] for more information.
 
 prometheus-exporter/::
 A standalone application, included under `bin/`, that montiors Solr instances and produces Prometheus metrics.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/jwt-authentication-plugin.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/jwt-authentication-plugin.adoc
@@ -23,9 +23,7 @@ The typical use case is to integrate Solr with an https://en.wikipedia.org/wiki/
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `jwt-auth`.
+This is provided via the `jwt-auth` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == Enable JWT Authentication
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/jwt-authentication-plugin.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/jwt-authentication-plugin.adoc
@@ -23,8 +23,9 @@ The typical use case is to integrate Solr with an https://en.wikipedia.org/wiki/
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be added to the classpath before use. Since this is a node-level
-plugin it must go in `sharedLib`, see xref:configuration-guide:configuring-solr-xml.adoc[] for details.
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `jwt-auth`.
 
 == Enable JWT Authentication
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
@@ -17,8 +17,8 @@
 // under the License.
 
 
-The Solr HDFS module has support for writing and reading its index and transaction log files to the HDFS distributed filesystem. This does
-not use Hadoop MapReduce to process Solr data, rather it only uses the HDFS filesystem for index and transaction log file storage.
+The Solr HDFS Module has support for writing and reading Solr's index and transaction log files to the HDFS distributed filesystem.
+It does not use Hadoop MapReduce to process Solr data.
 
 To use HDFS rather than a local filesystem, you must be using Hadoop 2.x and you will need to instruct Solr to use the `HdfsDirectoryFactory`.
 There are also several additional parameters to define.
@@ -32,9 +32,7 @@ These configuration changes would need to be repeated for every collection, so i
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `hdfs`.
+This is provided via the `hdfs` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == Starting Solr on HDFS
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
@@ -17,11 +17,8 @@
 // under the License.
 
 
-The Solr HDFS module has support for writing and reading its index and transaction log files to the HDFS distributed filesystem.
-This plugin must first be xref:configuration-guide:solr-plugins.adoc#installing-plugins[installed] before using.
-This module needs to be installed as lib, it is planned to evolve to a Solr package in a later release.
-
-This does not use Hadoop MapReduce to process Solr data, rather it only uses the HDFS filesystem for index and transaction log file storage.
+The Solr HDFS module has support for writing and reading its index and transaction log files to the HDFS distributed filesystem. This does
+not use Hadoop MapReduce to process Solr data, rather it only uses the HDFS filesystem for index and transaction log file storage.
 
 To use HDFS rather than a local filesystem, you must be using Hadoop 2.x and you will need to instruct Solr to use the `HdfsDirectoryFactory`.
 There are also several additional parameters to define.
@@ -32,6 +29,12 @@ These would need to be passed every time you start Solr with `bin/solr`.
 * Modify `solr.in.sh` (or `solr.in.cmd` on Windows) to pass the JVM arguments automatically when using `bin/solr` without having to set them manually.
 * Define the properties in `solrconfig.xml`.
 These configuration changes would need to be repeated for every collection, so is a good option if you only want some of your collections stored in HDFS.
+
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `hdfs`.
 
 == Starting Solr on HDFS
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-tika.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-tika.adoc
@@ -49,8 +49,15 @@ By default it maps to the same name but several parameters control how this is d
 * When Solr Cell finishes creating the internal `SolrInputDocument`, the rest of the indexing stack takes over.
 The next step after any update handler is the xref:configuration-guide:update-request-processors.adoc[Update Request Processor] chain.
 
-Solr Cell is a module, which means it's not automatically included with Solr but must be configured.
-The example configsets have Solr Cell configured, but if you are not using those, you will want to pay attention to the section <<solrconfig.xml Configuration>> below.
+
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `extraction`.
+
+The "techproducts" example included with Solr is pre-configured to have Solr Cell configured, but if you are not using it, you will want to pay attention to the section <<solrconfig.xml Configuration>> below.
+
 
 === Solr Cell Performance Implications
 
@@ -415,7 +422,7 @@ Also see the section <<Defining XPath Expressions>> for an example.
 
 If you have started Solr with one of the supplied xref:configuration-guide:config-sets.adoc[example configsets], you may already have the `ExtractingRequestHandler` configured by default.
 
-If it is not already configured, you will need to configure `solrconfig.xml` to find the `ExtractingRequestHandler` and its dependencies:
+If it is not already configured, you will need to configure `solrconfig.xml` to find the `ExtractingRequestHandler` and its dependencies, you must enable the xref:#module[Module]:
 
 [source,xml]
 ----

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-tika.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-tika.adoc
@@ -52,11 +52,10 @@ The next step after any update handler is the xref:configuration-guide:update-re
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+This is provided via the `extraction` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
-The module name is `extraction`.
-
-The "techproducts" example included with Solr is pre-configured to have Solr Cell configured, but if you are not using it, you will want to pay attention to the section <<solrconfig.xml Configuration>> below.
+The "techproducts" example included with Solr is pre-configured to have Solr Cell configured.
+If you are not using the example, you will want to pay attention to the section <<solrconfig.xml Configuration>> below.
 
 
 === Solr Cell Performance Implications
@@ -422,7 +421,8 @@ Also see the section <<Defining XPath Expressions>> for an example.
 
 If you have started Solr with one of the supplied xref:configuration-guide:config-sets.adoc[example configsets], you may already have the `ExtractingRequestHandler` configured by default.
 
-If it is not already configured, you will need to configure `solrconfig.xml` to find the `ExtractingRequestHandler` and its dependencies, you must enable the xref:#module[Module]:
+First, you must enable the xref:#module[Module].
+If `solrconfig.xml` is not already configured, you will need to modify it to find the `ExtractingRequestHandler` and its dependencies:
 
 [source,xml]
 ----

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
@@ -26,7 +26,7 @@ It is possible to access the same handler using more than one name, which can be
 
 A single unified update request handler supports XML, CSV, JSON, and javabin update requests, delegating to the appropriate `ContentStreamLoader` based on the `Content-Type` of the xref:content-streams.adoc[ContentStream].
 
-If you need to preprocess documents after they are loaded but before they are indexed (or even checked against the schema),
+If you need to pre-process documents after they are loaded but before they are indexed (or even checked against the schema),
 Solr has document preprocessing plugins for Update Request Handlers, called xref:configuration-guide:update-request-processors.adoc[], which allow for default and custom configuration chains.
 
 == UpdateRequestHandler Configuration

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
@@ -275,7 +275,7 @@ The status field will be non-zero in case of failure.
 The xref:configuration-guide:script-update-processor.adoc[Scripting module] provides a separate XSLT Update Request Handler that allows you to index any arbitrary XML by using the `<tr>` parameter to apply an https://en.wikipedia.org/wiki/XSLT[XSL transformation].
 You must have an XSLT stylesheet in the `conf/xslt` directory of your xref:configuration-guide:config-sets.adoc[configset] that can transform the incoming data to the expected `<add><doc/></add>` format, and use the `tr` parameter to specify the name of that stylesheet.
 
-You will need to enable the xref:configuration-guide:script-update-processor.adoc[Scripting module] before using this feature.
+You will need to enable the xref:configuration-guide:script-update-processor.adoc#module[scripting Module] before using this feature.
 
 === tr Parameter
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
@@ -18,7 +18,7 @@
 // under the License.
 
 Update handlers are request handlers designed to add, delete and update documents to the index.
-In addition to having plugins for importing rich documents xref:indexing-with-tika.adoc[], Solr natively supports indexing structured documents in XML, CSV, and JSON.
+In addition to having plugins for importing rich documents (see xref:indexing-with-tika.adoc[]), Solr natively supports indexing structured documents in XML, CSV, and JSON.
 
 The recommended way to configure and use request handlers is with path based names that map to paths in the request URL.
 However, request handlers can also be specified with the `qt` (query type) parameter if the xref:configuration-guide:requestdispatcher.adoc[`requestDispatcher`] is appropriately configured.
@@ -26,7 +26,7 @@ It is possible to access the same handler using more than one name, which can be
 
 A single unified update request handler supports XML, CSV, JSON, and javabin update requests, delegating to the appropriate `ContentStreamLoader` based on the `Content-Type` of the xref:content-streams.adoc[ContentStream].
 
-If you need to pre-process documents after they are loaded but before they are indexed (or even checked against the schema),
+If you need to preprocess documents after they are loaded but before they are indexed (or even checked against the schema),
 Solr has document preprocessing plugins for Update Request Handlers, called xref:configuration-guide:update-request-processors.adoc[], which allow for default and custom configuration chains.
 
 == UpdateRequestHandler Configuration
@@ -275,13 +275,12 @@ The status field will be non-zero in case of failure.
 The xref:configuration-guide:script-update-processor.adoc[Scripting module] provides a separate XSLT Update Request Handler that allows you to index any arbitrary XML by using the `<tr>` parameter to apply an https://en.wikipedia.org/wiki/XSLT[XSL transformation].
 You must have an XSLT stylesheet in the `conf/xslt` directory of your xref:configuration-guide:config-sets.adoc[configset] that can transform the incoming data to the expected `<add><doc/></add>` format, and use the `tr` parameter to specify the name of that stylesheet.
 
-Learn more about adding the `modules/scripting/lib/*` files into Solr's xref:configuration-guide:libs.adoc#lib-directories[Lib Directories].
+You will need to enable the xref:configuration-guide:script-update-processor.adoc[Scripting module] before using this feature.
 
 === tr Parameter
 
-The XSLT Update Request Handler accepts one parameter: the `tr` parameter, which identifies the XML transformation to use.
+The XSLT Update Request Handler accepts the `tr` parameter, which identifies the XML transformation to use.
 The transformation must be found in the Solr `conf/xslt` directory.
-
 
 === XSLT Configuration
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
@@ -692,7 +692,7 @@ On the other hand, it can reduce precision because language-specific character d
 
 == OpenNLP Integration
 
-The `lucene/analysis/opennlp` package provides OpenNLP integration via several analysis components: a tokenizer, a part-of-speech tagging filter, a phrase chunking filter, and a lemmatization filter.
+The Lucene module `lucene/analysis/opennlp` provides OpenNLP integration via several analysis components: a tokenizer, a part-of-speech tagging filter, a phrase chunking filter, and a lemmatization filter.
 In addition to these analysis components, Solr also provides an update request processor to extract named entities.
 See also xref:configuration-guide:update-request-processors.adoc#update-processor-factories-that-can-be-loaded-as-plugins[Update Processor Factories That Can Be Loaded as Plugins].
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
@@ -268,7 +268,7 @@ Unicode Collation in Solr is fast, because all the work is done at index time.
 Rather than specifying an analyzer within `<fieldtype ... class="solr.TextField">`, the `solr.CollationField` and `solr.ICUCollationField` field type classes provide this functionality.
 `solr.ICUCollationField`, which is backed by http://site.icu-project.org[the ICU4J library], provides more flexible configuration, has more locales, is significantly faster, and requires less memory and less index space, since its keys are smaller than those produced by the JDK implementation that backs `solr.CollationField`.
 
-To use `solr.ICUCollationField`, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use `solr.ICUCollationField`, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 
 `solr.ICUCollationField` and `solr.CollationField` fields can be created in two ways:
@@ -700,7 +700,7 @@ NOTE: The <<OpenNLP Tokenizer>> must be used with all other OpenNLP analysis com
 First, the OpenNLP Tokenizer detects and marks the sentence boundaries required by all the OpenNLP filters.
 Second, since the pre-trained OpenNLP models used by these filters were trained using the corresponding language-specific sentence-detection/tokenization models, the same tokenization using the same models must be used at runtime for optimal performance.
 
-To use the OpenNLP components, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use the OpenNLP components, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 
 === OpenNLP Tokenizer
@@ -1327,7 +1327,7 @@ The stemmer language, `Catalan` in this case.
 The default configuration of the xref:tokenizers.adoc#icu-tokenizer[ICU Tokenizer] is suitable for Traditional Chinese text.
 It follows the Word Break rules from the Unicode Text Segmentation algorithm for non-Chinese text, and uses a dictionary to segment Chinese words.
 
-To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 The xref:tokenizers.adoc#standard-tokenizer[Standard Tokenizer] can also be used to tokenize Traditional Chinese text.
 Following the Word Break rules from the Unicode Text Segmentation algorithm, it produces one token per Chinese character.
@@ -1440,11 +1440,11 @@ See the example under <<Traditional Chinese>>.
 
 For Simplified Chinese, Solr provides support for Chinese sentence and word segmentation with the <<HMM Chinese Tokenizer>>.
 This component includes a large dictionary and segments Chinese text into words with the Hidden Markov Model.
-To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 The default configuration of the xref:tokenizers.adoc#icu-tokenizer[ICU Tokenizer] is also suitable for Simplified Chinese text.
 It follows the Word Break rules from the Unicode Text Segmentation algorithm for non-Chinese text, and uses a dictionary to segment Chinese words.
-To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 Also useful for Chinese analysis:
 
@@ -1501,7 +1501,7 @@ Also useful for Chinese analysis:
 
 For Simplified Chinese, Solr provides support for Chinese sentence and word segmentation with the `solr.HMMChineseTokenizerFactory` in the `analysis-extras` module.
 This component includes a large dictionary and segments Chinese text into words with the Hidden Markov Model.
-To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 *Factory class:* `solr.HMMChineseTokenizerFactory`
 
@@ -2547,7 +2547,7 @@ This filter replaces term text with the Reading Attribute, the Hangul transcript
 === Hebrew, Lao, Myanmar, Khmer
 
 Lucene provides support, in addition to UAX#29 word break rules, for Hebrew's use of the double and single quote characters, and for segmenting Lao, Myanmar, and Khmer into syllables with the `solr.ICUTokenizerFactory` in the `analysis-extras` module.
-To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 See xref:tokenizers.adoc#icu-tokenizer[ICUTokenizer] for more information.
 
@@ -2821,7 +2821,7 @@ Solr includes support for normalizing Persian, and Lucene includes an example st
 
 Solr provides support for Polish stemming with the `solr.StempelPolishStemFilterFactory`, and `solr.MorphologikFilterFactory` for lemmatization, in the `analysis-extras` module.
 The `solr.StempelPolishStemFilterFactory` component includes an algorithmic stemmer with tables for Polish.
-To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 *Factory class:* `solr.StempelPolishStemFilterFactory` and `solr.MorfologikFilterFactory`
 
@@ -3368,7 +3368,7 @@ Solr includes support for stemming Turkish with the `solr.SnowballPorterFilterFa
 === Ukrainian
 
 Solr provides support for Ukrainian lemmatization with the `solr.MorphologikFilterFactory`, in the `analysis-extras` module.
-To use this filter, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+To use this filter, you must enable the xref:#analysis-extras-module[analysis-extras Module].
 
 Lucene also includes an example Ukrainian stopword list, in the `lucene-analyzers-morfologik` jar.
 
@@ -3426,10 +3426,6 @@ If the dictionary attribute is not provided, the Polish dictionary is loaded and
 
 == Analysis Extras Module
 
-Many of the language features listed above are supported by the Analysis Extras module.
+Many of the language features listed above are supported by the `analysis-extras` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `analysis-extras`.
-
-Additional details on the specific jar files required is documented in the `modules/analysis-extras/README.md`.
+Additional details on the specific jar files required can be found in the https://github.com/apache/solr/blob/main/solr/modules/analysis-extras/README.md[Module's README].

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
@@ -268,8 +268,8 @@ Unicode Collation in Solr is fast, because all the work is done at index time.
 Rather than specifying an analyzer within `<fieldtype ... class="solr.TextField">`, the `solr.CollationField` and `solr.ICUCollationField` field type classes provide this functionality.
 `solr.ICUCollationField`, which is backed by http://site.icu-project.org[the ICU4J library], provides more flexible configuration, has more locales, is significantly faster, and requires less memory and less index space, since its keys are smaller than those produced by the JDK implementation that backs `solr.CollationField`.
 
-To use `solr.ICUCollationField`, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See `solr/modules/analysis-extras/README.md` for instructions on which jars you need to add.
+To use `solr.ICUCollationField`, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+
 
 `solr.ICUCollationField` and `solr.CollationField` fields can be created in two ways:
 
@@ -692,7 +692,7 @@ On the other hand, it can reduce precision because language-specific character d
 
 == OpenNLP Integration
 
-The `lucene/analysis/opennlp` module provides OpenNLP integration via several analysis components: a tokenizer, a part-of-speech tagging filter, a phrase chunking filter, and a lemmatization filter.
+The `lucene/analysis/opennlp` package provides OpenNLP integration via several analysis components: a tokenizer, a part-of-speech tagging filter, a phrase chunking filter, and a lemmatization filter.
 In addition to these analysis components, Solr also provides an update request processor to extract named entities.
 See also xref:configuration-guide:update-request-processors.adoc#update-processor-factories-that-can-be-loaded-as-plugins[Update Processor Factories That Can Be Loaded as Plugins].
 
@@ -700,8 +700,8 @@ NOTE: The <<OpenNLP Tokenizer>> must be used with all other OpenNLP analysis com
 First, the OpenNLP Tokenizer detects and marks the sentence boundaries required by all the OpenNLP filters.
 Second, since the pre-trained OpenNLP models used by these filters were trained using the corresponding language-specific sentence-detection/tokenization models, the same tokenization using the same models must be used at runtime for optimal performance.
 
-To use the OpenNLP components, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See `solr/modules/analysis-extras/README.md` for instructions on which jars you need to add.
+To use the OpenNLP components, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
+
 
 === OpenNLP Tokenizer
 
@@ -1327,8 +1327,7 @@ The stemmer language, `Catalan` in this case.
 The default configuration of the xref:tokenizers.adoc#icu-tokenizer[ICU Tokenizer] is suitable for Traditional Chinese text.
 It follows the Word Break rules from the Unicode Text Segmentation algorithm for non-Chinese text, and uses a dictionary to segment Chinese words.
 
-To use this tokenizer, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See the `solr/modules/analysis-extras/README.md` for information on which jars you need to add.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 The xref:tokenizers.adoc#standard-tokenizer[Standard Tokenizer] can also be used to tokenize Traditional Chinese text.
 Following the Word Break rules from the Unicode Text Segmentation algorithm, it produces one token per Chinese character.
@@ -1441,13 +1440,11 @@ See the example under <<Traditional Chinese>>.
 
 For Simplified Chinese, Solr provides support for Chinese sentence and word segmentation with the <<HMM Chinese Tokenizer>>.
 This component includes a large dictionary and segments Chinese text into words with the Hidden Markov Model.
-To use this tokenizer, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See the `solr/modules/analysis-extras/README.md` for information on which jars you need to add.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 The default configuration of the xref:tokenizers.adoc#icu-tokenizer[ICU Tokenizer] is also suitable for Simplified Chinese text.
 It follows the Word Break rules from the Unicode Text Segmentation algorithm for non-Chinese text, and uses a dictionary to segment Chinese words.
-To use this tokenizer, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See the `solr/modules/analysis-extras/README.md` for information on which jars you need to add.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 Also useful for Chinese analysis:
 
@@ -1504,8 +1501,7 @@ Also useful for Chinese analysis:
 
 For Simplified Chinese, Solr provides support for Chinese sentence and word segmentation with the `solr.HMMChineseTokenizerFactory` in the `analysis-extras` module.
 This component includes a large dictionary and segments Chinese text into words with the Hidden Markov Model.
-To use this tokenizer, you must add additional .jars to Solr's classpath (as described in the section <xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See `solr/modules/analysis-extras/README.md` for instructions on which jars you need to add.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 *Factory class:* `solr.HMMChineseTokenizerFactory`
 
@@ -2551,8 +2547,7 @@ This filter replaces term text with the Reading Attribute, the Hangul transcript
 === Hebrew, Lao, Myanmar, Khmer
 
 Lucene provides support, in addition to UAX#29 word break rules, for Hebrew's use of the double and single quote characters, and for segmenting Lao, Myanmar, and Khmer into syllables with the `solr.ICUTokenizerFactory` in the `analysis-extras` module.
-To use this tokenizer, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See `solr/modules/analysis-extras/README.md` for instructions on which jars you need to add.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 See xref:tokenizers.adoc#icu-tokenizer[ICUTokenizer] for more information.
 
@@ -2826,8 +2821,7 @@ Solr includes support for normalizing Persian, and Lucene includes an example st
 
 Solr provides support for Polish stemming with the `solr.StempelPolishStemFilterFactory`, and `solr.MorphologikFilterFactory` for lemmatization, in the `analysis-extras` module.
 The `solr.StempelPolishStemFilterFactory` component includes an algorithmic stemmer with tables for Polish.
-To use either of these filters, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See `solr/modules/analysis-extras/README.md` for instructions on which jars you need to add.
+To use this tokenizer, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 *Factory class:* `solr.StempelPolishStemFilterFactory` and `solr.MorfologikFilterFactory`
 
@@ -3374,8 +3368,7 @@ Solr includes support for stemming Turkish with the `solr.SnowballPorterFilterFa
 === Ukrainian
 
 Solr provides support for Ukrainian lemmatization with the `solr.MorphologikFilterFactory`, in the `analysis-extras` module.
-To use this filter, you must add additional .jars to Solr's classpath (as described in the section xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins]).
-See `solr/modules/analysis-extras/README.md` for instructions on which jars you need to add.
+To use this filter, you must enable the xref:#analysis-extras-module[Analysis Extras] module.
 
 Lucene also includes an example Ukrainian stopword list, in the `lucene-analyzers-morfologik` jar.
 
@@ -3429,3 +3422,14 @@ The Morfologik `dictionary` parameter value is a constant specifying which dicti
 The dictionary resource must be named `path/to/_language_.dict` and have an associated `.info` metadata file.
 See http://morfologik.blogspot.com/[the Morfologik project] for details.
 If the dictionary attribute is not provided, the Polish dictionary is loaded and used by default.
+
+
+== Analysis Extras Module
+
+Many of the language features listed above are supported by the Analysis Extras module.
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `analysis-extras`.
+
+Additional details on the specific jar files required is documented in the `modules/analysis-extras/README.md`.

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/language-detection.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/language-detection.adoc
@@ -33,9 +33,7 @@ For more information about language analysis in Solr, see xref:language-analysis
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `langid`.
+This is provided via the `langid` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == Configuring Language Detection
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/language-detection.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/language-detection.adoc
@@ -31,6 +31,12 @@ For specific information on each of these language identification implementation
 
 For more information about language analysis in Solr, see xref:language-analysis.adoc[].
 
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `langid`.
+
 == Configuring Language Detection
 
 You can configure the `langid` UpdateRequestProcessor in `solrconfig.xml`.

--- a/solr/solr-ref-guide/modules/query-guide/pages/analytics.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/analytics.adoc
@@ -23,18 +23,18 @@ The Analytics Component allows users to calculate complex statistical aggregatio
 The component enables interacting with data in a variety of ways, both through a diverse set of analytics functions as well as powerful faceting functionality.
 The standard facets are supported within the analytics component with additions that leverage its analytical capabilities.
 
-== Analytics Configuration
+== Module
 
-The Analytics component is in a module, therefore it will need to be enabled in the `solrconfig.xml` for each collection where you would like to use it.
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `analytics`.
+
+== Analytics Configuration
 
 Since the Analytics framework is a _search component_, it must be declared as such and added to the search handler.
 
 For distributed analytics requests over cloud collections, the component uses the `AnalyticsHandler` strictly for inter-shard communication.
 The Analytics Handler should not be used by users to submit analytics requests.
-
-To use the Analytics Component, the first step is to install this module's plugins into Solr -- see the xref:configuration-guide:solr-plugins.adoc#installing-plugins[Installing Plugins] section on how to do this.
-Note: Method with `<lib/>` directive doesn't work.
-Instead, copy `${solr.install.dir}/modules/analytics/lib/solr-analytics-{solr-full-version}.jar` to `${solr.install.dir}/server/solr-webapp/webapp/WEB-INF/lib/`, as described in the xref:configuration-guide:libs.adoc[lib directories documentation].
 
 Next you need to register the request handler and search component.
 Add the following lines to `solrconfig.xml`, near the defintions for other request handlers:

--- a/solr/solr-ref-guide/modules/query-guide/pages/analytics.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/analytics.adoc
@@ -25,9 +25,7 @@ The standard facets are supported within the analytics component with additions 
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `analytics`.
+This is provided via the `analytics` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == Analytics Configuration
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
@@ -16,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-The Apache Solr *Dense Vector Search* module adds support for indexing and searching dense numerical vectors.
+Solr's *Dense Vector Search* adds support for indexing and searching dense numerical vectors.
 
 https://en.wikipedia.org/wiki/Deep_learning[Deep learning] can be used to produce a vector representation of both the query and the documents in a corpus of information.
 
@@ -57,7 +57,7 @@ The dense vector field gives the possibility of indexing and searching dense vec
 
 For example:
 
-`[1.0, 2.5, 3.7, 4.1]` 
+`[1.0, 2.5, 3.7, 4.1]`
 
 Here's how `DenseVectorField` should be configured in the schema:
 
@@ -96,7 +96,7 @@ this similarity is intended as an optimized way to perform cosine similarity. In
 
 * `cosine`: https://en.wikipedia.org/wiki/Cosine_similarity[Cosine similarity]
 
-[NOTE] 
+[NOTE]
 the preferred way to perform cosine similarity is to normalize all vectors to unit length, and instead use DOT_PRODUCT. You should only use this function if you need to preserve the original vectors and cannot normalize them in advance.
 
 To use the following advanced parameters that customise the codec format

--- a/solr/solr-ref-guide/modules/query-guide/pages/json-facet-api.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/json-facet-api.adoc
@@ -17,9 +17,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-== Facet & Analytics Module
+== JSON Faceting & Analytics
 
-The JSON Faceting module exposes similar functionality to Solr's traditional faceting module but with a stronger emphasis on usability.
+JSON Faceting exposes similar functionality to Solr's traditional faceting but with a stronger emphasis on usability.
 It has several benefits over traditional faceting:
 
 * easier programmatic construction of complex or nested facets

--- a/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
@@ -113,7 +113,7 @@ In the form of JSON files your trained model or models (e.g., different models f
 
 == Quick Start with LTR
 
-The `"techproducts"` example included with Solr is pre-configured with the `ltr` module and plugins required for learning-to-rank, but they are disabled by default.
+The `"techproducts"` example included with Solr is pre-configured to load the plugins required for learning-to-rank from the `ltr` module, but they are disabled by default.
 
 To enable the plugins, please specify the `solr.ltr.enabled` JVM System Property when running the example:
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
@@ -111,6 +111,10 @@ In the form of JSON files your trained model or models (e.g., different models f
 |(custom) |(custom class extending {solr-javadocs}/modules/ltr/org/apache/solr/ltr/model/LTRScoringModel.html[LTRScoringModel]) |(not applicable)
 |===
 
+== Module
+
+This is provided via the `ltr` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
 == Quick Start with LTR
 
 The `"techproducts"` example included with Solr is pre-configured to load the plugins required for learning-to-rank from the `ltr` xref:configuration-guide:solr-modules.adoc[Solr Module], but they are disabled by default.

--- a/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
@@ -113,9 +113,9 @@ In the form of JSON files your trained model or models (e.g., different models f
 
 == Quick Start with LTR
 
-The `"techproducts"` example included with Solr is pre-configured to load the plugins required for learning-to-rank from the `ltr` module, but they are disabled by default.
+The `"techproducts"` example included with Solr is pre-configured to load the plugins required for learning-to-rank from the `ltr` xref:configuration-guide:solr-modules.adoc[Solr Module], but they are disabled by default.
 
-To enable the plugins, please specify the `solr.ltr.enabled` JVM System Property when running the example:
+To enable the plugins, please specify the `solr.ltr.enabled` JVM System Property when running the `techproducts` example:
 
 [source,bash]
 ----

--- a/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
@@ -113,7 +113,7 @@ In the form of JSON files your trained model or models (e.g., different models f
 
 == Quick Start with LTR
 
-The `"techproducts"` example included with Solr is pre-configured with the plugins required for learning-to-rank, but they are disabled by default.
+The `"techproducts"` example included with Solr is pre-configured with the `ltr` module and plugins required for learning-to-rank, but they are disabled by default.
 
 To enable the plugins, please specify the `solr.ltr.enabled` JVM System Property when running the example:
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/result-clustering.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/result-clustering.adoc
@@ -36,6 +36,12 @@ The query issued to the system was _Apache Solr_.
 It seems clear that faceting could not yield a similar set of groups, although the goals of both techniques are similar -- to let the user explore the set of search results and either rephrase the query or narrow the focus to a subset of current documents.
 Clustering is also similar to xref:result-grouping.adoc[] in that it can help to look deeper into search results, beyond the top few hits.
 
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `clustering`.
+
 == Configuration Quick Starter
 
 The clustering extension works as a search component.
@@ -210,17 +216,6 @@ These identifiers correspond to the `uniqueKey` field declared in the schema.
 Sometimes cluster labels may not make much sense (this depends on many factors -- text in clustered fields, number of documents, algorithm paramerters).
 Also, some documents may be left out and not be clustered at all; these will be assigned to the synthetic _Other Topics_ group, marked with the `other-topics` property set to `true` (see the XML dump above for an example).
 The score of the other topics group is zero.
-
-== Installation
-
-The clustering module extension requires all JARs under `modules/clustering/lib`.
-
-You can include the required modules JARs in `solrconfig.xml` as shown below (by default paths are relative to the Solr core so they may need adjustments to your configuration, or an explicit specification of the `$solr.install.dir`):
-
-[source,xml]
-----
-<lib dir="${solr.install.dir:../../..}/modules/clustering/lib/" regex=".*\.jar" />
-----
 
 == Configuration
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/result-clustering.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/result-clustering.adoc
@@ -38,9 +38,7 @@ Clustering is also similar to xref:result-grouping.adoc[] in that it can help to
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `clustering`.
+This is provided via the `clustering` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == Configuration Quick Starter
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/sql-query.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/sql-query.adoc
@@ -21,15 +21,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-The Solr SQL module brings the power of SQL querying to Solr by seamlessly combining
+The Solr SQL Module brings the power of SQL querying to Solr by seamlessly combining
 SQL with Solr's full-text search capabilities.
 Both MapReduce style and JSON Facet API aggregations are supported, which means that SQL querying can be used to support both *high query volume* and *high cardinality* use cases.
 
 == Module
 
-This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
-
-The module name is `sql`.
+This is provided via the `sql` xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
 
 == SQL Architecture
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/sql-query.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/sql-query.adoc
@@ -21,10 +21,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-The Solr SQL module brings the power of SQL querying to Solr. The SQL module needs to be xref:configuration-guide:solr-modules.adoc[installed] to use.
-
-The SQL interface seamlessly combines SQL with Solr's full-text search capabilities.
+The Solr SQL module brings the power of SQL querying to Solr by seamlessly combining
+SQL with Solr's full-text search capabilities.
 Both MapReduce style and JSON Facet API aggregations are supported, which means that SQL querying can be used to support both *high query volume* and *high cardinality* use cases.
+
+== Module
+
+This is provided via a xref:configuration-guide:solr-modules.adoc[Solr Module] that needs to be enabled before use.
+
+The module name is `sql`.
 
 == SQL Architecture
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-7.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-7.adoc
@@ -230,7 +230,7 @@ Mentions of deprecations are likely superseded by removal in Solr 7, as noted in
 
 Note again that this is not a complete list of all changes that may impact your installation, so a thorough review of CHANGES.txt is highly recommended if upgrading from any version earlier than 6.6.
 
-* The Solr Modules `map-reduce`, `morphlines-core` and `morphlines-cell` have been removed.
+* The Solr contribs `map-reduce`, `morphlines-core` and `morphlines-cell` have been removed.
 * JSON Facet API now uses hyper-log-log for numBuckets cardinality calculation and calculates cardinality before filtering buckets by any `mincount` greater than 1.
 * If you use historical dates, specifically on or before the year 1582, you should reindex for better date handling.
 * If you use the JSON Facet API (json.facet) with `method=stream`, you must now set `sort='index asc'` to get the streaming behavior; otherwise it won't stream.

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-7.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-7.adoc
@@ -230,7 +230,7 @@ Mentions of deprecations are likely superseded by removal in Solr 7, as noted in
 
 Note again that this is not a complete list of all changes that may impact your installation, so a thorough review of CHANGES.txt is highly recommended if upgrading from any version earlier than 6.6.
 
-* The Solr modules `map-reduce`, `morphlines-core` and `morphlines-cell` have been removed.
+* The Solr Modules `map-reduce`, `morphlines-core` and `morphlines-cell` have been removed.
 * JSON Facet API now uses hyper-log-log for numBuckets cardinality calculation and calculates cardinality before filtering buckets by any `mincount` greater than 1.
 * If you use historical dates, specifically on or before the year 1582, you should reindex for better date handling.
 * If you use the JSON Facet API (json.facet) with `method=stream`, you must now set `sort='index asc'` to get the streaming behavior; otherwise it won't stream.

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -111,8 +111,8 @@ This may require some more disk space for logs than was the case in version 8.x.
 changed package name to `org.apache.solr.security.jwt`, but can still be loaded as shortform `class="solr.JWTAuthPlugin"`.
 * Dependency updates - A lot of dependency updates removes several security issues from dependencies, and thus make Solr more secure.
 * The allow-list defining allowed URLs for the `shards` parameter is not in the `shardHandler` configuration anymore. It is defined by the `allowUrls` top-level property of the `solr.xml` file. For more information, see xref:configuration-guide:configuring-solr-xml.adoc#allow-urls[Format of solr.allowUrls] documentation.
-* To improve security, `StatelessScriptUpdateProcessorFactory` has been renamed as `ScriptUpdateProcessorFactory` and moved to `scripting` module instead of shipping as part of Solr core.  Users need to add the module `scripting` to classpath.
-* To improve security, `XSLTResponseWriter` has been moved to `scripting` module instead of shipping as part of Solr core.  Users need to add the module `scripting` to classpath.
+* To improve security, `StatelessScriptUpdateProcessorFactory` has been renamed as `ScriptUpdateProcessorFactory` and moved to the xref:configuration-guide:script-update-processor.adoc#module[`scripting` Module] instead of shipping as part of Solr core. This module needs to be enabled explicitly.
+* To improve security, `XSLTResponseWriter` has been moved to the xref:configuration-guide:script-update-processor.adoc#module[`scripting` Module] instead of shipping as part of Solr core. This module needs to be enabled explicitly.
 
 
 === Stability and Scalability

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -111,8 +111,9 @@ This may require some more disk space for logs than was the case in version 8.x.
 changed package name to `org.apache.solr.security.jwt`, but can still be loaded as shortform `class="solr.JWTAuthPlugin"`.
 * Dependency updates - A lot of dependency updates removes several security issues from dependencies, and thus make Solr more secure.
 * The allow-list defining allowed URLs for the `shards` parameter is not in the `shardHandler` configuration anymore. It is defined by the `allowUrls` top-level property of the `solr.xml` file. For more information, see xref:configuration-guide:configuring-solr-xml.adoc#allow-urls[Format of solr.allowUrls] documentation.
-* To improve security, `StatelessScriptUpdateProcessorFactory` has been renamed as `ScriptUpdateProcessorFactory` and moved to `modules/scripting` package instead of shipping as part of Solr core.
-* To improve security, `XSLTResponseWriter` has been moved to `modules/scripting` package instead of shipping as part of Solr core.
+* To improve security, `StatelessScriptUpdateProcessorFactory` has been renamed as `ScriptUpdateProcessorFactory` and moved to `scripting` module instead of shipping as part of Solr core.  Users need to add the module `scripting` to classpath.
+* To improve security, `XSLTResponseWriter` has been moved to `scripting` module instead of shipping as part of Solr core.  Users need to add the module `scripting` to classpath.
+
 
 === Stability and Scalability
 * xref:deployment-guide:rate-limiters.adoc[Rate limiting] provides a way to throttle update and search requests based on usage metrics.
@@ -137,7 +138,7 @@ There are no longer ".distrib." named metrics; all metrics are assumed to be suc
 Switch back to synchronous logging if this is unacceptable, see comments in the log4j2 configuration files (log4j2.xml by default).
 * Log4J configuration & Solr MDC values - link:http://www.slf4j.org/apidocs/org/slf4j/MDC.html[MDC] values that Solr sets for use by Logging calls (such as the collection name, shard name, replica name, etc...) have been modified to now be "bare" values, without the special single character prefixes that were included in past version. The default `log4j2.xml` configuration file for Solr has been modified to prepend these same prefixes to MDC values when included in Log messages as part of the `<PatternLayout/>`. Users who have custom logging configurations that wish to ensure Solr 9.x logs are consistently formatted after upgrading will need to make similar changes to their logging configuration files.  See  link:https://issues.apache.org/jira/browse/SOLR-15630[SOLR-15630] for more details.
 * xref:deployment-guide:configuring-logging.adoc#request-logging[Jetty Request log] is now enabled by default, i.e. logging every request.
-* The prometheus-exporter is no longer packaged as a Solr module. It can be found under `solr/prometheus-exporter/`.
+* The prometheus-exporter is no longer packaged as a Solr Module. It can be found under `solr/prometheus-exporter/`.
 * Solr modules (formerly known as contribs) can now easily be enabled by an environment variable (e.g. in `solr.in.sh` or `solr.in.cmd`) or as a system property (e.g. in `SOLR_OPTS`). Example: `SOLR_MODULES=extraction,ltr`.
 
 === Deprecations and Removals
@@ -162,7 +163,7 @@ Other relevant placement strategies should be used instead, such as autoscaling 
 * Features lifted out as separate modules are: HDFS, Hadoop-Auth, SQL, Scripting, and JWT-Auth.
 * The "dist" folder in the release has been removed. Please update your `<lib>` entries in your `solrconfig.xml` to use the new location.
 ** The `solr-core` and `solr-solrj` jars can be found under `server/solr-webapp/webapp/WEB-INF/lib/`.
-** The Solr module jars and their dependencies can be found in `modules/<module-name>/lib`, packaged individually for each module.
+** The Solr Module jars and their dependencies can be found in `modules/<module-name>/lib`, packaged individually for each module.
 ** The `solrj-deps` (SolrJ Dependencies) are no longer separated out from the other Server jars.
 ** Please refer to the SolrJ Maven artifact to see the exact dependencies you need to include from `server/solr-webapp/webapp/WEB-INF/lib/` and `server/lib/ext/` if you are loading in SolrJ manually.
 If you plan on using SolrJ as a JDBC driver, please refer to the xref:query-guide:sql-query.adoc#generic-clients[JDBC documentation]

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
@@ -284,7 +284,7 @@ public class JDBCStream extends TupleStream implements Expressible {
     // Unfortunately it is impossible to use a custom ClassLoader with DriverManager, so we would
     // need to remove our use of this class in order to support JDBC drivers loaded in via solr's
     // additional library methods. This comment is relevant for JDBC drivers loaded in via custom
-    // plugins and even Solr modules.
+    // plugins and even Solr Modules.
     try {
       if (null != driverClassName) {
         Class.forName(driverClassName);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16228

# Description
Our docs reflect years of evolution of how we add things to solr, and don't put Solr Modules front and center.

# Solution

* Be consistent about referring to Solr Modules, remove use of the word for non Solr Modules where possible.

* Make sure EVERY Module in the Ref Guide lists the name of the module using the same terminology.

* Sets us up for better documentation around where just enabling a Solr Module isn't enough, and you have to do werid stuff.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [X ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
