### PR TITLE
SOLR-16287 : MapStream - remap tuple value(s)

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
@@ -1057,8 +1057,11 @@ update( destinationCollection,
 ----
 
 Expression above sends the tuples returned by the `search` function to the `destinationCollection` to be atomically
-updated, assumes the id in `collection1` and `destinationCollection` represent the same thing. Here we atomically
-update `a_i` by setting it to values from the `collection1` collection for collection1.id == destinationCollection.id
+updated, the rest of the document will remain as it was, existing requirements for atomic updates still apply.
+Assumes the id in `collection1` and `destinationCollection` represent the same thing.
+
+Here we atomically update `a_i` by setting it to values from the `collection1` collection for
+`collection1.id == destinationCollection.id`
 
 Without the map decorator, the update would simply overwrite any existing document.
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
@@ -1062,8 +1062,6 @@ update `a_i` by setting it to values from the `collection1` collection for colle
 
 Without the map decorator, the update would simply overwrite any existing document.
 
-----
-
 == merge
 
 The `merge` function merges two or more streaming expressions and maintains the ordering of the underlying streams.

--- a/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
@@ -1009,6 +1009,61 @@ list(tuple(a=search(collection1, q="*:*", fl="id, prod_ss", sort="id asc")),
      tuple(a=search(collection2, q="*:*", fl="id, prod_ss", sort="id asc")))
 ----
 
+[#map_expression]
+== map
+
+Given any number of "key=newKey" mappings, the `map` function wraps a Stream Expression
+and re-maps 'key=value' tuples into 'key=tuple(newKey,value)'
+
+=== map Parameters
+
+* `incoming stream`: (Mandatory) A single incoming stream.
+* `"key=newKey"` {1,*} : re-map tuples with `key=value` to `key=tuple(newKey,value)`
+
+=== map Syntax
+
+[source,text]
+----
+Given:
+
+{"id": "1",
+ "count_ii": "2"
+}
+
+Then:
+map(tuple(id=1,count_ii=2),"count_ii=add-distinct")
+
+Will output:
+{
+"count_ii": {
+  "add-distinct": "2"
+ },
+ "id": "1"
+}
+
+e.g. atomically update some records
+
+update( destinationCollection,
+        batchSize=500,
+        map(
+          search(collection1,
+                 q=*:*,
+                 qt="/export",
+                 fl="id,a_i",
+                 sort="a_i asc")),
+        "a_i=set"
+)
+
+----
+
+Expression above sends the tuples returned by the `search` function to the `destinationCollection` to be atomically
+updated, assumes the id in `collection1` and `destinationCollection` represent the same thing. Here we atomically
+update `a_i` by setting it to values from the `collection1` collection for collection1.id == destinationCollection.id
+
+Without the map decorator, the update would simply overwrite any existing document.
+
+----
+
 == merge
 
 The `merge` function merges two or more streaming expressions and maintains the ordering of the underlying streams.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/Lang.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/Lang.java
@@ -57,6 +57,7 @@ public class Lang {
 
         // decorator streams
         .withFunctionName("merge", MergeStream.class)
+        .withFunctionName("map", MapStream.class)
         .withFunctionName("unique", UniqueStream.class)
         .withFunctionName("top", RankStream.class)
         .withFunctionName("group", GroupOperation.class)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/MapStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/MapStream.java
@@ -1,0 +1,135 @@
+package org.apache.solr.client.solrj.io.stream;
+
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.comp.StreamComparator;
+import org.apache.solr.client.solrj.io.stream.expr.*;
+
+import java.io.IOException;
+import java.util.*;
+
+public class MapStream extends TupleStream implements Expressible {
+
+  private static final long serialVersionUID = 1;
+
+  private TupleStream stream;
+  private StreamContext streamContext;
+
+
+  private Map<String, String> mappings;
+
+  public MapStream(TupleStream stream, Map<String, String> mappings){
+    this.stream = stream;
+    this.mappings = mappings;
+  }
+
+  public MapStream(StreamExpression expression, StreamFactory factory) throws IOException {
+    List<StreamExpression> streamExpressions =
+            factory.getExpressionOperandsRepresentingTypes(
+                    expression, Expressible.class, TupleStream.class);
+    if (1 != streamExpressions.size()) {
+      throw new IOException(
+              String.format(
+                      Locale.ROOT,
+                      "Invalid expression %s - expecting single stream but found %d (must be TupleStream types)",
+                      expression,
+                      streamExpressions.size()));
+    }
+
+    stream = factory.constructStream(streamExpressions.get(0));
+
+    List<StreamExpressionParameter> mapFieldExpressions =
+            factory.getOperandsOfType(expression, StreamExpressionValue.class);
+    if (0 == mapFieldExpressions.size()) {
+      throw new IOException(
+              String.format(
+                      Locale.ROOT,
+                      "Invalid expression %s - expecting at least one select field but found %d",
+                      expression,
+                      streamExpressions.size()));
+    }
+
+    mappings = new HashMap<>();
+    mapFieldExpressions.forEach(
+        op -> {
+          String value = ((StreamExpressionValue) op).getValue().trim();
+          if (value.length() > 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+          }
+          String[] parts = value.split("=");
+          mappings.put(parts[0].trim(), parts[1].trim());
+        });
+  }
+
+  @Override
+  public void setStreamContext(StreamContext context) {
+    this.streamContext = context;
+    this.stream.setStreamContext(context);
+  }
+
+  @Override
+  public List<TupleStream> children() {
+    List<TupleStream> l = new ArrayList<>();
+    l.add(stream);
+    return l;
+  }
+
+  @Override
+  public void open() throws IOException {
+    stream.open();
+  }
+
+  @Override
+  public void close() throws IOException {
+    stream.close();
+  }
+
+  @Override
+  public Tuple read() throws IOException {
+    Tuple original = stream.read();
+    if (original.EOF)
+      return original;
+    final Tuple workingToReturn = new Tuple();
+    original.getFields().forEach((k,v) ->
+            workingToReturn.put(k,mappings.containsKey(k) ? new Tuple(mappings.get(k),v) : v));
+    return workingToReturn;
+  }
+
+  @Override
+  public StreamComparator getStreamSort() {
+    return null;
+  }
+
+  @Override
+  public StreamExpressionParameter toExpression(StreamFactory factory) throws IOException {
+    return toExpression(factory, true);
+  }
+
+  private StreamExpression toExpression(StreamFactory factory, boolean includeStreams)
+      throws IOException {
+    StreamExpression expression = new StreamExpression(factory.getFunctionName(this.getClass()));
+    if (includeStreams) {
+      // stream
+      if (stream instanceof Expressible) {
+        expression.addParameter(((Expressible) stream).toExpression(factory));
+      } else {
+        throw new IOException(
+            "This SelectStream contains a non-expressible TupleStream - it cannot be converted to an expression");
+      }
+    } else {
+      expression.addParameter("<stream>");
+    }
+    mappings.forEach((k, v) -> expression.addParameter(k + "=" + v));
+
+    return expression;
+  }
+
+  @Override
+  public Explanation toExplanation(StreamFactory factory) throws IOException {
+    return new StreamExplanation(getStreamNodeId().toString())
+            .withChildren(new Explanation[] {stream.toExplanation(factory)})
+            .withFunctionName(factory.getFunctionName(this.getClass()))
+            .withImplementingClass(this.getClass().getName())
+            .withExpressionType(Explanation.ExpressionType.STREAM_DECORATOR)
+            .withExpression(toExpression(factory, false).toString());
+  }
+}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/MapStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/MapStream.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.client.solrj.io.stream;
 
 import org.apache.solr.client.solrj.io.Tuple;

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/TestLang.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/TestLang.java
@@ -117,6 +117,7 @@ public class TestLang extends SolrTestCase {
     "copyOfRange",
     "copyOf",
     "cov",
+    "map",
     "corr",
     "describe",
     "distance",

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.solr.client.solrj.io.stream;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParser;
@@ -29,11 +33,6 @@ import org.apache.solr.cloud.SolrCloudTestCase;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 public class MapStreamTest extends SolrCloudTestCase {
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -82,19 +82,19 @@ public class MapStreamTest extends SolrCloudTestCase {
     List<Tuple> tuples;
     StreamContext streamContext = new StreamContext();
     StreamFactory factory =
-            new StreamFactory()
-                    .withCollectionZkHost("collection1", cluster.getZkServer().getZkAddress())
-                    .withFunctionName("search", CloudSolrStream.class)
-                    .withFunctionName("select", SelectStream.class)
-                    .withFunctionName("tuple", TupStream.class)
-                    .withFunctionName("map", MapStream.class);
+        new StreamFactory()
+            .withCollectionZkHost("collection1", cluster.getZkServer().getZkAddress())
+            .withFunctionName("search", CloudSolrStream.class)
+            .withFunctionName("select", SelectStream.class)
+            .withFunctionName("tuple", TupStream.class)
+            .withFunctionName("map", MapStream.class);
 
     String clause = "map(map(tuple(a=\"123\",c=\"345\"),\"a=inner\"),\"a=outer\")";
     stream = factory.constructStream(clause);
     stream.setStreamContext(streamContext);
     tuples = getTuples(stream);
     Tuple a = (Tuple) tuples.get(0).get("a");
-    assertTupleValue(a,"outer","inner","123");
+    assertTupleValue(a, "outer", "inner", "123");
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -93,8 +93,8 @@ public class MapStreamTest extends SolrCloudTestCase {
     stream = factory.constructStream(clause);
     stream.setStreamContext(streamContext);
     tuples = getTuples(stream);
-    Tuple outer = (Tuple) tuples.get(0).get("a");
-    assertTupleValue(outer,"outer","inner","123");
+    Tuple a = (Tuple) tuples.get(0).get("a");
+    assertTupleValue(a,"outer","inner","123");
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -77,6 +77,27 @@ public class MapStreamTest extends SolrCloudTestCase {
   }
 
   @Test
+  public void testNestedMapStream() throws Exception {
+    TupleStream stream;
+    List<Tuple> tuples;
+    StreamContext streamContext = new StreamContext();
+    StreamFactory factory =
+            new StreamFactory()
+                    .withCollectionZkHost("collection1", cluster.getZkServer().getZkAddress())
+                    .withFunctionName("search", CloudSolrStream.class)
+                    .withFunctionName("select", SelectStream.class)
+                    .withFunctionName("tuple", TupStream.class)
+                    .withFunctionName("map", MapStream.class);
+
+    String clause = "map(map(tuple(a=\"123\",c=\"345\"),\"a=inner\"),\"a=outer\")";
+    stream = factory.constructStream(clause);
+    stream.setStreamContext(streamContext);
+    tuples = getTuples(stream);
+    Tuple outer = (Tuple) tuples.get(0).get("a");
+    assertTupleValue(outer,"outer","inner","123");
+  }
+
+  @Test
   public void testMapStream() throws Exception {
 
     TupleStream stream;
@@ -98,6 +119,7 @@ public class MapStreamTest extends SolrCloudTestCase {
     assertString(tuples.get(0), "c", "345");
   }
 
+  @Test
   public void testMapStreamUpdate() throws Exception {
     UpdateResponse resp =
         new UpdateRequest()

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -90,8 +90,6 @@ public class MapStreamTest extends SolrCloudTestCase {
             .withFunctionName("tuple", TupStream.class)
             .withFunctionName("map", MapStream.class);
 
-    String fn = factory.getFunctionName(MapStream.class);
-
     String clause = "map(tuple(a=\"123\",c=\"345\"),\"a=b\")";
     stream = factory.constructStream(clause);
     stream.setStreamContext(streamContext);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -1,0 +1,170 @@
+package org.apache.solr.client.solrj.io.stream;
+
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParser;
+import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.cloud.AbstractDistribZkTestBase;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class MapStreamTest extends SolrCloudTestCase {
+
+  private static final String COLLECTIONORALIAS = "collection1";
+
+  private static final String id = "id";
+
+  private static final int TIMEOUT = DEFAULT_TIMEOUT;
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    configureCluster(4)
+        .addConfig(
+            "conf",
+            getFile("solrj")
+                .toPath()
+                .resolve("solr")
+                .resolve("configsets")
+                .resolve("streaming")
+                .resolve("conf"))
+        .addConfig(
+            "ml",
+            getFile("solrj")
+                .toPath()
+                .resolve("solr")
+                .resolve("configsets")
+                .resolve("ml")
+                .resolve("conf"))
+        .configure();
+
+    String collection = COLLECTIONORALIAS;
+    CollectionAdminRequest.createCollection(collection, "conf", 2, 1)
+        .setPerReplicaState(SolrCloudTestCase.USE_PER_REPLICA_STATE)
+        .process(cluster.getSolrClient());
+    AbstractDistribZkTestBase.waitForRecoveriesToFinish(
+        collection, cluster.getZkStateReader(), false, true, TIMEOUT);
+  }
+
+  @Before
+  public void cleanIndex() throws Exception {
+    new UpdateRequest().deleteByQuery("*:*").commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+  }
+
+  @Test
+  public void testMapStream() throws Exception {
+
+    TupleStream stream;
+    List<Tuple> tuples;
+    StreamContext streamContext = new StreamContext();
+    StreamFactory factory =
+        new StreamFactory()
+            .withCollectionZkHost("collection1", cluster.getZkServer().getZkAddress())
+            .withFunctionName("search", CloudSolrStream.class)
+            .withFunctionName("select", SelectStream.class)
+            .withFunctionName("tuple", TupStream.class)
+            .withFunctionName("map", MapStream.class);
+
+    String fn = factory.getFunctionName(MapStream.class);
+
+    String clause = "map(tuple(a=\"123\",c=\"345\"),\"a=b\")";
+    stream = factory.constructStream(clause);
+    stream.setStreamContext(streamContext);
+    tuples = getTuples(stream);
+    assertTupleValue(tuples.get(0), "a", "b", "123");
+    assertString(tuples.get(0), "c", "345");
+  }
+
+  public void testMapStreamUpdate() throws Exception {
+    UpdateResponse resp =
+        new UpdateRequest()
+            .add(id, "1", "a_ss", "foo", "b_i", "1", "c_d", "3.3", "d_b", "true")
+            .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    StreamExpression expression;
+    TupleStream stream;
+    List<Tuple> tuples;
+
+    StreamFactory factory =
+        new StreamFactory()
+            .withCollectionZkHost(COLLECTIONORALIAS, cluster.getZkServer().getZkAddress())
+            .withFunctionName("search", CloudSolrStream.class)
+            .withFunctionName("map", MapStream.class)
+            .withFunctionName("update", UpdateStream.class)
+            .withFunctionName("tuple", TupStream.class)
+            .withFunctionName("select", SelectStream.class);
+
+    // Basic test
+    expression =
+        StreamExpressionParser.parse(
+            "search(" + COLLECTIONORALIAS + ", q=\"id:1\", fl=\"id\", sort=\"id asc\")");
+
+    stream = factory.constructStream(Objects.requireNonNull(expression));
+    StreamContext streamContext = new StreamContext();
+    stream.setStreamContext(streamContext);
+    tuples = getTuples(stream);
+    assert (tuples.size() == 1);
+
+    expression =
+        StreamExpressionParser.parse(
+            "update("
+                + COLLECTIONORALIAS
+                + ",map(tuple(id=\"1\",a_ss=\"bar\"),\"a_ss=add-distinct\"))");
+    stream = new UpdateStream(expression, factory);
+    stream.setStreamContext(streamContext);
+    tuples = getTuples(stream);
+    cluster.getSolrClient().commit(COLLECTIONORALIAS);
+    assert (tuples.size() == 1);
+    Tuple t = tuples.get(0);
+    assert (!t.EOF);
+    assertEquals(1, t.get("batchIndexed"));
+
+    expression =
+        StreamExpressionParser.parse(
+            "search(" + COLLECTIONORALIAS + ", q=\"*:*\", fl=\"id,a_ss,c_d,*\", sort=\"id asc\")");
+
+    stream = factory.constructStream(Objects.requireNonNull(expression));
+    streamContext = new StreamContext();
+    stream.setStreamContext(streamContext);
+    tuples = getTuples(stream);
+    assert (tuples.size() == 1);
+    assertEquals("1", tuples.get(0).get("id"));
+    assertEquals(1L, tuples.get(0).get("b_i"));
+    assertEquals(List.of("foo", "bar"), tuples.get(0).get("a_ss"));
+  }
+
+  public boolean assertString(Tuple tuple, String fieldName, String v) throws Exception {
+    String lv = (String) tuple.get(fieldName);
+    if (!v.equals(lv)) {
+      throw new Exception("Strings not equal:" + v + " : " + lv);
+    }
+    return true;
+  }
+
+  public boolean assertTupleValue(Tuple t, String f, String k, Object v) throws Exception {
+    Object vv = ((Tuple) t.get(f)).get(k);
+    if (!v.equals(vv)) {
+      throw new Exception("Objects not equal:" + v + " : " + vv);
+    }
+    return true;
+  }
+
+  protected List<Tuple> getTuples(TupleStream tupleStream) throws IOException {
+    tupleStream.open();
+    List<Tuple> tuples = new ArrayList<>();
+    for (Tuple t = tupleStream.read(); !t.EOF; t = tupleStream.read()) {
+      tuples.add(t);
+    }
+    tupleStream.close();
+    return tuples;
+  }
+}

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/MapStreamTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.client.solrj.io.stream;
 
 import org.apache.solr.client.solrj.io.Tuple;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16287

# Description

Enables atomic updates for update stream by remapping a value to tuple, solr will recognise the map as an atomic update, otherwise update stream simply overwrites. Normal Solr requirements for atomic/in-place updates are still necessary.

# Solution

Remap from (k,v) => k -> newKey -> value

e.g.  with

map(<stream>,"cand_id=add-distinct") , convert stream tuples from

From:
`
{"cand_id":5718,id:123,v_i:345}
`
To:
`
{
  id:123,
  v_i:345,
  "cand_id": {
    "add-distinct": 5718
}, 
`
# Tests

e.g.
With:
`
new UpdateRequest()
            .add(id, "1", "a_ss", "foo", "b_i", "1", "c_d", "3.3", "d_b", "true")
`
Then:
`update(collection1,map(tuple(id="1",a_ss="bar"),"a_ss=add-distinct"))` will **add-distinct** 'bar' to `a_ss` to then contain ['foo','bar']


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
