### PR TITLE
SOLR-162680: toString is not required when crafting a string message

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
@@ -879,7 +879,7 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
             "Ran out of actual keys as of : " + i + "->" + expectedKey, actualKeys.hasNext());
         assertEquals(expectedKey, actualKeys.next());
         assertEquals(
-            "percentiles are off: " + p.toString(), expectedVals[i], p.get(expectedKey), 1.0D);
+            "percentiles are off: " + p, expectedVals[i], p.get(expectedKey), 1.0D);
       }
 
       //
@@ -2027,12 +2027,12 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
                   Boolean.TRUE,
                   rsp.getHeader().get(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY));
               assertTrue(
-                  "Expected to find error in the down shard info: " + info.toString(),
+                  "Expected to find error in the down shard info: " + info,
                   info.get("error") != null);
             } else {
               assertTrue(
                   "Expected timeAllowedError or to find shardAddress in the up shard info: "
-                      + info.toString(),
+                      + info,
                   info.get("shardAddress") != null);
             }
           } else {

--- a/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
@@ -878,8 +878,7 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
         assertTrue(
             "Ran out of actual keys as of : " + i + "->" + expectedKey, actualKeys.hasNext());
         assertEquals(expectedKey, actualKeys.next());
-        assertEquals(
-            "percentiles are off: " + p, expectedVals[i], p.get(expectedKey), 1.0D);
+        assertEquals("percentiles are off: " + p, expectedVals[i], p.get(expectedKey), 1.0D);
       }
 
       //
@@ -2031,8 +2030,7 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
                   info.get("error") != null);
             } else {
               assertTrue(
-                  "Expected timeAllowedError or to find shardAddress in the up shard info: "
-                      + info,
+                  "Expected timeAllowedError or to find shardAddress in the up shard info: " + info,
                   info.get("shardAddress") != null);
             }
           } else {

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionPropsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionPropsTest.java
@@ -63,7 +63,7 @@ public class CollectionPropsTest extends SolrCloudTestCase {
     CollectionAdminRequest.Create request =
         CollectionAdminRequest.createCollection(collectionName, "conf", 2, 2);
     CollectionAdminResponse response = request.process(cluster.getSolrClient());
-    assertTrue("Unable to create collection: " + response.toString(), response.isSuccess());
+    assertTrue("Unable to create collection: " + response, response.isSuccess());
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteShardTest.java
@@ -125,7 +125,7 @@ public class DeleteShardTest extends SolrCloudTestCase {
     }
 
     waitForState(
-        "Expected shard " + slice + " to be in state " + state.toString(),
+        "Expected shard " + slice + " to be in state " + state,
         collection,
         (n, c) -> {
           return c.getSlice(slice).getState() == state;

--- a/solr/core/src/test/org/apache/solr/cloud/FullSolrCloudDistribCmdsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/FullSolrCloudDistribCmdsTest.java
@@ -425,7 +425,7 @@ public class FullSolrCloudDistribCmdsTest extends SolrCloudTestCase {
               "Sanity check: leaderProps isn't a leader?: " + leaderProps.toString(),
               leaderProps.getStr(Slice.LEADER));
           assertTrue(
-              "Sanity check: leaderProps isn't using the proxy port?: " + leaderProps.toString(),
+              "Sanity check: leaderProps isn't using the proxy port?: " + leaderProps,
               leaderProps.getCoreUrl().contains("" + proxy.getListenPort()));
         }
 

--- a/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
@@ -301,12 +301,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     // try with recurse not specified
     args =
         new String[] {
-          "-src",
-          "file:" + srcPathCheck.toAbsolutePath(),
-          "-dst",
-          "zk:/cp5Fail",
-          "-zkHost",
-          zkAddr,
+          "-src", "file:" + srcPathCheck.toAbsolutePath(), "-dst", "zk:/cp5Fail", "-zkHost", zkAddr,
         };
 
     res =
@@ -359,10 +354,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:"
-              + srcPathCheck.normalize().toAbsolutePath()
-              + File.separator
-              + "solrconfig.xml",
+          "file:" + srcPathCheck.normalize().toAbsolutePath() + File.separator + "solrconfig.xml",
           "-dst",
           "zk:/powerup/",
           "-recurse",
@@ -385,10 +377,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:"
-              + srcPathCheck.normalize().toAbsolutePath()
-              + File.separator
-              + "solrconfig.xml",
+          "file:" + srcPathCheck.normalize().toAbsolutePath() + File.separator + "solrconfig.xml",
           "-dst",
           "zk:/copyUpFile.xml",
           "-recurse",
@@ -977,10 +966,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
 
       Path thisPath = Paths.get(fileRoot.toAbsolutePath().toString(), child);
       assertTrue(
-          "Znode "
-              + child
-              + " should have been found on disk at "
-              + fileRoot.toAbsolutePath(),
+          "Znode " + child + " should have been found on disk at " + fileRoot.toAbsolutePath(),
           Files.exists(thisPath));
       verifyAllZNodesAreFiles(thisPath, zkRoot + child);
     }

--- a/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
@@ -223,7 +223,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
           "-src",
           "zk:/configs/cp1",
           "-dst",
-          "file:" + tmp.toAbsolutePath().toString(),
+          "file:" + tmp.toAbsolutePath(),
           "-recurse",
           "true",
           "-zkHost",
@@ -282,7 +282,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + srcPathCheck.toAbsolutePath().toString(),
+          "file:" + srcPathCheck.toAbsolutePath(),
           "-dst",
           "zk:/cp4",
           "-recurse",
@@ -302,7 +302,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + srcPathCheck.toAbsolutePath().toString(),
+          "file:" + srcPathCheck.toAbsolutePath(),
           "-dst",
           "zk:/cp5Fail",
           "-zkHost",
@@ -319,7 +319,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + srcPathCheck.toAbsolutePath().toString(),
+          "file:" + srcPathCheck.toAbsolutePath(),
           "-dst",
           "zk:/cp6Fail",
           "-recurse",
@@ -360,7 +360,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
         new String[] {
           "-src",
           "file:"
-              + srcPathCheck.normalize().toAbsolutePath().toString()
+              + srcPathCheck.normalize().toAbsolutePath()
               + File.separator
               + "solrconfig.xml",
           "-dst",
@@ -386,7 +386,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
         new String[] {
           "-src",
           "file:"
-              + srcPathCheck.normalize().toAbsolutePath().toString()
+              + srcPathCheck.normalize().toAbsolutePath()
               + File.separator
               + "solrconfig.xml",
           "-dst",
@@ -410,7 +410,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     // src and cp3 are valid
 
     String localNamed =
-        tmp.normalize().toString() + File.separator + "localnamed" + File.separator + "renamed.txt";
+        tmp.normalize() + File.separator + "localnamed" + File.separator + "renamed.txt";
     args =
         new String[] {
           "-src",
@@ -463,7 +463,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + srcPathCheck.toAbsolutePath().toString(),
+          "file:" + srcPathCheck.toAbsolutePath(),
           "-dst",
           "zk:/cp7/",
           "-recurse",
@@ -489,7 +489,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + file.toAbsolutePath().toString(),
+          "file:" + file.toAbsolutePath(),
           "-dst",
           "zk:/cp7/conf/stopwords/",
           "-recurse",
@@ -521,7 +521,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
           "-src",
           "zk:/cp7",
           "-dst",
-          "file:" + tmp.toAbsolutePath().toString(),
+          "file:" + tmp.toAbsolutePath(),
           "-recurse",
           "true",
           "-zkHost",
@@ -541,7 +541,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + tmp.toAbsolutePath().toString(),
+          "file:" + tmp.toAbsolutePath(),
           "-dst",
           "zk:/cp9",
           "-recurse",
@@ -568,7 +568,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     args =
         new String[] {
           "-src",
-          "file:" + emptyFile.toAbsolutePath().toString(),
+          "file:" + emptyFile.toAbsolutePath(),
           "-dst",
           "zk:/cp7/conf/stopwords/emptyfile",
           "-recurse",
@@ -590,7 +590,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
           "-src",
           "zk:/cp7/conf/stopwords/emptyfile",
           "-dst",
-          "file:" + emptyDest.toAbsolutePath().toString(),
+          "file:" + emptyDest.toAbsolutePath(),
           "-recurse",
           "false",
           "-zkHost",
@@ -631,7 +631,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
           "-src",
           "zk:/cp10",
           "-dst",
-          "file:" + tmp2.toAbsolutePath().toString(),
+          "file:" + tmp2.toAbsolutePath(),
           "-recurse",
           "true",
           "-zkHost",
@@ -980,7 +980,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
           "Znode "
               + child
               + " should have been found on disk at "
-              + fileRoot.toAbsolutePath().toString(),
+              + fileRoot.toAbsolutePath(),
           Files.exists(thisPath));
       verifyAllZNodesAreFiles(thisPath, zkRoot + child);
     }

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudDeleteByQuery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudDeleteByQuery.java
@@ -143,8 +143,8 @@ public class TestCloudDeleteByQuery extends SolrCloudTestCase {
     for (Slice slice : clusterState.getCollection(COLLECTION_NAME).getSlices()) {
       String shardName = slice.getName();
       Replica leader = slice.getLeader();
-      assertNotNull("slice has null leader: " + slice.toString(), leader);
-      assertNotNull("slice leader has null node name: " + slice.toString(), leader.getNodeName());
+      assertNotNull("slice has null leader: " + slice, leader);
+      assertNotNull("slice leader has null node name: " + slice, leader.getNodeName());
       String leaderUrl = urlMap.remove(leader.getNodeName());
       assertNotNull(
           "could not find URL for " + shardName + " leader: " + leader.getNodeName(), leaderUrl);

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPseudoReturnFields.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPseudoReturnFields.java
@@ -160,10 +160,7 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
         assertNotNull(
             "Test depends on a (dynamic) field matching '" + name + "', Null response", frsp);
         assertEquals(
-            "Test depends on a (dynamic) field matching '"
-                + name
-                + "', bad status: "
-                + frsp,
+            "Test depends on a (dynamic) field matching '" + name + "', bad status: " + frsp,
             0,
             frsp.getStatus());
         assertNotNull(
@@ -956,10 +953,7 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
         "does not match exactly one doc: " + p.toString() + " => " + docs.toString(),
         1,
         docs.getNumFound());
-    assertEquals(
-        "does not contain exactly one doc: " + p + " => " + docs,
-        1,
-        docs.size());
+    assertEquals("does not contain exactly one doc: " + p + " => " + docs, 1, docs.size());
     return docs.get(0);
   }
 
@@ -974,8 +968,7 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
         "does not match at least one doc: " + p + " => " + rsp,
         1 <= rsp.getResults().getNumFound());
     assertTrue(
-        "rsp does not contain at least one doc: " + p + " => " + rsp,
-        1 <= rsp.getResults().size());
+        "rsp does not contain at least one doc: " + p + " => " + rsp, 1 <= rsp.getResults().size());
     return rsp.getResults();
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPseudoReturnFields.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPseudoReturnFields.java
@@ -163,20 +163,20 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
             "Test depends on a (dynamic) field matching '"
                 + name
                 + "', bad status: "
-                + frsp.toString(),
+                + frsp,
             0,
             frsp.getStatus());
         assertNotNull(
             "Test depends on a (dynamic) field matching '"
                 + name
                 + "', schema was changed out from under us? ... "
-                + frsp.toString(),
+                + frsp,
             frsp.getField());
         assertEquals(
             "Test depends on a multivalued dynamic field matching '"
                 + name
                 + "', schema was changed out from under us? ... "
-                + frsp.toString(),
+                + frsp,
             Boolean.TRUE,
             frsp.getField().get("multiValued"));
       } catch (SolrServerException e) {
@@ -957,7 +957,7 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
         1,
         docs.getNumFound());
     assertEquals(
-        "does not contain exactly one doc: " + p.toString() + " => " + docs.toString(),
+        "does not contain exactly one doc: " + p + " => " + docs,
         1,
         docs.size());
     return docs.get(0);
@@ -971,10 +971,10 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
     QueryResponse rsp = getRandClient(random()).query(p);
     assertEquals("failed request: " + p.toString() + " => " + rsp.toString(), 0, rsp.getStatus());
     assertTrue(
-        "does not match at least one doc: " + p.toString() + " => " + rsp.toString(),
+        "does not match at least one doc: " + p + " => " + rsp,
         1 <= rsp.getResults().getNumFound());
     assertTrue(
-        "rsp does not contain at least one doc: " + p.toString() + " => " + rsp.toString(),
+        "rsp does not contain at least one doc: " + p + " => " + rsp,
         1 <= rsp.getResults().size());
     return rsp.getResults();
   }

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
@@ -1479,7 +1479,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
           .process(cluster.getSolrClient())
           .getStatus();
     } catch (SolrServerException e1) {
-      throw new AssertionError("Server error uploading configset: " + e1.toString(), e1);
+      throw new AssertionError("Server error uploading configset: " + e1, e1);
     } catch (SolrException e2) {
       return e2.code();
     }
