### PR TITLE
SOLR-16250 Fix LIKE for string fields and multi terms

### DIFF
--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -44,6 +44,7 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
+import org.apache.solr.client.solrj.response.LukeResponse;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.StringUtils;
@@ -97,11 +98,16 @@ class SolrFilter extends Filter implements SolrRel {
     implementor.visitChild(0, getInput());
     if (getInput() instanceof SolrAggregate) {
       HavingTranslator translator =
-          new HavingTranslator(getRowType(), implementor.reverseAggMappings, builder);
+          new HavingTranslator(
+              getRowType(),
+              implementor.reverseAggMappings,
+              builder,
+              implementor.solrTable.getSolrFieldTypes());
       String havingPredicate = translator.translateMatch(condition);
       implementor.setHavingPredicate(havingPredicate);
     } else {
-      Translator translator = new Translator(getRowType(), builder);
+      Translator translator =
+          new Translator(getRowType(), builder, implementor.solrTable.getSolrFieldTypes());
       String query = translator.translateMatch(condition);
       implementor.addQuery(query);
       implementor.setNegativeQuery(query.startsWith("-"));
@@ -113,11 +119,16 @@ class SolrFilter extends Filter implements SolrRel {
     protected final RelDataType rowType;
     protected final List<String> fieldNames;
     private final RexBuilder builder;
+    private final Map<String, LukeResponse.FieldInfo> solrFieldTypes;
 
-    Translator(RelDataType rowType, RexBuilder builder) {
+    Translator(
+        RelDataType rowType,
+        RexBuilder builder,
+        Map<String, LukeResponse.FieldInfo> solrFieldTypes) {
       this.rowType = rowType;
       this.fieldNames = SolrRules.solrFieldNames(rowType);
       this.builder = builder;
+      this.solrFieldTypes = solrFieldTypes;
     }
 
     protected RelDataType getFieldType(String field) {
@@ -356,13 +367,16 @@ class SolrFilter extends Filter implements SolrRel {
       terms = translateLikeTermToSolrSyntax(terms, escapeChar);
 
       if (!terms.startsWith("(") && !terms.startsWith("[") && !terms.startsWith("{")) {
-        terms = escapeWithWildcard(terms);
+        String solrFieldType = solrFieldTypes.get(pair.getKey()).getType();
+        terms = escapeWithWildcard(terms, solrFieldType);
 
         // if terms contains multiple words and one or more wildcard chars, then we need to employ
         // the complexphrase parser
         // but that expects the terms wrapped in double-quotes, not parens
         boolean hasMultipleTerms = terms.split("\\s+").length > 1;
-        if (hasMultipleTerms && (terms.contains("*") || terms.contains("?"))) {
+        if (solrFieldType.equals("text")
+            && hasMultipleTerms
+            && (terms.contains("*") || terms.contains("?"))) {
           String quotedTerms = "\"" + terms.substring(1, terms.length() - 1) + "\"";
           String query = ClientUtils.encodeLocalParamVal(pair.getKey() + ":" + quotedTerms);
           return String.format(Locale.ROOT, "{!complexphrase v=%s}", query);
@@ -448,10 +462,11 @@ class SolrFilter extends Filter implements SolrRel {
       }
 
       String terms = toSolrLiteral(key, value).trim();
+      String solrFieldType = solrFieldTypes.get(key).getType();
 
       if (!terms.startsWith("(") && !terms.startsWith("[") && !terms.startsWith("{")) {
         if (terms.contains("*") || terms.contains("?")) {
-          terms = escapeWithWildcard(terms);
+          terms = escapeWithWildcard(terms, solrFieldType);
         } else {
           terms = "\"" + ClientUtils.escapeQueryChars(terms) + "\"";
         }
@@ -462,15 +477,14 @@ class SolrFilter extends Filter implements SolrRel {
 
     // Wrap filter criteria containing wildcard with parens and unescape the wildcards after
     // escaping protected query chars
-    private String escapeWithWildcard(String terms) {
-      String escaped =
-          ClientUtils.escapeQueryChars(terms)
-              .replace("\\*", "*")
-              .replace("\\?", "?")
-              .replace("\\ ", " ");
-      // if multiple terms, then wrap with parens
-      if (escaped.split("\\s+").length > 1) {
-        escaped = "(" + escaped + ")";
+    private String escapeWithWildcard(String terms, String solrFieldType) {
+      String escaped = ClientUtils.escapeQueryChars(terms).replace("\\*", "*").replace("\\?", "?");
+      if (solrFieldType.equals("text")) {
+        escaped = escaped.replace("\\ ", " ");
+        // if multiple terms, then wrap with parens
+        if (escaped.split("\\s+").length > 1) {
+          escaped = "(" + escaped + ")";
+        }
       }
       return escaped;
     }
@@ -705,8 +719,11 @@ class SolrFilter extends Filter implements SolrRel {
     private final Map<String, String> reverseAggMappings;
 
     HavingTranslator(
-        RelDataType rowType, Map<String, String> reverseAggMappings, RexBuilder builder) {
-      super(rowType, builder);
+        RelDataType rowType,
+        Map<String, String> reverseAggMappings,
+        RexBuilder builder,
+        Map<String, LukeResponse.FieldInfo> solrFieldTypes) {
+      super(rowType, builder, solrFieldTypes);
       this.reverseAggMappings = reverseAggMappings;
     }
 

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrTable.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrTable.java
@@ -56,6 +56,7 @@ import org.apache.solr.client.solrj.io.stream.*;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParser;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
 import org.apache.solr.client.solrj.io.stream.metrics.*;
+import org.apache.solr.client.solrj.response.LukeResponse;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 
@@ -890,6 +891,10 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     final RelOptCluster cluster = context.getCluster();
     return new SolrTableScan(
         cluster, cluster.traitSetOf(SolrRel.CONVENTION), relOptTable, this, null);
+  }
+
+  public Map<String, LukeResponse.FieldInfo> getSolrFieldTypes() {
+    return this.schema.getSolrFieldTypes();
   }
 
   @SuppressWarnings("WeakerAccess")

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2442,7 +2442,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "foo",
             "c_t",
-            "the quick brown fox jumped over the lazy dog")
+            "the quick brown fox jumped over the lazy dog",
+            "d_s",
+            "New York")
         .add(
             "id",
             "2",
@@ -2451,7 +2453,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "foo",
             "c_t",
-            "the sly black dog jumped over the sleeping pig")
+            "the sly black dog jumped over the sleeping pig",
+            "d_s",
+            "New Jersey")
         .add(
             "id",
             "3",
@@ -2460,7 +2464,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "foo",
             "c_t",
-            "the quick brown fox jumped over the lazy dog")
+            "the quick brown fox jumped over the lazy dog",
+            "d_s",
+            "New Hampshire")
         .add(
             "id",
             "4",
@@ -2469,7 +2475,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "foo",
             "c_t",
-            "the sly black dog jumped over the sleepy pig")
+            "the sly black dog jumped over the sleepy pig",
+            "d_s",
+            "New Mexico")
         .add(
             "id",
             "5",
@@ -2478,7 +2486,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "foo",
             "c_t",
-            "the quick brown fox jumped over the lazy dog")
+            "the quick brown fox jumped over the lazy dog",
+            "d_s",
+            "San Diego")
         .add(
             "id",
             "6",
@@ -2487,7 +2497,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "bar",
             "c_t",
-            "the sly black dog jumped over the sleepin piglet")
+            "the sly black dog jumped over the sleepin piglet",
+            "d_s",
+            "San Jose")
         .add(
             "id",
             "7",
@@ -2496,7 +2508,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "zaz",
             "c_t",
-            "the lazy dog jumped over the quick brown fox")
+            "the lazy dog jumped over the quick brown fox",
+            "d_s",
+            "San Francisco")
         .add(
             "id",
             "8",
@@ -2505,7 +2519,9 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "b_s",
             "zaz",
             "c_t",
-            "the lazy dog ducked over the quick brown fox")
+            "the lazy dog ducked over the quick brown fox",
+            "d_s",
+            "San Antonio")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'h_llo-%'", 3);
@@ -2520,6 +2536,8 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world''\\\\%' ESCAPE '\\'", 1);
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'w\\_o_ld%' ESCAPE '\\'", 1);
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\%\\__' ESCAPE '\\'", 1);
+
+    expectResults("SELECT d_s FROM $ALIAS WHERE d_s LIKE 'Sa* Jose'", 1);
 
     // not technically valid SQL but we support it for legacy purposes, see: SOLR-15463
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s='world-*'", 2);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16250

# Description

Solr SQL is not translating LIKE terms properly for string fields with multiple terms

# Solution

If the field type is string, do not use complex phrase parser and do not decode space

# Tests

Update existing unit test to verify

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
