### PR TITLE
SOLR-16262: Fix htaccess rules for ref-guide robots tag

### DIFF
--- a/dev-tools/scripts/refguide/gen-refguide-redirects.py
+++ b/dev-tools/scripts/refguide/gen-refguide-redirects.py
@@ -132,10 +132,8 @@ def main():
         print("""
 
 # Do not index old reference guide pages on search engines, except for pages that don't exist in 9+
-<If "%%{REQUEST_URI} =~ m#^/guide/(6|7|8)_.*#">
-  <If "%%{REQUEST_URI} !~ m#^/guide/8_11/%s$#">
-    Header set X-Robots-Tag "noindex,nofollow,noarchive"
-  </If>
+<If "%%{REQUEST_URI} =~ m#/guide/(6|7|8)_.*# && %%{REQUEST_URI} !~ m#/guide/8_11/%s$#">
+  Header set X-Robots-Tag "noindex,nofollow,noarchive"
 </If>""" % old_version_pages_regex)
     else:
         out("Regex mappings:")

--- a/dev-tools/scripts/refguide/gen-refguide-redirects.py
+++ b/dev-tools/scripts/refguide/gen-refguide-redirects.py
@@ -113,10 +113,11 @@ def main():
             failed[frm] = "404"
 
     if conf.htaccess:
-        print("# Existing pages moved to sub path")
+        print("# Existing pages moved to sub path in the 9.0 guide")
         for key in regex_new:
             print("RedirectMatch 301 ^/guide/(%s)\.html /guide/solr/latest/%s/$1.html" % ("|".join(regex_new[key]), key))
-        print("# Page renames in 9.0")
+        print("# Page renames between 8.x and 9.0")
+        print("RewriteRule ^guide/9_0/solr-tutorial.html /guide/solr/latest/getting-started/solr-tutorial.html [R=301,NE,L]")
         for key in result:
             if result[key].startswith("https://"):
                 print("RewriteRule ^guide/%s %s [R=301,NE,L]" % (key, result[key]))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16262

If you go to an old ref guide page (e.g. https://solr.apache.org/guide/8_10/libs.html) you will not currently see a response header with `X-Robots-Tag "noindex,nofollow,noarchive"`, which tells search engines to ignore this page.

This is because (while supported) for some reason httpd doesn't like nested if statements. Oh well, we can put it into one.

This has been tested locally via docker and the solr-site.