@@ -1539,7 +1539,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
           .process(cluster.getSolrClient())
           .getStatus();
     } catch (SolrServerException e1) {
-      throw new AssertionError("Server error uploading file to configset: " + e1.toString(), e1);
+      throw new AssertionError("Server error uploading file to configset: " + e1, e1);
     } catch (SolrException e2) {
       return e2.code();
     }

--- a/solr/core/src/test/org/apache/solr/cloud/TestRebalanceLeaders.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRebalanceLeaders.java
@@ -696,7 +696,7 @@ public class TestRebalanceLeaders extends SolrCloudTestCase {
       if (livePos == Integer.MAX_VALUE) {
         fail(
             "Invalid state! We should have a replica to add the property to! "
-                + docCollection.toString());
+                + docCollection);
       }
 
       uniquePropMap.put(slice.getName(), changedRep.getName());

--- a/solr/core/src/test/org/apache/solr/cloud/TestRebalanceLeaders.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRebalanceLeaders.java
@@ -694,9 +694,7 @@ public class TestRebalanceLeaders extends SolrCloudTestCase {
         }
       }
       if (livePos == Integer.MAX_VALUE) {
-        fail(
-            "Invalid state! We should have a replica to add the property to! "
-                + docCollection);
+        fail("Invalid state! We should have a replica to add the property to! " + docCollection);
       }
 
       uniquePropMap.put(slice.getName(), changedRep.getName());

--- a/solr/core/src/test/org/apache/solr/cloud/TestStressCloudBlindAtomicUpdates.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestStressCloudBlindAtomicUpdates.java
@@ -144,7 +144,7 @@ public class TestStressCloudBlindAtomicUpdates extends SolrCloudTestCase {
     for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
       assertNotNull("Cluster contains null jetty?", jetty);
       final URL baseUrl = jetty.getBaseUrl();
-      assertNotNull("Jetty has null baseUrl: " + jetty.toString(), baseUrl);
+      assertNotNull("Jetty has null baseUrl: " + jetty, baseUrl);
       CLIENTS.add(getHttpSolrClient(baseUrl + "/" + COLLECTION_NAME + "/"));
     }
 
@@ -305,7 +305,7 @@ public class TestStressCloudBlindAtomicUpdates extends SolrCloudTestCase {
       final int initValue = random().nextInt();
       SolrInputDocument doc = doc(f("id", "" + id), f(numericFieldName, initValue));
       UpdateResponse rsp = update(doc).process(CLOUD_CLIENT);
-      assertEquals(doc.toString() + " => " + rsp.toString(), 0, rsp.getStatus());
+      assertEquals(doc + " => " + rsp, 0, rsp.getStatus());
       if (0 == id % DOC_ID_INCR) {
         expected[id / DOC_ID_INCR] = new AtomicLong(initValue);
       }
@@ -541,7 +541,7 @@ public class TestStressCloudBlindAtomicUpdates extends SolrCloudTestCase {
     assertNotNull("expected contains no name: " + expected, fieldName);
     FieldResponse rsp = new Field(fieldName).process(CLOUD_CLIENT);
     assertNotNull("Field Null Response: " + fieldName, rsp);
-    assertEquals("Field Status: " + fieldName + " => " + rsp.toString(), 0, rsp.getStatus());
+    assertEquals("Field Status: " + fieldName + " => " + rsp, 0, rsp.getStatus());
     assertEquals("Field: " + fieldName, expected, rsp.getField());
   }
 
@@ -557,7 +557,7 @@ public class TestStressCloudBlindAtomicUpdates extends SolrCloudTestCase {
     assertNotNull("expected contains no type: " + expected, typeName);
     FieldTypeResponse rsp = new FieldType(typeName).process(CLOUD_CLIENT);
     assertNotNull("FieldType Null Response: " + typeName, rsp);
-    assertEquals("FieldType Status: " + typeName + " => " + rsp.toString(), 0, rsp.getStatus());
+    assertEquals("FieldType Status: " + typeName + " => " + rsp, 0, rsp.getStatus());
     assertEquals("FieldType: " + typeName, expected, rsp.getFieldType().getAttributes());
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestStressLiveNodes.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestStressLiveNodes.java
@@ -141,7 +141,7 @@ public class TestStressLiveNodes extends SolrCloudTestCase {
 
       // sanity check that ZK says there is in fact 1 live node
       List<String> actualLiveNodes = getTrueLiveNodesFromZk();
-      assertEquals("iter" + iter + ": " + actualLiveNodes.toString(), 1, actualLiveNodes.size());
+      assertEquals("iter" + iter + ": " + actualLiveNodes, 1, actualLiveNodes.size());
 
       // only here do we forcibly update the cached live nodes, so we don't have to wait for it to
       // catch up with all the ephemeral nodes that vanished after the last iteration

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorCloud.java
@@ -269,9 +269,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
                           doc(f("id", S_TWO_PRE + "Y"), f("foo_i", "bogus_val_Y")))
                       .process(c));
       assertEquals(
-          "not the type of error we were expecting (" + e.code() + "): " + e,
-          400,
-          e.code());
+          "not the type of error we were expecting (" + e.code() + "): " + e, 400, e.code());
 
       // verify malformed deleteByQuery's fail
       e =
@@ -727,9 +725,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         actualKnownErrs.add(err);
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata,
-          11,
-          actualKnownErrsCount);
+          "wrong number of errors in metadata: " + remoteErrMetadata, 11, actualKnownErrsCount);
       assertEquals(
           "at least one dup error in metadata: " + remoteErrMetadata,
           actualKnownErrsCount,
@@ -830,9 +826,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         actualKnownErrs.add(err);
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata,
-          11,
-          actualKnownErrsCount);
+          "wrong number of errors in metadata: " + remoteErrMetadata, 11, actualKnownErrsCount);
       assertEquals(
           "at least one dup error in metadata: " + remoteErrMetadata,
           actualKnownErrsCount,
@@ -939,9 +933,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         assertTrue("failed id didn't match 'unknown': " + err, err.getId().contains("unknown"));
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata,
-          11,
-          actualKnownErrsCount);
+          "wrong number of errors in metadata: " + remoteErrMetadata, 11, actualKnownErrsCount);
     }
 
     assertEquals(0, client.commit().getStatus()); // need to force since update didn't finish
