### PR TITLE
SOLR-16256: Fix documented key name for AffinityPlacementConfig.collectionNodeType

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/replica-placement-plugins.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/replica-placement-plugins.adoc
@@ -52,7 +52,7 @@ curl -X POST -H 'Content-type: application/json' -d '{
             "A_primary": "A_secondary",
             "B_primary": "B_secondary"
           },
-          "nodeType": {
+          "collectionNodeType": {
             "collection_A": "searchNode,indexNode",
             "collection_B": "analyticsNode"
           }
@@ -109,7 +109,7 @@ The autoscaling specification in the configuration linked above aimed to do the 
 It also supports additional per-collection constraints:
 
 * `withCollection` enforces the placement of co-located collections' replicas on the same nodes, and prevents deletions of collections and replicas that would break this constraint.
-* `nodeType` limits the nodes eligible for placement to only those that match one or more of the specified node types.
+* `collectionNodeType` limits the nodes eligible for placement to only those that match one or more of the specified node types.
 
 See below for more details on these constraints.
 
@@ -169,7 +169,7 @@ The plugin will assume that the secondary collection replicas are already in pla
 +
 See the section <<withCollection constraint>> below.
 
-`nodeType`::
+`collectionNodeType`::
 +
 [%autowidth,frame=none]
 |===
@@ -252,7 +252,7 @@ curl -X POST -H 'Content-type: application/json' -d '{
         "name": ".placement-plugin",
         "class": "org.apache.solr.cluster.placement.plugins.AffinityPlacementFactory",
         "config": {
-          "nodeType": {
+          "collectionNodeType": {
             "collection_A": "searchNode,indexNode",
             "collection_B": "analyticsNode"
           }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16256

# Description

The documentation for the [AffinityPlacementFactory](https://solr.apache.org/guide/solr/latest/configuration-guide/replica-placement-plugins.html#configuration) states that the `nodeType` configuration key limits the nodes eligible for placement to only those that match one or more of the specified node types.

The code for the [AffinityPlacementConfig](https://github.com/apache/solr/blob/main/solr/core/src/java/org/apache/solr/cluster/placement/plugins/AffinityPlacementConfig.java#L97) defines the key as `collectionNodeType` instead.

# Solution

Updated the documentation.

Alternatively, I could've changed the code to match the docs. I can update the PR if asked.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
