### PR TITLE
SOLR-16224: class level variables that can be safely made local, and are boilerpl…

### DIFF
--- a/solr/core/src/test/org/apache/solr/AnalysisAfterCoreReloadTest.java
+++ b/solr/core/src/test/org/apache/solr/AnalysisAfterCoreReloadTest.java
@@ -37,7 +37,6 @@ import org.junit.BeforeClass;
 
 public class AnalysisAfterCoreReloadTest extends SolrTestCaseJ4 {
 
-  private static String tmpSolrHome;
   int port = 0;
   static final String context = "/solr";
 
@@ -45,7 +44,7 @@ public class AnalysisAfterCoreReloadTest extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    tmpSolrHome = createTempDir().toFile().getAbsolutePath();
+    String tmpSolrHome = createTempDir().toFile().getAbsolutePath();
     FileUtils.copyDirectory(new File(TEST_HOME()), new File(tmpSolrHome).getAbsoluteFile());
     initCore("solrconfig.xml", "schema.xml", new File(tmpSolrHome).getAbsolutePath());
   }

--- a/solr/core/src/test/org/apache/solr/SolrTestCaseJ4Test.java
+++ b/solr/core/src/test/org/apache/solr/SolrTestCaseJ4Test.java
@@ -25,13 +25,11 @@ import org.junit.Test;
 
 public class SolrTestCaseJ4Test extends SolrTestCaseJ4 {
 
-  private static String tmpSolrHome;
-
   @BeforeClass
   public static void beforeClass() throws Exception {
     // Create a temporary directory that holds a core NOT named "collection1". Use the smallest
     // configuration sets we can, so we don't copy that much junk around.
-    tmpSolrHome = createTempDir().toFile().getAbsolutePath();
+    String tmpSolrHome = createTempDir().toFile().getAbsolutePath();
 
     File subHome = new File(new File(tmpSolrHome, "core0"), "conf");
     assertTrue("Failed to make subdirectory ", subHome.mkdirs());

--- a/solr/core/src/test/org/apache/solr/TestTolerantSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestTolerantSearch.java
@@ -42,7 +42,6 @@ public class TestTolerantSearch extends SolrJettyTestBase {
   private static SolrClient collection2;
   private static String shard1;
   private static String shard2;
-  private static File solrHome;
 
   private static File createSolrHome() throws Exception {
     File workDir = createTempDir().toFile();
@@ -57,7 +56,7 @@ public class TestTolerantSearch extends SolrJettyTestBase {
   @BeforeClass
   public static void createThings() throws Exception {
     systemSetPropertySolrDisableUrlAllowList("true");
-    solrHome = createSolrHome();
+    File solrHome = createSolrHome();
     createAndStartJetty(solrHome.getAbsolutePath());
     String url = jetty.getBaseUrl().toString();
     collection1 = getHttpSolrClient(url + "/collection1");

--- a/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
@@ -63,9 +63,6 @@ public class TestSolrConfigHandler extends RestTestBase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static File tmpSolrHome;
-  private static File tmpConfDir;
-
   private static final String collection = "collection1";
   private static final String confDir = collection + "/conf";
 
@@ -117,8 +114,8 @@ public class TestSolrConfigHandler extends RestTestBase {
 
   @Before
   public void before() throws Exception {
-    tmpSolrHome = createTempDir().toFile();
-    tmpConfDir = new File(tmpSolrHome, confDir);
+    File tmpSolrHome = createTempDir().toFile();
+    File tmpConfDir = new File(tmpSolrHome, confDir);
     FileUtils.copyDirectory(new File(TEST_HOME()), tmpSolrHome.getAbsoluteFile());
 
     final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
@@ -49,7 +49,6 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
   private static SolrClient collection2;
   private static String shard1;
   private static String shard2;
-  private static File solrHome;
 
   private static File createSolrHome() throws Exception {
     File workDir = createTempDir().toFile();
@@ -61,7 +60,7 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
   @BeforeClass
   public static void createThings() throws Exception {
     systemSetPropertySolrDisableUrlAllowList("true");
-    solrHome = createSolrHome();
+    File solrHome = createSolrHome();
     createAndStartJetty(solrHome.getAbsolutePath());
     String url = jetty.getBaseUrl().toString();
 

--- a/solr/core/src/test/org/apache/solr/request/TestRemoteStreaming.java
+++ b/solr/core/src/test/org/apache/solr/request/TestRemoteStreaming.java
@@ -45,12 +45,11 @@ import org.junit.Test;
 /** See SOLR-2854. */
 @SuppressSSL // does not yet work with ssl yet - uses raw java.net.URL API rather than HttpClient
 public class TestRemoteStreaming extends SolrJettyTestBase {
-  private static File solrHomeDirectory;
 
   @BeforeClass
   public static void beforeTest() throws Exception {
     // this one has handleSelect=true which a test here needs
-    solrHomeDirectory = createTempDir(LuceneTestCase.getTestClass().getSimpleName()).toFile();
+    File solrHomeDirectory = createTempDir(LuceneTestCase.getTestClass().getSimpleName()).toFile();
     setupJettyTestHome(solrHomeDirectory, "collection1");
     createAndStartJetty(solrHomeDirectory.getAbsolutePath());
   }

--- a/solr/core/src/test/org/apache/solr/rest/schema/TestBulkSchemaAPI.java
+++ b/solr/core/src/test/org/apache/solr/rest/schema/TestBulkSchemaAPI.java
@@ -56,11 +56,9 @@ import org.slf4j.LoggerFactory;
 public class TestBulkSchemaAPI extends RestTestBase {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static File tmpSolrHome;
-
   @Before
   public void before() throws Exception {
-    tmpSolrHome = createTempDir().toFile();
+    File tmpSolrHome = createTempDir().toFile();
     FileUtils.copyDirectory(new File(TEST_HOME()), tmpSolrHome.getAbsoluteFile());
 
     System.setProperty("managed.schema.mutable", "true");

--- a/solr/core/src/test/org/apache/solr/rest/schema/analysis/TestManagedStopFilterFactory.java
+++ b/solr/core/src/test/org/apache/solr/rest/schema/analysis/TestManagedStopFilterFactory.java
@@ -36,16 +36,14 @@ import org.junit.Test;
  * <p>PUT: add some words to the current list
  */
 public class TestManagedStopFilterFactory extends RestTestBase {
-  private static File tmpSolrHome;
-  private static File tmpConfDir;
 
   private static final String collection = "collection1";
   private static final String confDir = collection + "/conf";
 
   @Before
   public void before() throws Exception {
-    tmpSolrHome = createTempDir().toFile();
-    tmpConfDir = new File(tmpSolrHome, confDir);
+    File tmpSolrHome = createTempDir().toFile();
+    File tmpConfDir = new File(tmpSolrHome, confDir);
     FileUtils.copyDirectory(new File(TEST_HOME()), tmpSolrHome.getAbsoluteFile());
 
     final SortedMap<ServletHolder, String> extraServlets = new TreeMap<>();

--- a/solr/core/src/test/org/apache/solr/schema/TestUseDocValuesAsStored.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestUseDocValuesAsStored.java
@@ -49,9 +49,6 @@ public class TestUseDocValuesAsStored extends AbstractBadConfigTestBase {
 
   private int id = 1;
 
-  private static File tmpSolrHome;
-  private static File tmpConfDir;
-
   private static final String collection = "collection1";
   private static final String confDir = collection + "/conf";
 
@@ -98,8 +95,8 @@ public class TestUseDocValuesAsStored extends AbstractBadConfigTestBase {
 
   @Before
   private void initManagedSchemaCore() throws Exception {
-    tmpSolrHome = createTempDir().toFile();
-    tmpConfDir = new File(tmpSolrHome, confDir);
+    File tmpSolrHome = createTempDir().toFile();
+    File tmpConfDir = new File(tmpSolrHome, confDir);
     File testHomeConfDir = new File(TEST_HOME(), confDir);
     FileUtils.copyFileToDirectory(
         new File(testHomeConfDir, "solrconfig-managed-schema.xml"), tmpConfDir);

--- a/solr/core/src/test/org/apache/solr/search/TestAddFieldRealTimeGet.java
+++ b/solr/core/src/test/org/apache/solr/search/TestAddFieldRealTimeGet.java
@@ -25,17 +25,14 @@ import org.junit.Before;
 
 public class TestAddFieldRealTimeGet extends TestRTGBase {
 
-  private static File tmpSolrHome;
-  private static File tmpConfDir;
-
   private static final String collection = "collection1";
   private static final String confDir = collection + "/conf";
 
   @Before
   private void initManagedSchemaCore() throws Exception {
     final String tmpSolrHomePath = createTempDir().toFile().getAbsolutePath();
-    tmpSolrHome = new File(tmpSolrHomePath).getAbsoluteFile();
-    tmpConfDir = new File(tmpSolrHome, confDir);
+    File tmpSolrHome = new File(tmpSolrHomePath).getAbsoluteFile();
+    File tmpConfDir = new File(tmpSolrHome, confDir);
     File testHomeConfDir = new File(TEST_HOME(), confDir);
     final String configFileName = "solrconfig-managed-schema.xml";
     final String schemaFileName = "schema-id-and-version-fields-only.xml";

--- a/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
@@ -36,11 +36,10 @@ import org.junit.Test;
 
 /** A test case for the several HTTP cache headers emitted by Solr */
 public class CacheHeaderTest extends CacheHeaderTestBase {
-  private static File solrHomeDirectory;
 
   @BeforeClass
   public static void beforeTest() throws Exception {
-    solrHomeDirectory = createTempDir().toFile();
+    File solrHomeDirectory = createTempDir().toFile();
     setupJettyTestHome(solrHomeDirectory, "collection1");
     createAndStartJetty(solrHomeDirectory.getAbsolutePath());
   }

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -102,10 +102,10 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {
     String oldCacheNamePropValue = System.getProperty("blockJoinParentFilterCache");
-    boolean cachedMode;
+    final boolean cachedMode = random().nextBoolean();
     System.setProperty(
         "blockJoinParentFilterCache",
-        (cachedMode = random().nextBoolean()) ? "blockJoinParentFilterCache" : "don't cache");
+        cachedMode ? "blockJoinParentFilterCache" : "don't cache");
     if (oldCacheNamePropValue != null) {
       System.setProperty("blockJoinParentFilterCache", oldCacheNamePropValue);
     }

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -104,8 +104,7 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
     String oldCacheNamePropValue = System.getProperty("blockJoinParentFilterCache");
     final boolean cachedMode = random().nextBoolean();
     System.setProperty(
-        "blockJoinParentFilterCache",
-        cachedMode ? "blockJoinParentFilterCache" : "don't cache");
+        "blockJoinParentFilterCache", cachedMode ? "blockJoinParentFilterCache" : "don't cache");
     if (oldCacheNamePropValue != null) {
       System.setProperty("blockJoinParentFilterCache", oldCacheNamePropValue);
     }

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -91,7 +91,6 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
 
   private static final AtomicInteger counter = new AtomicInteger();
   private static ExecutorService exe;
-  private static boolean cachedMode;
 
   private static XMLInputFactory inputFactory;
 
@@ -103,6 +102,7 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {
     String oldCacheNamePropValue = System.getProperty("blockJoinParentFilterCache");
+    boolean cachedMode;
     System.setProperty(
         "blockJoinParentFilterCache",
         (cachedMode = random().nextBoolean()) ? "blockJoinParentFilterCache" : "don't cache");

--- a/solr/core/src/test/org/apache/solr/update/DataDrivenBlockJoinTest.java
+++ b/solr/core/src/test/org/apache/solr/update/DataDrivenBlockJoinTest.java
@@ -23,16 +23,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DataDrivenBlockJoinTest extends SolrTestCaseJ4 {
-  private File tmpSolrHome;
-  private File tmpConfDir;
 
   private static final String collection = "collection1";
   private static final String confDir = collection + "/conf";
 
   @Before
   public void before() throws Exception {
-    tmpSolrHome = createTempDir().toFile();
-    tmpConfDir = new File(tmpSolrHome, confDir);
+    File tmpSolrHome = createTempDir().toFile();
+    File tmpConfDir = new File(tmpSolrHome, confDir);
     File testHomeConfDir = new File(TEST_HOME(), confDir);
     FileUtils.copyFileToDirectory(
         new File(testHomeConfDir, "solrconfig-schemaless.xml"), tmpConfDir);

--- a/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
@@ -39,16 +39,13 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
       "solrconfig-add-schema-fields-update-processor-chains.xml";
   private static final String SCHEMA_XML = "schema-add-schema-fields-update-processor.xml";
 
-  private static File tmpSolrHome;
-  private static File tmpConfDir;
-
   private static final String collection = "collection1";
   private static final String confDir = collection + "/conf";
 
   @Before
   private void initManagedSchemaCore() throws Exception {
-    tmpSolrHome = createTempDir().toFile();
-    tmpConfDir = new File(tmpSolrHome, confDir);
+    File tmpSolrHome = createTempDir().toFile();
+    File tmpConfDir = new File(tmpSolrHome, confDir);
     File testHomeConfDir = new File(TEST_HOME(), confDir);
     FileUtils.copyFileToDirectory(new File(testHomeConfDir, SOLRCONFIG_XML), tmpConfDir);
     FileUtils.copyFileToDirectory(new File(testHomeConfDir, SCHEMA_XML), tmpConfDir);


### PR DESCRIPTION
…ate in nature, they dont help you understand how the test works

https://issues.apache.org/jira/browse/SOLR-16224
# Description

In the unit tests we have variables defined at the class level that don't actually need to be as they are used in a single method.  However defining these at the top of the class CAN be helpful to understand the unit test.

Having said that, there are some really boilerplate parameters that aren't specific to any individual test's behavior, like `tmpSolrHome`.

# Solution
Review the variables defined at the class level and if they don't help you understand the unit test, then move them to a method variable.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