@@ -1133,9 +1125,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         actualKnownErrs.add(err);
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata,
-          4,
-          actualKnownErrsCount);
+          "wrong number of errors in metadata: " + remoteErrMetadata, 4, actualKnownErrsCount);
       assertEquals(
           "at least one dup error in metadata: " + remoteErrMetadata,
           actualKnownErrsCount,
@@ -1178,9 +1168,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
     assertNotNull(assertionMsgPrefix + ": Null errors: " + response, errors);
     assertEquals(
-        assertionMsgPrefix + ": Num error ids: " + errors,
-        expectedErrs.length,
-        errors.size());
+        assertionMsgPrefix + ": Num error ids: " + errors, expectedErrs.length, errors.size());
 
     for (SimpleOrderedMap<String> err : errors) {
       String assertErrPre = assertionMsgPrefix + ": " + err.toString();

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorCloud.java
@@ -132,8 +132,8 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
     for (Slice slice : clusterState.getCollection(COLLECTION_NAME).getSlices()) {
       String shardName = slice.getName();
       Replica leader = slice.getLeader();
-      assertNotNull("slice has null leader: " + slice.toString(), leader);
-      assertNotNull("slice leader has null node name: " + slice.toString(), leader.getNodeName());
+      assertNotNull("slice has null leader: " + slice, leader);
+      assertNotNull("slice leader has null node name: " + slice, leader.getNodeName());
       String leaderUrl = urlMap.remove(leader.getNodeName());
       assertNotNull(
           "could not find URL for " + shardName + " leader: " + leader.getNodeName(), leaderUrl);
@@ -269,7 +269,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
                           doc(f("id", S_TWO_PRE + "Y"), f("foo_i", "bogus_val_Y")))
                       .process(c));
       assertEquals(
-          "not the type of error we were expecting (" + e.code() + "): " + e.toString(),
+          "not the type of error we were expecting (" + e.code() + "): " + e,
           400,
           e.code());
 
@@ -702,7 +702,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
       // we can't make any reliable assertions about the error message, because
       // it varies based on how the request was routed -- see SOLR-8830
       assertEquals(
-          "not the type of error we were expecting (" + e.code() + "): " + e.toString(),
+          "not the type of error we were expecting (" + e.code() + "): " + e,
           // NOTE: we always expect a 400 because we know that's what we would get from these types
           // of errors on a single node setup -- a 5xx type error isn't something we should have
           // triggered
@@ -711,7 +711,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
       // verify that the Exceptions' metadata can tell us what failed.
       NamedList<String> remoteErrMetadata = e.getMetadata();
-      assertNotNull("no metadata in: " + e.toString(), remoteErrMetadata);
+      assertNotNull("no metadata in: " + e, remoteErrMetadata);
       Set<ToleratedUpdateError> actualKnownErrs =
           new LinkedHashSet<ToleratedUpdateError>(remoteErrMetadata.size());
       int actualKnownErrsCount = 0;
@@ -727,11 +727,11 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         actualKnownErrs.add(err);
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata.toString(),
+          "wrong number of errors in metadata: " + remoteErrMetadata,
           11,
           actualKnownErrsCount);
       assertEquals(
-          "at least one dup error in metadata: " + remoteErrMetadata.toString(),
+          "at least one dup error in metadata: " + remoteErrMetadata,
           actualKnownErrsCount,
           actualKnownErrs.size());
       for (ToleratedUpdateError err : actualKnownErrs) {
@@ -805,7 +805,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
       // we can't make any reliable assertions about the error message, because
       // it varies based on how the request was routed -- see SOLR-8830
       assertEquals(
-          "not the type of error we were expecting (" + e.code() + "): " + e.toString(),
+          "not the type of error we were expecting (" + e.code() + "): " + e,
           // NOTE: we always expect a 400 because we know that's what we would get from these types
           // of errors on a single node setup -- a 5xx type error isn't something we should have
           // triggered
@@ -814,7 +814,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
       // verify that the Exceptions' metadata can tell us what failed.
       NamedList<String> remoteErrMetadata = e.getMetadata();
-      assertNotNull("no metadata in: " + e.toString(), remoteErrMetadata);
+      assertNotNull("no metadata in: " + e, remoteErrMetadata);
       Set<ToleratedUpdateError> actualKnownErrs =
           new LinkedHashSet<ToleratedUpdateError>(remoteErrMetadata.size());
       int actualKnownErrsCount = 0;
@@ -830,11 +830,11 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         actualKnownErrs.add(err);
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata.toString(),
+          "wrong number of errors in metadata: " + remoteErrMetadata,
           11,
           actualKnownErrsCount);
       assertEquals(
-          "at least one dup error in metadata: " + remoteErrMetadata.toString(),
+          "at least one dup error in metadata: " + remoteErrMetadata,
           actualKnownErrsCount,
           actualKnownErrs.size());
       for (ToleratedUpdateError err : actualKnownErrs) {
@@ -915,7 +915,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
       // we can't make any reliable assertions about the error message, because
       // it varies based on how the request was routed -- see SOLR-8830
       assertEquals(
-          "not the type of error we were expecting (" + e.code() + "): " + e.toString(),
+          "not the type of error we were expecting (" + e.code() + "): " + e,
           // NOTE: we always expect a 400 because we know that's what we would get from these types
           // of errors on a single node setup -- a 5xx type error isn't something we should have
           // triggered
@@ -924,7 +924,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
       // verify that the Exceptions' metadata can tell us what failed.
       NamedList<String> remoteErrMetadata = e.getMetadata();
-      assertNotNull("no metadata in: " + e.toString(), remoteErrMetadata);
+      assertNotNull("no metadata in: " + e, remoteErrMetadata);
       int actualKnownErrsCount = 0;
       for (int i = 0; i < remoteErrMetadata.size(); i++) {
         ToleratedUpdateError err =
@@ -939,7 +939,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         assertTrue("failed id didn't match 'unknown': " + err, err.getId().contains("unknown"));
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata.toString(),
+          "wrong number of errors in metadata: " + remoteErrMetadata,
           11,
           actualKnownErrsCount);
     }
@@ -1110,14 +1110,14 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
       // likewise, we can't make a firm(er) assertion about the response code...
       assertTrue(
-          "not the type of error we were expecting (" + e.code() + "): " + e.toString(),
+          "not the type of error we were expecting (" + e.code() + "): " + e,
           // should be one these 2 depending on order that the async errors were hit...
           // on a single node setup -- a 5xx type error isn't something we should have triggered
           400 == e.code() || 409 == e.code());
 
       // verify that the Exceptions' metadata can tell us what failed.
       NamedList<String> remoteErrMetadata = e.getMetadata();
-      assertNotNull("no metadata in: " + e.toString(), remoteErrMetadata);
+      assertNotNull("no metadata in: " + e, remoteErrMetadata);
       Set<ToleratedUpdateError> actualKnownErrs =
           new LinkedHashSet<ToleratedUpdateError>(remoteErrMetadata.size());
       int actualKnownErrsCount = 0;
@@ -1133,11 +1133,11 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
         actualKnownErrs.add(err);
       }
       assertEquals(
-          "wrong number of errors in metadata: " + remoteErrMetadata.toString(),
+          "wrong number of errors in metadata: " + remoteErrMetadata,
           4,
           actualKnownErrsCount);
       assertEquals(
-          "at least one dup error in metadata: " + remoteErrMetadata.toString(),
+          "at least one dup error in metadata: " + remoteErrMetadata,
           actualKnownErrsCount,
           actualKnownErrs.size());
     }
@@ -1176,9 +1176,9 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
     List<SimpleOrderedMap<String>> errors =
         (List<SimpleOrderedMap<String>>) response.getResponseHeader().get("errors");
 
-    assertNotNull(assertionMsgPrefix + ": Null errors: " + response.toString(), errors);
+    assertNotNull(assertionMsgPrefix + ": Null errors: " + response, errors);
     assertEquals(
-        assertionMsgPrefix + ": Num error ids: " + errors.toString(),
+        assertionMsgPrefix + ": Num error ids: " + errors,
         expectedErrs.length,
         errors.size());
 
@@ -1202,7 +1202,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
           break;
         }
       }
-      assertTrue(assertErrPre + " ... unexpected err in: " + response.toString(), found);
+      assertTrue(assertErrPre + " ... unexpected err in: " + response, found);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
@@ -262,7 +262,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
         }
       }
       assertEquals(
-          "expected error count sanity check: " + req.toString(),
+          "expected error count sanity check: " + req,
           expectedErrorsCount,
           expectedErrors.size());
 
@@ -273,7 +273,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
 
       final UpdateResponse rsp = req.process(client);
       assertUpdateTolerantErrors(
-          client.toString() + " => " + expectedErrors.toString(),
+          client.toString() + " => " + expectedErrors,
           rsp,
           expectedErrors.toArray(new ExpectedErr[expectedErrors.size()]));
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
@@ -262,7 +262,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
         }
       }
       assertEquals(
-          "expected error count sanity check: " + req, expectedErrorsCount, expectedErrors.size());
+          "expected error count check: " + req, expectedErrorsCount, expectedErrors.size());
 
       final SolrClient client =
           random().nextBoolean()

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
@@ -262,9 +262,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
         }
       }
       assertEquals(
-          "expected error count sanity check: " + req,
-          expectedErrorsCount,
-          expectedErrors.size());
+          "expected error count sanity check: " + req, expectedErrorsCount, expectedErrors.size());
 
       final SolrClient client =
           random().nextBoolean()

