### PR TITLE
SOLR-16223: unused throws identified by IntelliJ (round 2)

### DIFF
--- a/solr/core/src/test/org/apache/solr/AnalysisAfterCoreReloadTest.java
+++ b/solr/core/src/test/org/apache/solr/AnalysisAfterCoreReloadTest.java
@@ -50,7 +50,7 @@ public class AnalysisAfterCoreReloadTest extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void AfterClass() throws Exception {}
+  public static void AfterClass() {}
 
   public void testStopwordsAfterCoreReload() throws Exception {
     SolrInputDocument doc = new SolrInputDocument();

--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -103,7 +103,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
   ***/
 
   @Test
-  public void testIgnoredFields() throws Exception {
+  public void testIgnoredFields() {
     lrf.args.put(CommonParams.VERSION, "2.2");
     assertU("adding doc with ignored field", adoc("id", "42", "foo_ignored", "blah blah"));
     assertU("commit", commit());
@@ -118,7 +118,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSomeStuff() throws Exception {
+  public void testSomeStuff() {
     clearIndex();
 
     SolrCore core = h.getCore();
@@ -213,7 +213,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
   }
 
   /** verify that delete by query works with the QParser framework and pure negative queries */
-  public void testNonTrivialDeleteByQuery() throws Exception {
+  public void testNonTrivialDeleteByQuery() {
     clearIndex();
 
     // setup
@@ -291,7 +291,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testClientErrorOnMalformedDate() throws Exception {
+  public void testClientErrorOnMalformedDate() {
     final String BAD_VALUE = "NOT_A_DATE";
     ignoreException(BAD_VALUE);
 
@@ -346,7 +346,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testClientErrorOnMalformedNumbers() throws Exception {
+  public void testClientErrorOnMalformedNumbers() {
 
     final String BAD_VALUE = "NOT_A_NUMBER";
     ignoreException(BAD_VALUE);
@@ -585,7 +585,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSolrParams() throws Exception {
+  public void testSolrParams() {
     NamedList<Object> nl = new NamedList<>();
     nl.add("i", 555);
     nl.add("s", "bbb");

--- a/solr/core/src/test/org/apache/solr/CursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/CursorPagingTest.java
@@ -77,7 +77,7 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     assertU(delQ("*:*"));
     assertU(commit());
   }
@@ -1160,7 +1160,7 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
   }
 
   /** execute a local request, verify that we get an expected error */
-  public void assertFail(SolrParams p, ErrorCode expCode, String expSubstr) throws Exception {
+  public void assertFail(SolrParams p, ErrorCode expCode, String expSubstr) {
 
     try {
       SolrException e =

--- a/solr/core/src/test/org/apache/solr/DistributedIntervalFacetingTest.java
+++ b/solr/core/src/test/org/apache/solr/DistributedIntervalFacetingTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class DistributedIntervalFacetingTest extends BaseDistributedSearchTestCase {
 
   @BeforeClass
-  public static void beforeSuperClass() throws Exception {
+  public static void beforeSuperClass() {
     schemaString = "schema-distrib-interval-faceting.xml";
     configString = "solrconfig-basic.xml";
   }

--- a/solr/core/src/test/org/apache/solr/SolrTestCaseJ4Test.java
+++ b/solr/core/src/test/org/apache/solr/SolrTestCaseJ4Test.java
@@ -53,7 +53,7 @@ public class SolrTestCaseJ4Test extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void AfterClass() throws Exception {}
+  public static void AfterClass() {}
 
   @Test
   public void testCorrectCore() {
@@ -61,7 +61,7 @@ public class SolrTestCaseJ4Test extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testParams() throws Exception {
+  public void testParams() {
     final ModifiableSolrParams params = new ModifiableSolrParams();
     assertEquals(params.toString(), params().toString());
 

--- a/solr/core/src/test/org/apache/solr/TestCursorMarkWithoutUniqueKey.java
+++ b/solr/core/src/test/org/apache/solr/TestCursorMarkWithoutUniqueKey.java
@@ -47,7 +47,7 @@ public class TestCursorMarkWithoutUniqueKey extends SolrTestCaseJ4 {
     deleteCore();
   }
 
-  public void test() throws Exception {
+  public void test() {
 
     assertU(adoc("fld", "val"));
     assertU(commit());

--- a/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
@@ -2061,7 +2061,7 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
         control.getHeader().get(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY));
   }
 
-  private void validateCommonQueryParameters() throws Exception {
+  private void validateCommonQueryParameters() {
     ignoreException("parameter cannot be negative");
 
     SolrException e1 =

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -1859,7 +1859,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testGroupWithMinExactHitCount() throws Exception {
+  public void testGroupWithMinExactHitCount() {
     final int NUM_DOCS = 20;
     for (int i = 0; i < NUM_DOCS; i++) {
       assertU(adoc("id", String.valueOf(i), FOO_STRING_FIELD, "Book1"));

--- a/solr/core/src/test/org/apache/solr/analysis/CommonGramsPhraseQueryTest.java
+++ b/solr/core/src/test/org/apache/solr/analysis/CommonGramsPhraseQueryTest.java
@@ -50,7 +50,7 @@ public class CommonGramsPhraseQueryTest extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  public void testCommonGrams() throws Exception {
+  public void testCommonGrams() {
     testCommonQueries("x_commongrams");
     // individual stop words should also match in this field....
     for (String word : Arrays.asList("the", "and")) {
@@ -68,7 +68,7 @@ public class CommonGramsPhraseQueryTest extends SolrTestCaseJ4 {
     assertQ(req("x_commongrams:not"), "//*[@numFound='1']", "//str[@name='id' and .='3']");
   }
 
-  public void testCommonGramsStop() throws Exception {
+  public void testCommonGramsStop() {
     testCommonQueries("x_commongrams_stop");
     // individual stop words should not match anything in this field...
     for (String word : Arrays.asList("the", "and", "not", "a")) {

--- a/solr/core/src/test/org/apache/solr/analysis/PathHierarchyTokenizerFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/analysis/PathHierarchyTokenizerFactoryTest.java
@@ -87,7 +87,7 @@ public class PathHierarchyTokenizerFactoryTest extends SolrTestCaseJ4 {
         "//str[@name='id' and .='43']");
   }
 
-  public void testAncestors() throws Exception {
+  public void testAncestors() {
 
     assertQ(
         req("{!field f=cat_ancestor}Books/NonFic/Science"),

--- a/solr/core/src/test/org/apache/solr/cloud/ClusterStateTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ClusterStateTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class ClusterStateTest extends SolrTestCaseJ4 {
 
   @Test
-  public void testStoreAndRead() throws Exception {
+  public void testStoreAndRead() {
     Map<String, DocCollection> collectionStates = new HashMap<>();
     Set<String> liveNodes = new HashSet<>();
     liveNodes.add("node1");

--- a/solr/core/src/test/org/apache/solr/cloud/ClusterStateUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ClusterStateUpdateTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class ClusterStateUpdateTest extends SolrCloudTestCase {
   }
 
   @AfterClass
-  public static void afterClass() throws InterruptedException, IOException {
+  public static void afterClass() {
     System.clearProperty("solrcloud.skip.autorecovery");
     System.clearProperty("genericCoreNodeNames");
   }

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTest.java
@@ -628,7 +628,7 @@ public class CollectionsAPISolrJTest extends SolrCloudTestCase {
   }
 
   @Test
-  public void testClusterProp() throws InterruptedException, IOException, SolrServerException {
+  public void testClusterProp() throws IOException, SolrServerException {
 
     // sanity check our expected default
     final ClusterProperties props = new ClusterProperties(zkClient());

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
@@ -59,7 +59,7 @@ public class DeleteReplicaTest extends SolrCloudTestCase {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
-  public static void setupCluster() throws Exception {
+  public static void setupCluster() {
     System.setProperty("solr.zkclienttimeout", "45000");
     System.setProperty("distribUpdateSoTimeout", "15000");
   }

--- a/solr/core/src/test/org/apache/solr/cloud/DistributedVersionInfoTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistributedVersionInfoTest.java
@@ -344,7 +344,7 @@ public class DistributedVersionInfoTest extends SolrCloudTestCase {
     }
   }
 
-  protected HttpSolrClient getHttpSolrClient(Replica replica) throws Exception {
+  protected HttpSolrClient getHttpSolrClient(Replica replica) {
     return getHttpSolrClient(replica.getCoreUrl());
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/ForceLeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ForceLeaderTest.java
@@ -59,7 +59,7 @@ public class ForceLeaderTest extends HttpPartitionTest {
   @Test
   @Override
   @Ignore
-  public void test() throws Exception {}
+  public void test() {}
 
   /**
    * Tests that FORCELEADER can get an active leader even only replicas with term lower than

--- a/solr/core/src/test/org/apache/solr/cloud/HttpPartitionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/HttpPartitionTest.java
@@ -562,7 +562,7 @@ public class HttpPartitionTest extends AbstractFullDistribZkTestBase {
     }
   }
 
-  protected HttpSolrClient getHttpSolrClient(Replica replica, String coll) throws Exception {
+  protected HttpSolrClient getHttpSolrClient(Replica replica, String coll) {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + coll;
     return getHttpSolrClient(url);

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
@@ -151,7 +151,7 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
   }
 
   @AfterClass
-  public static void afterClass() throws InterruptedException {
+  public static void afterClass() {
     System.clearProperty("solrcloud.skip.autorecovery");
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderVoteWaitTimeoutTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderVoteWaitTimeoutTest.java
@@ -58,7 +58,7 @@ public class LeaderVoteWaitTimeoutTest extends SolrCloudTestCase {
   private static Map<URI, JettySolrRunner> jettys;
 
   @BeforeClass
-  public static void setupCluster() throws Exception {
+  public static void setupCluster() {
     System.setProperty("solr.directoryFactory", "solr.StandardDirectoryFactory");
     System.setProperty("solr.ulog.numRecordsToKeep", "1000");
     System.setProperty("leaderVoteWait", "2000");
@@ -70,7 +70,7 @@ public class LeaderVoteWaitTimeoutTest extends SolrCloudTestCase {
   }
 
   @AfterClass
-  public static void tearDownCluster() throws Exception {
+  public static void tearDownCluster() {
     proxies = null;
     jettys = null;
     System.clearProperty("solr.directoryFactory");
@@ -347,7 +347,7 @@ public class LeaderVoteWaitTimeoutTest extends SolrCloudTestCase {
     return solr.request(qr);
   }
 
-  protected HttpSolrClient getHttpSolrClient(Replica replica, String coll) throws Exception {
+  protected HttpSolrClient getHttpSolrClient(Replica replica, String coll) {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + coll;
     return getHttpSolrClient(url);

--- a/solr/core/src/test/org/apache/solr/cloud/MultiSolrCloudTestCaseTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MultiSolrCloudTestCaseTest.java
@@ -73,7 +73,7 @@ public class MultiSolrCloudTestCaseTest extends MultiSolrCloudTestCase {
   }
 
   @Test
-  public void test() throws Exception {
+  public void test() {
     assertEquals("numClouds", numClouds, clusterId2cluster.size());
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/NodeMutatorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/NodeMutatorTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import java.io.IOException;
 import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.SolrTestCaseJ4Test;
@@ -41,7 +40,7 @@ public class NodeMutatorTest extends SolrTestCaseJ4Test {
   private static final String NODE1_URL = "http://baseUrl1:8983";
 
   @Test
-  public void downNodeReportsAllImpactedCollectionsAndNothingElse() throws IOException {
+  public void downNodeReportsAllImpactedCollectionsAndNothingElse() {
     NodeMutator nm = new NodeMutator(null);
 
     // Collection1: 2 shards X 1 replica = replica1 on node1 and replica2 on node2

--- a/solr/core/src/test/org/apache/solr/cloud/OutOfBoxZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OutOfBoxZkACLAndCredentialsProvidersTest.java
@@ -50,7 +50,7 @@ public class OutOfBoxZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws InterruptedException {
+  public static void afterClass() {
     System.clearProperty("solrcloud.skip.autorecovery");
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/OverriddenZkACLAndCredentialsProvidersTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverriddenZkACLAndCredentialsProvidersTest.java
@@ -56,7 +56,7 @@ public class OverriddenZkACLAndCredentialsProvidersTest extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws InterruptedException {
+  public static void afterClass() {
     System.clearProperty("solrcloud.skip.autorecovery");
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerCollectionConfigSetProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerCollectionConfigSetProcessorTest.java
@@ -179,7 +179,7 @@ public class OverseerCollectionConfigSetProcessorTest extends SolrTestCaseJ4 {
   }
 
   @BeforeClass
-  public static void setUpOnce() throws Exception {
+  public static void setUpOnce() {
     assumeWorkingMockito();
 
     workQueueMock = mock(OverseerTaskQueue.class);

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -142,7 +142,7 @@ public class OverseerTest extends SolrTestCaseJ4 {
     private List<Overseer> overseers;
 
     public MockZKController(String zkAddress, String nodeName, List<Overseer> overseers)
-        throws InterruptedException, TimeoutException, IOException, KeeperException {
+        throws InterruptedException, IOException, KeeperException {
       this.overseers = overseers;
       this.nodeName = nodeName;
       zkClient = new SolrZkClient(zkAddress, TIMEOUT);

--- a/solr/core/src/test/org/apache/solr/cloud/ReplaceNodeTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplaceNodeTest.java
@@ -54,7 +54,7 @@ public class ReplaceNodeTest extends SolrCloudTestCase {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
-  public static void setupCluster() throws Exception {
+  public static void setupCluster() {
     System.setProperty("metricsEnabled", "true");
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudConsistency.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudConsistency.java
@@ -356,7 +356,7 @@ public class TestCloudConsistency extends SolrCloudTestCase {
     return solr.request(qr);
   }
 
-  protected HttpSolrClient getHttpSolrClient(Replica replica, String coll) throws Exception {
+  protected HttpSolrClient getHttpSolrClient(Replica replica, String coll) {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + coll;
     return getHttpSolrClient(url);

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPivotFacet.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPivotFacet.java
@@ -241,8 +241,7 @@ public class TestCloudPivotFacet extends AbstractFullDistribZkTestBase {
    * facet values in the response, treating each one as a filter query to assert the pivot counts
    * are correct.
    */
-  private void assertPivotCountsAreCorrect(SolrParams baseParams, SolrParams pivotParams)
-      throws SolrServerException {
+  private void assertPivotCountsAreCorrect(SolrParams baseParams, SolrParams pivotParams) {
 
     SolrParams initParams = SolrParams.wrapAppended(pivotParams, baseParams);
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery.java
@@ -56,7 +56,7 @@ public class TestCloudRecovery extends SolrCloudTestCase {
   private int tlogReplicas;
 
   @BeforeClass
-  public static void setupCluster() throws Exception {
+  public static void setupCluster() {
     System.setProperty("metricsEnabled", "true");
     System.setProperty("solr.directoryFactory", "solr.StandardDirectoryFactory");
     System.setProperty("solr.ulog.numRecordsToKeep", "1000");

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
@@ -1332,7 +1332,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
             .get("id"));
   }
 
-  private static String getSecurityJson() throws KeeperException, InterruptedException {
+  private static String getSecurityJson() {
     String securityJson =
         "{\n"
             + "  'authentication':{\n"
@@ -1734,8 +1734,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
   }
 
   private void verifyException(
-      SolrClient solrClient, ConfigSetAdminRequest<?, ?> request, String errorContains)
-      throws Exception {
+      SolrClient solrClient, ConfigSetAdminRequest<?, ?> request, String errorContains) {
     ignoreException(errorContains);
     Exception e = expectThrows(Exception.class, () -> solrClient.request(request));
     assertTrue(
@@ -1828,7 +1827,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
    * @see ConfigSetService#getDefaultConfigDirPath
    */
   @Test
-  public void testUserAndTestDefaultConfigsetsAreSame() throws IOException {
+  public void testUserAndTestDefaultConfigsetsAreSame() {
     final Path extPath = Path.of(ExternalPaths.DEFAULT_CONFIGSET);
     assertTrue(
         "_default dir doesn't exist: " + ExternalPaths.DEFAULT_CONFIGSET, Files.exists(extPath));
@@ -1935,6 +1934,6 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
     public void init(Map<String, Object> initInfo) {}
 
     @Override
-    public void close() throws IOException {}
+    public void close() {}
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestDistribDocBasedVersion.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestDistribDocBasedVersion.java
@@ -260,7 +260,7 @@ public class TestDistribDocBasedVersion extends AbstractFullDistribZkTestBase {
     solrClient.request(req);
   }
 
-  void vaddFail(String id, long version, int errCode, String... params) throws Exception {
+  void vaddFail(String id, long version, int errCode, String... params) {
     boolean failed = false;
     try {
       vadd(id, version, params);
@@ -273,7 +273,7 @@ public class TestDistribDocBasedVersion extends AbstractFullDistribZkTestBase {
     assertTrue(failed);
   }
 
-  void vdeleteFail(String id, long version, int errCode, String... params) throws Exception {
+  void vdeleteFail(String id, long version, int errCode, String... params) {
     boolean failed = false;
     try {
       vdelete(id, version, params);

--- a/solr/core/src/test/org/apache/solr/cloud/TestMiniSolrCloudClusterSSL.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestMiniSolrCloudClusterSSL.java
@@ -395,7 +395,7 @@ public class TestMiniSolrCloudClusterSSL extends SolrTestCaseJ4 {
    * Returns a new HttpClient that supports both HTTP and HTTPS (with the default test truststore),
    * but has no keystore -- so servers requiring client authentication should fail.
    */
-  private static CloseableHttpClient getSslAwareClientWithNoClientCerts() throws Exception {
+  private static CloseableHttpClient getSslAwareClientWithNoClientCerts() {
 
     // NOTE: This method explicitly does *NOT* use HttpClientUtil code because that
     // will change the global static HttpClientBuilder / SchemeRegistryProvider, and

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaErrorHandling.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaErrorHandling.java
@@ -95,7 +95,7 @@ public class TestPullReplicaErrorHandling extends SolrCloudTestCase {
   }
 
   @AfterClass
-  public static void tearDownCluster() throws Exception {
+  public static void tearDownCluster() {
     if (null != proxies) {
       for (SocketProxy proxy : proxies.values()) {
         proxy.close();

--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
@@ -197,7 +197,7 @@ public class TestRandomFlRTGCloud extends SolrCloudTestCase {
    * @see #FL_VALIDATORS
    * @see TransformerFactory#defaultFactories
    */
-  public void testCoverage() throws Exception {
+  public void testCoverage() {
     final Set<String> implicit = new LinkedHashSet<>();
     for (String t : TransformerFactory.defaultFactories.keySet()) {
       implicit.add(t);

--- a/solr/core/src/test/org/apache/solr/cloud/TestTlogReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTlogReplica.java
@@ -1104,7 +1104,7 @@ public class TestTlogReplica extends SolrCloudTestCase {
     };
   }
 
-  private List<SolrCore> getSolrCore(boolean isLeader) throws IOException {
+  private List<SolrCore> getSolrCore(boolean isLeader) {
     List<SolrCore> rs = new ArrayList<>();
 
     CloudSolrClient cloudClient = cluster.getSolrClient();
@@ -1143,7 +1143,7 @@ public class TestTlogReplica extends SolrCloudTestCase {
     }
   }
 
-  private List<JettySolrRunner> getSolrRunner(boolean isLeader) throws IOException {
+  private List<JettySolrRunner> getSolrRunner(boolean isLeader) {
     List<JettySolrRunner> rs = new ArrayList<>();
     CloudSolrClient cloudClient = cluster.getSolrClient();
     DocCollection docCollection = cloudClient.getClusterState().getCollection(collectionName);

--- a/solr/core/src/test/org/apache/solr/cloud/TrollingIndexReaderFactory.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TrollingIndexReaderFactory.java
@@ -56,7 +56,7 @@ public class TrollingIndexReaderFactory extends StandardIndexReaderFactory {
     public abstract boolean hasCaught();
 
     @Override
-    public final void close() throws IOException {
+    public final void close() {
       setTrap(null);
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/ZkCLITest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkCLITest.java
@@ -70,7 +70,7 @@ public class ZkCLITest extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws InterruptedException {
+  public static void afterClass() {
     System.clearProperty("solrcloud.skip.autorecovery");
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
@@ -59,10 +59,10 @@ public class ZkControllerTest extends SolrTestCaseJ4 {
   static final int TIMEOUT = 10000;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {}
+  public static void beforeClass() {}
 
   @AfterClass
-  public static void afterClass() throws Exception {}
+  public static void afterClass() {}
 
   public void testNodeNameUrlConversion() throws Exception {
 

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -448,8 +448,7 @@ public class ShardSplitTest extends BasicDistributedZkTest {
       Slice.State expectedState,
       int numNrt,
       int numTlog,
-      int numPull)
-      throws Exception {
+      int numPull) {
     Slice s = coll.getSlice(shard);
     assertEquals("unexpected shard state", expectedState, s.getState());
     AtomicInteger actualNrt = new AtomicInteger();

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestLocalFSCloudBackupRestore.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestLocalFSCloudBackupRestore.java
@@ -168,7 +168,7 @@ public class TestLocalFSCloudBackupRestore extends AbstractCloudBackupRestoreTes
     }
 
     @Override
-    public IndexInput openInput(URI dirPath, String fileName, IOContext ctx) throws IOException {
+    public IndexInput openInput(URI dirPath, String fileName, IOContext ctx) {
       throw new UnsupportedOperationException(poisoned);
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestRequestStatusCollectionAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestRequestStatusCollectionAPI.java
@@ -39,7 +39,7 @@ public class TestRequestStatusCollectionAPI extends BasicDistributedZkTest {
   }
 
   @Test
-  public void test() throws Exception {
+  public void test() {
     ModifiableSolrParams params = new ModifiableSolrParams();
 
     params.set(CollectionParams.ACTION, CollectionParams.CollectionAction.CREATE.toString());

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/TestClusterStateMutator.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/TestClusterStateMutator.java
@@ -37,7 +37,7 @@ public class TestClusterStateMutator extends SolrTestCaseJ4 {
     assumeWorkingMockito();
   }
 
-  public void testCreateCollection() throws Exception {
+  public void testCreateCollection() {
     ClusterState clusterState =
         new ClusterState(
             Collections.<String>emptySet(), Collections.<String, DocCollection>emptyMap());

--- a/solr/core/src/test/org/apache/solr/cluster/events/AllEventsListener.java
+++ b/solr/core/src/test/org/apache/solr/cluster/events/AllEventsListener.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.cluster.events;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,5 +51,5 @@ public class AllEventsListener implements ClusterEventListener {
     }
   }
 
-  public void close() throws IOException {}
+  public void close() {}
 }

--- a/solr/core/src/test/org/apache/solr/cluster/events/ClusterEventProducerTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/events/ClusterEventProducerTest.java
@@ -22,7 +22,6 @@ import static org.apache.solr.client.solrj.SolrRequest.METHOD.GET;
 import static org.apache.solr.client.solrj.SolrRequest.METHOD.POST;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.util.Collections;
@@ -306,7 +305,7 @@ public class ClusterEventProducerTest extends SolrCloudTestCase {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
       if (log.isDebugEnabled()) {
         log.debug("starting {}", Integer.toHexString(hashCode()));
       }
@@ -327,7 +326,7 @@ public class ClusterEventProducerTest extends SolrCloudTestCase {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
       if (log.isDebugEnabled()) {
         log.debug("closing {}", Integer.toHexString(hashCode()));
       }

--- a/solr/core/src/test/org/apache/solr/core/AlternateDirectoryTest.java
+++ b/solr/core/src/test/org/apache/solr/core/AlternateDirectoryTest.java
@@ -52,8 +52,7 @@ public class AlternateDirectoryTest extends SolrTestCaseJ4 {
     public static volatile Directory dir;
 
     @Override
-    public Directory create(String path, LockFactory lockFactory, DirContext dirContext)
-        throws IOException {
+    public Directory create(String path, LockFactory lockFactory, DirContext dirContext) {
       openCalled = true;
 
       return dir = newFSDirectory(Path.of(path), lockFactory);

--- a/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
+++ b/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
@@ -70,7 +70,7 @@ public class BlobRepositoryMockingTest {
   }
 
   @Before
-  public void setUp() throws IllegalAccessException, NoSuchFieldException {
+  public void setUp() {
     blobFetched = false;
     blobKey = "";
     reset(mocks);

--- a/solr/core/src/test/org/apache/solr/core/CountUsageValueSourceParser.java
+++ b/solr/core/src/test/org/apache/solr/core/CountUsageValueSourceParser.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.core;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -74,8 +73,7 @@ public class CountUsageValueSourceParser extends ValueSourceParser {
     }
 
     @Override
-    public FunctionValues getValues(Map<Object, Object> context, LeafReaderContext readerContext)
-        throws IOException {
+    public FunctionValues getValues(Map<Object, Object> context, LeafReaderContext readerContext) {
       return new DoubleDocValues(this) {
         @Override
         public double doubleVal(int doc) {

--- a/solr/core/src/test/org/apache/solr/core/FakeDeletionPolicy.java
+++ b/solr/core/src/test/org/apache/solr/core/FakeDeletionPolicy.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.core;
 
-import java.io.IOException;
 import java.util.List;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexDeletionPolicy;
@@ -44,12 +43,12 @@ public class FakeDeletionPolicy extends IndexDeletionPolicy implements NamedList
   }
 
   @Override
-  public void onCommit(List<? extends IndexCommit> arg0) throws IOException {
+  public void onCommit(List<? extends IndexCommit> arg0) {
     System.setProperty("onCommit", "test.org.apache.solr.core.FakeDeletionPolicy.onCommit");
   }
 
   @Override
-  public void onInit(List<? extends IndexCommit> arg0) throws IOException {
+  public void onInit(List<? extends IndexCommit> arg0) {
     System.setProperty("onInit", "test.org.apache.solr.core.FakeDeletionPolicy.onInit");
   }
 }

--- a/solr/core/src/test/org/apache/solr/core/HelloStream.java
+++ b/solr/core/src/test/org/apache/solr/core/HelloStream.java
@@ -47,13 +47,13 @@ public class HelloStream extends TupleStream implements Expressible {
   }
 
   @Override
-  public void open() throws IOException {}
+  public void open() {}
 
   @Override
-  public void close() throws IOException {}
+  public void close() {}
 
   @Override
-  public Tuple read() throws IOException {
+  public Tuple read() {
     if (isSentHelloWorld) {
       return Tuple.EOF();
     } else {

--- a/solr/core/src/test/org/apache/solr/core/SolrCoreTest.java
+++ b/solr/core/src/test/org/apache/solr/core/SolrCoreTest.java
@@ -146,7 +146,7 @@ public class SolrCoreTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testClose() throws Exception {
+  public void testClose() {
     final CoreContainer cores = h.getCoreContainer();
     SolrCore core = cores.getCore(SolrTestCaseJ4.DEFAULT_TEST_CORENAME);
 
@@ -376,7 +376,7 @@ class ClosingRequestHandler extends EmptyRequestHandler implements SolrCoreAware
 /** An empty handler for testing */
 class EmptyRequestHandler extends RequestHandlerBase {
   @Override
-  public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+  public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) {
     // nothing!
   }
 

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -27,7 +27,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -63,7 +62,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
   private static final String SOLR_HOME_PROP = "solr.solr.home";
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     oldSolrHome = System.getProperty(SOLR_HOME_PROP);
     System.setProperty("configsets", getFile("solr/configsets").getAbsolutePath());
   }
@@ -82,7 +81,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
     return init(solrHomeDirectory, xml);
   }
 
-  private CoreContainer init(Path homeDirectory, String xml) throws Exception {
+  private CoreContainer init(Path homeDirectory, String xml) {
     CoreContainer ret = new CoreContainer(SolrXmlConfig.fromString(homeDirectory, xml));
     ret.load();
     return ret;
@@ -320,7 +319,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDeleteBadCores() throws Exception {
+  public void testDeleteBadCores() {
 
     MockCoresLocator cl = new MockCoresLocator();
 
@@ -562,50 +561,48 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
     }
 
     @Override
-    public boolean checkConfigExists(String configName) throws IOException {
+    public boolean checkConfigExists(String configName) {
       return false;
     }
 
     @Override
-    public void deleteConfig(String configName) throws IOException {}
+    public void deleteConfig(String configName) {}
 
     @Override
-    public void deleteFilesFromConfig(String configName, List<String> filesToDelete)
-        throws IOException {}
+    public void deleteFilesFromConfig(String configName, List<String> filesToDelete) {}
 
-    public void copyConfig(String fromConfig, String toConfig) throws IOException {}
+    public void copyConfig(String fromConfig, String toConfig) {}
 
     @Override
-    public void uploadConfig(String configName, Path dir) throws IOException {}
+    public void uploadConfig(String configName, Path dir) {}
 
     @Override
     public void uploadFileToConfig(
-        String configName, String fileName, byte[] data, boolean overwriteOnExists)
-        throws IOException {}
+        String configName, String fileName, byte[] data, boolean overwriteOnExists) {}
 
     @Override
-    public void setConfigMetadata(String configName, Map<String, Object> data) throws IOException {}
+    public void setConfigMetadata(String configName, Map<String, Object> data) {}
 
     @Override
-    public Map<String, Object> getConfigMetadata(String configName) throws IOException {
+    public Map<String, Object> getConfigMetadata(String configName) {
       return null;
     }
 
     @Override
-    public void downloadConfig(String configName, Path dir) throws IOException {}
+    public void downloadConfig(String configName, Path dir) {}
 
     @Override
-    public List<String> listConfigs() throws IOException {
+    public List<String> listConfigs() {
       return null;
     }
 
     @Override
-    public byte[] downloadFileFromConfig(String configName, String filePath) throws IOException {
+    public byte[] downloadFileFromConfig(String configName, String filePath) {
       return new byte[0];
     }
 
     @Override
-    public List<String> getAllConfigFiles(String configName) throws IOException {
+    public List<String> getAllConfigFiles(String configName) {
       return null;
     }
 
@@ -616,7 +613,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
 
     @Override
     protected Long getCurrentSchemaModificationVersion(
-        String configSet, SolrConfig solrConfig, String schemaFileName) throws IOException {
+        String configSet, SolrConfig solrConfig, String schemaFileName) {
       return null;
     }
   }

--- a/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
@@ -141,7 +141,7 @@ public class TestCoreDiscovery extends SolrTestCaseJ4 {
   }
 
   @After
-  public void after() throws Exception {}
+  public void after() {}
 
   // Test the basic setup, create some dirs with core.properties files in them, but solr.xml has
   // discoverCores set and ensure that we find all the cores and can load them.

--- a/solr/core/src/test/org/apache/solr/core/TestJmxIntegration.java
+++ b/solr/core/src/test/org/apache/solr/core/TestJmxIntegration.java
@@ -92,7 +92,7 @@ public class TestJmxIntegration extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     if (newMbeanServer != null) {
       MBeanServerFactory.releaseMBeanServer(newMbeanServer);
     }
@@ -101,7 +101,7 @@ public class TestJmxIntegration extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void resetIndex() throws Exception {
+  public void resetIndex() {
     clearIndex();
     assertU("commit", commit());
   }

--- a/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
+++ b/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
@@ -385,8 +385,7 @@ public class TestLazyCores extends SolrTestCaseJ4 {
     }
   }
 
-  private void tryCreateFail(CoreAdminHandler admin, String name, String dataDir, String... errs)
-      throws Exception {
+  private void tryCreateFail(CoreAdminHandler admin, String name, String dataDir, String... errs) {
     SolrException thrown =
         expectThrows(
             SolrException.class,

--- a/solr/core/src/test/org/apache/solr/core/TestMergePolicyConfig.java
+++ b/solr/core/src/test/org/apache/solr/core/TestMergePolicyConfig.java
@@ -46,7 +46,7 @@ public class TestMergePolicyConfig extends SolrTestCaseJ4 {
   private static AtomicInteger docIdCounter = new AtomicInteger(42);
 
   @After
-  public void after() throws Exception {
+  public void after() {
     deleteCore();
   }
 

--- a/solr/core/src/test/org/apache/solr/core/TestNRTOpen.java
+++ b/solr/core/src/test/org/apache/solr/core/TestNRTOpen.java
@@ -44,7 +44,7 @@ public class TestNRTOpen extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     // ensure we clean up after ourselves, this will fire before superclass...
     System.clearProperty("solr.directoryFactory");
     System.clearProperty("solr.tests.maxBufferedDocs");

--- a/solr/core/src/test/org/apache/solr/core/TestReloadAndDeleteDocs.java
+++ b/solr/core/src/test/org/apache/solr/core/TestReloadAndDeleteDocs.java
@@ -23,7 +23,7 @@ import org.junit.After;
 public class TestReloadAndDeleteDocs extends SolrTestCaseJ4 {
 
   @After
-  public void after() throws Exception {
+  public void after() {
     System.clearProperty("enable.update.log");
     deleteCore();
   }

--- a/solr/core/src/test/org/apache/solr/handler/FieldAnalysisRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/FieldAnalysisRequestHandlerTest.java
@@ -838,7 +838,7 @@ public class FieldAnalysisRequestHandlerTest extends AnalysisRequestHandlerTestB
     }
 
     @Override
-    public void reset() throws IOException {
+    public void reset() {
       sentOneToken = false;
     }
 

--- a/solr/core/src/test/org/apache/solr/handler/JsonLoaderTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/JsonLoaderTest.java
@@ -163,7 +163,7 @@ public class JsonLoaderTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testInvalidJsonProducesBadRequestSolrException() throws Exception {
+  public void testInvalidJsonProducesBadRequestSolrException() {
     SolrQueryResponse rsp = new SolrQueryResponse();
     BufferingRequestProcessor p = new BufferingRequestProcessor(null);
     JsonLoader loader = new JsonLoader();
@@ -639,7 +639,7 @@ public class JsonLoaderTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testAddBigIntegerValueToTrieField() throws Exception {
+  public void testAddBigIntegerValueToTrieField() {
     // Adding a BigInteger to a long field should fail
     // BigInteger.longValue() returns only the low-order 64 bits.
 

--- a/solr/core/src/test/org/apache/solr/handler/TestContainerPlugin.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestContainerPlugin.java
@@ -354,7 +354,7 @@ public class TestContainerPlugin extends SolrCloudTestCase {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
       state = State.STARTING;
       startCalled = true;
       state = State.RUNNING;
@@ -378,7 +378,7 @@ public class TestContainerPlugin extends SolrCloudTestCase {
     private SolrResourceLoader resourceLoader;
 
     @Override
-    public void inform(ResourceLoader loader) throws IOException {
+    public void inform(ResourceLoader loader) {
       this.resourceLoader = (SolrResourceLoader) loader;
       try {
         InputStream is = resourceLoader.openResource("org/apache/solr/handler/MyPlugin.class");

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -270,7 +270,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void doTestHandlerPathUnchanged() throws Exception {
+  public void doTestHandlerPathUnchanged() {
     assertEquals("/replication", ReplicationHandler.PATH);
   }
 
@@ -1529,7 +1529,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void doTestIllegalFilePaths() throws Exception {
+  public void doTestIllegalFilePaths() {
     // Loop through the file=, cf=, tlogFile= params and prove that it throws exception for path
     // traversal attempts
     String absFile = Paths.get("foo").toAbsolutePath().toString();
@@ -1588,7 +1588,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testShouldReportErrorWhenRequiredCommandArgMissing() throws Exception {
+  public void testShouldReportErrorWhenRequiredCommandArgMissing() {
     SolrQuery q = new SolrQuery();
     q.add("qt", "/replication").add("wt", "json");
     SolrException thrown =

--- a/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
@@ -72,12 +72,12 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
   private String coreName;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     System.setProperty("solr.allowPaths", "*");
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     System.clearProperty("solr.allowPaths");
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/ThrowErrorOnInitRequestHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/ThrowErrorOnInitRequestHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.handler;
 
-import java.io.IOException;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -25,7 +24,7 @@ import org.apache.solr.security.AuthorizationContext;
 /** throws a {@link java.lang.Error} on init for testing purposes */
 public class ThrowErrorOnInitRequestHandler extends RequestHandlerBase {
   @Override
-  public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws IOException {
+  public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) {
     /* NOOP */
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/V2ApiIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/V2ApiIntegrationTest.java
@@ -78,7 +78,7 @@ public class V2ApiIntegrationTest extends SolrCloudTestCase {
   }
 
   @Test
-  public void testException() throws Exception {
+  public void testException() {
     String notFoundPath = "/c/" + COLL_NAME + "/abccdef";
     String incorrectPayload = "{rebalance-leaders: {maxAtOnce: abc, maxWaitSeconds: xyz}}";
     testException(new XMLResponseParser(), 404, notFoundPath, incorrectPayload);

--- a/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminCreateDiscoverTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminCreateDiscoverTest.java
@@ -55,7 +55,7 @@ public class CoreAdminCreateDiscoverTest extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     admin = null; // Release it or the test harness complains.
     solrHomeDirectory = null;
   }

--- a/solr/core/src/test/org/apache/solr/handler/admin/MBeansHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MBeansHandlerTest.java
@@ -125,7 +125,7 @@ public class MBeansHandlerTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testXMLDiffWithExternalEntity() throws Exception {
+  public void testXMLDiffWithExternalEntity() {
     String file = getFile("mailing_lists.pdf").toURI().toASCIIString();
     String xml =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -826,7 +826,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     Map<String, Object> gaugevals;
 
     @Override
-    public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+    public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) {
       rsp.add("key", key);
     }
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/V2ConfigAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/V2ConfigAPIMappingTest.java
@@ -46,7 +46,7 @@ public class V2ConfigAPIMappingTest extends V2ApiMappingTest<SolrConfigHandler> 
 
   // GET /v2/c/collectionName/config is a pure pass-through to the underlying request handler
   @Test
-  public void testGetAllConfig() throws Exception {
+  public void testGetAllConfig() {
     assertAnnotatedApiExistsFor("GET", "/config");
   }
 
@@ -54,7 +54,7 @@ public class V2ConfigAPIMappingTest extends V2ApiMappingTest<SolrConfigHandler> 
   // handler.  Just check
   // the API lookup works for a handful of the valid config "components".
   @Test
-  public void testGetSingleComponentConfig() throws Exception {
+  public void testGetSingleComponentConfig() {
     assertAnnotatedApiExistsFor("GET", "/config/overlay");
     assertAnnotatedApiExistsFor("GET", "/config/query");
     assertAnnotatedApiExistsFor("GET", "/config/jmx");
@@ -64,7 +64,7 @@ public class V2ConfigAPIMappingTest extends V2ApiMappingTest<SolrConfigHandler> 
   }
 
   @Test
-  public void testGetParamsetsConfig() throws Exception {
+  public void testGetParamsetsConfig() {
     assertAnnotatedApiExistsFor("GET", "/config/params");
     final AnnotatedApi getParamSetsApi = getAnnotatedApiFor("GET", "/config/params");
     // Ensure that the /config/params path redirects to the /config/params specific endpoint (and

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/V2SchemaAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/V2SchemaAPIMappingTest.java
@@ -70,7 +70,7 @@ public class V2SchemaAPIMappingTest extends V2ApiMappingTest<SchemaHandler> {
   }
 
   @Test
-  public void testSchemaBulkModificationApiMapping() throws Exception {
+  public void testSchemaBulkModificationApiMapping() {
     assertAnnotatedApiExistsFor("POST", "/schema");
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/PhrasesIdentificationComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/PhrasesIdentificationComponentTest.java
@@ -50,7 +50,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void addSomeDocs() throws Exception {
+  public void addSomeDocs() {
     assertU(
         adoc(
             "id", "42",
@@ -76,7 +76,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
   }
 
   @After
-  public void deleteAllDocs() throws Exception {
+  public void deleteAllDocs() {
     assertU(delQ("*:*"));
     assertU((commit()));
   }
@@ -237,8 +237,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
       final List<Phrase> phrases,
       final int inputPositionLength,
       final int maxIndexedPositionLength,
-      final int maxQueryPositionLength)
-      throws Exception {
+      final int maxQueryPositionLength) {
     assert 0 < phrases.size() : "Don't use this method if phrases might be empty";
 
     assertEmptyStream(
@@ -605,7 +604,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testExpectedUserErrors() throws Exception {
+  public void testExpectedUserErrors() {
     assertQEx(
         "empty field list should error",
         "must specify a (weighted) list of fields",
@@ -659,7 +658,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
         ErrorCode.BAD_REQUEST);
   }
 
-  public void testMaxShingleSizeHelper() throws Exception {
+  public void testMaxShingleSizeHelper() {
     IndexSchema schema = h.getCore().getLatestSchema();
 
     assertEquals(
@@ -690,7 +689,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
             schema.getFieldTypeByName("text").getQueryAnalyzer()));
   }
 
-  public void testSimplePhraseRequest() throws Exception {
+  public void testSimplePhraseRequest() {
     final String input = " did  a Quick    brown FOX perniciously jump over the lazy dog";
     final String expected = " did  a Quick    {brown FOX} perniciously jump over {the lazy dog}";
 
@@ -723,7 +722,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testSimpleSearchRequests() throws Exception {
+  public void testSimpleSearchRequests() {
     final String input = "\"brown fox\"";
 
     assertQ(
@@ -807,7 +806,7 @@ public class PhrasesIdentificationComponentTest extends SolrTestCaseJ4 {
         "count(//lst[@name='phrases']/arr[@name='details']/lst) = 0");
   }
 
-  public void testGreyboxShardSearchRequests() throws Exception {
+  public void testGreyboxShardSearchRequests() {
     final String input = "quick brown fox ran";
 
     final String phrase_xpath = "//lst[@name='phrases']";

--- a/solr/core/src/test/org/apache/solr/handler/component/ResourceSharingTestComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ResourceSharingTestComponent.java
@@ -20,7 +20,6 @@ package org.apache.solr.handler.component;
 import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandles;
@@ -44,7 +43,7 @@ public class ResourceSharingTestComponent extends SearchComponent implements Sol
 
   @SuppressWarnings("SynchronizeOnNonFinalField")
   @Override
-  public void prepare(ResponseBuilder rb) throws IOException {
+  public void prepare(ResponseBuilder rb) {
     SolrParams params = rb.req.getParams();
     ModifiableSolrParams mParams = new ModifiableSolrParams(params);
     String q = "text:" + getTestObj().getLastCollection();
@@ -55,7 +54,7 @@ public class ResourceSharingTestComponent extends SearchComponent implements Sol
   }
 
   @Override
-  public void process(ResponseBuilder rb) throws IOException {}
+  public void process(ResponseBuilder rb) {}
 
   @Override
   public String getDescription() {

--- a/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
@@ -145,7 +145,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void doTestFieldStatisticsResult(String f, SolrParams[] baseParamsSet) throws Exception {
+  public void doTestFieldStatisticsResult(String f, SolrParams[] baseParamsSet) {
     // used when doing key overrides in conjunction with the baseParamsSet
     //
     // even when these aren't included in the request, using them helps us
@@ -325,7 +325,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         "count(" + kpre + "/*)=1");
   }
 
-  public void doTestMVFieldStatisticsResult(String f) throws Exception {
+  public void doTestMVFieldStatisticsResult(String f) {
     assertU(adoc("id", "1", f, "-10", f, "-100", "active_s", "true"));
     assertU(adoc("id", "2", f, "-20", f, "200", "active_s", "true"));
     assertU(commit());
@@ -462,7 +462,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testFieldStatisticsResultsStringField() throws Exception {
+  public void testFieldStatisticsResultsStringField() {
     String f = "active_s";
 
     SolrCore core = h.getCore();
@@ -553,7 +553,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testFieldStatisticsResultsDateField() throws Exception {
+  public void testFieldStatisticsResultsDateField() {
     SolrCore core = h.getCore();
 
     DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT);
@@ -595,7 +595,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
   }
 
   // Check for overflow of sumOfSquares
-  public void testFieldStatisticsResultsDateFieldOverflow() throws Exception {
+  public void testFieldStatisticsResultsDateFieldOverflow() {
     SolrCore core = h.getCore();
 
     assertU(adoc("id", "1", "active_dt", "2015-12-14T09:00:00Z"));
@@ -637,8 +637,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         "//double[@name='stddev'][.='" + Double.toString(3155673599999.999) + "']");
   }
 
-  public void doTestFieldStatisticsMissingResult(String f, SolrParams[] baseParamsSet)
-      throws Exception {
+  public void doTestFieldStatisticsMissingResult(String f, SolrParams[] baseParamsSet) {
     assertU(adoc("id", "1", f, "-10"));
     assertU(adoc("id", "2", f, "-20"));
     assertU(commit());
@@ -716,7 +715,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void doTestFacetStatisticsResult(String f, SolrParams[] baseParamsSet) throws Exception {
+  public void doTestFacetStatisticsResult(String f, SolrParams[] baseParamsSet) {
     assertU(adoc("id", "1", f, "10", "active_s", "true", "other_s", "foo"));
     assertU(adoc("id", "2", f, "20", "active_s", "true", "other_s", "bar"));
     assertU(commit());
@@ -846,8 +845,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         pre + "/lst[@name='false']/long[@name='cardinality'][.='2']");
   }
 
-  public void doTestFacetStatisticsMissingResult(String f, SolrParams[] baseParamsSet)
-      throws Exception {
+  public void doTestFacetStatisticsMissingResult(String f, SolrParams[] baseParamsSet) {
     assertU(adoc("id", "1", f, "10", "active_s", "true"));
     assertU(adoc("id", "2", f, "20", "active_s", "true"));
     assertU(commit());
@@ -902,7 +900,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         "//lst[@name='active_s']/lst[@name='false']/long[@name='cardinality'][.='1']");
   }
 
-  public void testFieldStatisticsResultsNumericFieldAlwaysMissing() throws Exception {
+  public void testFieldStatisticsResultsNumericFieldAlwaysMissing() {
     SolrCore core = h.getCore();
     assertU(adoc("id", "1"));
     assertU(adoc("id", "2"));
@@ -940,7 +938,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         "//lst[@name='active_i']/long[@name='cardinality'][.='0']");
   }
 
-  public void testFieldStatisticsResultsStringFieldAlwaysMissing() throws Exception {
+  public void testFieldStatisticsResultsStringFieldAlwaysMissing() {
     SolrCore core = h.getCore();
     assertU(adoc("id", "1"));
     assertU(adoc("id", "2"));
@@ -973,7 +971,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
   }
 
   // SOLR-3160
-  public void testFieldStatisticsResultsDateFieldAlwaysMissing() throws Exception {
+  public void testFieldStatisticsResultsDateFieldAlwaysMissing() {
     SolrCore core = h.getCore();
 
     assertU(adoc("id", "1"));
@@ -1010,7 +1008,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         "//lst[@name='active_dt']/long[@name='cardinality'][.='0']");
   }
 
-  public void testStatsFacetMultivaluedErrorHandling() throws Exception {
+  public void testStatsFacetMultivaluedErrorHandling() {
     SolrCore core = h.getCore();
     SchemaField foo_ss = core.getLatestSchema().getField("foo_ss");
 
@@ -1038,7 +1036,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
   }
 
   // SOLR-3177
-  public void testStatsExcludeFilterQuery() throws Exception {
+  public void testStatsExcludeFilterQuery() {
     SolrCore core = h.getCore();
     assertU(adoc("id", "1"));
     assertU(adoc("id", "2"));
@@ -1225,7 +1223,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
     assertQEx("can not use FieldCache on multivalued field: cat_intDocValues", req, 400);
   }
 
-  public void testMiscQueryStats() throws Exception {
+  public void testMiscQueryStats() {
     final String kpre = XPRE + "lst[@name='stats_fields']/lst[@name='k']/";
 
     assertU(adoc("id", "1", "a_f", "2.3", "b_f", "9.7", "foo_t", "how now brown cow"));
@@ -1265,7 +1263,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
   /**
    * Whitebox test of {@link StatsField} parsing to ensure expected equivalence operations hold up
    */
-  public void testStatsFieldWhitebox() throws Exception {
+  public void testStatsFieldWhitebox() {
     StatsComponent component = new StatsComponent();
     List<SearchComponent> components = new ArrayList<>(1);
     components.add(component);
@@ -1385,7 +1383,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         "//lst[@name='" + fieldName + "']/long[@name='cardinality'][.='9']");
   }
 
-  public void testEnumFieldTypeStatus() throws Exception {
+  public void testEnumFieldTypeStatus() {
     clearIndex();
 
     String fieldName = "severity";
@@ -1476,8 +1474,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
       List<FldType> types,
       String fieldName,
       String id,
-      @SuppressWarnings({"rawtypes"}) Comparable... values)
-      throws Exception {
+      @SuppressWarnings({"rawtypes"}) Comparable... values) {
     Doc doc = createDoc(types);
     doc.getValues("id").set(0, id);
     initMultyValued(doc.getValues(fieldName), values);
@@ -1533,7 +1530,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testIndividualStatLocalParams() throws Exception {
+  public void testIndividualStatLocalParams() {
     final String kpre = ExpectedStat.KPRE;
 
     assertU(adoc("id", "1", "a_f", "2.3", "b_f", "9.7", "a_i", "9", "foo_t", "how now brown cow"));
@@ -1727,7 +1724,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
   }
 
   // Test for Solr-6349
-  public void testCalcDistinctStats() throws Exception {
+  public void testCalcDistinctStats() {
     final String kpre = XPRE + "lst[@name='stats_fields']/lst[@name='k']/";
     final String min = "count(" + kpre + "/double[@name='min'])";
     final String countDistinct = "count(" + kpre + "/long[@name='countDistinct'])";
@@ -1916,7 +1913,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
   /**
    * @see #testHllOptions
    */
-  public void testCardinality() throws Exception {
+  public void testCardinality() {
     SolrCore core = h.getCore();
     // insure we have the same hasher a_l would use
     HashFunction hasher =
@@ -2006,7 +2003,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
    * @see #testCardinality
    * @see #testHllOptionsErrors
    */
-  public void testHllOptions() throws Exception {
+  public void testHllOptions() {
     SolrCore core = h.getCore();
 
     SchemaField field_l = core.getLatestSchema().getField("field_l");
@@ -2134,7 +2131,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
    * @see #testCardinality
    * @see #testHllOptions
    */
-  public void testHllOptionsErrors() throws Exception {
+  public void testHllOptionsErrors() {
     String[] baseParams = new String[] {"q", "*:*", "stats", "true", "indent", "true", "rows", "0"};
     SolrCore core = h.getCore();
     SchemaField foo_s = core.getLatestSchema().getField("foo_s");

--- a/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
@@ -82,7 +82,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testEmptyLower() throws Exception {
+  public void testEmptyLower() {
     assertQ(
         req("indent", "true", "qt", "/terms", "terms.fl", "lowerfilt", "terms.upper", "b"),
         "count(//lst[@name='lowerfilt']/*)=6",
@@ -95,7 +95,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testMultipleFields() throws Exception {
+  public void testMultipleFields() {
     assertQ(
         req(
             "indent",
@@ -113,7 +113,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testUnlimitedRows() throws Exception {
+  public void testUnlimitedRows() {
     assertQ(
         req("indent", "true", "qt", "/terms", "terms.fl", "lowerfilt", "terms.fl", "standardfilt"),
         "count(//lst[@name='lowerfilt']/*)=9",
@@ -135,7 +135,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testPrefix() throws Exception {
+  public void testPrefix() {
     assertQ(
         req(
             "indent",
@@ -163,7 +163,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRegexp() throws Exception {
+  public void testRegexp() {
     assertQ(
         req(
             "indent",
@@ -216,7 +216,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRegexpWithFlags() throws Exception {
+  public void testRegexpWithFlags() {
     // TODO: there are no uppercase or mixed-case terms in the index!
     assertQ(
         req(
@@ -242,7 +242,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSortCount() throws Exception {
+  public void testSortCount() {
     assertQ(
         req(
             "indent",
@@ -266,7 +266,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testTermsList() throws Exception {
+  public void testTermsList() {
     // Terms list always returns in index order
     assertQ(
         req(
@@ -294,7 +294,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testStats() throws Exception {
+  public void testStats() {
     // Terms list always returns in index order
     assertQ(
         req(
@@ -312,7 +312,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSortIndex() throws Exception {
+  public void testSortIndex() {
     assertQ(
         req(
             "indent",
@@ -336,7 +336,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testPastUpper() throws Exception {
+  public void testPastUpper() {
     assertQ(
         req(
             "indent",
@@ -352,7 +352,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testLowerExclusive() throws Exception {
+  public void testLowerExclusive() {
     assertQ(
         req(
             "indent",
@@ -392,7 +392,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void test() throws Exception {
+  public void test() {
     assertQ(
         req(
             "indent",
@@ -449,7 +449,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testMinMaxFreq() throws Exception {
+  public void testMinMaxFreq() {
     assertQ(
         req(
             "indent",
@@ -539,7 +539,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDocFreqAndTotalTermFreq() throws Exception {
+  public void testDocFreqAndTotalTermFreq() {
     SolrQueryRequest req =
         req(
             "indent", "true",
@@ -582,7 +582,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDocFreqAndTotalTermFreqForNonExistingTerm() throws Exception {
+  public void testDocFreqAndTotalTermFreqForNonExistingTerm() {
     SolrQueryRequest req =
         req(
             "indent", "true",
@@ -598,7 +598,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDocFreqAndTotalTermFreqForMultipleFields() throws Exception {
+  public void testDocFreqAndTotalTermFreqForMultipleFields() {
     SolrQueryRequest req =
         req(
             "indent", "true",
@@ -825,7 +825,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDatePointField() throws Exception {
+  public void testDatePointField() {
     String[] dates = new String[] {"2015-01-03T14:30:00Z", "2014-03-15T12:00:00Z"};
     for (int i = 0; i < 100; i++) {
       assertU(adoc("id", Integer.toString(100000 + i), "foo_pdt", dates[i % 2]));

--- a/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
@@ -55,7 +55,7 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
     return floatAppend;
   }
 
-  public void testString() throws Exception {
+  public void testString() {
     _testExpand("group_s", "", maybeTopFc());
   }
 
@@ -63,7 +63,7 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
     _testExpand("group_s_dv", "", maybeTopFc());
   }
 
-  public void testInt() throws Exception {
+  public void testInt() {
     _testExpand("group_i", "", "");
   }
 
@@ -71,7 +71,7 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
     _testExpand("group_ti_dv", "", "");
   }
 
-  public void testFloat() throws Exception {
+  public void testFloat() {
     _testExpand("group_f", floatAppend(), "");
     _testExpand("group_f", ".0", ""); // explicit 0 check for 0 vs null group
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
@@ -48,7 +48,7 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
   private static float expectedLoadBalancerRequestsMaximumFraction = 1.0f;
 
   @BeforeClass
-  public static void beforeTests() throws Exception {
+  public static void beforeTests() {
     expectedLoadBalancerRequestsMinimumAbsolute = random().nextInt(3); // 0 .. 2
     expectedLoadBalancerRequestsMaximumFraction = (1 + random().nextInt(10)) / 10f; // 0.1 .. 1.0
     System.setProperty(

--- a/solr/core/src/test/org/apache/solr/legacy/TestLegacyNumericUtils.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestLegacyNumericUtils.java
@@ -137,7 +137,7 @@ public class TestLegacyNumericUtils extends SolrTestCase {
     }
   }
 
-  public void testIntSpecialValues() throws Exception {
+  public void testIntSpecialValues() {
     int[] vals =
         new int[] {
           Integer.MIN_VALUE,
@@ -200,7 +200,7 @@ public class TestLegacyNumericUtils extends SolrTestCase {
     }
   }
 
-  public void testDoubles() throws Exception {
+  public void testDoubles() {
     double[] vals =
         new double[] {
           Double.NEGATIVE_INFINITY,
@@ -259,7 +259,7 @@ public class TestLegacyNumericUtils extends SolrTestCase {
     }
   }
 
-  public void testFloats() throws Exception {
+  public void testFloats() {
     float[] vals =
         new float[] {
           Float.NEGATIVE_INFINITY,
@@ -371,7 +371,7 @@ public class TestLegacyNumericUtils extends SolrTestCase {
   }
 
   /** LUCENE-2541: LegacyNumericRangeQuery errors with endpoints near long min and max values */
-  public void testLongExtremeValues() throws Exception {
+  public void testLongExtremeValues() {
     // upper end extremes
     assertLongRangeSplit(
         Long.MAX_VALUE,

--- a/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery32.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery32.java
@@ -507,7 +507,7 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
   }
 
   @Test
-  public void testEqualsAndHash() throws Exception {
+  public void testEqualsAndHash() {
     QueryUtils.checkHashEquals(LegacyNumericRangeQuery.newIntRange("test1", 4, 10, 20, true, true));
     QueryUtils.checkHashEquals(
         LegacyNumericRangeQuery.newIntRange("test2", 4, 10, 20, false, true));

--- a/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery64.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery64.java
@@ -540,7 +540,7 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
   }
 
   @Test
-  public void testEqualsAndHash() throws Exception {
+  public void testEqualsAndHash() {
     QueryUtils.checkHashEquals(
         LegacyNumericRangeQuery.newLongRange("test1", 4, 10L, 20L, true, true));
     QueryUtils.checkHashEquals(

--- a/solr/core/src/test/org/apache/solr/metrics/MetricsConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/MetricsConfigTest.java
@@ -54,7 +54,7 @@ public class MetricsConfigTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDefaults() throws Exception {
+  public void testDefaults() {
     NodeConfig cfg = loadNodeConfig("solr-metricsconfig.xml");
     SolrMetricManager mgr =
         new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig());

--- a/solr/core/src/test/org/apache/solr/metrics/MetricsDisabledCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/MetricsDisabledCloudTest.java
@@ -37,7 +37,7 @@ public class MetricsDisabledCloudTest extends SolrCloudTestCase {
   }
 
   @Test
-  public void testBasic() throws Exception {
+  public void testBasic() {
     NodeConfig cfg = cluster.getRandomJetty(random()).getCoreContainer().getNodeConfig();
     MetricsConfig metricsConfig = cfg.getMetricsConfig();
     assertFalse("metrics should be disabled", metricsConfig.isEnabled());

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricsIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricsIntegrationTest.java
@@ -128,7 +128,7 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
   }
 
   @After
-  public void afterTest() throws Exception {
+  public void afterTest() {
     if (null == metricManager) {
       return; // test failed to init, nothing to clean up
     }
@@ -195,7 +195,7 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testCoreContainerMetrics() throws Exception {
+  public void testCoreContainerMetrics() {
     String registryName = SolrMetricManager.getRegistryName(SolrInfoBean.Group.node);
     assertTrue(
         cc.getMetricManager().registryNames().toString(),

--- a/solr/core/src/test/org/apache/solr/metrics/reporters/MockMetricReporter.java
+++ b/solr/core/src/test/org/apache/solr/metrics/reporters/MockMetricReporter.java
@@ -18,7 +18,6 @@ package org.apache.solr.metrics.reporters;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import java.io.IOException;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import org.apache.solr.metrics.SolrMetricManager;
@@ -42,7 +41,7 @@ public class MockMetricReporter extends SolrMetricReporter {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     didClose = true;
   }
 

--- a/solr/core/src/test/org/apache/solr/metrics/reporters/SolrJmxReporterTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/reporters/SolrJmxReporterTest.java
@@ -62,13 +62,13 @@ public class SolrJmxReporterTest extends SolrTestCaseJ4 {
   private String rootName;
 
   @BeforeClass
-  public static void init() throws Exception {
+  public static void init() {
     TEST_MBEAN_SERVER = MBeanServerFactory.createMBeanServer();
     PREFIX = getSimpleClassName() + "-";
   }
 
   @AfterClass
-  public static void shutdown() throws Exception {
+  public static void shutdown() {
     if (null != TEST_MBEAN_SERVER) {
       MBeanServerFactory.releaseMBeanServer(TEST_MBEAN_SERVER);
       TEST_MBEAN_SERVER = null;

--- a/solr/core/src/test/org/apache/solr/parser/SolrQueryParserBaseTest.java
+++ b/solr/core/src/test/org/apache/solr/parser/SolrQueryParserBaseTest.java
@@ -64,7 +64,7 @@ public class SolrQueryParserBaseTest {
   private MockSolrQueryParser solrQueryParser;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     solrQueryParser = new MockSolrQueryParser();
   }
 

--- a/solr/core/src/test/org/apache/solr/pkg/TestPackages.java
+++ b/solr/core/src/test/org/apache/solr/pkg/TestPackages.java
@@ -721,7 +721,7 @@ public class TestPackages extends SolrCloudTestCase {
     static boolean informCalled = false;
 
     @Override
-    public void inform(ResourceLoader loader) throws IOException {
+    public void inform(ResourceLoader loader) {
       informCalled = true;
     }
 

--- a/solr/core/src/test/org/apache/solr/request/SimpleFacetsTest.java
+++ b/solr/core/src/test/org/apache/solr/request/SimpleFacetsTest.java
@@ -255,7 +255,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
     add_doc("id", "2004", "hotel_s1", "b", "airport_s1", "ams", "duration_i1", "5");
   }
 
-  public void testDvMethodNegativeFloatRangeFacet() throws Exception {
+  public void testDvMethodNegativeFloatRangeFacet() {
     String field = "negative_num_f1_dv";
     assertTrue(
         "Unexpected schema configuration",
@@ -294,7 +294,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
         String.format(Locale.ROOT, countAssertion, field));
   }
 
-  public void testDefaultsAndAppends() throws Exception {
+  public void testDefaultsAndAppends() {
     // all defaults
     assertQ(
         req("indent", "true", "q", "*:*", "rows", "0", "facet", "true", "qt", "/search-facet-def"),
@@ -336,7 +336,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
         "count(//lst[@name='facet_queries']/int)=2");
   }
 
-  public void testInvariants() throws Exception {
+  public void testInvariants() {
     // no matter if we try to use facet.field or facet.query, results shouldn't change
     for (String ff : new String[] {"facet.field", "bogus"}) {
       for (String fq : new String[] {"facet.query", "bogus"}) {
@@ -369,7 +369,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testCachingBigTerms() throws Exception {
+  public void testCachingBigTerms() {
     assertQ(
         req(
             "indent",
@@ -402,7 +402,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSimpleGroupedQueryRangeFacets() throws Exception {
+  public void testSimpleGroupedQueryRangeFacets() {
     // for the purposes of our test data, it shouldn't matter
     // if we use facet.limit -100, -1, or 100 ...
     // our set of values is small enough either way
@@ -518,7 +518,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
     testSimpleGroupedFacets("-1");
   }
 
-  private void testSimpleGroupedFacets(String facetLimit) throws Exception {
+  private void testSimpleGroupedFacets(String facetLimit) {
     assertQ(
         "Return 5 docs with id range 1937 till 1940",
         req("id_i1:[2000 TO 2004]"),
@@ -1123,7 +1123,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
         "//lst[@name='facet_queries']/int[@name='k'][.='0']");
   }
 
-  public void testBehaviorEquivilenceOfUninvertibleFalse() throws Exception {
+  public void testBehaviorEquivilenceOfUninvertibleFalse() {
     // NOTE: mincount=0 affects method detection/coercion, so we include permutations of it
 
     {
@@ -2663,7 +2663,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFacetExistsShouldThrowExceptionForMincountGreaterThanOne() throws Exception {
+  public void testFacetExistsShouldThrowExceptionForMincountGreaterThanOne() {
     final String f = "t_s";
     final List<String> msg = Arrays.asList("facet.mincount", "facet.exists", f);
     Collections.shuffle(msg, random());
@@ -4801,7 +4801,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testFacetPrefixWithFacetThreads() throws Exception {
+  public void testFacetPrefixWithFacetThreads() {
     assertQ(
         "Test facet.prefix with facet.thread",
         req(

--- a/solr/core/src/test/org/apache/solr/request/TestRemoteStreaming.java
+++ b/solr/core/src/test/org/apache/solr/request/TestRemoteStreaming.java
@@ -55,7 +55,7 @@ public class TestRemoteStreaming extends SolrJettyTestBase {
   }
 
   @AfterClass
-  public static void afterTest() throws Exception {}
+  public static void afterTest() {}
 
   @Before
   public void doBefore() throws IOException, SolrServerException {

--- a/solr/core/src/test/org/apache/solr/response/TestCustomDocTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestCustomDocTransformer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.response;
 
-import java.io.IOException;
 import org.apache.lucene.index.IndexableField;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrDocument;
@@ -37,7 +36,7 @@ public class TestCustomDocTransformer extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     assertU(delQ("*:*"));
     assertU(commit());
   }
@@ -102,7 +101,7 @@ public class TestCustomDocTransformer extends SolrTestCaseJ4 {
 
     /** This transformer simply concatenates the values of multiple fields */
     @Override
-    public void transform(SolrDocument doc, int docid) throws IOException {
+    public void transform(SolrDocument doc, int docid) {
       str.setLength(0);
       for (String s : extra) {
         String v = getAsString(s, doc);

--- a/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
@@ -127,7 +127,7 @@ public class TestRawTransformer extends SolrCloudTestCase {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     if (JSR != null) {
       assertU(delQ("*:*"));
       assertU(commit());

--- a/solr/core/src/test/org/apache/solr/response/TestSolrQueryResponse.java
+++ b/solr/core/src/test/org/apache/solr/response/TestSolrQueryResponse.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class TestSolrQueryResponse extends SolrTestCase {
 
   @Test
-  public void testName() throws Exception {
+  public void testName() {
     assertEquals("SolrQueryResponse.NAME value changed", "response", SolrQueryResponse.NAME);
   }
 
@@ -77,7 +77,7 @@ public class TestSolrQueryResponse extends SolrTestCase {
   }
 
   @Test
-  public void testResponse() throws Exception {
+  public void testResponse() {
     final SolrQueryResponse response = new SolrQueryResponse();
     assertEquals("response initial value", null, response.getResponse());
     final Object newValue =
@@ -265,7 +265,7 @@ public class TestSolrQueryResponse extends SolrTestCase {
   }
 
   @Test
-  public void testException() throws Exception {
+  public void testException() {
     final SolrQueryResponse response = new SolrQueryResponse();
     assertEquals("exception initial value", null, response.getException());
     final Exception newValue =

--- a/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformer.java
@@ -42,7 +42,7 @@ public class TestChildDocTransformer extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     assertU(delQ("*:*"));
     assertU(commit());
   }

--- a/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
@@ -72,7 +72,7 @@ public class TestChildDocTransformerHierarchy extends SolrTestCaseJ4 {
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     assertU(delQ(fqToExcludeNonTestedDocs));
     assertU(commit());
   }

--- a/solr/core/src/test/org/apache/solr/response/transform/TestExplainDocTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestExplainDocTransformer.java
@@ -97,7 +97,7 @@ public class TestExplainDocTransformer extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     assertU(delQ("*:*"));
     assertU(commit());
   }

--- a/solr/core/src/test/org/apache/solr/rest/schema/TestCopyFieldCollectionResource.java
+++ b/solr/core/src/test/org/apache/solr/rest/schema/TestCopyFieldCollectionResource.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 public class TestCopyFieldCollectionResource extends SolrRestletTestBase {
   @Test
-  public void testXMLGetAllCopyFields() throws Exception {
+  public void testXMLGetAllCopyFields() {
     assertQ(
         "/schema/copyfields?indent=on&wt=xml",
         "/response/arr[@name='copyFields']/lst[    str[@name='source'][.='src_sub_no_ast_i']"
@@ -83,7 +83,7 @@ public class TestCopyFieldCollectionResource extends SolrRestletTestBase {
   }
 
   @Test
-  public void testRestrictSource() throws Exception {
+  public void testRestrictSource() {
     assertQ(
         "/schema/copyfields/?wt=xml&source.fl=title,*_i,*_src_sub_i,src_sub_no_ast_i",
         "count(/response/arr[@name='copyFields']/lst) = 16", // 4 + 4 + 4 + 4
@@ -94,7 +94,7 @@ public class TestCopyFieldCollectionResource extends SolrRestletTestBase {
   }
 
   @Test
-  public void testRestrictDest() throws Exception {
+  public void testRestrictDest() {
     assertQ(
         "/schema/copyfields/?wt=xml&dest.fl=title,*_s,*_dest_sub_s,dest_sub_no_ast_s",
         "count(/response/arr[@name='copyFields']/lst) = 16", // 3 + 4 + 4 + 5
@@ -105,7 +105,7 @@ public class TestCopyFieldCollectionResource extends SolrRestletTestBase {
   }
 
   @Test
-  public void testRestrictSourceAndDest() throws Exception {
+  public void testRestrictSourceAndDest() {
     assertQ(
         "/schema/copyfields/?wt=xml&source.fl=title,*_i&dest.fl=title,dest_sub_no_ast_s",
         "count(/response/arr[@name='copyFields']/lst) = 3",

--- a/solr/core/src/test/org/apache/solr/schema/DocValuesMissingTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DocValuesMissingTest.java
@@ -130,286 +130,286 @@ public class DocValuesMissingTest extends SolrTestCaseJ4 {
 
   /** float with default lucene sort (treats as 0) */
   @Test
-  public void testFloatSort() throws Exception {
+  public void testFloatSort() {
     checkSortMissingDefault("floatdv", "-1.3", "4.2");
   }
   /** dynamic float with default lucene sort (treats as 0) */
   @Test
-  public void testDynFloatSort() throws Exception {
+  public void testDynFloatSort() {
     checkSortMissingDefault("dyn_floatdv", "-1.3", "4.2");
   }
 
   /** float with sort missing always first */
   @Test
-  public void testFloatSortMissingFirst() throws Exception {
+  public void testFloatSortMissingFirst() {
     checkSortMissingFirst("floatdv_missingfirst", "-1.3", "4.2");
   }
   /** dynamic float with sort missing always first */
   @Test
-  public void testDynFloatSortMissingFirst() throws Exception {
+  public void testDynFloatSortMissingFirst() {
     checkSortMissingFirst("dyn_floatdv_missingfirst", "-1.3", "4.2");
   }
 
   /** float with sort missing always last */
   @Test
-  public void testFloatSortMissingLast() throws Exception {
+  public void testFloatSortMissingLast() {
     checkSortMissingLast("floatdv_missinglast", "-1.3", "4.2");
   }
   /** dynamic float with sort missing always last */
   @Test
-  public void testDynFloatSortMissingLast() throws Exception {
+  public void testDynFloatSortMissingLast() {
     checkSortMissingLast("dyn_floatdv_missinglast", "-1.3", "4.2");
   }
 
   /** float function query based on missing */
   @Test
-  public void testFloatMissingFunction() throws Exception {
+  public void testFloatMissingFunction() {
     checkSortMissingFunction("floatdv", "-1.3", "4.2");
   }
   /** dyanmic float function query based on missing */
   @Test
-  public void testDynFloatMissingFunction() throws Exception {
+  public void testDynFloatMissingFunction() {
     checkSortMissingFunction("dyn_floatdv", "-1.3", "4.2");
   }
 
   /** float missing facet count */
   @Test
-  public void testFloatMissingFacet() throws Exception {
+  public void testFloatMissingFacet() {
     checkSortMissingFacet("floatdv", "-1.3", "4.2");
   }
   /** dynamic float missing facet count */
   @Test
-  public void testDynFloatMissingFacet() throws Exception {
+  public void testDynFloatMissingFacet() {
     checkSortMissingFacet("dyn_floatdv", "-1.3", "4.2");
   }
 
   /** int with default lucene sort (treats as 0) */
   @Test
-  public void testIntSort() throws Exception {
+  public void testIntSort() {
     checkSortMissingDefault("intdv", "-1", "4");
   }
   /** dynamic int with default lucene sort (treats as 0) */
   @Test
-  public void testDynIntSort() throws Exception {
+  public void testDynIntSort() {
     checkSortMissingDefault("dyn_intdv", "-1", "4");
   }
 
   /** int with sort missing always first */
   @Test
-  public void testIntSortMissingFirst() throws Exception {
+  public void testIntSortMissingFirst() {
     checkSortMissingFirst("intdv_missingfirst", "-1", "4");
   }
   /** dynamic int with sort missing always first */
   @Test
-  public void testDynIntSortMissingFirst() throws Exception {
+  public void testDynIntSortMissingFirst() {
     checkSortMissingFirst("dyn_intdv_missingfirst", "-1", "4");
   }
 
   /** int with sort missing always last */
   @Test
-  public void testIntSortMissingLast() throws Exception {
+  public void testIntSortMissingLast() {
     checkSortMissingLast("intdv_missinglast", "-1", "4");
   }
   /** dynamic int with sort missing always last */
   @Test
-  public void testDynIntSortMissingLast() throws Exception {
+  public void testDynIntSortMissingLast() {
     checkSortMissingLast("dyn_intdv_missinglast", "-1", "4");
   }
 
   /** int function query based on missing */
   @Test
-  public void testIntMissingFunction() throws Exception {
+  public void testIntMissingFunction() {
     checkSortMissingFunction("intdv", "-1", "4");
   }
   /** dynamic int function query based on missing */
   @Test
-  public void testDynIntMissingFunction() throws Exception {
+  public void testDynIntMissingFunction() {
     checkSortMissingFunction("dyn_intdv", "-1", "4");
   }
 
   /** int missing facet count */
   @Test
-  public void testIntMissingFacet() throws Exception {
+  public void testIntMissingFacet() {
     checkSortMissingFacet("intdv", "-1", "4");
   }
   /** dynamic int missing facet count */
   @Test
-  public void testDynIntMissingFacet() throws Exception {
+  public void testDynIntMissingFacet() {
     checkSortMissingFacet("dyn_intdv", "-1", "4");
   }
 
   /** double with default lucene sort (treats as 0) */
   @Test
-  public void testDoubleSort() throws Exception {
+  public void testDoubleSort() {
     checkSortMissingDefault("doubledv", "-1.3", "4.2");
   }
   /** dynamic double with default lucene sort (treats as 0) */
   @Test
-  public void testDynDoubleSort() throws Exception {
+  public void testDynDoubleSort() {
     checkSortMissingDefault("dyn_doubledv", "-1.3", "4.2");
   }
 
   /** double with sort missing always first */
   @Test
-  public void testDoubleSortMissingFirst() throws Exception {
+  public void testDoubleSortMissingFirst() {
     checkSortMissingFirst("doubledv_missingfirst", "-1.3", "4.2");
   }
   /** dynamic double with sort missing always first */
   @Test
-  public void testDynDoubleSortMissingFirst() throws Exception {
+  public void testDynDoubleSortMissingFirst() {
     checkSortMissingFirst("dyn_doubledv_missingfirst", "-1.3", "4.2");
   }
 
   /** double with sort missing always last */
   @Test
-  public void testDoubleSortMissingLast() throws Exception {
+  public void testDoubleSortMissingLast() {
     checkSortMissingLast("doubledv_missinglast", "-1.3", "4.2");
   }
   /** dynamic double with sort missing always last */
   @Test
-  public void testDynDoubleSortMissingLast() throws Exception {
+  public void testDynDoubleSortMissingLast() {
     checkSortMissingLast("dyn_doubledv_missinglast", "-1.3", "4.2");
   }
 
   /** double function query based on missing */
   @Test
-  public void testDoubleMissingFunction() throws Exception {
+  public void testDoubleMissingFunction() {
     checkSortMissingFunction("doubledv", "-1.3", "4.2");
   }
   /** dyanmic double function query based on missing */
   @Test
-  public void testDynDoubleMissingFunction() throws Exception {
+  public void testDynDoubleMissingFunction() {
     checkSortMissingFunction("dyn_doubledv", "-1.3", "4.2");
   }
 
   /** double missing facet count */
   @Test
-  public void testDoubleMissingFacet() throws Exception {
+  public void testDoubleMissingFacet() {
     checkSortMissingFacet("doubledv", "-1.3", "4.2");
   }
   /** dynamic double missing facet count */
   @Test
-  public void testDynDoubleMissingFacet() throws Exception {
+  public void testDynDoubleMissingFacet() {
     checkSortMissingFacet("dyn_doubledv", "-1.3", "4.2");
   }
 
   /** long with default lucene sort (treats as 0) */
   @Test
-  public void testLongSort() throws Exception {
+  public void testLongSort() {
     checkSortMissingDefault("longdv", "-1", "4");
   }
   /** dynamic long with default lucene sort (treats as 0) */
   @Test
-  public void testDynLongSort() throws Exception {
+  public void testDynLongSort() {
     checkSortMissingDefault("dyn_longdv", "-1", "4");
   }
 
   /** long with sort missing always first */
   @Test
-  public void testLongSortMissingFirst() throws Exception {
+  public void testLongSortMissingFirst() {
     checkSortMissingFirst("longdv_missingfirst", "-1", "4");
   }
   /** dynamic long with sort missing always first */
   @Test
-  public void testDynLongSortMissingFirst() throws Exception {
+  public void testDynLongSortMissingFirst() {
     checkSortMissingFirst("dyn_longdv_missingfirst", "-1", "4");
   }
 
   /** long with sort missing always last */
   @Test
-  public void testLongSortMissingLast() throws Exception {
+  public void testLongSortMissingLast() {
     checkSortMissingLast("longdv_missinglast", "-1", "4");
   }
   /** dynamic long with sort missing always last */
   @Test
-  public void testDynLongSortMissingLast() throws Exception {
+  public void testDynLongSortMissingLast() {
     checkSortMissingLast("dyn_longdv_missinglast", "-1", "4");
   }
 
   /** long function query based on missing */
   @Test
-  public void testLongMissingFunction() throws Exception {
+  public void testLongMissingFunction() {
     checkSortMissingFunction("longdv", "-1", "4");
   }
   /** dynamic long function query based on missing */
   @Test
-  public void testDynLongMissingFunction() throws Exception {
+  public void testDynLongMissingFunction() {
     checkSortMissingFunction("dyn_longdv", "-1", "4");
   }
 
   /** long missing facet count */
   @Test
-  public void testLongMissingFacet() throws Exception {
+  public void testLongMissingFacet() {
     checkSortMissingFacet("longdv", "-1", "4");
   }
   /** dynamic long missing facet count */
   @Test
-  public void testDynLongMissingFacet() throws Exception {
+  public void testDynLongMissingFacet() {
     checkSortMissingFacet("dyn_longdv", "-1", "4");
   }
 
   /** date with default lucene sort (treats as 1970) */
   @Test
-  public void testDateSort() throws Exception {
+  public void testDateSort() {
     checkSortMissingDefault("datedv", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
   /** dynamic date with default lucene sort (treats as 1970) */
   @Test
-  public void testDynDateSort() throws Exception {
+  public void testDynDateSort() {
     checkSortMissingDefault("dyn_datedv", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
 
   /** date with sort missing always first */
   @Test
-  public void testDateSortMissingFirst() throws Exception {
+  public void testDateSortMissingFirst() {
     checkSortMissingFirst(
         "datedv_missingfirst", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
   /** dynamic date with sort missing always first */
   @Test
-  public void testDynDateSortMissingFirst() throws Exception {
+  public void testDynDateSortMissingFirst() {
     checkSortMissingFirst(
         "dyn_datedv_missingfirst", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
 
   /** date with sort missing always last */
   @Test
-  public void testDateSortMissingLast() throws Exception {
+  public void testDateSortMissingLast() {
     checkSortMissingLast(
         "datedv_missinglast", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
   /** dynamic date with sort missing always last */
   @Test
-  public void testDynDateSortMissingLast() throws Exception {
+  public void testDynDateSortMissingLast() {
     checkSortMissingLast(
         "dyn_datedv_missinglast", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
 
   /** date function query based on missing */
   @Test
-  public void testDateMissingFunction() throws Exception {
+  public void testDateMissingFunction() {
     checkSortMissingFunction("datedv", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
   /** dynamic date function query based on missing */
   @Test
-  public void testDynDateMissingFunction() throws Exception {
+  public void testDynDateMissingFunction() {
     checkSortMissingFunction("dyn_datedv", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
 
   /** date missing facet count */
   @Test
-  public void testDateMissingFacet() throws Exception {
+  public void testDateMissingFacet() {
     checkSortMissingFacet("datedv", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
   /** dynamic date missing facet count */
   @Test
-  public void testDynDateMissingFacet() throws Exception {
+  public void testDynDateMissingFacet() {
     checkSortMissingFacet("dyn_datedv", "1900-12-31T23:59:59.999Z", "2005-12-31T23:59:59.999Z");
   }
 
   /** string (and dynamic string) with default lucene sort (treats as "") */
   @Test
-  public void testStringSort() throws Exception {
+  public void testStringSort() {
 
     // note: cant use checkSortMissingDefault because
     // nothing sorts lower then the default of ""
@@ -433,40 +433,40 @@ public class DocValuesMissingTest extends SolrTestCaseJ4 {
 
   /** string with sort missing always first */
   @Test
-  public void testStringSortMissingFirst() throws Exception {
+  public void testStringSortMissingFirst() {
     checkSortMissingFirst("stringdv_missingfirst", "a", "z");
   }
   /** dynamic string with sort missing always first */
   @Test
-  public void testDynStringSortMissingFirst() throws Exception {
+  public void testDynStringSortMissingFirst() {
     checkSortMissingFirst("dyn_stringdv_missingfirst", "a", "z");
   }
 
   /** string with sort missing always last */
   @Test
-  public void testStringSortMissingLast() throws Exception {
+  public void testStringSortMissingLast() {
     checkSortMissingLast("stringdv_missinglast", "a", "z");
   }
   /** dynamic string with sort missing always last */
   @Test
-  public void testDynStringSortMissingLast() throws Exception {
+  public void testDynStringSortMissingLast() {
     checkSortMissingLast("dyn_stringdv_missinglast", "a", "z");
   }
 
   /** string function query based on missing */
   @Test
-  public void testStringMissingFunction() throws Exception {
+  public void testStringMissingFunction() {
     checkSortMissingFunction("stringdv", "a", "z");
   }
   /** dynamic string function query based on missing */
   @Test
-  public void testDynStringMissingFunction() throws Exception {
+  public void testDynStringMissingFunction() {
     checkSortMissingFunction("dyn_stringdv", "a", "z");
   }
 
   /** string missing facet count */
   @Test
-  public void testStringMissingFacet() throws Exception {
+  public void testStringMissingFacet() {
     assertU(adoc("id", "0")); // missing
     assertU(adoc("id", "1")); // missing
     assertU(adoc("id", "2", "stringdv", "a"));
@@ -491,7 +491,7 @@ public class DocValuesMissingTest extends SolrTestCaseJ4 {
 
   /** bool (and dynamic bool) with default lucene sort (treats as "") */
   @Test
-  public void testBoolSort() throws Exception {
+  public void testBoolSort() {
     // note: cant use checkSortMissingDefault because
     // nothing sorts lower then the default of "" and
     // bool fields are, at root, string fields.
@@ -515,40 +515,40 @@ public class DocValuesMissingTest extends SolrTestCaseJ4 {
 
   /** bool with sort missing always first */
   @Test
-  public void testBoolSortMissingFirst() throws Exception {
+  public void testBoolSortMissingFirst() {
     checkSortMissingFirst("booldv_missingfirst", "false", "ture");
   }
   /** dynamic bool with sort missing always first */
   @Test
-  public void testDynBoolSortMissingFirst() throws Exception {
+  public void testDynBoolSortMissingFirst() {
     checkSortMissingFirst("dyn_booldv_missingfirst", "false", "true");
   }
 
   /** bool with sort missing always last */
   @Test
-  public void testBoolSortMissingLast() throws Exception {
+  public void testBoolSortMissingLast() {
     checkSortMissingLast("booldv_missinglast", "false", "true");
   }
   /** dynamic bool with sort missing always last */
   @Test
-  public void testDynBoolSortMissingLast() throws Exception {
+  public void testDynBoolSortMissingLast() {
     checkSortMissingLast("dyn_booldv_missinglast", "false", "true");
   }
 
   /** bool function query based on missing */
   @Test
-  public void testBoolMissingFunction() throws Exception {
+  public void testBoolMissingFunction() {
     checkSortMissingFunction("booldv", "false", "true");
   }
   /** dynamic bool function query based on missing */
   @Test
-  public void testDynBoolMissingFunction() throws Exception {
+  public void testDynBoolMissingFunction() {
     checkSortMissingFunction("dyn_booldv", "false", "true");
   }
 
   /** bool missing facet count */
   @Test
-  public void testBoolMissingFacet() throws Exception {
+  public void testBoolMissingFacet() {
     assertU(adoc("id", "0")); // missing
     assertU(adoc("id", "1")); // missing
     assertU(adoc("id", "2", "booldv", "false"));

--- a/solr/core/src/test/org/apache/solr/schema/DocValuesTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DocValuesTest.java
@@ -766,7 +766,7 @@ public class DocValuesTest extends SolrTestCaseJ4 {
    * that are not inverted (indexed "forward" only)
    */
   @Test
-  public void testDocValuesMatch() throws Exception {
+  public void testDocValuesMatch() {
     assertU(
         adoc(
             "id",
@@ -994,7 +994,7 @@ public class DocValuesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFloatAndDoubleRangeQueryRandom() throws Exception {
+  public void testFloatAndDoubleRangeQueryRandom() {
 
     String fieldName[] = new String[] {"floatdv", "doubledv"};
 
@@ -1147,7 +1147,7 @@ public class DocValuesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFloatAndDoubleRangeQuery() throws Exception {
+  public void testFloatAndDoubleRangeQuery() {
     String fieldName[] = new String[] {"floatdv", "doubledv"};
     String largestNegative[] =
         new String[] {

--- a/solr/core/src/test/org/apache/solr/schema/IndexSchemaTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/IndexSchemaTest.java
@@ -90,7 +90,7 @@ public class IndexSchemaTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testProperties() throws Exception {
+  public void testProperties() {
     SolrCore core = h.getCore();
     IndexSchema schema = core.getLatestSchema();
     assertFalse(schema.getField("id").multiValued());

--- a/solr/core/src/test/org/apache/solr/schema/OpenExchangeRatesOrgProviderTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/OpenExchangeRatesOrgProviderTest.java
@@ -47,7 +47,7 @@ public class OpenExchangeRatesOrgProviderTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testInit() throws Exception {
+  public void testInit() {
     oerp.init(mockParams);
     // don't inform, we don't want to hit any of these URLs
 

--- a/solr/core/src/test/org/apache/solr/schema/SchemaWatcherTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/SchemaWatcherTest.java
@@ -35,7 +35,7 @@ public class SchemaWatcherTest {
   private SchemaWatcher schemaWatcher;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     SolrTestCaseJ4.assumeWorkingMockito();
 
     mockSchemaReader = mock(ZkIndexSchemaReader.class);

--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -273,7 +273,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testIntPointFieldRangeFacet() throws Exception {
+  public void testIntPointFieldRangeFacet() {
     String docValuesField = "number_p_i_dv";
     String nonDocValuesField = "number_p_i";
     int numValues = 10 * RANDOM_MULTIPLIER;
@@ -413,7 +413,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testIntPointStats() throws Exception {
+  public void testIntPointStats() {
     int numValues = 10 * RANDOM_MULTIPLIER;
     // don't produce numbers with exponents, since XPath comparison operators can't handle them
     List<Integer> values = getRandomInts(numValues, false, 9999999);
@@ -476,7 +476,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testIntPointFieldMultiValuedRangeFacet() throws Exception {
+  public void testIntPointFieldMultiValuedRangeFacet() {
     String docValuesField = "number_p_i_mv_dv";
     String nonDocValuesField = "number_p_i_mv";
     int numValues = 20 * RANDOM_MULTIPLIER;
@@ -748,7 +748,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testIntPointSetQuery() throws Exception {
+  public void testIntPointSetQuery() {
     doTestSetQueries("number_p_i", toStringArray(getRandomInts(20, false)), false);
     doTestSetQueries("number_p_i_mv", toStringArray(getRandomInts(20, false)), true);
     doTestSetQueries("number_p_i_ni_dv", toStringArray(getRandomInts(20, false)), false);
@@ -891,7 +891,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDoublePointFieldRangeFacet() throws Exception {
+  public void testDoublePointFieldRangeFacet() {
     String docValuesField = "number_p_d_dv";
     String nonDocValuesField = "number_p_d";
     int numValues = 10 * RANDOM_MULTIPLIER;
@@ -1039,7 +1039,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDoublePointStats() throws Exception {
+  public void testDoublePointStats() {
     int numValues = 10 * RANDOM_MULTIPLIER;
     // don't produce numbers with exponents, since XPath comparison operators can't handle them: 7
     // digits of precision
@@ -1097,7 +1097,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDoublePointFieldMultiValuedRangeFacet() throws Exception {
+  public void testDoublePointFieldMultiValuedRangeFacet() {
     String docValuesField = "number_p_d_mv_dv";
     SchemaField dvSchemaField = h.getCore().getLatestSchema().getField(docValuesField);
     assertTrue(dvSchemaField.multiValued());
@@ -1308,7 +1308,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     doTestFieldNotIndexed("number_p_d_ni_mv", doubles);
   }
 
-  private void doTestFloatPointFieldsAtomicUpdates(String field) throws Exception {
+  private void doTestFloatPointFieldsAtomicUpdates(String field) {
     float number1 = getRandomFloats(1, false).get(0);
     float number2;
     double inc1;
@@ -1335,7 +1335,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertQ(req("q", "id:1"), "//result/doc[1]/float[@name='" + field + "'][.='" + number3 + "']");
   }
 
-  private void doTestDoublePointFieldsAtomicUpdates(String field) throws Exception {
+  private void doTestDoublePointFieldsAtomicUpdates(String field) {
     double number1 = getRandomDoubles(1, false).get(0);
     double number2;
     BigDecimal inc1;
@@ -1363,7 +1363,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDoublePointSetQuery() throws Exception {
+  public void testDoublePointSetQuery() {
     doTestSetQueries("number_p_d", toStringArray(getRandomDoubles(20, false)), false);
     doTestSetQueries("number_p_d_mv", toStringArray(getRandomDoubles(20, false)), true);
     doTestSetQueries("number_p_d_ni_dv", toStringArray(getRandomDoubles(20, false)), false);
@@ -1506,7 +1506,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFloatPointFieldRangeFacet() throws Exception {
+  public void testFloatPointFieldRangeFacet() {
     String docValuesField = "number_p_f_dv";
     String nonDocValuesField = "number_p_f";
     int numValues = 10 * RANDOM_MULTIPLIER;
@@ -1654,7 +1654,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFloatPointStats() throws Exception {
+  public void testFloatPointStats() {
     int numValues = 10 * RANDOM_MULTIPLIER;
     // don't produce numbers with exponents, since XPath comparison operators can't handle them: 7
     // digits of precision
@@ -1704,7 +1704,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFloatPointFieldMultiValuedRangeFacet() throws Exception {
+  public void testFloatPointFieldMultiValuedRangeFacet() {
     String docValuesField = "number_p_f_mv_dv";
     SchemaField dvSchemaField = h.getCore().getLatestSchema().getField(docValuesField);
     assertTrue(dvSchemaField.multiValued());
@@ -1917,7 +1917,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFloatPointSetQuery() throws Exception {
+  public void testFloatPointSetQuery() {
     doTestSetQueries("number_p_f", toStringArray(getRandomFloats(20, false)), false);
     doTestSetQueries("number_p_f_mv", toStringArray(getRandomFloats(20, false)), true);
     doTestSetQueries("number_p_f_ni_dv", toStringArray(getRandomFloats(20, false)), false);
@@ -2085,7 +2085,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testLongPointFieldRangeFacet() throws Exception {
+  public void testLongPointFieldRangeFacet() {
     String docValuesField = "number_p_l_dv";
     String nonDocValuesField = "number_p_l";
     int numValues = 10 * RANDOM_MULTIPLIER;
@@ -2236,7 +2236,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testLongPointStats() throws Exception {
+  public void testLongPointStats() {
     int numValues = 10 * RANDOM_MULTIPLIER;
     // don't produce numbers with exponents, since XPath comparison operators can't handle them
     List<Long> values = getRandomLongs(numValues, false, 9999999L);
@@ -2289,7 +2289,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testLongPointFieldMultiValuedRangeFacet() throws Exception {
+  public void testLongPointFieldMultiValuedRangeFacet() {
     String docValuesField = "number_p_l_mv_dv";
     String nonDocValuesField = "number_p_l_mv";
     int numValues = 20 * RANDOM_MULTIPLIER;
@@ -2479,7 +2479,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testLongPointSetQuery() throws Exception {
+  public void testLongPointSetQuery() {
     doTestSetQueries("number_p_l", toStringArray(getRandomLongs(20, false)), false);
     doTestSetQueries("number_p_l_mv", toStringArray(getRandomLongs(20, false)), true);
     doTestSetQueries("number_p_l_ni_dv", toStringArray(getRandomLongs(20, false)), false);
@@ -2698,7 +2698,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDatePointFieldRangeFacet() throws Exception {
+  public void testDatePointFieldRangeFacet() {
     String docValuesField = "number_p_dt_dv";
     String nonDocValuesField = "number_p_dt";
     int numValues = 10 * RANDOM_MULTIPLIER;
@@ -2859,7 +2859,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDatePointStats() throws Exception {
+  public void testDatePointStats() {
     String[] randomSortedDates = toAscendingStringArray(getRandomInstants(10, false), true);
     doTestDatePointStats("number_p_dt", "number_p_dt_dv", randomSortedDates);
     doTestDatePointStats("number_p_dt_mv", "number_p_dt_mv_dv", randomSortedDates);
@@ -2904,7 +2904,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDatePointFieldMultiValuedRangeFacet() throws Exception {
+  public void testDatePointFieldMultiValuedRangeFacet() {
     String docValuesField = "number_p_dt_mv_dv";
     SchemaField dvSchemaField = h.getCore().getLatestSchema().getField(docValuesField);
     assertTrue(dvSchemaField.multiValued());
@@ -3115,7 +3115,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDatePointSetQuery() throws Exception {
+  public void testDatePointSetQuery() {
     doTestSetQueries("number_p_dt", toStringArray(getRandomInstants(20, false)), false);
     doTestSetQueries("number_p_dt_mv", toStringArray(getRandomInstants(20, false)), true);
     doTestSetQueries("number_p_dt_ni_dv", toStringArray(getRandomInstants(20, false)), false);
@@ -3129,7 +3129,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testIndexOrDocValuesQuery() throws Exception {
+  public void testIndexOrDocValuesQuery() {
     String[] fieldTypeNames = new String[] {"_p_i", "_p_l", "_p_d", "_p_f", "_p_dt"};
     FieldType[] fieldTypes =
         new FieldType[] {
@@ -3365,7 +3365,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    *     only stored and searches should always get numFound=0
    */
   private void doTestIntPointFieldExactQuery(
-      final String field, final boolean testLong, final boolean searchable) throws Exception {
+      final String field, final boolean testLong, final boolean searchable) {
     int numValues = 10 * RANDOM_MULTIPLIER;
     Map<String, Integer> randCount = new HashMap<>(numValues);
     String[] rand =
@@ -3413,7 +3413,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  private void doTestPointFieldReturn(String field, String type, String[] values) throws Exception {
+  private void doTestPointFieldReturn(String field, String type, String[] values) {
     SchemaField sf = h.getCore().getLatestSchema().getField(field);
     assert sf.stored() || (sf.hasDocValues() && sf.useDocValuesAsStored())
         : "Unexpected field definition for " + field;
@@ -3457,8 +3457,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  private void doTestPointFieldNonSearchableRangeQuery(String fieldName, String... values)
-      throws Exception {
+  private void doTestPointFieldNonSearchableRangeQuery(String fieldName, String... values) {
     for (int i = 9; i >= 0; i--) {
       SolrInputDocument doc = sdoc("id", String.valueOf(i));
       for (String value : values) {
@@ -3472,8 +3471,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
         "//*[@numFound='0']");
   }
 
-  private void doTestIntPointFieldRangeQuery(String fieldName, String type, boolean testLong)
-      throws Exception {
+  private void doTestIntPointFieldRangeQuery(String fieldName, String type, boolean testLong) {
     for (int i = 9; i >= 0; i--) {
       assertU(adoc("id", String.valueOf(i), fieldName, String.valueOf(i)));
     }
@@ -3632,7 +3630,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   private void doTestPointFieldFacetField(
-      String nonDocValuesField, String docValuesField, String[] numbers) throws Exception {
+      String nonDocValuesField, String docValuesField, String[] numbers) {
     assert numbers != null && numbers.length == 10;
 
     assertFalse(h.getCore().getLatestSchema().getField(docValuesField).multiValued());
@@ -3720,7 +3718,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
         SolrException.ErrorCode.BAD_REQUEST);
   }
 
-  private void doTestIntPointFunctionQuery(String field) throws Exception {
+  private void doTestIntPointFunctionQuery(String field) {
     assertTrue(h.getCore().getLatestSchema().getField(field).getType() instanceof PointField);
     int numVals = 10 * RANDOM_MULTIPLIER;
     List<Integer> values = getRandomInts(numVals, false);
@@ -3809,7 +3807,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  private void doTestLongPointFunctionQuery(String field) throws Exception {
+  private void doTestLongPointFunctionQuery(String field) {
     assertTrue(h.getCore().getLatestSchema().getField(field).getType() instanceof PointField);
     int numVals = 10 * RANDOM_MULTIPLIER;
     List<Long> values = getRandomLongs(numVals, false);
@@ -3907,8 +3905,8 @@ public class TestPointFields extends SolrTestCaseJ4 {
    * @param values one or more values to put into the doc(s) in the index - may be more than one for
    *     multivalued fields
    */
-  private void doTestPointFieldFunctionQueryError(String field, String errSubStr, String... values)
-      throws Exception {
+  private void doTestPointFieldFunctionQueryError(
+      String field, String errSubStr, String... values) {
     final int numDocs = atLeast(random(), 10);
     for (int i = 0; i < numDocs; i++) {
       SolrInputDocument doc = sdoc("id", String.valueOf(i));
@@ -4010,7 +4008,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    *     only stored and searches should always get numFound=0
    */
   private void doTestPointFieldMultiValuedExactQuery(
-      final String fieldName, final String[] numbers, final boolean searchable) throws Exception {
+      final String fieldName, final String[] numbers, final boolean searchable) {
 
     final String MATCH_ONE = "//*[@numFound='" + (searchable ? "1" : "0") + "']";
     final String MATCH_TWO = "//*[@numFound='" + (searchable ? "2" : "0") + "']";
@@ -4062,8 +4060,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     }
   }
 
-  private void doTestPointFieldMultiValuedReturn(String fieldName, String type, String[] numbers)
-      throws Exception {
+  private void doTestPointFieldMultiValuedReturn(String fieldName, String type, String[] numbers) {
     assert numbers != null && numbers.length == 20;
     assertTrue(h.getCore().getLatestSchema().getField(fieldName).multiValued());
     assertTrue(h.getCore().getLatestSchema().getField(fieldName).getType() instanceof PointField);
@@ -4122,7 +4119,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   private void doTestPointFieldMultiValuedRangeQuery(
-      String fieldName, String type, String[] numbers) throws Exception {
+      String fieldName, String type, String[] numbers) {
     assert numbers != null && numbers.length == 20;
     SchemaField sf = h.getCore().getLatestSchema().getField(fieldName);
     assertTrue(sf.multiValued());
@@ -4285,7 +4282,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   private void doTestPointFieldMultiValuedFacetField(
-      String nonDocValuesField, String dvFieldName, String[] numbers) throws Exception {
+      String nonDocValuesField, String dvFieldName, String[] numbers) {
     assert numbers != null && numbers.length == 20;
     assertTrue(h.getCore().getLatestSchema().getField(dvFieldName).multiValued());
     assertTrue(h.getCore().getLatestSchema().getField(dvFieldName).hasDocValues());
@@ -4596,8 +4593,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   private void doTestPointMultiValuedFunctionQuery(
-      String nonDocValuesField, String docValuesField, String type, String[] numbers)
-      throws Exception {
+      String nonDocValuesField, String docValuesField, String type, String[] numbers) {
     assert numbers != null && numbers.length == 20;
     for (int i = 0; i < 10; i++) {
       assertU(
@@ -4657,8 +4653,8 @@ public class TestPointFields extends SolrTestCaseJ4 {
         SolrException.ErrorCode.BAD_REQUEST);
   }
 
-  private void doTestMultiValuedPointFieldsAtomicUpdates(String field, String type, String[] values)
-      throws Exception {
+  private void doTestMultiValuedPointFieldsAtomicUpdates(
+      String field, String type, String[] values) {
     assertEquals(3, values.length);
     assertU(adoc(sdoc("id", "1", field, String.valueOf(values[0]))));
     assertU(commit());
@@ -4701,7 +4697,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertQ(req("q", "id:1"), "count(//result/doc[1]/arr[@name='" + field + "']/" + type + ")=0");
   }
 
-  private void doTestIntPointFieldsAtomicUpdates(String field) throws Exception {
+  private void doTestIntPointFieldsAtomicUpdates(String field) {
     int number1 = random().nextInt();
     int number2;
     long inc1;
@@ -4727,7 +4723,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertQ(req("q", "id:1"), "//result/doc[1]/int[@name='" + field + "'][.='" + number3 + "']");
   }
 
-  private void doTestLongPointFieldsAtomicUpdates(String field) throws Exception {
+  private void doTestLongPointFieldsAtomicUpdates(String field) {
     long number1 = random().nextLong();
     long number2;
     BigInteger inc1;
@@ -4763,7 +4759,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    *     only stored and searches should always get numFound=0
    */
   private void doTestFloatPointFieldExactQuery(
-      final String field, final boolean searchable, final boolean testDouble) throws Exception {
+      final String field, final boolean searchable, final boolean testDouble) {
     int numValues = 10 * RANDOM_MULTIPLIER;
     Map<String, Integer> randCount = new HashMap<>(numValues);
     String[] rand =
@@ -4811,8 +4807,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    * @param field name of field to sort on
    * @param values list of values in ascending order
    */
-  private <T extends Comparable<T>> void doTestPointFieldSort(String field, List<T> values)
-      throws Exception {
+  private <T extends Comparable<T>> void doTestPointFieldSort(String field, List<T> values) {
     assert values != null && 2 <= values.size();
 
     final List<SolrInputDocument> docs = new ArrayList<>(values.size());
@@ -4866,8 +4861,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    * @param values one or more values to put into the doc(s) in the index - may be more than one for
    *     multivalued fields
    */
-  private void doTestPointFieldSortError(String field, String errSubStr, String... values)
-      throws Exception {
+  private void doTestPointFieldSortError(String field, String errSubStr, String... values) {
 
     final int numDocs = atLeast(random(), 10);
     for (int i = 0; i < numDocs; i++) {
@@ -4895,8 +4889,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
         SolrException.ErrorCode.BAD_REQUEST);
   }
 
-  private void doTestFloatPointFieldRangeQuery(String fieldName, String type, boolean testDouble)
-      throws Exception {
+  private void doTestFloatPointFieldRangeQuery(String fieldName, String type, boolean testDouble) {
     for (int i = 9; i >= 0; i--) {
       assertU(adoc("id", String.valueOf(i), fieldName, String.valueOf(i)));
     }
@@ -5089,7 +5082,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
         "//*[@numFound='" + countInclusiveInclusive + "']");
   }
 
-  private void doTestFloatPointFunctionQuery(String field) throws Exception {
+  private void doTestFloatPointFunctionQuery(String field) {
     assertTrue(h.getCore().getLatestSchema().getField(field).getType() instanceof PointField);
     int numVals = 10 * RANDOM_MULTIPLIER;
     List<Float> values = getRandomFloats(numVals, false);
@@ -5178,7 +5171,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  private void doTestDoublePointFunctionQuery(String field) throws Exception {
+  private void doTestDoublePointFunctionQuery(String field) {
     assertTrue(h.getCore().getLatestSchema().getField(field).getType() instanceof PointField);
     int numVals = 10 * RANDOM_MULTIPLIER;
     // Restrict values to float range; otherwise conversion to float will cause truncation ->
@@ -5402,7 +5395,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    *     only stored and searches should always get numFound=0
    */
   private void doTestDatePointFieldExactQuery(
-      final String field, final String baseDate, final boolean searchable) throws Exception {
+      final String field, final String baseDate, final boolean searchable) {
     final String MATCH_ONE = "//*[@numFound='" + (searchable ? "1" : "0") + "']";
     final String MATCH_TWO = "//*[@numFound='" + (searchable ? "2" : "0") + "']";
 
@@ -5432,7 +5425,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  private void doTestDatePointFieldRangeQuery(String fieldName) throws Exception {
+  private void doTestDatePointFieldRangeQuery(String fieldName) {
     String baseDate = "1995-12-31T10:59:59Z";
     for (int i = 9; i >= 0; i--) {
       assertU(
@@ -5707,7 +5700,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
         SolrException.ErrorCode.BAD_REQUEST);
   }
 
-  private void doTestDatePointFieldsAtomicUpdates(String field) throws Exception {
+  private void doTestDatePointFieldsAtomicUpdates(String field) {
     long millis1 = random().nextLong() % MAX_DATE_EPOCH_MILLIS;
     long millis2;
     DateGapCeiling gap;
@@ -5854,8 +5847,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
   }
 
   public void doTestReturnNonStored(
-      final String fieldName, boolean shouldReturnFieldIfRequested, final String... values)
-      throws Exception {
+      final String fieldName, boolean shouldReturnFieldIfRequested, final String... values) {
     final String RETURN_FIELD = "count(//doc/*[@name='" + fieldName + "'])=10";
     final String DONT_RETURN_FIELD = "count(//doc/*[@name='" + fieldName + "'])=0";
     assertFalse(h.getCore().getLatestSchema().getField(fieldName).stored());
@@ -5953,7 +5945,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
    * <code>pointType</code> is included if and only if the SchemaField is "indexed"
    */
   private List<IndexableField> callAndCheckCreateFields(
-      final String fieldName, final Class<?> pointType, final Object value) throws Exception {
+      final String fieldName, final Class<?> pointType, final Object value) {
     final SchemaField sf = h.getCore().getLatestSchema().getField(fieldName);
     final List<IndexableField> results = sf.createFields(value);
     final Set<IndexableField> resultSet = new LinkedHashSet<>(results);

--- a/solr/core/src/test/org/apache/solr/schema/TestSortableTextField.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestSortableTextField.java
@@ -85,11 +85,11 @@ public class TestSortableTextField extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void cleanup() throws Exception {
+  public void cleanup() {
     clearIndex();
   }
 
-  public void testSimple() throws Exception {
+  public void testSimple() {
     assertU(
         adoc("id", "1", "whitespace_stxt", "how now brown cow ?", "whitespace_f_stxt", "aaa bbb"));
     assertU(

--- a/solr/core/src/test/org/apache/solr/search/AnalyticsTestQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/AnalyticsTestQParserPlugin.java
@@ -47,7 +47,7 @@ public class AnalyticsTestQParserPlugin extends QParserPlugin {
       super(query, localParams, params, req);
     }
 
-    public Query parse() throws SyntaxError {
+    public Query parse() {
       int base = localParams.getInt("base", 0);
       boolean iterate = localParams.getBool("iterate", false);
       if (iterate) return new TestAnalyticsQuery(base, new TestIterative());

--- a/solr/core/src/test/org/apache/solr/search/DelayingSearchComponent.java
+++ b/solr/core/src/test/org/apache/solr/search/DelayingSearchComponent.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.search;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.SearchComponent;
@@ -25,12 +24,12 @@ import org.apache.solr.handler.component.SearchComponent;
 public class DelayingSearchComponent extends SearchComponent {
 
   @Override
-  public void prepare(ResponseBuilder rb) throws IOException {
+  public void prepare(ResponseBuilder rb) {
     rb.rsp.addHttpHeader("Warning", "This is a test warning");
   }
 
   @Override
-  public void process(ResponseBuilder rb) throws IOException {
+  public void process(ResponseBuilder rb) {
     final long totalSleepMillis = rb.req.getParams().getLong("sleep", 0);
     if (totalSleepMillis > 0) {
       final long totalSleepNanos =

--- a/solr/core/src/test/org/apache/solr/search/GoodbyeQueryBuilder.java
+++ b/solr/core/src/test/org/apache/solr/search/GoodbyeQueryBuilder.java
@@ -17,7 +17,6 @@
 package org.apache.solr.search;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.queryparser.xml.ParserException;
 import org.apache.lucene.queryparser.xml.QueryBuilder;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -31,7 +30,7 @@ public class GoodbyeQueryBuilder extends SolrQueryBuilder {
     super(defaultField, analyzer, req, queryFactory);
   }
 
-  public Query getQuery(Element e) throws ParserException {
+  public Query getQuery(Element e) {
     return new MatchNoDocsQuery();
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/HelloQueryBuilder.java
+++ b/solr/core/src/test/org/apache/solr/search/HelloQueryBuilder.java
@@ -17,7 +17,6 @@
 package org.apache.solr.search;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.queryparser.xml.ParserException;
 import org.apache.lucene.queryparser.xml.QueryBuilder;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -31,7 +30,7 @@ public class HelloQueryBuilder extends SolrQueryBuilder {
     super(defaultField, analyzer, req, queryFactory);
   }
 
-  public Query getQuery(Element e) throws ParserException {
+  public Query getQuery(Element e) {
     return new MatchAllDocsQuery();
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/MaxScoreCollectorTest.java
+++ b/solr/core/src/test/org/apache/solr/search/MaxScoreCollectorTest.java
@@ -70,7 +70,7 @@ public class MaxScoreCollectorTest extends SolrTestCase {
     float minCompetitiveScore = 0f;
 
     @Override
-    public float score() throws IOException {
+    public float score() {
       return nextScore;
     }
 

--- a/solr/core/src/test/org/apache/solr/search/MockSearchComponent.java
+++ b/solr/core/src/test/org/apache/solr/search/MockSearchComponent.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.search;
 
-import java.io.IOException;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.SearchComponent;
@@ -32,10 +31,10 @@ public class MockSearchComponent extends SearchComponent {
   }
 
   @Override
-  public void prepare(ResponseBuilder rb) throws IOException {}
+  public void prepare(ResponseBuilder rb) {}
 
   @Override
-  public void process(ResponseBuilder rb) throws IOException {
+  public void process(ResponseBuilder rb) {
     rb.rsp.add(this.getName(), this.testParam);
   }
 

--- a/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
@@ -1440,7 +1440,7 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testPayloadScoreQuery() throws Exception {
+  public void testPayloadScoreQuery() {
     // There was a bug with PayloadScoreQuery's .equals() method that said two queries were equal
     // with different includeSpanScore settings
 
@@ -1454,7 +1454,7 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
                 "{!payload_score f=foo_dpf v=query func=min includeSpanScore=true}"));
   }
 
-  public void testPayloadCheckQuery() throws Exception {
+  public void testPayloadCheckQuery() {
     expectThrows(
         AssertionError.class,
         "queries should not have been equal",

--- a/solr/core/src/test/org/apache/solr/search/RankQueryTestPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/RankQueryTestPlugin.java
@@ -79,7 +79,7 @@ public class RankQueryTestPlugin extends QParserPlugin {
       super(query, localParams, params, req);
     }
 
-    public Query parse() throws SyntaxError {
+    public Query parse() {
 
       int mergeStrategy = localParams.getInt("mergeStrategy", 0);
       int collector = localParams.getInt("collector", 0);

--- a/solr/core/src/test/org/apache/solr/search/SortSpecParsingTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SortSpecParsingTest.java
@@ -42,7 +42,7 @@ public class SortSpecParsingTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSort() throws Exception {
+  public void testSort() {
     Sort sort;
     SortSpec spec;
     SolrQueryRequest req = req();
@@ -230,7 +230,7 @@ public class SortSpecParsingTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testBad() throws Exception {
+  public void testBad() {
     Sort sort;
     SolrQueryRequest req = req();
 

--- a/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
+++ b/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
@@ -45,7 +45,7 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     clearIndex();
     assertU(commit());
   }
@@ -289,7 +289,7 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
     }
   }
 
-  public void testSimple() throws Exception {
+  public void testSimple() {
 
     { // convert our docs to update commands, along with some commits, in a shuffled order and
       // process all of them...

--- a/solr/core/src/test/org/apache/solr/search/TestCaffeineCache.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCaffeineCache.java
@@ -19,7 +19,6 @@ package org.apache.solr.search;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,7 +43,7 @@ public class TestCaffeineCache extends SolrTestCase {
   String scope = TestUtil.randomSimpleString(random(), 2, 10);
 
   @Test
-  public void testSimple() throws IOException {
+  public void testSimple() {
     CaffeineCache<Integer, String> lfuCache = new CaffeineCache<>();
     SolrMetricsContext solrMetricsContext = new SolrMetricsContext(metricManager, registry, "foo");
     lfuCache.initializeMetrics(solrMetricsContext, scope + "-1");

--- a/solr/core/src/test/org/apache/solr/search/TestComplexPhraseLeadingWildcard.java
+++ b/solr/core/src/test/org/apache/solr/search/TestComplexPhraseLeadingWildcard.java
@@ -39,13 +39,13 @@ public class TestComplexPhraseLeadingWildcard extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testReverseWithOriginal() throws Exception {
+  public void testReverseWithOriginal() {
     checkField(withOriginal);
   }
 
   // prefix query won't match without original tokens
   @Test
-  public void testReverseWithoutOriginal() throws Exception {
+  public void testReverseWithoutOriginal() {
     assertQ(
         "prefix query doesn't work without original term",
         req("q", "{!complexphrase inOrder=true}\"on* for*\"", "df", withoutOriginal),
@@ -58,7 +58,7 @@ public class TestComplexPhraseLeadingWildcard extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testWithoutReverse() throws Exception {
+  public void testWithoutReverse() {
     checkField(noReverseText);
   }
 

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -64,7 +64,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
     index();
   }
 
-  public static void index() throws Exception {
+  public static void index() {
     assertU(
         adoc("id", "42", "trait_ss", "Tool", "trait_ss", "Obnoxious", "name", "Zapp Brannigan"));
     assertU(adoc("id", "43", "title", "Democratic Order op Planets"));
@@ -243,7 +243,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
     }
   }
 
-  public void testCharFilter() throws Exception {
+  public void testCharFilter() {
     // test that charfilter was applied by the indexer
     assertQ(
         req("defType", "edismax", "stopwords", "false", "qf", "isocharfilter", "q", "nino"),
@@ -808,7 +808,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
     assertQ(req("defType", "edismax", "uf", "* -id", "q", "42", "qf", "id"), oner);
   }
 
-  public void testAliasing() throws Exception {
+  public void testAliasing() {
     String oner = "*[count(//doc)=1]";
     String twor = "*[count(//doc)=2]";
     String nor = "*[count(//doc)=0]";
@@ -928,7 +928,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
         twor);
   }
 
-  public void testAliasingBoost() throws Exception {
+  public void testAliasingBoost() {
     assertQ(
         req(
             "defType",
@@ -956,7 +956,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   /** SOLR-13203 * */
-  public void testUfDynamicField() throws Exception {
+  public void testUfDynamicField() {
     try {
       ignoreException("dynamic field");
 
@@ -973,7 +973,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
     assertQ(req("uf", "trait* id", "defType", "edismax"));
   }
 
-  public void testCyclicAliasing() throws Exception {
+  public void testCyclicAliasing() {
     try {
       ignoreException(".*Field aliases lead to a cycle.*");
 
@@ -1406,7 +1406,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testWhitespaceCharacters() throws Exception {
+  public void testWhitespaceCharacters() {
     assertU(adoc("id", "whitespaceChars", "cat_s", "foo\nfoo"));
     assertU(commit());
 
@@ -1428,7 +1428,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testDoubleQuoteCharacters() throws Exception {
+  public void testDoubleQuoteCharacters() {
     assertU(adoc("id", "doubleQuote", "cat_s", "foo\"foo"));
     assertU(commit());
 
@@ -1451,7 +1451,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
    * @see ExtendedDismaxQParser#splitIntoClauses(String, boolean)
    */
   @Test
-  public void testEscapingOfReservedCharacters() throws Exception {
+  public void testEscapingOfReservedCharacters() {
     // create a document that contains all reserved characters
     String allReservedCharacters = "!():^[]{}~*?\"+-\\|&/";
 
@@ -1511,7 +1511,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
 
   /** Repeating some of test cases as direct calls to splitIntoClauses */
   @Test
-  public void testSplitIntoClauses() throws Exception {
+  public void testSplitIntoClauses() {
     String query = "(\"foo\nfoo\")";
     SolrQueryRequest request = req("q", query, "qf", "cat_s", "defType", "edismax");
     ExtendedDismaxQParser parser =
@@ -1587,7 +1587,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   /** SOLR-3589: Edismax parser does not honor mm parameter if analyzer splits a token */
-  public void testCJK() throws Exception {
+  public void testCJK() {
     assertQ(
         "test cjk (disjunction)",
         req(
@@ -1615,7 +1615,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   /** test that minShouldMatch works with aliasing for implicit boolean queries */
-  public void testCJKAliasing() throws Exception {
+  public void testCJKAliasing() {
     // single field
     assertQ(
         "test cjk (aliasing+disjunction)",
@@ -1669,7 +1669,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   /** Test that we apply boosts correctly */
-  public void testCJKBoosts() throws Exception {
+  public void testCJKBoosts() {
     assertQ(
         "test cjk (disjunction)",
         req(
@@ -1732,7 +1732,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
    * always apply minShouldMatch to the inner booleanqueries created from whitespace, as these are
    * never structured lucene queries but only come from unstructured text
    */
-  public void testCJKStructured() throws Exception {
+  public void testCJKStructured() {
     assertQ(
         "test cjk (disjunction)",
         req(
@@ -1764,7 +1764,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
    * Test that we don't apply minShouldMatch to the inner boolean queries when there are synonyms
    * (these are indicated by coordination factor)
    */
-  public void testSynonyms() throws Exception {
+  public void testSynonyms() {
     // document only contains baraaa, but should still match.
     assertQ(
         "test synonyms",
@@ -1777,7 +1777,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   /** Test that the default operator and MM are interacting appropriately when both provided */
-  public void testDefaultOperatorWithMm() throws Exception {
+  public void testDefaultOperatorWithMm() {
     // Text we are searching
     // "line up and fly directly at the enemy death cannons, clogging them with wreckage!"
     assertQ(
@@ -1855,7 +1855,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
   }
 
   /** Test that minShouldMatch applies to Optional terms only */
-  public void testMinShouldMatchOptional() throws Exception {
+  public void testMinShouldMatchOptional() {
     for (String sow : Arrays.asList("true", "false")) {
       assertQ(
           "test minShouldMatch (top level optional terms only)",
@@ -2011,7 +2011,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
 
   /* SOLR-8812 */
   @Test
-  public void testDefaultMM() throws Exception {
+  public void testDefaultMM() {
     // Ensure MM is off when explicit operators (+/-/OR/NOT) are used and no explicit mm spec is
     // specified.
     for (String sow : Arrays.asList("true", "false")) {
@@ -3311,7 +3311,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
 
   /** SOLR-11512 */
   @Test
-  public void killInfiniteRecursionParse() throws Exception {
+  public void killInfiniteRecursionParse() {
     SolrException exception =
         expectThrows(
             SolrException.class,

--- a/solr/core/src/test/org/apache/solr/search/TestIndexSearcher.java
+++ b/solr/core/src/test/org/apache/solr/search/TestIndexSearcher.java
@@ -437,10 +437,10 @@ public class TestIndexSearcher extends SolrTestCaseJ4 {
     static boolean registerSlowSearcherListener = false;
 
     @Override
-    public void prepare(ResponseBuilder rb) throws IOException {}
+    public void prepare(ResponseBuilder rb) {}
 
     @Override
-    public void process(ResponseBuilder rb) throws IOException {}
+    public void process(ResponseBuilder rb) {}
 
     @Override
     public String getDescription() {

--- a/solr/core/src/test/org/apache/solr/search/TestInitQParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestInitQParser.java
@@ -52,7 +52,7 @@ public class TestInitQParser extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testQueryParserInit() throws Exception {
+  public void testQueryParserInit() {
     // should query using registered fail (defType=fail) QParser and match only one doc
     assertQ(req("q", "id:1", "indent", "true", "defType", "fail"), "//*[@numFound='1']");
   }

--- a/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
@@ -52,7 +52,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     if (RESTORE_UFFSQ_PROP == null) {
       System.clearProperty(TEST_UFFSQ_PROPNAME);
     } else {

--- a/solr/core/src/test/org/apache/solr/search/TestMissingGroups.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMissingGroups.java
@@ -35,7 +35,7 @@ public class TestMissingGroups extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     clearIndex();
     assertU(optimize());
   }

--- a/solr/core/src/test/org/apache/solr/search/TestPseudoReturnFields.java
+++ b/solr/core/src/test/org/apache/solr/search/TestPseudoReturnFields.java
@@ -237,7 +237,7 @@ public class TestPseudoReturnFields extends SolrTestCaseJ4 {
     }
   }
 
-  public void testFunctions() throws Exception {
+  public void testFunctions() {
     assertQ(
         "fl=log(val_i)",
         req("q", "*:*", "rows", "1", "fl", "log(val_i)"),

--- a/solr/core/src/test/org/apache/solr/search/TestSearcherReuse.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSearcherReuse.java
@@ -81,7 +81,7 @@ public class TestSearcherReuse extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  public void test() throws Exception {
+  public void test() {
 
     // seed some docs & segments
     int numDocs = atLeast(1);

--- a/solr/core/src/test/org/apache/solr/search/TestSimpleQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSimpleQParserPlugin.java
@@ -28,7 +28,7 @@ public class TestSimpleQParserPlugin extends SolrTestCaseJ4 {
     index();
   }
 
-  public static void index() throws Exception {
+  public static void index() {
     assertU(
         adoc("id", "42", "text0", "t0 t0 t0", "text1", "t0 t1 t2", "text-keyword0", "kw0 kw0 kw0"));
     assertU(

--- a/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
@@ -75,7 +75,7 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
   private static final List<String> HAS_NAN_FIELDS = new ArrayList<String>(12);
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     HAS_VAL_FIELDS.clear();
     HAS_NAN_FIELDS.clear();
   }

--- a/solr/core/src/test/org/apache/solr/search/TestTrieFacet.java
+++ b/solr/core/src/test/org/apache/solr/search/TestTrieFacet.java
@@ -134,7 +134,7 @@ public class TestTrieFacet extends SolrTestCaseJ4 {
     return 0 != TestUtil.nextInt(random(), 0, 9);
   }
 
-  private static void doTestNoZeros(final String field, final String method) throws Exception {
+  private static void doTestNoZeros(final String field, final String method) {
 
     assertQ(
         "sanity check # docs in index: " + NUM_DOCS,

--- a/solr/core/src/test/org/apache/solr/search/TestValueSourceCache.java
+++ b/solr/core/src/test/org/apache/solr/search/TestValueSourceCache.java
@@ -35,7 +35,7 @@ public class TestValueSourceCache extends SolrTestCaseJ4 {
   static QParser _func;
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     _func = null;
   }
 

--- a/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetSKGEquiv.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestCloudJSONFacetSKGEquiv.java
@@ -724,7 +724,7 @@ public class TestCloudJSONFacetSKGEquiv extends SolrCloudTestCase {
     }
   }
 
-  public void testRandom() throws Exception {
+  public void testRandom() {
 
     final int numIters = atLeast(10);
     for (int iter = 0; iter < numIters; iter++) {

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -5020,7 +5020,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   }
 
   /** test code to ensure TDigest is working as we expect. */
-  public void XtestTDigest() throws Exception {
+  public void XtestTDigest() {
     AVLTreeDigest t1 = new AVLTreeDigest(100);
     t1.add(10, 1);
     t1.add(90, 1);

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetsStatsParsing.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetsStatsParsing.java
@@ -57,7 +57,7 @@ public class TestJsonFacetsStatsParsing extends SolrTestCaseJ4 {
         not(new FacetRequest.FacetSort("foo", FacetRequest.SortDirection.desc)));
   }
 
-  public void testEquality() throws IOException {
+  public void testEquality() {
     try (SolrQueryRequest req =
         req(
             "custom_req_param", "foo_i",

--- a/solr/core/src/test/org/apache/solr/search/function/SortByFunctionTest.java
+++ b/solr/core/src/test/org/apache/solr/search/function/SortByFunctionTest.java
@@ -36,7 +36,7 @@ public class SortByFunctionTest extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
-  public void test() throws Exception {
+  public void test() {
     assertU(
         adoc("id", "1", "x_td1", "0", "y_td1", "2", "w_td1", "25", "z_td1", "5", "f_t", "ipod"));
     assertU(

--- a/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
@@ -979,7 +979,7 @@ public class TestFunctionQuery extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testFuncs() throws Exception {
+  public void testFuncs() {
     clearIndex();
 
     assertU(adoc("id", "1", "foo_d", "9"));

--- a/solr/core/src/test/org/apache/solr/search/function/TestMinMaxOnMultiValuedField.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestMinMaxOnMultiValuedField.java
@@ -113,7 +113,7 @@ public class TestMinMaxOnMultiValuedField extends SolrTestCaseJ4 {
 
   /** Deletes all docs (which may be left over from a previous test */
   @Before
-  public void before() throws Exception {
+  public void before() {
     clearIndex();
     assertU(commit());
   }
@@ -498,7 +498,7 @@ public class TestMinMaxOnMultiValuedField extends SolrTestCaseJ4 {
         SolrException.ErrorCode.BAD_REQUEST);
   }
 
-  public void testRandom() throws Exception {
+  public void testRandom() {
 
     @SuppressWarnings({"rawtypes"})
     Comparable[] vals = new Comparable[TestUtil.nextInt(random(), 1, 17)];

--- a/solr/core/src/test/org/apache/solr/search/function/TestOrdValues.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestOrdValues.java
@@ -162,7 +162,7 @@ public class TestOrdValues extends SolrTestCase {
   }
 
   // LUCENE-1250
-  public void testEqualsNull() throws Exception {
+  public void testEqualsNull() {
     OrdFieldSource ofs = new OrdFieldSource("f");
     assertFalse(ofs.equals(null));
 

--- a/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
@@ -52,7 +52,7 @@ public class BJQParserTest extends SolrTestCaseJ4 {
     createIndex();
   }
 
-  public static void createIndex() throws IOException {
+  public static void createIndex() {
     int i = 0;
     List<List<String[]>> blocks = createBlocks();
     for (List<String[]> block : blocks) {

--- a/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPNoScore.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPNoScore.java
@@ -199,7 +199,7 @@ public class TestScoreJoinQPNoScore extends SolrTestCaseJ4 {
         "/response=={'numFound':3,'start':0,'numFoundExact':true,'docs':[{'id':'1'},{'id':'4'},{'id':'5'}]}");
   }
 
-  public void testNotEquals() throws SyntaxError, IOException {
+  public void testNotEquals() throws SyntaxError {
     try (SolrQueryRequest req = req("*:*")) {
       Query x =
           QParser.getParser("{!join from=dept_id_s to=dept_ss score=none}text_t:develop", req)

--- a/solr/core/src/test/org/apache/solr/search/mlt/SimpleMLTQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/mlt/SimpleMLTQParserTest.java
@@ -31,7 +31,7 @@ public class SimpleMLTQParserTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void doTest() throws Exception {
+  public void doTest() {
     String id = "id";
     String FIELD1 = "lowerfilt";
     String FIELD2 = "lowerfilt1";

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -98,7 +98,7 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanUp() throws Exception {
+  public void cleanUp() {
     clearIndex();
     deleteCore();
   }

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestBM25SimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestBM25SimilarityFactory.java
@@ -28,12 +28,12 @@ public class TestBM25SimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** bm25 with default parameters */
-  public void test() throws Exception {
+  public void test() {
     assertEquals(BM25Similarity.class, getSimilarity("text").getClass());
   }
 
   /** bm25 with parameters */
-  public void testParameters() throws Exception {
+  public void testParameters() {
     Similarity sim = getSimilarity("text_params");
     assertEquals(BM25Similarity.class, sim.getClass());
     BM25Similarity bm25 = (BM25Similarity) sim;

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestBooleanSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestBooleanSimilarityFactory.java
@@ -32,7 +32,7 @@ public class TestBooleanSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** Boolean w/ default parameters */
-  public void testDefaults() throws Exception {
+  public void testDefaults() {
     BooleanSimilarity sim = getSimilarity("text", BooleanSimilarity.class);
     assertEquals(BooleanSimilarity.class, sim.getClass());
   }

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestClassicSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestClassicSimilarityFactory.java
@@ -32,12 +32,12 @@ public class TestClassicSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** Classic w/ default parameters */
-  public void testDefaults() throws Exception {
+  public void testDefaults() {
     ClassicSimilarity sim = getSimilarity("text", ClassicSimilarity.class);
     assertEquals(true, sim.getDiscountOverlaps());
   }
   /** Classic w/ explicit params */
-  public void testParams() throws Exception {
+  public void testParams() {
     ClassicSimilarity sim = getSimilarity("text_overlap", ClassicSimilarity.class);
     assertEquals(false, sim.getDiscountOverlaps());
   }

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestDFISimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestDFISimilarityFactory.java
@@ -30,7 +30,7 @@ public class TestDFISimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** dfi with no parameters */
-  public void test() throws Exception {
+  public void test() {
     Similarity sim = getSimilarity("text");
     assertEquals(DFISimilarity.class, sim.getClass());
     DFISimilarity dfi = (DFISimilarity) sim;
@@ -39,7 +39,7 @@ public class TestDFISimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** dfi with discountOverlaps parameter set to false */
-  public void testParameters() throws Exception {
+  public void testParameters() {
     Similarity sim = getSimilarity("text_params");
     assertEquals(DFISimilarity.class, sim.getClass());
     DFISimilarity dfr = (DFISimilarity) sim;

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestDFRSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestDFRSimilarityFactory.java
@@ -34,7 +34,7 @@ public class TestDFRSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** dfr with default parameters */
-  public void test() throws Exception {
+  public void test() {
     Similarity sim = getSimilarity("text");
     assertEquals(DFRSimilarity.class, sim.getClass());
     DFRSimilarity dfr = (DFRSimilarity) sim;
@@ -44,7 +44,7 @@ public class TestDFRSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** dfr with parametrized normalization */
-  public void testParameters() throws Exception {
+  public void testParameters() {
     Similarity sim = getSimilarity("text_params");
     assertEquals(DFRSimilarity.class, sim.getClass());
     DFRSimilarity dfr = (DFRSimilarity) sim;

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestIBSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestIBSimilarityFactory.java
@@ -34,7 +34,7 @@ public class TestIBSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** spl/df/h2 with default parameters */
-  public void test() throws Exception {
+  public void test() {
     Similarity sim = getSimilarity("text");
     assertEquals(IBSimilarity.class, sim.getClass());
     IBSimilarity ib = (IBSimilarity) sim;
@@ -44,7 +44,7 @@ public class TestIBSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** ll/ttf/h3 with parametrized normalization */
-  public void testParameters() throws Exception {
+  public void testParameters() {
     Similarity sim = getSimilarity("text_params");
     assertEquals(IBSimilarity.class, sim.getClass());
     IBSimilarity ib = (IBSimilarity) sim;

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestLMDirichletSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestLMDirichletSimilarityFactory.java
@@ -28,12 +28,12 @@ public class TestLMDirichletSimilarityFactory extends BaseSimilarityTestCase {
   }
 
   /** dirichlet with default parameters */
-  public void test() throws Exception {
+  public void test() {
     assertEquals(LMDirichletSimilarity.class, getSimilarity("text").getClass());
   }
 
   /** dirichlet with parameters */
-  public void testParameters() throws Exception {
+  public void testParameters() {
     Similarity sim = getSimilarity("text_params");
     assertEquals(LMDirichletSimilarity.class, sim.getClass());
     LMDirichletSimilarity lm = (LMDirichletSimilarity) sim;

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestLMJelinekMercerSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestLMJelinekMercerSimilarityFactory.java
@@ -28,12 +28,12 @@ public class TestLMJelinekMercerSimilarityFactory extends BaseSimilarityTestCase
   }
 
   /** jelinek-mercer with default parameters */
-  public void test() throws Exception {
+  public void test() {
     assertEquals(LMJelinekMercerSimilarity.class, getSimilarity("text").getClass());
   }
 
   /** jelinek-mercer with parameters */
-  public void testParameters() throws Exception {
+  public void testParameters() {
     Similarity sim = getSimilarity("text_params");
     assertEquals(LMJelinekMercerSimilarity.class, sim.getClass());
     LMJelinekMercerSimilarity lm = (LMJelinekMercerSimilarity) sim;

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestNonDefinedSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestNonDefinedSimilarityFactory.java
@@ -31,7 +31,7 @@ import org.junit.After;
 public class TestNonDefinedSimilarityFactory extends BaseSimilarityTestCase {
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     deleteCore();
   }
 

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestPerFieldSimilarity.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestPerFieldSimilarity.java
@@ -30,7 +30,7 @@ public class TestPerFieldSimilarity extends BaseSimilarityTestCase {
   }
 
   /** test a field where the sim is specified directly */
-  public void testDirect() throws Exception {
+  public void testDirect() {
     assertEquals(SweetSpotSimilarity.class, getSimilarity("sim1text").getClass());
   }
 
@@ -54,7 +54,7 @@ public class TestPerFieldSimilarity extends BaseSimilarityTestCase {
   }
 
   /** test a field where no similarity is specified */
-  public void testDefaults() throws Exception {
+  public void testDefaults() {
     Similarity sim = getSimilarity("sim3text");
     assertEquals(BM25Similarity.class, sim.getClass());
   }

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestPerFieldSimilarityWithDefaultOverride.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestPerFieldSimilarityWithDefaultOverride.java
@@ -33,7 +33,7 @@ public class TestPerFieldSimilarityWithDefaultOverride extends BaseSimilarityTes
   }
 
   /** test a field where the sim is specified directly */
-  public void testDirect() throws Exception {
+  public void testDirect() {
     assertNotNull(getSimilarity("sim1text", SweetSpotSimilarity.class));
   }
 
@@ -55,7 +55,7 @@ public class TestPerFieldSimilarityWithDefaultOverride extends BaseSimilarityTes
   }
 
   /** test a field where no similarity is specified */
-  public void testDefaults() throws Exception {
+  public void testDefaults() {
     MockConfigurableSimilarity sim = getSimilarity("sim3text", MockConfigurableSimilarity.class);
     assertEquals("is there an echo?", sim.getPassthrough());
   }

--- a/solr/core/src/test/org/apache/solr/security/MockAuthenticationPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/MockAuthenticationPlugin.java
@@ -70,5 +70,5 @@ public class MockAuthenticationPlugin extends AuthenticationPlugin {
   }
 
   @Override
-  public void close() throws IOException {}
+  public void close() {}
 }

--- a/solr/core/src/test/org/apache/solr/security/MockAuthorizationPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/MockAuthorizationPlugin.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.security;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Map;
@@ -57,5 +56,5 @@ public class MockAuthorizationPlugin implements AuthorizationPlugin {
   public void init(Map<String, Object> initInfo) {}
 
   @Override
-  public void close() throws IOException {}
+  public void close() {}
 }

--- a/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
@@ -45,7 +45,7 @@ public class CacheHeaderTest extends CacheHeaderTestBase {
   }
 
   @AfterClass
-  public static void afterTest() throws Exception {}
+  public static void afterTest() {}
 
   protected static final String CONTENTS = "id\n100\n101\n102";
 

--- a/solr/core/src/test/org/apache/solr/servlet/ResponseHeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/ResponseHeaderTest.java
@@ -77,12 +77,12 @@ public class ResponseHeaderTest extends SolrJettyTestBase {
   public static class ComponentThatAddsHeader extends SearchComponent {
 
     @Override
-    public void prepare(ResponseBuilder rb) throws IOException {
+    public void prepare(ResponseBuilder rb) {
       rb.rsp.addHttpHeader("Warning", "This is a test warning");
     }
 
     @Override
-    public void process(ResponseBuilder rb) throws IOException {}
+    public void process(ResponseBuilder rb) {}
 
     @Override
     public String getDescription() {

--- a/solr/core/src/test/org/apache/solr/spelling/ConjunctionSolrSpellCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/ConjunctionSolrSpellCheckerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.spelling;
 
-import java.io.IOException;
 import org.apache.lucene.search.spell.JaroWinklerDistance;
 import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.search.spell.LuceneLevenshteinDistance;
@@ -84,10 +83,10 @@ public class ConjunctionSolrSpellCheckerTest extends SolrTestCase {
     }
 
     @Override
-    public void reload(SolrCore core, SolrIndexSearcher searcher) throws IOException {}
+    public void reload(SolrCore core, SolrIndexSearcher searcher) {}
 
     @Override
-    public void build(SolrCore core, SolrIndexSearcher searcher) throws IOException {}
+    public void build(SolrCore core, SolrIndexSearcher searcher) {}
 
     @Override
     public SpellingResult getSuggestions(SpellingOptions options) {

--- a/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
@@ -503,7 +503,7 @@ public class SpellCheckCollatorTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testContextSensitiveCollate() throws Exception {
+  public void testContextSensitiveCollate() {
     //                     DirectSolrSpellChecker   IndexBasedSpellChecker
     String[] dictionary = {"direct", "default_teststop"};
     for (int i = 0; i <= 1; i++) {
@@ -606,7 +606,7 @@ public class SpellCheckCollatorTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testEstimatedHitCounts() throws Exception {
+  public void testEstimatedHitCounts() {
     final String xpathPrefix =
         "//lst[@name='spellcheck']/lst[@name='collations']/lst[@name='collation']/";
     final SolrParams reusedParams =

--- a/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorWithCollapseTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorWithCollapseTest.java
@@ -40,7 +40,7 @@ public class SpellCheckCollatorWithCollapseTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void test() throws Exception {
+  public void test() {
     for (int i = 0; i < 200; i++) {
       String[] doc = {
         "id", "" + i, "group_i", "" + (i % 10), "a_s", ((i % 2) == 0 ? "love" : "peace")

--- a/solr/core/src/test/org/apache/solr/spelling/SpellingQueryConverterTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/SpellingQueryConverterTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class SpellingQueryConverterTest extends SolrTestCase {
 
   @Test
-  public void test() throws Exception {
+  public void test() {
     SpellingQueryConverter converter = new SpellingQueryConverter();
     converter.init(new NamedList<>());
     converter.setAnalyzer(new WhitespaceAnalyzer());

--- a/solr/core/src/test/org/apache/solr/spelling/TestSuggestSpellingConverter.java
+++ b/solr/core/src/test/org/apache/solr/spelling/TestSuggestSpellingConverter.java
@@ -32,13 +32,13 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 public class TestSuggestSpellingConverter extends BaseTokenStreamTestCase {
   SuggestQueryConverter converter = new SuggestQueryConverter();
 
-  public void testSimple() throws Exception {
+  public void testSimple() {
     // lowercases only!
     converter.setAnalyzer(new MockAnalyzer(random(), MockTokenizer.KEYWORD, true));
     assertConvertsTo("This is a test", new String[] {"this is a test"});
   }
 
-  public void testComplicated() throws Exception {
+  public void testComplicated() {
     // lowercases, removes field names, other syntax, collapses runs of whitespace, etc.
     converter.setAnalyzer(
         new Analyzer() {

--- a/solr/core/src/test/org/apache/solr/spelling/WordBreakSolrSpellCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/WordBreakSolrSpellCheckerTest.java
@@ -158,7 +158,7 @@ public class WordBreakSolrSpellCheckerTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testInConjunction() throws Exception {
+  public void testInConjunction() {
     assertQ(
         req(
             "q",
@@ -230,7 +230,7 @@ public class WordBreakSolrSpellCheckerTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testCollate() throws Exception {
+  public void testCollate() {
     assertQ(
         req(
             "q",

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/RandomTestDictionaryFactory.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/RandomTestDictionaryFactory.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.spelling.suggest;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import org.apache.lucene.search.spell.Dictionary;
 import org.apache.lucene.search.suggest.InputIterator;
@@ -92,7 +91,7 @@ public class RandomTestDictionaryFactory extends DictionaryFactory {
       private static final int MAX_LENGTH = 100;
 
       @Override
-      public BytesRef next() throws IOException {
+      public BytesRef next() {
         BytesRef next = null;
         if (System.getProperty(enabledSysProp) != null) {
           if (emittedItems < maxItems) {

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestAnalyzeInfixSuggestions.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestAnalyzeInfixSuggestions.java
@@ -31,7 +31,7 @@ public class TestAnalyzeInfixSuggestions extends SolrTestCaseJ4 {
     assertQ(req("qt", URI_SUGGEST_DEFAULT, "q", "", SuggesterParams.SUGGEST_BUILD_ALL, "true"));
   }
 
-  public void testSingle() throws Exception {
+  public void testSingle() {
 
     assertQ(
         req("qt", URI_DEFAULT, "q", "japan", SpellingParams.SPELLCHECK_COUNT, "1"),

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestFileDictionaryLookup.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestFileDictionaryLookup.java
@@ -38,7 +38,7 @@ public class TestFileDictionaryLookup extends SolrTestCaseJ4 {
             "true"));
   }
 
-  public void testDefault() throws Exception {
+  public void testDefault() {
 
     // tests to demonstrate default maxEdit parameter (value: 1), control for testWithMaxEdit2
     assertQ(

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestFuzzyAnalyzedSuggestions.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestFuzzyAnalyzedSuggestions.java
@@ -36,7 +36,7 @@ public class TestFuzzyAnalyzedSuggestions extends SolrTestCaseJ4 {
     assertQ(req("qt", URI_MIN_FUZZY_LENGTH, "q", "", SpellingParams.SPELLCHECK_BUILD, "true"));
   }
 
-  public void testDefault() throws Exception {
+  public void testDefault() {
 
     // tests to demonstrate default maxEdit parameter (value: 1), control for testWithMaxEdit2
     assertQ(

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestHighFrequencyDictionaryFactory.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestHighFrequencyDictionaryFactory.java
@@ -47,7 +47,7 @@ public class TestHighFrequencyDictionaryFactory extends SolrTestCaseJ4 {
             "true"));
   }
 
-  public void testDefault() throws Exception {
+  public void testDefault() {
 
     // tests to demonstrate default maxEdit parameter (value: 1), control for testWithMaxEdit2
     assertQ(

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -152,7 +152,7 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     if (null != exe) {
       exe.shutdownNow();
       exe = null;

--- a/solr/core/src/test/org/apache/solr/update/SolrCmdDistributorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrCmdDistributorTest.java
@@ -73,7 +73,7 @@ public class SolrCmdDistributorTest extends BaseDistributedSearchTestCase {
   private AtomicInteger id = new AtomicInteger();
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     // we can't use the Randomized merge policy because the test depends on
     // being able to call optimize to have all deletes expunged.
     systemSetPropertySolrTestsMergePolicyFactory(LogDocMergePolicyFactory.class.getName());

--- a/solr/core/src/test/org/apache/solr/update/TestExceedMaxTermLength.java
+++ b/solr/core/src/test/org/apache/solr/update/TestExceedMaxTermLength.java
@@ -38,7 +38,7 @@ public class TestExceedMaxTermLength extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     assertU(delQ("*:*"));
     assertU(commit());
   }

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesDistrib.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesDistrib.java
@@ -113,7 +113,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
     return false;
   }
 
-  public TestInPlaceUpdatesDistrib() throws Exception {
+  public TestInPlaceUpdatesDistrib() {
     super();
     sliceCount = 1;
     fixShardCount(3);
@@ -1441,8 +1441,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
   // This returns an UpdateRequest with the given fields that represent a document.
   // This request is constructed such that it is a simulation of a request coming from
   // a leader to a replica.
-  UpdateRequest simulatedUpdateRequest(Long prevVersion, Object... fields)
-      throws SolrServerException, IOException {
+  UpdateRequest simulatedUpdateRequest(Long prevVersion, Object... fields) throws IOException {
     SolrInputDocument doc = sdoc(fields);
 
     // get baseUrl of the leader
@@ -1459,8 +1458,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
     return ur;
   }
 
-  UpdateRequest simulatedDeleteRequest(int id, long version)
-      throws SolrServerException, IOException {
+  UpdateRequest simulatedDeleteRequest(int id, long version) throws IOException {
     String baseUrl = getBaseUrl("" + id);
 
     UpdateRequest ur = new UpdateRequest();
@@ -1475,8 +1473,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
     return ur;
   }
 
-  UpdateRequest simulatedDeleteRequest(String query, long version)
-      throws SolrServerException, IOException {
+  UpdateRequest simulatedDeleteRequest(String query, long version) {
     String baseUrl = getBaseUrl((HttpSolrClient) LEADER);
 
     UpdateRequest ur = new UpdateRequest();
@@ -1487,27 +1484,27 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
     return ur;
   }
 
-  private String getBaseUrl(String id) throws IOException {
+  private String getBaseUrl(String id) {
     DocCollection collection = cloudClient.getClusterState().getCollection(DEFAULT_COLLECTION);
     Slice slice = collection.getRouter().getTargetSlice(id, null, null, null, collection);
     String baseUrl = slice.getLeader().getCoreUrl();
     return baseUrl;
   }
 
-  UpdateRequest regularUpdateRequest(Object... fields) throws SolrServerException, IOException {
+  UpdateRequest regularUpdateRequest(Object... fields) {
     UpdateRequest ur = new UpdateRequest();
     SolrInputDocument doc = sdoc(fields);
     ur.add(doc);
     return ur;
   }
 
-  UpdateRequest regularDeleteRequest(int id) throws SolrServerException, IOException {
+  UpdateRequest regularDeleteRequest(int id) {
     UpdateRequest ur = new UpdateRequest();
     ur.deleteById("" + id);
     return ur;
   }
 
-  UpdateRequest regularDeleteByQueryRequest(String q) throws SolrServerException, IOException {
+  UpdateRequest regularDeleteByQueryRequest(String q) {
     UpdateRequest ur = new UpdateRequest();
     ur.deleteByQuery(q);
     return ur;

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -117,7 +117,7 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void deleteAllAndCommit() throws Exception {
+  public void deleteAllAndCommit() {
     clearIndex();
     assertU(commit("softCommit", "false"));
   }

--- a/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
+++ b/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
@@ -109,7 +109,7 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     clearIndex();
     assertU(commit());
   }

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java
@@ -48,7 +48,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemove() throws Exception {
+  public void testRemove() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -118,7 +118,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveInteger() throws Exception {
+  public void testRemoveInteger() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -209,7 +209,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveIntegerInDocSavedWithInteger() throws Exception {
+  public void testRemoveIntegerInDocSavedWithInteger() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -300,7 +300,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveIntegerUsingStringType() throws Exception {
+  public void testRemoveIntegerUsingStringType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -372,7 +372,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveIntegerUsingLongType() throws Exception {
+  public void testRemoveIntegerUsingLongType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -445,7 +445,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveIntegerUsingFloatType() throws Exception {
+  public void testRemoveIntegerUsingFloatType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -537,7 +537,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveIntegerUsingDoubleType() throws Exception {
+  public void testRemoveIntegerUsingDoubleType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -612,7 +612,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveDateUsingStringType() throws Exception {
+  public void testRemoveDateUsingStringType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -733,7 +733,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
 
   @Ignore("Remove Date is not supported in other formats than UTC")
   @Test
-  public void testRemoveDateUsingDateType() throws Exception {
+  public void testRemoveDateUsingDateType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -854,7 +854,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveFloatUsingFloatType() throws Exception {
+  public void testRemoveFloatUsingFloatType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -925,7 +925,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveFloatUsingStringType() throws Exception {
+  public void testRemoveFloatUsingStringType() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -1002,7 +1002,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveregex() throws Exception {
+  public void testRemoveregex() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -1073,7 +1073,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRemoveregexMustMatchWholeValue() throws Exception {
+  public void testRemoveregexMustMatchWholeValue() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -1115,7 +1115,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testAdd() throws Exception {
+  public void testAdd() {
     SolrInputDocument doc = new SolrInputDocument();
     doc.setField("id", "3");
     doc.setField("cat", new String[] {"aaa", "ccc"});
@@ -1146,7 +1146,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testAddDistinct() throws Exception {
+  public void testAddDistinct() {
     SolrInputDocument doc = new SolrInputDocument();
     doc.setField("id", "3");
     doc.setField("cat", new String[] {"aaa", "ccc"});
@@ -1204,7 +1204,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testAddMultiple() throws Exception {
+  public void testAddMultiple() {
     SolrInputDocument doc = new SolrInputDocument();
     doc.setField("id", "3");
     doc.setField("cat", new String[] {"aaa", "ccc"});
@@ -1258,7 +1258,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSet() throws Exception {
+  public void testSet() {
     SolrInputDocument doc;
 
     doc = new SolrInputDocument();
@@ -1295,7 +1295,7 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
     assertFailedU(adoc(doc));
   }
 
-  public void testAtomicUpdatesOnDateFields() throws Exception {
+  public void testAtomicUpdatesOnDateFields() {
     String[] dateFieldNames = {"simple_tdt1", "simple_tdts", "simple_tdtdv1", "simple_tdtdvs"};
 
     SolrInputDocument doc = new SolrInputDocument();

--- a/solr/core/src/test/org/apache/solr/update/processor/TestDocBasedVersionConstraints.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TestDocBasedVersionConstraints.java
@@ -47,7 +47,7 @@ public class TestDocBasedVersionConstraints extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     assertU(delQ("*:*"));
     assertU(commit());
   }

--- a/solr/core/src/test/org/apache/solr/util/DateMathParserTest.java
+++ b/solr/core/src/test/org/apache/solr/util/DateMathParserTest.java
@@ -53,20 +53,20 @@ public class DateMathParserTest extends SolrTestCaseJ4 {
   }
 
   /** MACRO: Round: parses s, rounds with u, fmts */
-  protected String r(String s, String u) throws Exception {
+  protected String r(String s, String u) {
     Date dt = DateMathParser.parseMath(null, s + "Z/" + u);
     return fmt.format(dt.toInstant());
   }
 
   /** MACRO: Add: parses s, adds v u, fmts */
-  protected String a(String s, int v, String u) throws Exception {
+  protected String a(String s, int v, String u) {
     char sign = v >= 0 ? '+' : '-';
     Date dt = DateMathParser.parseMath(null, s + 'Z' + sign + Math.abs(v) + u);
     return fmt.format(dt.toInstant());
   }
 
   /** MACRO: Expected: parses s, fmts */
-  protected String e(String s) throws Exception {
+  protected String e(String s) {
     return fmt.format(parser.parse(s, Instant::from));
   }
 

--- a/solr/core/src/test/org/apache/solr/util/FileUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/FileUtilsTest.java
@@ -17,12 +17,11 @@
 package org.apache.solr.util;
 
 import java.io.File;
-import java.io.IOException;
 import org.apache.solr.SolrTestCase;
 
 public class FileUtilsTest extends SolrTestCase {
 
-  public void testResolve() throws IOException {
+  public void testResolve() {
     String cwd = new File(".").getAbsolutePath();
     assertEquals(new File("conf/data"), FileUtils.resolvePath(new File("conf"), "data"));
     assertEquals(

--- a/solr/core/src/test/org/apache/solr/util/TestSolrCLIRunExample.java
+++ b/solr/core/src/test/org/apache/solr/util/TestSolrCLIRunExample.java
@@ -61,7 +61,7 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
-  public static void beforeClass() throws IOException {
+  public static void beforeClass() {
     assumeFalse(
         "FIXME: This test does not work with whitespace in CWD (https://issues.apache.org/jira/browse/SOLR-8877)",
         Paths.get(".").toAbsolutePath().toString().contains(" "));
@@ -273,7 +273,7 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
       if (solrCloudCluster != null) {
         try {
           solrCloudCluster.shutdown();

--- a/solr/core/src/test/org/apache/solr/util/TimeZoneUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/TimeZoneUtilsTest.java
@@ -131,7 +131,7 @@ public class TimeZoneUtilsTest extends SolrTestCase {
     }
   }
 
-  public void testRandom() throws Exception {
+  public void testRandom() {
     final String ONE_DIGIT = "%1d";
     final String TWO_DIGIT = "%02d";
 

--- a/solr/core/src/test/org/apache/solr/util/configuration/SSLConfigurationsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/configuration/SSLConfigurationsTest.java
@@ -20,7 +20,6 @@ package org.apache.solr.util.configuration;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -180,7 +179,7 @@ public class SSLConfigurationsTest {
   }
 
   @Test
-  public void testSystemPropertyPriorityOverEnvVar() throws IOException {
+  public void testSystemPropertyPriorityOverEnvVar() {
     envs.put(EnvSSLCredentialProvider.EnvVars.SOLR_SSL_KEY_STORE_PASSWORD, SAMPLE_PW2);
     assertThat(createSut().getKeyStorePassword(), is(SAMPLE_PW2));
     System.setProperty(KEY_STORE_PASSWORD, SAMPLE_PW1);

--- a/solr/core/src/test/org/apache/solr/util/hll/HLLSerializationTest.java
+++ b/solr/core/src/test/org/apache/solr/util/hll/HLLSerializationTest.java
@@ -92,7 +92,7 @@ public class HLLSerializationTest extends SolrTestCase {
   @Test
   @Slow
   @Monster("may require as much as -Dtests.heapsize=4g depending on random values picked")
-  public void manyValuesHLLSerializationTest() throws Exception {
+  public void manyValuesHLLSerializationTest() {
 
     final HLLType[] ALL_TYPES = EnumSet.allOf(HLLType.class).toArray(new HLLType[0]);
     Arrays.sort(ALL_TYPES);
@@ -137,7 +137,7 @@ public class HLLSerializationTest extends SolrTestCase {
   @Test
   @Slow
   @Monster("can require as much as -Dtests.heapsize=4g because of the massive data structs")
-  public void manyValuesMonsterHLLSerializationTest() throws Exception {
+  public void manyValuesMonsterHLLSerializationTest() {
 
     final HLLType[] ALL_TYPES = EnumSet.allOf(HLLType.class).toArray(new HLLType[0]);
     Arrays.sort(ALL_TYPES);

--- a/solr/core/src/test/org/apache/solr/util/tracing/TestDistributedTracing.java
+++ b/solr/core/src/test/org/apache/solr/util/tracing/TestDistributedTracing.java
@@ -23,7 +23,6 @@ import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -69,8 +68,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
   }
 
   @Test
-  public void test()
-      throws IOException, SolrServerException, TimeoutException, InterruptedException {
+  public void test() throws IOException, SolrServerException {
     // TODO it would be clearer if we could compare the complete Span tree between reality
     //   and what we assert it looks like in a structured visual way.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16223


# Description

The first pass through looking for unused Exceptions was by hand, file by file.  However IntelliJ flagged many other examples, and I finally learned how to use IntelliJ to automatically fix things.

# Solution

Use IntelliJ.

# Tests

Ran the tests!

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
