### PR TITLE
SOLR-16270: address dangling javadocs

### DIFF
--- a/solr/core/src/test/org/apache/solr/CursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/CursorPagingTest.java
@@ -909,7 +909,7 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
    * once, or if an id is encountered which is not expected, or if an id is <code>[elevated]
    * </code> and comes "after" any ids which were not <code>[elevated]</code>
    *
-   * @returns set of all elevated ids encountered in the walk
+   * @return set of all elevated ids encountered in the walk
    * @see #assertFullWalkNoDups(SolrParams,Consumer)
    */
   public SentinelIntSet assertFullWalkNoDupsElevated(
@@ -947,7 +947,7 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
    * positive ints) encountered and throws an assertion failure if any id is encountered more than
    * once, or if the set grows above maxSize
    *
-   * @returns set of all ids encountered in the walk
+   * @return set of all ids encountered in the walk
    * @see #assertFullWalkNoDups(SolrParams,Consumer)
    */
   public SentinelIntSet assertFullWalkNoDups(int maxSize, SolrParams params) throws Exception {

--- a/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
@@ -29,7 +29,7 @@ public class DisMaxRequestHandlerTest extends SolrTestCaseJ4 {
     lrf =
         h.getRequestFactory(
             "/dismax", 0, 20, CommonParams.VERSION, "2.2", "facet", "true", "facet.field", "t_s");
-    // Add some documents to the index 
+    // Add some documents to the index
     assertNull(
         h.validateUpdate(
             adoc(

--- a/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
@@ -29,7 +29,7 @@ public class DisMaxRequestHandlerTest extends SolrTestCaseJ4 {
     lrf =
         h.getRequestFactory(
             "/dismax", 0, 20, CommonParams.VERSION, "2.2", "facet", "true", "facet.field", "t_s");
-    /** Add some documents to the index */
+    // Add some documents to the index 
     assertNull(
         h.validateUpdate(
             adoc(

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -1574,7 +1574,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
 
   @Test
   public void testRandomGrouping() throws Exception {
-    /**
+    /*
      * updateJ("{\"add\":{\"doc\":{\"id\":\"77\"}}}", params("commit","true"));
      * assertJQ(req("q","id:77"), "/response/numFound==1");
      *

--- a/solr/core/src/test/org/apache/solr/TestRandomDVFaceting.java
+++ b/solr/core/src/test/org/apache/solr/TestRandomDVFaceting.java
@@ -298,7 +298,7 @@ public class TestRandomDVFaceting extends SolrTestCaseJ4 {
         responses.add(strResponse);
       }
 
-      /**
+      /*
        * String strResponse = h.query(req(params)); Object realResponse =
        * ObjectBuilder.fromJSON(strResponse);
        */

--- a/solr/core/src/test/org/apache/solr/TestRandomFaceting.java
+++ b/solr/core/src/test/org/apache/solr/TestRandomFaceting.java
@@ -318,7 +318,7 @@ public class TestRandomFaceting extends SolrTestCaseJ4 {
         }
       }
 
-      /**
+      /*
        * String strResponse = h.query(req(params)); Object realResponse =
        * ObjectBuilder.fromJSON(strResponse);
        */

--- a/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
@@ -776,7 +776,7 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
    * than once, or if an id is encountered which is not expected, or if an id is <code>[elevated]
    * </code> and comes "after" any ids which were not <code>[elevated]</code>
    *
-   * @returns set of all elevated ids encountered in the walk
+   * @return set of all elevated ids encountered in the walk
    * @see #assertFullWalkNoDups(SolrParams,Consumer)
    */
   public SentinelIntSet assertFullWalkNoDupsElevated(
@@ -838,7 +838,7 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
    * the sorting in some cases and cause false negatives in the response comparisons (even if we
    * don't include "score" in the "fl")
    *
-   * @returns set of all ids encountered in the walk
+   * @return set of all ids encountered in the walk
    * @see #assertFullWalkNoDups(SolrParams,Consumer)
    */
   public SentinelIntSet assertFullWalkNoDups(int maxSize, SolrParams params) throws Exception {

--- a/solr/core/src/test/org/apache/solr/cloud/RestartWhileUpdatingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/RestartWhileUpdatingTest.java
@@ -20,12 +20,12 @@ import org.apache.lucene.tests.util.LuceneTestCase.Nightly;
 import org.apache.lucene.tests.util.LuceneTestCase.Slow;
 import org.junit.Test;
 
-@Slow
-@Nightly
 /**
  * Implementation moved to AbstractRestartWhileUpdatingTestBase because it is used by HDFS contrib
  * module tests
  */
+@Slow
+@Nightly
 public class RestartWhileUpdatingTest extends AbstractRestartWhileUpdatingTestBase {
 
   public RestartWhileUpdatingTest() throws Exception {

--- a/solr/core/src/test/org/apache/solr/cloud/TestQueryingOnDownCollection.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestQueryingOnDownCollection.java
@@ -51,11 +51,9 @@ public class TestQueryingOnDownCollection extends SolrCloudTestCase {
         .configure();
   }
 
-
   /**
    * Assert that requests to "down collection", i.e. a collection which has all replicas in down
    * state (but are hosted on nodes that are live), fail fast and throw meaningful exceptions
-   *
    */
   @Test
   public void testQueryToDownCollectionShouldFailFast() throws Exception {

--- a/solr/core/src/test/org/apache/solr/cloud/TestQueryingOnDownCollection.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestQueryingOnDownCollection.java
@@ -51,11 +51,13 @@ public class TestQueryingOnDownCollection extends SolrCloudTestCase {
         .configure();
   }
 
-  @Test
+
   /**
    * Assert that requests to "down collection", i.e. a collection which has all replicas in down
    * state (but are hosted on nodes that are live), fail fast and throw meaningful exceptions
+   *
    */
+  @Test
   public void testQueryToDownCollectionShouldFailFast() throws Exception {
 
     CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 2, 1)

--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
@@ -265,7 +265,7 @@ public class TestRandomFlRTGCloud extends SolrCloudTestCase {
    * Randomly chooses to do a commit, where the probability of doing so increases the longer it's
    * been since a commit was done.
    *
-   * @returns <code>0</code> if a commit was done, else <code>itersSinceLastCommit + 1</code>
+   * @return <code>0</code> if a commit was done, else <code>itersSinceLastCommit + 1</code>
    */
   private static int maybeCommit(
       final Random rand, final int itersSinceLastCommit, final int numIters)

--- a/solr/core/src/test/org/apache/solr/cluster/events/ClusterEventProducerTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/events/ClusterEventProducerTest.java
@@ -52,7 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadLeakLingering(linger = 0)
-/** */
 @LogLevel("org.apache.solr.cluster.events=DEBUG")
 public class ClusterEventProducerTest extends SolrCloudTestCase {
   private AllEventsListener eventsListener;

--- a/solr/core/src/test/org/apache/solr/handler/admin/ThreadDumpHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ThreadDumpHandlerTest.java
@@ -65,7 +65,7 @@ public class ThreadDumpHandlerTest extends SolrTestCaseJ4 {
         "monitor checking not supported on this JVM",
         ManagementFactory.getThreadMXBean().isObjectMonitorUsageSupported());
 
-    /** unique class name to show up as a lock class name in output */
+    // unique class name to show up as a lock class name in output
     final class TestMonitorStruct {
       /* empty */
     }
@@ -190,7 +190,7 @@ public class ThreadDumpHandlerTest extends SolrTestCaseJ4 {
         "ownable sync checking not supported on this JVM",
         ManagementFactory.getThreadMXBean().isSynchronizerUsageSupported());
 
-    /** unique class name to show up as a lock class name in output */
+    // unique class name to show up as a lock class name in output
     final class TestReentrantLockStruct extends ReentrantLock {
       /* empty */
     }

--- a/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
@@ -697,7 +697,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     try {
       SchemaField sf = req.getSchema().getField("foo_pi");
 
-      /**
+      /*
        * LeafReader r = req.getSearcher().getIndexReader().leaves().get(0).reader(); PointValues pv
        * = r.getPointValues("foo_pi"); System.out.println("pv=" + pv); if (pv instanceof
        * AssertingLeafReader.AssertingPointValues) { pv =

--- a/solr/core/src/test/org/apache/solr/search/TestComplexPhraseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestComplexPhraseQParserPlugin.java
@@ -289,7 +289,7 @@ public class TestComplexPhraseQParserPlugin extends SolrTestCaseJ4 {
     assertU(commit());
     assertU(optimize());
 
-    /** ordered phrase query return only fist document */
+    // ordered phrase query return only fist document
     assertQ(
         req("q", "{!complexphrase} \"protein digest\""),
         "//result[@numFound='1']",
@@ -310,7 +310,7 @@ public class TestComplexPhraseQParserPlugin extends SolrTestCaseJ4 {
         "//result[@numFound='1']",
         "//doc[./str[@name='id']='3']");
 
-    /** unordered phrase query returns two documents. */
+    // unordered phrase query returns two documents.
     assertQ(
         req("q", "{!complexphrase inOrder=false} \"digest protein\""),
         "//result[@numFound='2']",
@@ -335,7 +335,7 @@ public class TestComplexPhraseQParserPlugin extends SolrTestCaseJ4 {
         "//doc[./str[@name='id']='3']",
         "//doc[./str[@name='id']='4']");
 
-    /** inOrder parameter can be defined with local params syntax. */
+    // inOrder parameter can be defined with local params syntax.
     assertQ(
         req("q", "{!complexphrase inOrder=false} \"di* pro*\""),
         "//result[@numFound='2']",
@@ -344,7 +344,7 @@ public class TestComplexPhraseQParserPlugin extends SolrTestCaseJ4 {
 
     assertQ(req("q", "{!complexphrase inOrder=true} \"di* pro*\""), "//result[@numFound='1']");
 
-    /** inOrder and df parameters can be defined with local params syntax. */
+    // inOrder and df parameters can be defined with local params syntax.
     assertQ(
         req("q", "{!complexphrase inOrder=false df=name} \"di* pro*\""),
         "//result[@numFound='2']",

--- a/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPNoScore.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPNoScore.java
@@ -269,7 +269,7 @@ public class TestScoreJoinQPNoScore extends SolrTestCaseJ4 {
 
       List<FldType> types = new ArrayList<FldType>();
       types.add(new FldType("id", ONE_ONE, new SVal('A', 'Z', 4, 4)));
-      /**
+      /*
        * no numeric fields so far LUCENE-5868 types.add(new FldType("score_f_dv",ONE_ONE, new
        * FVal(1,100))); // field used to score
        */
@@ -280,7 +280,7 @@ public class TestScoreJoinQPNoScore extends SolrTestCaseJ4 {
       types.add(
           new FldType("small2_ss_dv", ZERO_TWO, new SVal('a', (char) ('c' + indexSize / 3), 1, 1)));
       types.add(new FldType("small3_ss_dv", new IRange(0, 25), new SVal('A', 'z', 1, 1)));
-      /**
+      /*
        * no numeric fields so far LUCENE-5868 types.add(new FldType("small_i_dv",ZERO_ONE, new
        * IRange(0,5+indexSize/3))); types.add(new FldType("small2_i_dv",ZERO_ONE, new
        * IRange(0,5+indexSize/3))); types.add(new FldType("small2_is_dv",ZERO_TWO, new

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -1501,11 +1501,13 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
     assertTrue(inPlaceUpdatedFields.isEmpty());
   }
 
-  @Test
+
   /**
    * Test the @see {@link AtomicUpdateDocumentMerger#doInPlaceUpdateMerge(AddUpdateCommand,Set)}
    * method is working fine
+   *
    */
+  @Test
   public void testDoInPlaceUpdateMerge() throws Exception {
     long version1 = addAndGetVersion(sdoc("id", "1", "title_s", "first"), null);
     long version2 = addAndGetVersion(sdoc("id", "2", "title_s", "second"), null);

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -1501,11 +1501,9 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
     assertTrue(inPlaceUpdatedFields.isEmpty());
   }
 
-
   /**
    * Test the @see {@link AtomicUpdateDocumentMerger#doInPlaceUpdateMerge(AddUpdateCommand,Set)}
    * method is working fine
-   *
    */
   @Test
   public void testDoInPlaceUpdateMerge() throws Exception {

--- a/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
+++ b/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
@@ -56,10 +56,8 @@ public class UpdateLogTest extends SolrTestCaseJ4 {
     ulog = null;
   }
 
-
   /**
    * @see org.apache.solr.update.UpdateLog#applyPartialUpdates
-   *
    */
   @Test
   public void testApplyPartialUpdatesOnMultipleInPlaceUpdatesInSequence() {

--- a/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
+++ b/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
@@ -56,10 +56,12 @@ public class UpdateLogTest extends SolrTestCaseJ4 {
     ulog = null;
   }
 
-  @Test
+
   /**
    * @see org.apache.solr.update.UpdateLog#applyPartialUpdates
+   * @return
    */
+  @Test
   public void testApplyPartialUpdatesOnMultipleInPlaceUpdatesInSequence() {
     // Add a full update, two in-place updates and verify applying partial updates is working
     ulogAdd(

--- a/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
+++ b/solr/core/src/test/org/apache/solr/update/UpdateLogTest.java
@@ -59,7 +59,7 @@ public class UpdateLogTest extends SolrTestCaseJ4 {
 
   /**
    * @see org.apache.solr.update.UpdateLog#applyPartialUpdates
-   * @return
+   *
    */
   @Test
   public void testApplyPartialUpdatesOnMultipleInPlaceUpdatesInSequence() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16270
# Description

intellij is warning of "dangling javadocs" and "invalid @returns" tags.

# Solution

Fix them!  Make some javadocs actuall inline comments and block comments.  fix the `@returns` tags.

# Tests

manual

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