--- a/solr/core/src/test/org/apache/solr/cloud/TriLevelCompositeIdRoutingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TriLevelCompositeIdRoutingTest.java
@@ -159,7 +159,7 @@ public class TriLevelCompositeIdRoutingTest extends ShardRoutingTest {
     Set<String> uniqueKeys = new HashSet<>();
     for (SolrDocument doc : rsp.getResults()) {
       final String id = (String) doc.get("id");
-      assertNotNull("null id WTF? " + doc.toString(), id);
+      assertNotNull("null id WTF? " + doc, id);
       uniqueKeys.add(id);
     }
     return uniqueKeys;

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
@@ -46,7 +46,7 @@ public class PurgeGraphTest extends SolrTestCaseJ4 {
     repository = new LocalFileSystemRepository();
     baseLocationUri =
         repository.createDirectoryURI(
-            createTempDir("backup_files_" + UUID.randomUUID()).toAbsolutePath().toString());
+            createTempDir("backup_files_" + UUID.randomUUID()).toAbsolutePath());
     backupPaths = new BackupFilePaths(repository, baseLocationUri);
 
     backupPaths.createIncrementalBackupFolders();

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
@@ -46,7 +46,7 @@ public class PurgeGraphTest extends SolrTestCaseJ4 {
     repository = new LocalFileSystemRepository();
     baseLocationUri =
         repository.createDirectoryURI(
-            createTempDir("backup_files_" + UUID.randomUUID()).toAbsolutePath());
+            createTempDir("backup_files_" + UUID.randomUUID()).toAbsolutePath().toString());
     backupPaths = new BackupFilePaths(repository, baseLocationUri);
 
     backupPaths.createIncrementalBackupFolders();

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
@@ -46,9 +46,7 @@ public class PurgeGraphTest extends SolrTestCaseJ4 {
     repository = new LocalFileSystemRepository();
     baseLocationUri =
         repository.createDirectoryURI(
-            createTempDir("backup_files_" + UUID.randomUUID())
-                .toAbsolutePath()
-                .toString());
+            createTempDir("backup_files_" + UUID.randomUUID()).toAbsolutePath().toString());
     backupPaths = new BackupFilePaths(repository, baseLocationUri);
 
     backupPaths.createIncrementalBackupFolders();

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/PurgeGraphTest.java
@@ -46,7 +46,7 @@ public class PurgeGraphTest extends SolrTestCaseJ4 {
     repository = new LocalFileSystemRepository();
     baseLocationUri =
         repository.createDirectoryURI(
-            createTempDir("backup_files_" + UUID.randomUUID().toString())
+            createTempDir("backup_files_" + UUID.randomUUID())
                 .toAbsolutePath()
                 .toString());
     backupPaths = new BackupFilePaths(repository, baseLocationUri);

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ReplicaPropertiesBase.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ReplicaPropertiesBase.java
@@ -74,7 +74,7 @@ public abstract class ReplicaPropertiesBase extends AbstractFullDistribZkTestBas
             + ". Replica props: "
             + replica.getProperties().toString()
             + ". Cluster state is "
-            + clusterState.toString());
+            + clusterState);
   }
 
   // The params are triplets,
@@ -197,6 +197,6 @@ public abstract class ReplicaPropertiesBase extends AbstractFullDistribZkTestBas
         "Collection "
             + collectionName
             + " does not have roles evenly distributed. Collection is: "
-            + col.toString());
+            + col);
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkCollectionPropsCachingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkCollectionPropsCachingTest.java
@@ -59,7 +59,7 @@ public class ZkCollectionPropsCachingTest extends SolrCloudTestCase {
     CollectionAdminRequest.Create request =
         CollectionAdminRequest.createCollection(collectionName, "conf", 2, 2);
     CollectionAdminResponse response = request.process(cluster.getSolrClient());
-    assertTrue("Unable to create collection: " + response.toString(), response.isSuccess());
+    assertTrue("Unable to create collection: " + response, response.isSuccess());
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/cluster/placement/impl/PlacementPluginIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/impl/PlacementPluginIntegrationTest.java
@@ -377,7 +377,7 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
       fail("should have failed due to no nodes with the types: " + rsp);
     } catch (Exception e) {
       assertTrue(
-          "should contain 'no nodes with types':" + e.toString(),
+          "should contain 'no nodes with types':" + e,
           e.toString().contains("no nodes with types"));
     }
     System.setProperty(AffinityPlacementConfig.NODE_TYPE_SYSPROP, "type_0");

--- a/solr/core/src/test/org/apache/solr/cluster/placement/plugins/AffinityPlacementFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/plugins/AffinityPlacementFactoryTest.java
@@ -903,7 +903,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
     try {
       plugin.verifyAllowedModification(deleteReplicasRequest, placementContext);
     } catch (PlacementException pe) {
-      fail("should have succeeded: " + pe.toString());
+      fail("should have succeeded: " + pe);
     }
 
     secondaryCollection

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -1044,7 +1044,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
     assertTrue("init failure isn't SAXParseException", ex instanceof SAXParseException);
     SAXParseException saxEx = (SAXParseException) ex;
     assertTrue(
-        "init failure doesn't mention problem: " + saxEx.toString(),
+        "init failure doesn't mention problem: " + saxEx,
         saxEx.getSystemId().contains("solrconfig.xml"));
 
     // ----

