### PR TITLE
Fix bug in in-place update when failOnVersionConflicts=false

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -85,6 +85,8 @@ Bug Fixes
 
 * SOLR-16110: Using Schema/Config API breaks the File-Upload of Config Set File (Steffen Moldenhauer, Kevin Risden)
 
+* SOLR-16218: failOnVersionConflicts option not working for in-place updates (Lamine Idjeraoui)
+
 Other Changes
 ---------------------
 * SOLR-15897: Remove <jmx/> from all unit test solrconfig.xml files. (Eric Pugh)

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -798,6 +798,10 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
     SolrInputDocument mergedDoc;
     if (oldRootDocWithChildren == null) {
       if (versionOnUpdate > 0 || !rootDocIdString.equals(cmd.getSelfOrNestedDocIdStr())) {
+        if (cmd.getReq().getParams().getBool(CommonParams.FAIL_ON_VERSION_CONFLICTS, true)
+            == false) {
+          return false;
+        }
         // could just let the optimistic locking throw the error
         throw new SolrException(
             ErrorCode.CONFLICT, "Document not found for update.  id=" + rootDocIdString);

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -1579,6 +1579,28 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
     assertQ(req("q", "title_s:second"), "//*[@numFound='1']");
     assertQ(req("q", "title_s:first1"), "//*[@numFound='1']"); // but the old value exists
     assertQ(req("q", "title_s:first2"), "//*[@numFound='0']"); // and the new value does not reflect
+
+    // tests inplace updates when doc does not exist
+    assertFailedU(add(doc("id", "3", "title_s", "third", "_version_", "1")));
+    params.set(CommonParams.FAIL_ON_VERSION_CONFLICTS, "true");
+    params.set("_version_", "1");
+    SolrInputDocument doc1_v3 = sdoc("id", "1", "title_s", map("set", "first3"));
+    SolrInputDocument doc3 = sdoc("id", "3", "title_s", map("set", "third"));
+    ex =
+        expectThrows(
+            SolrException.class,
+            "This should have failed",
+            () -> updateJ(jsonAdd(doc1_v3, doc3), params));
+    assertTrue(ex.getMessage().contains("Document not found for update"));
+
+    params.set(CommonParams.FAIL_ON_VERSION_CONFLICTS, "false");
+    SolrInputDocument doc1_v4 = sdoc("id", "1", "title_s", map("set", "first4"));
+    updateJ(jsonAdd(doc1_v4, doc3), params); // this should not throw any error
+
+    assertU(commit());
+    assertQ(req("q", "title_s:first4"), "//*[@numFound='1']"); // the new value does reflect
+    assertQ(req("q", "title_s:first1"), "//*[@numFound='0']"); // but the old value does not exist
+    assertQ(req("q", "title_s:third"), "//*[@numFound='0']"); // doc3 does not exist
   }
   /**
    * Helper method that sets up a req/cmd to run {@link


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16218
 
# Description

Fix a bug in in-place update when _failOnVersionConflicts_=false.

When sending in-place/atomic updates for a non-existent doc with __version_=1_ Solr throws 409 error even if _failOnVersionConflicts_ is set to _false_.

# Steps to Reproduce
- Send an update request (single or batch) that includes Update in-place/atomic command of a non-existent doc.
- Set _Version_=1
- Solr will throw 409 exception with  "_Document not found for update_" message error.

Set failOnVersionConflicts=false
- Solr still throws the same error.

 
#  Expected 
if _failOnVersionConflicts=false_ Solr should ignore the error silently and continue processing the rest of the commands.

# Actual Result
Solr throws 409 exception with  "_Document not found for update_" message error.


# Solution

Check in _getUpdatedDocument_ if _failOnVersionConflicts=true_ before throwing the exception.
# Tests

Added test cases catching the expected behavior when __failOnVersionConflicts_ is set to _true_ or _false_ (default is true).

 
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
