### PR TITLE
SOLR-9661 added missing operations[withField,withValue] for expression on stream operations

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -95,6 +95,8 @@ Bug Fixes
 
 * SOLR-16142: Fix Admin UI's spatial parameter generation. (Arsal Jalib, Christine Poerschke)
 
+* SOLR-9661: Fix explanation of select() streaming expression that uses replace() operation  (Ahmet Can Kepenek via Eric Pugh) 
+
 Other Changes
 ---------------------
 * SOLR-16245: Make DenseVectorField codec agnostic (Elia Porciani via Alessandro Benedetti)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/Lang.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/Lang.java
@@ -28,6 +28,8 @@ import org.apache.solr.client.solrj.io.graph.ShortestPathStream;
 import org.apache.solr.client.solrj.io.ops.DistinctOperation;
 import org.apache.solr.client.solrj.io.ops.GroupOperation;
 import org.apache.solr.client.solrj.io.ops.ReplaceOperation;
+import org.apache.solr.client.solrj.io.ops.ReplaceWithFieldOperation;
+import org.apache.solr.client.solrj.io.ops.ReplaceWithValueOperation;
 import org.apache.solr.client.solrj.io.stream.*;
 import org.apache.solr.client.solrj.io.stream.expr.Explanation;
 import org.apache.solr.client.solrj.io.stream.expr.Expressible;
@@ -116,6 +118,8 @@ public class Lang {
 
         // tuple manipulation operations
         .withFunctionName("replace", ReplaceOperation.class)
+        .withFunctionName("withValue", ReplaceWithValueOperation.class)
+        .withFunctionName("withField", ReplaceWithFieldOperation.class)
 
         // stream reduction operations
         .withFunctionName("group", GroupOperation.class)

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/TestLang.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/TestLang.java
@@ -103,6 +103,8 @@ public class TestLang extends SolrTestCase {
     "sum",
     "count",
     "replace",
+    "withValue",
+    "withField",
     "concat",
     "group",
     "distinct",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-9661

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Fixed the `withField` and `withValue` usage problem while executing the stream enabled expression.
# Solution

Defined the functions for `withField` and `withValue` 
# Tests

expression (withField and withValue) is tested manually.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)

screenshot about improvement:

![Screenshot from 2022-07-08 02-29-42](https://user-images.githubusercontent.com/1234305/177888929-8aea2a01-0615-4f8d-906f-b4c10bcd3021.png)


![Screenshot from 2022-07-08 02-29-22](https://user-images.githubusercontent.com/1234305/177888942-a88f4f7d-6df8-49f2-9a1d-a7ea497c6091.png)