--- a/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
@@ -614,7 +614,7 @@ public class TestCoreDiscovery extends SolrTestCaseJ4 {
       "<solr> "
           + "<int name=\"transientCacheSize\">2</int> "
           + "<str name=\"configSetBaseDir\">"
-          + Paths.get(TEST_HOME()).resolve("configsets").toString()
+          + Paths.get(TEST_HOME()).resolve("configsets")
           + "</str>"
           + "<solrcloud> "
           + "<str name=\"hostContext\">solrprop</str> "

--- a/solr/core/src/test/org/apache/solr/core/TestJmxIntegration.java
+++ b/solr/core/src/test/org/apache/solr/core/TestJmxIntegration.java
@@ -115,7 +115,7 @@ public class TestJmxIntegration extends SolrTestCaseJ4 {
     int numDynamicMbeans = 0;
     for (ObjectInstance o : objects) {
       ObjectName name = o.getObjectName();
-      assertNotNull("Null name on: " + o.toString(), name);
+      assertNotNull("Null name on: " + o, name);
       MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(name);
       if (name.getDomain().equals("solr")) {
         numDynamicMbeans++;

--- a/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
+++ b/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
@@ -778,7 +778,7 @@ public class TestLazyCores extends SolrTestCaseJ4 {
 
     if (ok) {
       if (failures.size() != 0) {
-        fail("Should have cleared the error, but there are failures " + failures.toString());
+        fail("Should have cleared the error, but there are failures " + failures);
       }
     } else {
       if (failures.size() == 0) {

--- a/solr/core/src/test/org/apache/solr/core/TestMergePolicyConfig.java
+++ b/solr/core/src/test/org/apache/solr/core/TestMergePolicyConfig.java
@@ -256,7 +256,7 @@ public class TestMergePolicyConfig extends SolrTestCaseJ4 {
           atomic.reader() instanceof SegmentReader);
 
       assertEquals(
-          "Compound status incorrect for: " + atomic.reader().toString(),
+          "Compound status incorrect for: " + atomic.reader(),
           compound,
           ((SegmentReader) atomic.reader()).getSegmentInfo().info.getUseCompoundFile());
     }

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -1084,9 +1084,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
         int cnt = indexDirCount(ddir);
         // if after reload, there may be 2 index dirs while the reloaded SolrCore closes.
         if (afterReload) {
-          assertTrue(
-              "found:" + cnt + Arrays.asList(new File(ddir).list()),
-              1 == cnt || 2 == cnt);
+          assertTrue("found:" + cnt + Arrays.asList(new File(ddir).list()), 1 == cnt || 2 == cnt);
         } else {
           assertTrue("found:" + cnt + Arrays.asList(new File(ddir).list()), 1 == cnt);
         }

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -340,7 +340,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
         }
 
         assertNotNull(
-            "Expected to see that the follower has replicated" + i + ": " + details.toString(),
+            "Expected to see that the follower has replicated" + i + ": " + details,
             replicatedAtCount);
 
         // we can have more replications than we added docs because a replication can legally fail
@@ -1085,10 +1085,10 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
         // if after reload, there may be 2 index dirs while the reloaded SolrCore closes.
         if (afterReload) {
           assertTrue(
-              "found:" + cnt + Arrays.asList(new File(ddir).list()).toString(),
+              "found:" + cnt + Arrays.asList(new File(ddir).list()),
               1 == cnt || 2 == cnt);
         } else {
-          assertTrue("found:" + cnt + Arrays.asList(new File(ddir).list()).toString(), 1 == cnt);
+          assertTrue("found:" + cnt + Arrays.asList(new File(ddir).list()), 1 == cnt);
         }
       }
     }

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerBackup.java
@@ -246,11 +246,11 @@ public class TestReplicationHandlerBackup extends SolrJettyTestBase {
         new BackupStatusChecker(leaderClient, "/" + DEFAULT_TEST_CORENAME + "/replication");
     for (int i = 0; i < 2; i++) {
       final Path p = Paths.get(leader.getDataDir(), "snapshot." + backupNames[i]);
-      assertTrue("WTF: Backup doesn't exist: " + p.toString(), Files.exists(p));
+      assertTrue("WTF: Backup doesn't exist: " + p, Files.exists(p));
       runBackupCommand(
           leaderJetty, ReplicationHandler.CMD_DELETE_BACKUP, "&name=" + backupNames[i]);
       backupStatus.waitForBackupDeletionSuccess(backupNames[i], 30);
-      assertFalse("backup still exists after deletion: " + p.toString(), Files.exists(p));
+      assertFalse("backup still exists after deletion: " + p, Files.exists(p));
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerDiskOverFlow.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerDiskOverFlow.java
@@ -235,7 +235,7 @@ public class TestReplicationHandlerDiskOverFlow extends SolrTestCaseJ4 {
                 .add("qt", "/replication")
                 .add("command", ReplicationHandler.CMD_DETAILS));
     if (log.isInfoEnabled()) {
-      log.info("DETAILS {}", Utils.writeJson(response, new StringWriter(), true).toString());
+      log.info("DETAILS {}", Utils.writeJson(response, new StringWriter(), true));
     }
     assertEquals(
         "follower's clearedLocalIndexFirst (from rep details)",

--- a/solr/core/src/test/org/apache/solr/handler/TestSnapshotCoreBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSnapshotCoreBackup.java
@@ -447,19 +447,19 @@ public class TestSnapshotCoreBackup extends SolrTestCaseJ4 {
       final File backup, final int numDocs, final String expectedSegmentsFileName)
       throws IOException {
     assertNotNull(backup);
-    assertTrue("Backup doesn't exist" + backup.toString(), backup.exists());
+    assertTrue("Backup doesn't exist" + backup, backup.exists());
     if (null != expectedSegmentsFileName) {
       assertTrue(
-          expectedSegmentsFileName + " doesn't exist in " + backup.toString(),
+          expectedSegmentsFileName + " doesn't exist in " + backup,
           new File(backup, expectedSegmentsFileName).exists());
     }
     try (Directory dir = FSDirectory.open(backup.toPath())) {
       TestUtil.checkIndex(dir, true, true, true, null);
       try (DirectoryReader r = DirectoryReader.open(dir)) {
-        assertEquals("numDocs in " + backup.toString(), numDocs, r.numDocs());
+        assertEquals("numDocs in " + backup, numDocs, r.numDocs());
         if (null != expectedSegmentsFileName) {
           assertEquals(
-              "segmentsFile of IndexCommit for: " + backup.toString(),
+              "segmentsFile of IndexCommit for: " + backup,
               expectedSegmentsFileName,
               r.getIndexCommit().getSegmentsFileName());
         }

--- a/solr/core/src/test/org/apache/solr/handler/TestStressIncrementalBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressIncrementalBackup.java
@@ -134,7 +134,7 @@ public class TestStressIncrementalBackup extends SolrCloudTestCase {
                 log.info("Heavy Committing #{}: {}", docIdCounter, req);
                 final UpdateResponse rsp = req.process(coreClient);
                 assertEquals(
-                    "Dummy Doc#" + docIdCounter + " add status: " + rsp.toString(),
+                    "Dummy Doc#" + docIdCounter + " add status: " + rsp,
                     0,
                     rsp.getStatus());
               }
@@ -162,7 +162,7 @@ public class TestStressIncrementalBackup extends SolrCloudTestCase {
         req.setParam(UpdateParams.OPEN_SEARCHER, "false"); // we don't care about searching
 
         final UpdateResponse rsp = req.process(coreClient);
-        assertEquals("Real Doc#" + i + " add status: " + rsp.toString(), 0, rsp.getStatus());
+        assertEquals("Real Doc#" + i + " add status: " + rsp, 0, rsp.getStatus());
 
         makeBackup();
       }

--- a/solr/core/src/test/org/apache/solr/handler/TestStressIncrementalBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressIncrementalBackup.java
@@ -134,9 +134,7 @@ public class TestStressIncrementalBackup extends SolrCloudTestCase {
                 log.info("Heavy Committing #{}: {}", docIdCounter, req);
                 final UpdateResponse rsp = req.process(coreClient);
                 assertEquals(
-                    "Dummy Doc#" + docIdCounter + " add status: " + rsp,
-                    0,
-                    rsp.getStatus());
+                    "Dummy Doc#" + docIdCounter + " add status: " + rsp, 0, rsp.getStatus());
               }
             } catch (Throwable t) {
               heavyCommitFailure.set(t);

--- a/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
@@ -191,7 +191,7 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
                 log.info("Heavy Committing #{}: {}", docIdCounter, req);
                 final UpdateResponse rsp = req.process(coreClient);
                 assertEquals(
-                    "Dummy Doc#" + docIdCounter + " add status: " + rsp.toString(),
+                    "Dummy Doc#" + docIdCounter + " add status: " + rsp,
                     0,
                     rsp.getStatus());
               }
@@ -221,7 +221,7 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
         req.setParam(UpdateParams.OPEN_SEARCHER, "false"); // we don't care about searching
 
         final UpdateResponse rsp = req.process(coreClient);
-        assertEquals("Real Doc#" + i + " add status: " + rsp.toString(), 0, rsp.getStatus());
+        assertEquals("Real Doc#" + i + " add status: " + rsp, 0, rsp.getStatus());
 
         // create a backup of the 'current' index
         impl.makeBackup("backup_currentAt_" + i);
@@ -278,7 +278,7 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
       delAll.setParam(UpdateParams.OPTIMIZE, "true");
       delAll.setParam(UpdateParams.MAX_OPTIMIZE_SEGMENTS, "1"); // purge as many files as possible
       final UpdateResponse delRsp = delAll.process(coreClient);
-      assertEquals("dellAll status: " + delRsp.toString(), 0, delRsp.getStatus());
+      assertEquals("dellAll status: " + delRsp, 0, delRsp.getStatus());
     }
 
     { // Validate some backups at random...
@@ -330,14 +330,14 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
     log.info("Checking Validity of {}", backup);
     assertTrue(backup.toString() + ": isDir?", backup.isDirectory());
     final Matcher m = ENDS_WITH_INT_DIGITS.matcher(backup.getName());
-    assertTrue("Backup dir name does not end with int digits: " + backup.toString(), m.find());
+    assertTrue("Backup dir name does not end with int digits: " + backup, m.find());
     final int numRealDocsExpected = Integer.parseInt(m.group());
 
     try (Directory dir = FSDirectory.open(backup.toPath())) {
       TestUtil.checkIndex(dir, true, true, true, null);
       try (DirectoryReader r = DirectoryReader.open(dir)) {
         assertEquals(
-            "num real docs in " + backup.toString(),
+            "num real docs in " + backup,
             numRealDocsExpected,
             r.docFreq(new Term("type_s", "real")));
       }

--- a/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
@@ -191,9 +191,7 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
                 log.info("Heavy Committing #{}: {}", docIdCounter, req);
                 final UpdateResponse rsp = req.process(coreClient);
                 assertEquals(
-                    "Dummy Doc#" + docIdCounter + " add status: " + rsp,
-                    0,
-                    rsp.getStatus());
+                    "Dummy Doc#" + docIdCounter + " add status: " + rsp, 0, rsp.getStatus());
               }
             } catch (Throwable t) {
               heavyCommitFailure.set(t);

--- a/solr/core/src/test/org/apache/solr/handler/admin/IndexSizeEstimatorTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/IndexSizeEstimatorTest.java
@@ -103,7 +103,7 @@ public class IndexSizeEstimatorTest extends SolrCloudTestCase {
       fieldsBySize.forEach((k, v) -> assertTrue("unexpected size of " + k + ": " + v, v > 0));
       Map<String, Long> typesBySize = estimate.getTypesBySize();
       assertFalse("empty typesBySize", typesBySize.isEmpty());
-      assertTrue("expected at least 8 types: " + typesBySize.toString(), typesBySize.size() >= 8);
+      assertTrue("expected at least 8 types: " + typesBySize, typesBySize.size() >= 8);
       typesBySize.forEach((k, v) -> assertTrue("unexpected size of " + k + ": " + v, v > 0));
       Map<String, Object> summary = estimate.getSummary();
       assertNotNull("summary", summary);
@@ -196,7 +196,7 @@ public class IndexSizeEstimatorTest extends SolrCloudTestCase {
       Map<String, Object> typesBySize =
           (Map<String, Object>) rawSizeMap.get(IndexSizeEstimator.TYPES_BY_SIZE);
       assertNotNull("typesBySize missing", typesBySize);
-      assertTrue("expected at least 8 types: " + typesBySize.toString(), typesBySize.size() >= 8);
+      assertTrue("expected at least 8 types: " + typesBySize, typesBySize.size() >= 8);
       @SuppressWarnings({"unchecked"})
       Map<String, Object> summary =
           (Map<String, Object>) rawSizeMap.get(IndexSizeEstimator.SUMMARY);

--- a/solr/core/src/test/org/apache/solr/handler/admin/MBeansHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MBeansHandlerTest.java
@@ -204,7 +204,7 @@ public class MBeansHandlerTest extends SolrTestCaseJ4 {
                 } catch (Exception e) {
                   runSnapshots = false;
                   e.printStackTrace();
-                  fail("Exception getting metrics snapshot: " + e.toString());
+                  fail("Exception getting metrics snapshot: " + e);
                 }
                 try {
                   Thread.sleep(53);

--- a/solr/core/src/test/org/apache/solr/handler/admin/ThreadDumpHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ThreadDumpHandlerTest.java
@@ -85,7 +85,7 @@ public class ThreadDumpHandlerTest extends SolrTestCaseJ4 {
                     failures.add("ownerT: never saw doneWithTestLatch released");
                   }
                 } catch (InterruptedException ie) {
-                  failures.add("ownerT: " + ie.toString());
+                  failures.add("ownerT: " + ie);
                 }
               }
             },
@@ -211,7 +211,7 @@ public class ThreadDumpHandlerTest extends SolrTestCaseJ4 {
                     failures.add("ownerT: never saw doneWithTestLatch release");
                   }
                 } catch (InterruptedException ie) {
-                  failures.add("ownerT: " + ie.toString());
+                  failures.add("ownerT: " + ie);
                 }
               } finally {
                 lock.unlock();

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
@@ -245,7 +245,7 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
         assertDebug(r, all || results, "explain");
         assertDebug(r, all || timing, "timing");
       } catch (AssertionError e) {
-        throw new AssertionError(q.toString() + ": " + e.getMessage(), e);
+        throw new AssertionError(q + ": " + e.getMessage(), e);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotLargeTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotLargeTest.java
@@ -205,7 +205,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
           assertEquals(company.toString(), 1, company.getCount());
         }
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -275,7 +275,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
           assertPivot("real_b", null, expectedNumDocsMissingBool, pivots.get(1));
 
         } catch (AssertionFailedError ae) {
-          throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+          throw new AssertionError(ae.getMessage() + " <== " + p, ae);
         }
       }
     }
@@ -312,7 +312,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         firstCompany = firstPlace.getPivot().get(0);
         assertPivot("company_t", "bbc", 6, firstCompany);
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -351,7 +351,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         // - twoShard   = 52 ... above per-shard min of 50/(numShards=4)
         // = threeShard =  0 ... should be refined and still match nothing
       } catch (AssertionError ae) {
-        throw new AssertionError(ae.getMessage() + ": " + p.toString() + " ==> " + rsp, ae);
+        throw new AssertionError(ae.getMessage() + ": " + p + " ==> " + rsp, ae);
       }
     }
 
@@ -392,7 +392,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         assertPivot("company_t", "microsoft", 56, firstPlace.getPivot().get(2));
         assertPivot("company_t", "polecat", 52, firstPlace.getPivot().get(3));
       } catch (AssertionError ae) {
-        throw new AssertionError(ae.getMessage() + ": " + p.toString() + " ==> " + rsp, ae);
+        throw new AssertionError(ae.getMessage() + ": " + p + " ==> " + rsp, ae);
       }
     }
 
@@ -431,7 +431,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         assertPivot("company_t", "microsoft", 56, firstPlace.getPivot().get(2));
         assertPivot("company_t", "polecat", 52, firstPlace.getPivot().get(3));
       } catch (AssertionError ae) {
-        throw new AssertionError(ae.getMessage() + ": " + p.toString() + " ==> " + rsp, ae);
+        throw new AssertionError(ae.getMessage() + ": " + p + " ==> " + rsp, ae);
       }
     }
 
