### PR TITLE
SOLR-16269 clean up use of final keyword

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
@@ -567,7 +567,7 @@ public class DeleteReplicaTest extends SolrCloudTestCase {
    * same node. Instead tests should only assert that the number of watchers has decreased by 1 per
    * known replica removed)
    */
-  private static final long countUnloadCoreOnDeletedWatchers(
+  private static long countUnloadCoreOnDeletedWatchers(
       final Set<DocCollectionWatcher> watchers) {
     return watchers.stream()
         .filter(w -> w instanceof ZkController.UnloadCoreOnDeletedWatcher)

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
@@ -567,8 +567,7 @@ public class DeleteReplicaTest extends SolrCloudTestCase {
    * same node. Instead tests should only assert that the number of watchers has decreased by 1 per
    * known replica removed)
    */
-  private static long countUnloadCoreOnDeletedWatchers(
-      final Set<DocCollectionWatcher> watchers) {
+  private static long countUnloadCoreOnDeletedWatchers(final Set<DocCollectionWatcher> watchers) {
     return watchers.stream()
         .filter(w -> w instanceof ZkController.UnloadCoreOnDeletedWatcher)
         .count();

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
@@ -352,7 +352,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
    * Given a BitSet, returns a random bit that is currently false, or -1 if all bits are true. NOTE:
    * this method is not fair.
    */
-  public static final int randomUnsetBit(Random r, BitSet bits, final int max) {
+  public static int randomUnsetBit(Random r, BitSet bits, final int max) {
     // NOTE: don't forget, BitSet will grow automatically if not careful
     if (bits.cardinality() == max + 1) {
       return -1;
@@ -378,14 +378,14 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
   }
 
   /** returns the numFound from a *:* query */
-  public static final long countDocs(SolrClient c) throws Exception {
+  public static long countDocs(SolrClient c) throws Exception {
     return c.query(params("q", "*:*", "rows", "0")).getResults().getNumFound();
   }
 
   /**
    * uses a Cursor to iterate over every doc in the index, recording the 'id_i' value in a BitSet
    */
-  private static final BitSet allDocs(final SolrClient c, final int maxDocIdExpected)
+  private static BitSet allDocs(final SolrClient c, final int maxDocIdExpected)
       throws Exception {
     BitSet docs = new BitSet(maxDocIdExpected + 1);
     String cursorMark = CURSOR_MARK_START;

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
@@ -385,8 +385,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
   /**
    * uses a Cursor to iterate over every doc in the index, recording the 'id_i' value in a BitSet
    */
-  private static BitSet allDocs(final SolrClient c, final int maxDocIdExpected)
-      throws Exception {
+  private static BitSet allDocs(final SolrClient c, final int maxDocIdExpected) throws Exception {
     BitSet docs = new BitSet(maxDocIdExpected + 1);
     String cursorMark = CURSOR_MARK_START;
     int docsOnThisPage = Integer.MAX_VALUE;

--- a/solr/core/src/test/org/apache/solr/core/MockEventListener.java
+++ b/solr/core/src/test/org/apache/solr/core/MockEventListener.java
@@ -23,7 +23,7 @@ public class MockEventListener implements SolrEventListener {
 
   static final AtomicInteger createCounter = new AtomicInteger(0);
 
-  public static final int getCreateCount() {
+  public static int getCreateCount() {
     return createCounter.intValue();
   }
 

--- a/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
+++ b/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
@@ -898,7 +898,7 @@ public class TestLazyCores extends SolrTestCaseJ4 {
     return new LocalSolrQueryRequest(core, params(paramPairs));
   }
 
-  private static final String makePath(String... args) {
+  private static String makePath(String... args) {
     return String.join(File.separator, args);
   }
 

--- a/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
+++ b/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
@@ -1063,7 +1063,7 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
   }
 
   /** returns a (new) list of the block based documents used in our test methods */
-  protected static final List<SolrInputDocument> makeBlockDocs() {
+  protected static List<SolrInputDocument> makeBlockDocs() {
     // NOTE: block_i and block_s1 will contain identical content so these need to be "numbers"...
     // The specific numbers shouldn't matter (and we explicitly test '0' to confirm legacy
     // bug/behavior

--- a/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
@@ -1131,15 +1131,15 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
     }
   }
 
-  private static final ModelRange emptyVals() {
+  private static ModelRange emptyVals() {
     return new ModelRange(-1, -100);
   }
 
-  private static final ModelRange modelVals(int value) {
+  private static ModelRange modelVals(int value) {
     return modelVals(value, value);
   }
 
-  private static final ModelRange modelVals(int lower, int upper) {
+  private static ModelRange modelVals(int lower, int upper) {
     assertTrue(upper + " < " + lower, lower <= upper);
     assertTrue("negative lower", 0 <= lower);
     assertTrue("negative upper", 0 <= upper);
@@ -1147,7 +1147,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
   }
 
   /** randomized helper */
-  private static final Integer pickSubFacetLimit(final boolean doSubFacet) {
+  private static Integer pickSubFacetLimit(final boolean doSubFacet) {
     if (!doSubFacet) {
       return null;
     }
@@ -1155,7 +1155,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
     return (result <= 0) ? -1 : result;
   }
   /** randomized helper */
-  private static final CharSequence makeSubFacet(final Integer subFacetLimit) {
+  private static CharSequence makeSubFacet(final Integer subFacetLimit) {
     if (null == subFacetLimit) {
       return "";
     }
@@ -1182,7 +1182,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
    * @see #formatFacetRangeOther
    * @see #OTHERS
    */
-  private static final List<EnumSet<FacetRangeOther>> buildListOfFacetRangeOtherOptions() {
+  private static List<EnumSet<FacetRangeOther>> buildListOfFacetRangeOtherOptions() {
     assertEquals(
         "If someone adds to FacetRangeOther this method (and bulk of test) needs updated",
         5,
@@ -1206,7 +1206,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
    * @see #assertBeforeAfterBetween
    * @see #buildListOfFacetRangeOtherOptions
    */
-  private static final String formatFacetRangeOther(EnumSet<FacetRangeOther> other) {
+  private static String formatFacetRangeOther(EnumSet<FacetRangeOther> other) {
     if (other.contains(FacetRangeOther.NONE) && random().nextBoolean()) {
       return ""; // sometimes don't output a param at all when we're dealing with the default NONE
     }

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -5076,7 +5076,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   }
 
   /** atomically resets the actual AtomicLong value matches the expected and resets it to 0 */
-    private static void assertEqualsAndReset(String msg, long expected, AtomicLong actual) {
+  private static void assertEqualsAndReset(String msg, long expected, AtomicLong actual) {
     final long current = actual.getAndSet(0);
     assertEquals(msg, expected, current);
   }

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -5076,12 +5076,12 @@ public class TestJsonFacets extends SolrTestCaseHS {
   }
 
   /** atomically resets the actual AtomicLong value matches the expected and resets it to 0 */
-  private static final void assertEqualsAndReset(String msg, long expected, AtomicLong actual) {
+    private static void assertEqualsAndReset(String msg, long expected, AtomicLong actual) {
     final long current = actual.getAndSet(0);
     assertEquals(msg, expected, current);
   }
   /** atomically resets the actual AtomicLong value matches the expected and resets it to 0 */
-  private static final void assertEqualsAndReset(long expected, AtomicLong actual) {
+  private static void assertEqualsAndReset(long expected, AtomicLong actual) {
     final long current = actual.getAndSet(0);
     assertEquals(expected, current);
   }

--- a/solr/core/src/test/org/apache/solr/search/function/TestMinMaxOnMultiValuedField.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestMinMaxOnMultiValuedField.java
@@ -1073,7 +1073,7 @@ public class TestMinMaxOnMultiValuedField extends SolrTestCaseJ4 {
    *       other documents in the result.
    * </ul>
    */
-  private static final List<SolrInputDocument> buildMultiValueSortedDocuments(
+  private static List<SolrInputDocument> buildMultiValueSortedDocuments(
       final String f, final List<Object> vals) {
     // build a list of docIds that we can shuffle (so the id order doesn't match the value order)
     List<Integer> ids = new ArrayList<>(vals.size());

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -1040,7 +1040,7 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
     }
 
     /** pick a random type of RandomUpdate */
-    public static final RandomUpdate pick(Random r) {
+    public static RandomUpdate pick(Random r) {
       final int target = TestUtil.nextInt(r, 1, 100);
       int cumulative_odds = 0;
       for (RandomUpdate candidate : RandomUpdate.values()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16269
# Description

IntelliJ flagged that some methods had extra keywords on them.

# Solution

Apply fixes suggested by IntelliJ

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
