### PR TITLE
SOLR-16275 use standard charset instead of string forName version

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/stats/StatsUtil.java
+++ b/solr/core/src/java/org/apache/solr/search/stats/StatsUtil.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;

--- a/solr/core/src/java/org/apache/solr/search/stats/StatsUtil.java
+++ b/solr/core/src/java/org/apache/solr/search/stats/StatsUtil.java
@@ -21,6 +21,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -199,11 +200,11 @@ public class StatsUtil {
           output.append(c);
       }
     }
-    return URLEncoder.encode(output.toString(), Charset.forName("UTF-8"));
+    return URLEncoder.encode(output.toString(), StandardCharsets.UTF_8);
   }
 
   public static String decode(String value) throws IOException {
-    value = URLDecoder.decode(value, Charset.forName("UTF-8"));
+    value = URLDecoder.decode(value, StandardCharsets.UTF_8);
     StringBuilder output = new StringBuilder(value.length());
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);

--- a/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
@@ -80,7 +80,7 @@ public class SolrRequestParsers {
   public static final String SIMPLE = "simple";
   public static final String STANDARD = "standard";
 
-  private static final Charset CHARSET_US_ASCII = Charset.forName("US-ASCII");
+  private static final Charset CHARSET_US_ASCII = StandardCharsets.US_ASCII;
 
   public static final String INPUT_ENCODING_KEY = "ie";
   private static final byte[] INPUT_ENCODING_BYTES = INPUT_ENCODING_KEY.getBytes(CHARSET_US_ASCII);

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -27,6 +27,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -984,7 +985,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
             entry
                 + " should've been either ADD or UPDATE_INPLACE update"
                 + ", while looking for id="
-                + new String(id.bytes, Charset.forName("UTF-8")));
+                + new String(id.bytes, StandardCharsets.UTF_8));
       }
       // if this is an ADD (i.e. full document update), stop here
       if ((flags & UpdateLog.ADD) == UpdateLog.ADD) {

--- a/solr/core/src/test/org/apache/solr/cloud/DistributedQueueTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistributedQueueTest.java
@@ -17,6 +17,7 @@
 package org.apache.solr.cloud;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -36,7 +37,7 @@ import org.junit.Test;
 
 public class DistributedQueueTest extends SolrTestCaseJ4 {
 
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   protected ZkTestServer zkServer;
   protected SolrZkClient zkClient;

--- a/solr/core/src/test/org/apache/solr/cloud/OutOfBoxZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OutOfBoxZkACLAndCredentialsProvidersTest.java
@@ -18,6 +18,7 @@ package org.apache.solr.cloud;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +39,7 @@ public class OutOfBoxZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final Charset DATA_ENCODING = Charset.forName("UTF-8");
+  private static final Charset DATA_ENCODING = StandardCharsets.UTF_8;
 
   protected ZkTestServer zkServer;
 

--- a/solr/core/src/test/org/apache/solr/cloud/OverriddenZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverriddenZkACLAndCredentialsProvidersTest.java
@@ -44,7 +44,7 @@ public class OverriddenZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final Charset DATA_ENCODING = Charset.forName("UTF-8");
+  private static final Charset DATA_ENCODING = StandardCharsets.UTF_8;
 
   protected ZkTestServer zkServer;
 

--- a/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
@@ -422,7 +422,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     assertTrue("Should be an individual file", Files.isRegularFile(locPath));
     assertTrue("File should have some data", Files.size(locPath) > 100);
     boolean foundApache = false;
-    for (String line : Files.readAllLines(locPath, Charset.forName("UTF-8"))) {
+    for (String line : Files.readAllLines(locPath, StandardCharsets.UTF_8)) {
       if (line.contains("Apache Software Foundation")) {
         foundApache = true;
         break;
@@ -473,7 +473,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     Path file = Paths.get(tmp.toAbsolutePath().toString(), "zknode.data");
     List<String> lines = new ArrayList<>();
     lines.add("{Some Arbitrary Data}");
-    Files.write(file, lines, Charset.forName("UTF-8"));
+    Files.write(file, lines, StandardCharsets.UTF_8);
     // First, just copy the data up the cp7 since it's a directory.
     args =
         new String[] {

--- a/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
@@ -543,7 +543,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
             + "                 },\n"
             + "    }";
 
-    ByteBuffer buff = Charset.forName("UTF-8").encode(payload);
+    ByteBuffer buff = UTF_8.encode(payload);
     Map<?, ?> map =
         postDataAndGetResponse(
             cluster.getSolrClient(),

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
@@ -32,7 +32,6 @@ import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Principal;

--- a/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
+++ b/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.solr.SolrTestCaseJ4;
@@ -45,7 +46,7 @@ import org.junit.Test;
 
 public class BlobRepositoryMockingTest {
 
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
   private static final String[][] PARSED =
       new String[][] {{"foo", "bar", "baz"}, {"bang", "boom", "bash"}};
   private static final String BLOBSTR = "foo,bar,baz\nbang,boom,bash";

--- a/solr/core/src/test/org/apache/solr/handler/component/ResourceSharingTestComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ResourceSharingTestComponent.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -109,7 +110,7 @@ public class ResourceSharingTestComponent extends SearchComponent implements Sol
       // baz,bam
 
       try (Stream<String> lines =
-          new BufferedReader(new InputStreamReader(inputStream, Charset.forName("UTF-8")))
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
               .lines()) {
         lines.forEach(this::processSimpleCsvRow);
       } catch (Exception e) {

--- a/solr/core/src/test/org/apache/solr/handler/component/ResourceSharingTestComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ResourceSharingTestComponent.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -110,8 +109,7 @@ public class ResourceSharingTestComponent extends SearchComponent implements Sol
       // baz,bam
 
       try (Stream<String> lines =
-          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
-              .lines()) {
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()) {
         lines.forEach(this::processSimpleCsvRow);
       } catch (Exception e) {
         log.error("failed to read dictionary {}", getResourceName());

--- a/solr/core/src/test/org/apache/solr/security/BasicAuthStandaloneTest.java
+++ b/solr/core/src/test/org/apache/solr/security/BasicAuthStandaloneTest.java
@@ -121,7 +121,7 @@ public class BasicAuthStandaloneTest extends SolrTestCaseJ4 {
       assertTrue(
           new String(
                   Utils.toJSON(securityConfHandler.getSecurityConfig(false).getData()),
-                  Charset.forName("UTF-8"))
+                  UTF_8)
               .contains("harry"));
 
       // Edit authorization

--- a/solr/core/src/test/org/apache/solr/security/BasicAuthStandaloneTest.java
+++ b/solr/core/src/test/org/apache/solr/security/BasicAuthStandaloneTest.java
@@ -23,7 +23,6 @@ import static org.apache.solr.security.BasicAuthIntegrationTest.verifySecuritySt
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -119,9 +118,7 @@ public class BasicAuthStandaloneTest extends SolrTestCaseJ4 {
 
       // Read file from SOLR_HOME and verify that it contains our new user
       assertTrue(
-          new String(
-                  Utils.toJSON(securityConfHandler.getSecurityConfig(false).getData()),
-                  UTF_8)
+          new String(Utils.toJSON(securityConfHandler.getSecurityConfig(false).getData()), UTF_8)
               .contains("harry"));
 
       // Edit authorization

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/HttpParamDelegationTokenPlugin.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/HttpParamDelegationTokenPlugin.java
@@ -17,7 +17,6 @@
 package org.apache.solr.security.hadoop;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Enumeration;
@@ -178,7 +177,7 @@ public class HttpParamDelegationTokenPlugin extends KerberosPlugin {
 
   private static String getHttpParam(HttpServletRequest request, String param) {
     List<NameValuePair> pairs =
-        URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
     for (NameValuePair nvp : pairs) {
       if (param.equals(nvp.getName())) {
         return nvp.getValue();
@@ -276,7 +275,7 @@ public class HttpParamDelegationTokenPlugin extends KerberosPlugin {
       // forwarded.
       List<NameValuePair> newPairs = new LinkedList<NameValuePair>();
       List<NameValuePair> pairs =
-          URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+          URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
       for (NameValuePair nvp : pairs) {
         if (!USER_PARAM.equals(nvp.getName())) {
           newPairs.add(nvp);

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -219,7 +219,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     try (Writer writer =
         new OutputStreamWriter(
             Files.newOutputStream(coreDirectory.resolve(CORE_PROPERTIES_FILENAME)),
-                StandardCharsets.UTF_8)) {
+            StandardCharsets.UTF_8)) {
       properties.store(writer, testname);
     }
   }

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -220,7 +219,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     try (Writer writer =
         new OutputStreamWriter(
             Files.newOutputStream(coreDirectory.resolve(CORE_PROPERTIES_FILENAME)),
-            Charset.forName("UTF-8"))) {
+                StandardCharsets.UTF_8)) {
       properties.store(writer, testname);
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16275


# Description

Use a class defined constant instead of a forName()

# Solution

Fixed in tests.  Should it be done globally???

# Tests

ran tests

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