@@ -792,7 +792,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         firstCompany = firstPlace.getPivot().get(0);
         assertPivot("company_t", "bbc", 101, firstCompany);
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -824,7 +824,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         assertPivot("place_s", "cardiff", 257, firstPlace);
         assertEquals(257, firstPlace.getPivot().size());
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -856,7 +856,7 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
         assertPivot("place_s", "cardiff", 257, firstPlace);
         assertEquals(100, firstPlace.getPivot().size()); // default
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -1223,8 +1223,8 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
       int count, // int numKids,
       PivotField actual) {
     assertEquals("FIELD: " + actual.toString(), field, actual.getField());
-    assertEquals("VALUE: " + actual.toString(), value, actual.getValue());
-    assertEquals("COUNT: " + actual.toString(), count, actual.getCount());
+    assertEquals("VALUE: " + actual, value, actual.getValue());
+    assertEquals("COUNT: " + actual, count, actual.getCount());
     // TODO: add arg && assert on number of kids
     // assertEquals("#KIDS: " + actual.toString(), numKids, actual.getPivot().size());
   }
@@ -1233,10 +1233,10 @@ public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCas
   private <B, G> void assertRange(
       String name, B start, G gap, B end, int numCount, RangeFacet<B, G> actual) {
     assertEquals("NAME: " + actual.toString(), name, actual.getName());
-    assertEquals("START: " + actual.toString(), start, actual.getStart());
-    assertEquals("GAP: " + actual.toString(), gap, actual.getGap());
-    assertEquals("END: " + actual.toString(), end, actual.getEnd());
-    assertEquals("#COUNT: " + actual.toString(), numCount, actual.getCounts().size());
+    assertEquals("START: " + actual, start, actual.getStart());
+    assertEquals("GAP: " + actual, gap, actual.getGap());
+    assertEquals("END: " + actual, end, actual.getEnd());
+    assertEquals("#COUNT: " + actual, numCount, actual.getCounts().size());
   }
 
   private void setupDistributedPivotFacetDocuments() throws Exception {

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallTest.java
@@ -313,7 +313,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(6, pivots.get(3).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -350,7 +350,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(6, pivots.get(2).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -388,7 +388,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(pivots.toString(), 6, pivots.get(0).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -1095,7 +1095,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(6, pivots.get(3).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -1138,7 +1138,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(6, pivots.get(2).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -1177,7 +1177,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(pivots.toString(), 6, pivots.get(0).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
   }
@@ -2041,7 +2041,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(6, pivots.get(3).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -2084,7 +2084,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(6, pivots.get(2).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
 
@@ -2123,7 +2123,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
         assertEquals(pivots.toString(), 6, pivots.get(0).getCount());
 
       } catch (AssertionFailedError ae) {
-        throw new AssertionError(ae.getMessage() + " <== " + p.toString(), ae);
+        throw new AssertionError(ae.getMessage() + " <== " + p, ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/metrics/reporters/SolrSlf4jReporterTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/reporters/SolrSlf4jReporterTest.java
@@ -94,13 +94,13 @@ public class SolrSlf4jReporterTest extends SolrTestCaseJ4 {
     // dot-separated names are treated like class names and collapsed
     // in regular log output, but here we get the full name
     if (history.stream().filter(d -> "solr.node".equals(d.getFirstValue("logger"))).count() == 0) {
-      fail("No 'solr.node' logs in: " + history.toString());
+      fail("No 'solr.node' logs in: " + history);
     }
     if (history.stream().filter(d -> "foobar".equals(d.getFirstValue("logger"))).count() == 0) {
-      fail("No 'foobar' logs in: " + history.toString());
+      fail("No 'foobar' logs in: " + history);
     }
     if (history.stream().filter(d -> "collection1".equals(d.getFirstValue("core"))).count() == 0) {
-      fail("No 'solr.core' or MDC context in logs: " + history.toString());
+      fail("No 'solr.core' or MDC context in logs: " + history);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/response/TestRetrieveFieldsOptimizer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestRetrieveFieldsOptimizer.java
@@ -128,23 +128,23 @@ public class TestRetrieveFieldsOptimizer extends SolrTestCaseJ4 {
       typesHolder.addFieldType(schema, myName, type);
       fieldsToAdd.put(myName, map("stored", "true", "docValues", "false", "multiValued", "false"));
 
-      myName = type.toString() + storedAndDvSv;
+      myName = type + storedAndDvSv;
       typesHolder.addFieldType(schema, myName, type);
       fieldsToAdd.put(myName, map("stored", "true", "docValues", "true", "multiValued", "false"));
 
-      myName = type.toString() + notStoredDvSv;
+      myName = type + notStoredDvSv;
       typesHolder.addFieldType(schema, myName, type);
       fieldsToAdd.put(myName, map("stored", "false", "docValues", "true", "multiValued", "false"));
 
-      myName = type.toString() + storedNotDvMv;
+      myName = type + storedNotDvMv;
       typesHolder.addFieldType(schema, myName, type);
       fieldsToAdd.put(myName, map("stored", "true", "docValues", "false", "multiValued", "true"));
 
-      myName = type.toString() + storedAndDvMv;
+      myName = type + storedAndDvMv;
       typesHolder.addFieldType(schema, myName, type);
       fieldsToAdd.put(myName, map("stored", "true", "docValues", "true", "multiValued", "true"));
 
-      myName = type.toString() + notStoredDvMv;
+      myName = type + notStoredDvMv;
       typesHolder.addFieldType(schema, myName, type);
       fieldsToAdd.put(myName, map("stored", "false", "docValues", "true", "multiValued", "true"));
     }
@@ -257,7 +257,7 @@ public class TestRetrieveFieldsOptimizer extends SolrTestCaseJ4 {
         toCheck = new ArrayList(fieldsHolder.allFields);
         break;
       default:
-        fail("Value passed to checkFetchSources unknown: " + source.toString());
+        fail("Value passed to checkFetchSources unknown: " + source);
     }
 
     // MultiValued fields are _always_ read from stored data.

--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -3399,7 +3399,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
       builder.append(value);
     }
     assertQ(
-        req("debug", "true", "q", field + ":(" + builder.toString() + ")"),
+        req("debug", "true", "q", field + ":(" + builder + ")"),
         getTestString(searchable, numValues));
 
     assertU(
@@ -4797,7 +4797,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
       builder.append(value);
     }
     assertQ(
-        req("debug", "true", "q", field + ":(" + builder.toString() + ")"),
+        req("debug", "true", "q", field + ":(" + builder + ")"),
         getTestString(searchable, numValues));
 
     clearIndex();
@@ -5724,7 +5724,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
 
     assertQ(req("q", "id:1"), "//result/doc[1]/date[@name='" + field + "'][.='" + date1 + "']");
 
-    assertU(adoc(sdoc("id", "1", field, ImmutableMap.of("set", date1 + gap.toString()))));
+    assertU(adoc(sdoc("id", "1", field, ImmutableMap.of("set", date1 + gap))));
     assertU(commit());
 
     assertQ(req("q", "id:1"), "//result/doc[1]/date[@name='" + field + "'][.='" + date2 + "']");
@@ -5958,7 +5958,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     final List<IndexableField> results = sf.createFields(value);
     final Set<IndexableField> resultSet = new LinkedHashSet<>(results);
     assertEquals(
-        "duplicates found in results? " + results.toString(), results.size(), resultSet.size());
+        "duplicates found in results? " + results, results.size(), resultSet.size());
 
     final Set<Class<?>> resultClasses = new HashSet<>();
     for (IndexableField f : results) {

--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -5957,8 +5957,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     final SchemaField sf = h.getCore().getLatestSchema().getField(fieldName);
     final List<IndexableField> results = sf.createFields(value);
     final Set<IndexableField> resultSet = new LinkedHashSet<>(results);
-    assertEquals(
-        "duplicates found in results? " + results, results.size(), resultSet.size());
+    assertEquals("duplicates found in results? " + results, results.size(), resultSet.size());
 
     final Set<Class<?>> resultClasses = new HashSet<>();
     for (IndexableField f : results) {

--- a/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
@@ -538,7 +538,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
 
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
@@ -181,7 +181,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           }
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
         }
 
         // same basic logic, w/json.facet
@@ -239,7 +239,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           }
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -306,7 +306,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -365,7 +365,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
@@ -180,8 +180,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
             }
           }
         } catch (AssertionError | RuntimeException ae) {
-          throw new AssertionError(
-              solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+          throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
         }
 
         // same basic logic, w/json.facet
@@ -238,8 +237,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
             }
           }
         } catch (AssertionError | RuntimeException ae) {
-          throw new AssertionError(
-              solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+          throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -305,8 +303,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           }
         }
       } catch (AssertionError | RuntimeException ae) {
-        throw new AssertionError(
-            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+        throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -364,8 +361,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           }
         }
       } catch (AssertionError | RuntimeException ae) {
-        throw new AssertionError(
-            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+        throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -537,8 +533,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
 
       } catch (AssertionError | RuntimeException ae) {
-        throw new AssertionError(
-            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+        throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -614,8 +609,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           assertEquals("bucket #" + i, (i == 2 || i == 3) ? 1L : 0L, bucket.get("count"));
         }
       } catch (AssertionError | RuntimeException ae) {
-        throw new AssertionError(
-            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+        throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
@@ -181,7 +181,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           }
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
 
         // same basic logic, w/json.facet
@@ -239,7 +239,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
           }
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -306,7 +306,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -365,7 +365,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -538,7 +538,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
 
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
       }
     }
   }
