### PR TITLE
SOLR-16255: Introduce DirectUpdateHandler2#shouldCommit

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/CommitUpdateCommand.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitUpdateCommand.java
@@ -27,7 +27,11 @@ public class CommitUpdateCommand extends UpdateCommand {
   public boolean expungeDeletes = false;
   public boolean softCommit = false;
   public boolean prepareCommit = false;
-  /** User provided commit data. Can be let to null if there is none. */
+  /**
+   * User provided commit data. Can be let to null if there is none.
+   * It is possible to commit this user data, even if there is no uncommitted change in the
+   * index writer, provided this user data is not empty.
+   */
   public Map<String, String> commitData;
 
   /**

--- a/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
+++ b/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
@@ -744,7 +744,7 @@ public class DirectUpdateHandler2 extends UpdateHandler
 
           // SolrCore.verbose("writer.commit() start writer=",writer);
 
-          if (writer.hasUncommittedChanges()) {
+          if (shouldCommit(cmd, writer)) {
             SolrIndexWriter.setCommitData(writer, cmd.getVersion(), cmd.commitData);
             writer.commit();
           } else {
@@ -822,6 +822,15 @@ public class DirectUpdateHandler2 extends UpdateHandler
         SolrException.log(log, e);
       }
     }
+  }
+
+  /**
+   * Determines whether the commit command should effectively trigger a commit on the index writer.
+   * This method is called with the commit lock and is the last step before effectively calling
+   * {@link IndexWriter#commit()}.
+   */
+  protected boolean shouldCommit(CommitUpdateCommand cmd, IndexWriter writer) throws IOException {
+    return writer.hasUncommittedChanges() || (cmd.commitData != null && !cmd.commitData.isEmpty());
   }
 
   @Override


### PR DESCRIPTION
DirectUpdateHandler2.shouldCommit() contains the same logic as before: writer.hasUncommittedChanges().
In addition (logical OR) it checks if the CommitUpdateCommand contains user defined commit metadata. If so, it allows to commit with no changes but with user defined commit metadata.