@@ -615,7 +615,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CurrencyRangeFacetCloudTest.java
@@ -615,7 +615,7 @@ public class CurrencyRangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
@@ -461,7 +461,7 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
             new SolrReturnFields(req("fl", allFieldNames + ",bogus1,bogus2,bogus3")))) {
 
       docOut = convertLuceneDocToSolrDoc(docIn, schema, rf);
-      final String debug = rf + " => " + docOut.toString();
+      final String debug = rf + " => " + docOut;
       assertEquals(debug, 24, docOut.size());
       assertTrue(debug, docOut.get("id") instanceof StringField);
       assertTrue(debug, docOut.get("store") instanceof StringField);

--- a/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
@@ -435,7 +435,7 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
             new SolrReturnFields(req("fl", "id,xxx:[geo f=store],uniq,foo_2_s1,subword")),
             new SolrReturnFields(req("fl", "id,xxx:subword,uniq,yyy:foo_2_s1,[geo f=store]")))) {
       docOut = convertLuceneDocToSolrDoc(docIn, schema, rf);
-      final String debug = rf + " => " + docOut.toString();
+      final String debug = rf + " => " + docOut;
       assertEquals(debug, 5, docOut.size());
       assertEquals(
           debug,

--- a/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
@@ -435,7 +435,7 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
             new SolrReturnFields(req("fl", "id,xxx:[geo f=store],uniq,foo_2_s1,subword")),
             new SolrReturnFields(req("fl", "id,xxx:subword,uniq,yyy:foo_2_s1,[geo f=store]")))) {
       docOut = convertLuceneDocToSolrDoc(docIn, schema, rf);
-      final String debug = rf.toString() + " => " + docOut.toString();
+      final String debug = rf + " => " + docOut.toString();
       assertEquals(debug, 5, docOut.size());
       assertEquals(
           debug,
@@ -461,7 +461,7 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
             new SolrReturnFields(req("fl", allFieldNames + ",bogus1,bogus2,bogus3")))) {
 
       docOut = convertLuceneDocToSolrDoc(docIn, schema, rf);
-      final String debug = rf.toString() + " => " + docOut.toString();
+      final String debug = rf + " => " + docOut.toString();
       assertEquals(debug, 24, docOut.size());
       assertTrue(debug, docOut.get("id") instanceof StringField);
       assertTrue(debug, docOut.get("store") instanceof StringField);

--- a/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
@@ -355,17 +355,17 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
         if (!boostedResults.get(i).equals(controlResults.get(i))) {
           throw new Exception(
               "boosted results do not match control results, boostedResults size:"
-                  + boostedResults.toString()
+                  + boostedResults
                   + ", controlResults size:"
-                  + controlResults.toString());
+                  + controlResults);
         }
       }
     } else {
       throw new Exception(
           "boosted results do not match control results, boostedResults size:"
-              + boostedResults.toString()
+              + boostedResults
               + ", controlResults size:"
-              + controlResults.toString());
+              + controlResults);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/search/TestRandomCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRandomCollapseQParserPlugin.java
@@ -209,7 +209,7 @@ public class TestRandomCollapseQParserPlugin extends SolrTestCaseJ4 {
             final String checkFQ =
                 ((null == collapseVal)
                     ? ("-" + checkField + ":[* TO *]")
-                    : ("{!field f=" + checkField + "}" + collapseVal.toString()));
+                    : ("{!field f=" + checkField + "}" + collapseVal));
 
             final SolrParams checkP =
                 params(

--- a/solr/core/src/test/org/apache/solr/search/TestSort.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSort.java
@@ -175,7 +175,7 @@ public class TestSort extends SolrTestCaseJ4 {
               "sorts["
                   + j
                   + "] resulted in a '"
-                  + type.toString()
+                  + type
                   + "', either sort parsing code is broken, or func/query "
                   + "semantics have gotten broader and munging in this test "
                   + "needs improved: "
@@ -187,7 +187,7 @@ public class TestSort extends SolrTestCaseJ4 {
               names[j],
               sorts[j].getField());
           assertEquals(
-              "fields[" + j + "] (" + type.toString() + ") had unexpected name in: " + input,
+              "fields[" + j + "] (" + type + ") had unexpected name in: " + input,
               names[j],
               fields.get(j).getName());
         }

--- a/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
@@ -173,7 +173,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -220,7 +220,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -267,7 +267,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -327,7 +327,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -371,7 +371,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -420,7 +420,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -469,7 +469,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -519,7 +519,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -569,7 +569,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -622,7 +622,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -697,7 +697,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
 
           // second query, using mincount...
@@ -746,7 +746,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -798,7 +798,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -849,7 +849,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
           }
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -899,7 +899,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
           }
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
         }
       }
     }
@@ -955,7 +955,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
       }
 
       // with mincount
@@ -995,7 +995,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
         }
       } catch (AssertionError | RuntimeException ae) {
         throw new AssertionError(
-            solrQuery.toString() + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+            solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
@@ -172,8 +172,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
                 other, modelVals(0), modelVals(5), modelVals(1, 4), subFacetLimit, foo);
 
           } catch (AssertionError | RuntimeException ae) {
-            throw new AssertionError(
-                solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+            throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -219,8 +218,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
                 other, emptyVals(), emptyVals(), modelVals(0, 5), subFacetLimit, foo);
 
           } catch (AssertionError | RuntimeException ae) {
-            throw new AssertionError(
-                solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+            throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -266,8 +264,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
                 other, emptyVals(), modelVals(5), modelVals(0, 4), subFacetLimit, foo);
 
           } catch (AssertionError | RuntimeException ae) {
-            throw new AssertionError(
-                solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+            throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -326,8 +323,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
               other, modelVals(0), modelVals(5), modelVals(1, 4), subFacetLimit, foo);
 
         } catch (AssertionError | RuntimeException ae) {
-          throw new AssertionError(
-              solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
+          throw new AssertionError(solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
         }
       }
     }

--- a/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/RangeFacetCloudTest.java
@@ -173,7 +173,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -220,7 +220,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -267,7 +267,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
           } catch (AssertionError | RuntimeException ae) {
             throw new AssertionError(
-                solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+                solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
           }
         }
       }
@@ -327,7 +327,7 @@ public class RangeFacetCloudTest extends SolrCloudTestCase {
 
         } catch (AssertionError | RuntimeException ae) {
           throw new AssertionError(
-              solrQuery + " -> " + rsp.toString() + " ===> " + ae.getMessage(), ae);
+              solrQuery + " -> " + rsp + " ===> " + ae.getMessage(), ae);
         }
       }
     }

--- a/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetJoinDomain.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetJoinDomain.java
@@ -738,7 +738,7 @@ public class TestCloudJSONFacetJoinDomain extends SolrCloudTestCase {
       this.refine = refine;
       if (isRefinementNeeded(limit, overrequest)) {
         assertEquals(
-            "Invalid refine param based on limit & overrequest: " + this.toString(),
+            "Invalid refine param based on limit & overrequest: " + this,
             Boolean.TRUE,
             refine);
       }

--- a/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetJoinDomain.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetJoinDomain.java
@@ -738,9 +738,7 @@ public class TestCloudJSONFacetJoinDomain extends SolrCloudTestCase {
       this.refine = refine;
       if (isRefinementNeeded(limit, overrequest)) {
         assertEquals(
-            "Invalid refine param based on limit & overrequest: " + this,
-            Boolean.TRUE,
-            refine);
+            "Invalid refine param based on limit & overrequest: " + this, Boolean.TRUE, refine);
       }
     }
 

--- a/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetSKG.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetSKG.java
@@ -521,7 +521,7 @@ public class TestCloudJSONFacetSKG extends SolrCloudTestCase {
     final String bucketQ = facet.field + ":" + fieldVal;
     @SuppressWarnings({"unchecked"})
     final NamedList<Object> skgBucket = (NamedList<Object>) bucket.get("skg");
-    assertNotNull(facetKey + "/bucket:" + bucket.toString(), skgBucket);
+    assertNotNull(facetKey + "/bucket:" + bucket, skgBucket);
 
     // TODO: make this more efficient?
     // ideally we'd do a single query w/4 facet.queries, one for each count

--- a/solr/core/src/test/org/apache/solr/search/stats/TestDistribIDF.java
+++ b/solr/core/src/test/org/apache/solr/search/stats/TestDistribIDF.java
@@ -214,7 +214,7 @@ public class TestDistribIDF extends SolrTestCaseJ4 {
     }
 
     if (response.getStatus() != 0 || response.getErrorMessages() != null) {
-      fail("Could not create collection. Response" + response.toString());
+      fail("Could not create collection. Response" + response);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/uninverting/TestUninvertingReader.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestUninvertingReader.java
@@ -294,7 +294,7 @@ public class TestUninvertingReader extends SolrTestCase {
                 + " values per segment, got "
                 + valSetSize
                 + " from: "
-                + ar.toString(),
+                + ar,
             valSetSize <= EXPECTED_VALSET_SIZE);
 
         if (1 == NUM_LEAVES && MULTI_VALUES.contains(f)) {

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesDistrib.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesDistrib.java
@@ -724,8 +724,8 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
       final int id = Integer.parseInt(doc.get("id").toString());
       final Object val = doc.get(fieldName);
       final Object docid = doc.get("[docid]");
-      assertEquals(msgPre + " wrong val for " + doc.toString(), valuesList.get(id), val);
-      assertEquals(msgPre + " wrong [docid] for " + doc.toString(), luceneDocids.get(id), docid);
+      assertEquals(msgPre + " wrong val for " + doc, valuesList.get(id), val);
+      assertEquals(msgPre + " wrong [docid] for " + doc, luceneDocids.get(id), docid);
     }
   }
 
@@ -1403,7 +1403,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
     assertNotNull("expected contains no name: " + expected, fieldName);
     FieldResponse rsp = new Field(fieldName).process(this.cloudClient);
     assertNotNull("Field Null Response: " + fieldName, rsp);
-    assertEquals("Field Status: " + fieldName + " => " + rsp.toString(), 0, rsp.getStatus());
+    assertEquals("Field Status: " + fieldName + " => " + rsp, 0, rsp.getStatus());
     assertEquals("Field: " + fieldName, expected, rsp.getField());
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
@@ -99,8 +99,7 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertNotNull(schema.getFieldOrNull(fieldName));
     assertEquals("pfloats", schema.getFieldType(fieldName).getTypeName());
     assertU(commit());
-    assertQ(
-        req("id:2"), "//arr[@name='" + fieldName + "']/float[.='" + floatValue + "']");
+    assertQ(req("id:2"), "//arr[@name='" + fieldName + "']/float[.='" + floatValue + "']");
   }
 
   public void testSingleFieldMixedFieldTypesRoundTrip() throws Exception {

--- a/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
@@ -100,7 +100,7 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertEquals("pfloats", schema.getFieldType(fieldName).getTypeName());
     assertU(commit());
     assertQ(
-        req("id:2"), "//arr[@name='" + fieldName + "']/float[.='" + floatValue.toString() + "']");
+        req("id:2"), "//arr[@name='" + fieldName + "']/float[.='" + floatValue + "']");
   }
 
   public void testSingleFieldMixedFieldTypesRoundTrip() throws Exception {
@@ -118,8 +118,8 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertU(commit());
     assertQ(
         req("id:3"),
-        "//arr[@name='" + fieldName + "']/double[.='" + fieldValue1.toString() + "']",
-        "//arr[@name='" + fieldName + "']/double[.='" + fieldValue2.toString() + "']");
+        "//arr[@name='" + fieldName + "']/double[.='" + fieldValue1 + "']",
+        "//arr[@name='" + fieldName + "']/double[.='" + fieldValue2 + "']");
   }
 
   public void testSingleFieldDefaultFieldTypeRoundTrip() throws Exception {
@@ -141,9 +141,9 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertU(commit());
     assertQ(
         req("id:4"),
-        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue1.toString() + "']",
-        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue2.toString() + "']",
-        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue3.toString() + "']");
+        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue1 + "']",
+        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue2 + "']",
+        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue3 + "']");
   }
 
   public void testSingleFieldDefaultTypeMappingRoundTrip() throws Exception {
@@ -166,9 +166,9 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertU(commit());
     assertQ(
         req("id:4"),
-        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue1.toString() + "']",
-        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue2.toString() + "']",
-        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue3.toString() + "']");
+        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue1 + "']",
+        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue2 + "']",
+        "//arr[@name='" + fieldName + "']/str[.='" + fieldValue3 + "']");
   }
 
   public void testMultipleFieldsRoundTrip() throws Exception {
@@ -198,11 +198,11 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertU(commit());
     assertQ(
         req("id:5"),
-        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value1.toString() + "']",
-        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value2.toString() + "']",
+        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value1 + "']",
+        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value2 + "']",
         "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value3.doubleValue() + "']",
-        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value1.toString() + "']",
-        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2.toString() + "']");
+        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value1 + "']",
+        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2 + "']");
   }
 
   public void testParseAndAddMultipleFieldsRoundTrip() throws Exception {
@@ -260,11 +260,11 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     assertU(commit());
     assertQ(
         req("id:6"),
-        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value1.toString() + "']",
-        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value2.toString() + "']",
+        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value1 + "']",
+        "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value2 + "']",
         "//arr[@name='" + fieldName1 + "']/double[.='" + field1Value3.doubleValue() + "']",
-        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value1.toString() + "']",
-        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2.toString() + "']",
+        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value1 + "']",
+        "//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2 + "']",
         "//arr[@name='" + fieldName3 + "']/str[.='" + field3String1 + "']",
         "//arr[@name='" + fieldName3 + "']/str[.='" + field3String2 + "']",
         "//arr[@name='" + fieldName4 + "']/date[.='" + field4Value1String + "']");

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateProcessorFactoryTest.java
@@ -230,7 +230,7 @@ public class AtomicUpdateProcessorFactoryTest extends SolrTestCaseJ4 {
 
     assertQ(
         "Check the total number of docs",
-        req("q", "cat:(" + queryString.toString() + ")"),
+        req("q", "cat:(" + queryString + ")"),
         "//result[@numFound=1]");
 
     assertQ(

--- a/solr/core/src/test/org/apache/solr/update/processor/CategoryRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/CategoryRoutedAliasUpdateProcessorTest.java
@@ -559,7 +559,7 @@ public class CategoryRoutedAliasUpdateProcessorTest extends RoutedAliasUpdatePro
       final Object errors = resp.getResponseHeader().get("errors"); // Tolerant URP
       assertNotNull(errors);
       assertTrue(
-          "Expected to find " + errorMsg + " in errors: " + errors.toString(),
+          "Expected to find " + errorMsg + " in errors: " + errors,
           errors.toString().contains(errorMsg));
     } catch (SolrException e) {
       assertTrue(e.getMessage().contains(errorMsg));

--- a/solr/core/src/test/org/apache/solr/update/processor/RecordingUpdateProcessorFactory.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/RecordingUpdateProcessorFactory.java
@@ -80,7 +80,7 @@ public final class RecordingUpdateProcessorFactory extends UpdateRequestProcesso
     private void record(UpdateCommand cmd) {
       if (!commandQueue.offer(cmd)) {
         throw new RuntimeException(
-            "WTF: commandQueue should be unbounded but offer failed: " + cmd.toString());
+            "WTF: commandQueue should be unbounded but offer failed: " + cmd);
       }
     }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/TolerantUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TolerantUpdateProcessorTest.java
@@ -105,7 +105,7 @@ public class TolerantUpdateProcessorTest extends UpdateProcessorTestBase {
       assertEquals(
           "base class(es) has changed, TolerantUpdateProcessor needs updated to ensure it "
               + "overrides all solr update lifcycle methods with exception tracking: "
-              + method.toString(),
+              + method,
           TolerantUpdateProcessor.class,
           method.getDeclaringClass());
     }

--- a/solr/core/src/test/org/apache/solr/update/processor/UpdateRequestProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpdateRequestProcessorFactoryTest.java
@@ -113,7 +113,7 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
 
       // either explicitly, or because of injection
       assertEquals(
-          name + " factory chain length: " + chain.toString(),
+          name + " factory chain length: " + chain,
           EXPECTED_CHAIN_LENGTH,
           chain.getProcessors().size());
 
@@ -131,11 +131,11 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
         expectedProcLen++; // NestedUpdate sneaks in via RunUpdate's Factory.
       }
 
-      assertEquals(name + " procs size: " + procs.toString(), expectedProcLen, procs.size());
+      assertEquals(name + " procs size: " + procs, expectedProcLen, procs.size());
 
       // Custom comes first in all three of our chains
       assertTrue(
-          name + " first processor isn't a CustomUpdateRequestProcessor: " + procs.toString(),
+          name + " first processor isn't a CustomUpdateRequestProcessor: " + procs,
           ( // compare them both just because I'm going insane and the more checks the better
           proc instanceof CustomUpdateRequestProcessor
               && procs.get(0) instanceof CustomUpdateRequestProcessor));
@@ -145,7 +145,7 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
       assertNotNull(name + " second proc is null", procs.get(1));
 
       assertTrue(
-          name + " second proc isn't LogUpdateProcessor: " + procs.toString(),
+          name + " second proc isn't LogUpdateProcessor: " + procs,
           ( // compare them both just because I'm going insane and the more checks the better
           proc.next instanceof LogUpdateProcessorFactory.LogUpdateProcessor
               && procs.get(1) instanceof LogUpdateProcessorFactory.LogUpdateProcessor));
@@ -163,14 +163,14 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
       assertTrue(
           name
               + " (distrib) first proc should be LogUpdateProcessor because of @RunAlways: "
-              + procs.toString(),
+              + procs,
           ( // compare them both just because I'm going insane and the more checks the better
           proc instanceof LogUpdateProcessorFactory.LogUpdateProcessor
               && procs.get(0) instanceof LogUpdateProcessorFactory.LogUpdateProcessor));
 
       // for these 3 (distrib) chains, the last proc should always be RunUpdateProcessor
       assertTrue(
-          name + " (distrib) last processor isn't a RunUpdateProcessor: " + procs.toString(),
+          name + " (distrib) last processor isn't a RunUpdateProcessor: " + procs,
           procs.get(procs.size() - 1) instanceof RunUpdateProcessorFactory.RunUpdateProcessor);
 
       // either 1 proc was droped in distrib mode, or 1 for the "implicit" chain
@@ -187,7 +187,7 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
         expectedProcLen++; // NestedUpdate sneaks in via RunUpdate's Factory.
       }
       assertEquals(
-          name + " (distrib) chain has wrong length: " + procs.toString(),
+          name + " (distrib) chain has wrong length: " + procs,
           expectedProcLen,
           procs.size());
     }

--- a/solr/core/src/test/org/apache/solr/update/processor/UpdateRequestProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpdateRequestProcessorFactoryTest.java
@@ -187,9 +187,7 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
         expectedProcLen++; // NestedUpdate sneaks in via RunUpdate's Factory.
       }
       assertEquals(
-          name + " (distrib) chain has wrong length: " + procs,
-          expectedProcLen,
-          procs.size());
+          name + " (distrib) chain has wrong length: " + procs, expectedProcLen, procs.size());
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/util/TimeZoneUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/TimeZoneUtilsTest.java
@@ -37,7 +37,7 @@ public class TimeZoneUtilsTest extends SolrTestCase {
     final boolean same = expected.hasSameRules(actual);
 
     assertTrue(
-        label + ": " + expected.toString() + " [[NOT SAME RULES]] " + actual.toString(), same);
+        label + ": " + expected + " [[NOT SAME RULES]] " + actual, same);
   }
 
   public void testValidIds() {

--- a/solr/core/src/test/org/apache/solr/util/TimeZoneUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/TimeZoneUtilsTest.java
@@ -36,8 +36,7 @@ public class TimeZoneUtilsTest extends SolrTestCase {
 
     final boolean same = expected.hasSameRules(actual);
 
-    assertTrue(
-        label + ": " + expected + " [[NOT SAME RULES]] " + actual, same);
+    assertTrue(label + ": " + expected + " [[NOT SAME RULES]] " + actual, same);
   }
 
   public void testValidIds() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-162680

# Description

We sprinkle in a lot of our messages in the tests a lot of `.toString()`, however we don't need them.  They make the methods longer to read.

# Solution

Strip out toString() that aren't needed.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ x] I have created a Jira issue and added the issue ID to my pull request title.
- [ x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
