### PR TITLE
SOLR-16291 : Decay function queries gauss,linear,exponential

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
@@ -1,0 +1,246 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.queries.function.FunctionValues;
+import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.queries.function.docvalues.DoubleDocValues;
+import org.apache.lucene.spatial.SpatialStrategy;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.schema.*;
+import org.apache.solr.search.FunctionQParser;
+import org.apache.solr.search.SyntaxError;
+import org.apache.solr.search.ValueSourceParser;
+import org.apache.solr.util.DateMathParser;
+import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.shape.Point;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public abstract class DecayFunctionValueSourceParser extends ValueSourceParser {
+  @Override
+  public ValueSource parse(FunctionQParser fp) throws SyntaxError {
+
+    String field = fp.parseArg();
+    SchemaField f = fp.getReq().getSchema().getField(field);
+    FieldType ft = f.getType();
+
+    // if DatePointField field then assume dates -> numericvaluesource
+    if (ft instanceof DatePointField) {
+      return parseDateVariable(fp, ft.getValueSource(f, fp));
+    }
+    // if LatLonPointSpatialField then assume distances -> geovaluesource
+    else if (ft instanceof LatLonPointSpatialField) {
+      return parseGeoVariable(fp, field, (LatLonPointSpatialField) ft);
+    }
+    // if NumericFieldType field -> numericvaluesource
+    else if (ft instanceof NumericFieldType) {
+      return parseNumericVariable(fp, ft.getValueSource(f, fp));
+    }
+    // else exception
+    else {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST,
+          String.format(
+              "field [%s] is of type [%s], but only numeric types are supported.", field, ft));
+    }
+  }
+
+  abstract DecayStrategy getDecayStrategy();
+
+  abstract String name();
+
+  protected ValueSource parseGeoVariable(
+      FunctionQParser fp, String field, LatLonPointSpatialField ft) throws SyntaxError {
+
+    String scaleString = fp.parseArg();
+    if (scaleString == null)
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST, "[scale] must be set for geo fields.");
+
+    double lat = fp.parseDouble();
+    double lon = fp.parseDouble();
+    SpatialStrategy strategy = ft.getStrategy(field);
+    Point origin = strategy.getSpatialContext().getShapeFactory().pointXY(lon, lat);
+    String offsetString = fp.hasMoreArguments() ? fp.parseArg() : "0km";
+    double decay = fp.hasMoreArguments() ? fp.parseDouble() : 0.5;
+
+    ValueSource vs =
+        ValueSource.fromDoubleValuesSource(
+            strategy.makeDistanceValueSource(
+                origin, DistanceUtils.DEG_TO_KM)); // this does the distance calculation from origin
+
+    double scale = DistanceUnit.KILOMETERS.parse(scaleString, DistanceUnit.KILOMETERS);
+    double offset = DistanceUnit.KILOMETERS.parse(offsetString, DistanceUnit.KILOMETERS);
+
+    return new GeoDecayFunctionValueSource(scale, offset, decay, getDecayStrategy(), vs, name());
+  }
+
+  protected ValueSource parseNumericVariable(FunctionQParser fp, ValueSource vs)
+      throws SyntaxError {
+    double scale = fp.parseDouble();
+    double origin = fp.parseDouble();
+    double offset = fp.hasMoreArguments() ? fp.parseDouble() : 0;
+    double decay = fp.hasMoreArguments() ? fp.parseDouble() : 0.5; // def 0.5
+    return new NumericDecayFunctionValueSource(
+        origin, scale, decay, offset, getDecayStrategy(), vs, name());
+  }
+
+  protected ValueSource parseDateVariable(FunctionQParser fp, ValueSource vs) throws SyntaxError {
+    String originString;
+    String offsetString = "+0DAY";
+    double decay = 0.5;
+
+    String scaleString = fp.parseArg(); // 1st arg
+    if (scaleString == null) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST, "[scale] must be set for date fields.");
+    }
+
+    originString = fp.parseArg(); // 2nd arg
+    Date originDate =
+        DateMathParser.parseMath(null, Optional.ofNullable(originString).orElse("NOW"));
+    long origin = originDate.getTime();
+
+    long scale = DateMathParser.parseMath(originDate, "NOW" + scaleString).getTime() - origin;
+
+    if (fp.hasMoreArguments()) offsetString = fp.parseArg(); // 3rd arg
+    long offset = DateMathParser.parseMath(originDate, "NOW" + offsetString).getTime() - origin;
+
+    if (fp.hasMoreArguments()) decay = fp.parseDouble();
+
+    return new NumericDecayFunctionValueSource(
+        origin, scale, decay, offset, getDecayStrategy(), vs, name());
+  }
+}
+
+class GeoDecayFunctionValueSource extends ValueSource {
+
+  private final double scale;
+  private final double offset;
+  private final double decay;
+  private final DecayStrategy decayStrategy;
+  private final ValueSource vs;
+  private final String name;
+
+  public GeoDecayFunctionValueSource(
+      double scale,
+      double offset,
+      double decay,
+      DecayStrategy decayStrategy,
+      ValueSource vs,
+      String name) {
+    this.scale = scale;
+    this.offset = offset;
+    this.decay = decay;
+    this.decayStrategy = decayStrategy;
+    this.vs = vs;
+    this.name = name;
+  }
+
+  @Override
+  public FunctionValues getValues(Map<Object,Object> context, LeafReaderContext readerContext) throws IOException {
+    FunctionValues values = vs.getValues(context, readerContext);
+    double s = decayStrategy.scale(scale, decay);
+    return new DoubleDocValues(vs) {
+
+      @Override
+      public double doubleVal(int doc) throws IOException {
+        double distance = values.doubleVal(doc);
+        return decayStrategy.calculate(Math.max(0.0d, distance - offset), s);
+      }
+    };
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    GeoDecayFunctionValueSource that = (GeoDecayFunctionValueSource) o;
+    return Objects.equals(scale, that.scale)
+        && Objects.equals(offset, that.offset)
+        && Objects.equals(decay, that.decay)
+        && Objects.equals(decayStrategy, that.decayStrategy)
+        && Objects.equals(vs, that.vs)
+        && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scale, offset, decay, decayStrategy, vs, name);
+  }
+
+  @Override
+  public String description() {
+    return name + "(" + decayStrategy.explain(scale) + ")";
+  }
+}
+
+class NumericDecayFunctionValueSource extends ValueSource {
+
+  private final double origin;
+  private final double scale;
+  private final double decay;
+  private final double offset;
+  private final DecayStrategy decayStrategy;
+  private final ValueSource vs;
+  private final String name;
+
+  public NumericDecayFunctionValueSource(
+      double origin,
+      double scale,
+      double decay,
+      double offset,
+      DecayStrategy decayStrategy,
+      ValueSource vs,
+      String name) {
+    this.origin = origin;
+    this.scale = scale;
+    this.decay = decay;
+    this.offset = offset;
+    this.decayStrategy = decayStrategy;
+    this.vs = vs;
+    this.name = name;
+  }
+
+  @Override
+  public FunctionValues getValues(Map<Object,Object> context, LeafReaderContext readerContext) throws IOException {
+    double s = decayStrategy.scale(scale, decay);
+    FunctionValues values = vs.getValues(context, readerContext);
+    return new DoubleDocValues(vs) {
+      @Override
+      public double doubleVal(int doc) throws IOException {
+        double val = values.doubleVal(doc);
+        return decayStrategy.calculate(Math.max(0.0d, Math.abs(val - origin) - offset), s);
+      }
+    };
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    NumericDecayFunctionValueSource that = (NumericDecayFunctionValueSource) o;
+    return Objects.equals(origin, that.origin)
+        && Objects.equals(scale, that.scale)
+        && Objects.equals(offset, that.offset)
+        && Objects.equals(decayStrategy, that.decayStrategy)
+        && Objects.equals(vs, that.vs)
+        && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(origin, scale, offset, decayStrategy, vs, name);
+  }
+
+  @Override
+  public String description() {
+    return name + "(" + decayStrategy.explain(scale) + ")";
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
@@ -242,19 +242,19 @@ class NumericDecayFunctionValueSource extends ValueSource {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-
     NumericDecayFunctionValueSource that = (NumericDecayFunctionValueSource) o;
-    return Objects.equals(origin, that.origin)
-        && Objects.equals(scale, that.scale)
-        && Objects.equals(offset, that.offset)
-        && Objects.equals(decayStrategy, that.decayStrategy)
-        && Objects.equals(vs, that.vs)
-        && Objects.equals(name, that.name);
+    return Double.compare(that.origin, origin) == 0 &&
+            Double.compare(that.scale, scale) == 0 &&
+            Double.compare(that.decay, decay) == 0 &&
+            Double.compare(that.offset, offset) == 0 &&
+            Objects.equals(decayStrategy, that.decayStrategy) &&
+            Objects.equals(vs, that.vs) &&
+            Objects.equals(name, that.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(origin, scale, offset, decayStrategy, vs, name);
+    return Objects.hash(origin, scale, decay, offset, decayStrategy, vs, name);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.apache.lucene.index.LeafReaderContext;

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayFunctionValueSourceParser.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.apache.lucene.index.LeafReaderContext;

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayStrategy.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayStrategy.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 public interface DecayStrategy {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayStrategy.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 public interface DecayStrategy {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayStrategy.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DecayStrategy.java
@@ -1,0 +1,9 @@
+package org.apache.solr.search.function.decayfunction;
+
+public interface DecayStrategy {
+  double scale(double scale, double decay);
+
+  double calculate(double value, double scale);
+
+  String explain(double scale);
+}

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DistanceUnit.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DistanceUnit.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 public enum DistanceUnit {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DistanceUnit.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DistanceUnit.java
@@ -1,0 +1,144 @@
+package org.apache.solr.search.function.decayfunction;
+
+public enum DistanceUnit {
+  INCH(0.0254, "in", "inch"),
+  YARD(0.9144, "yd", "yards"),
+  FEET(0.3048, "ft", "feet"),
+  KILOMETERS(1000.0, "km", "kilometers"),
+  NAUTICALMILES(1852.0, "NM", "nmi", "nauticalmiles"),
+  MILLIMETERS(0.001, "mm", "millimeters"),
+  CENTIMETERS(0.01, "cm", "centimeters"),
+
+  // 'm' is a suffix of 'nmi' so it must follow 'nmi'
+  MILES(1609.344, "mi", "miles"),
+
+  // since 'm' is suffix of other unit
+  // it must be the last entry of unit
+  // names ending with 'm'. otherwise
+  // parsing would fail
+  METERS(1, "m", "meters");
+
+  public static final DistanceUnit DEFAULT = METERS;
+
+  private final double meters;
+  private final String[] names;
+
+  DistanceUnit(double meters, String... names) {
+    this.meters = meters;
+    this.names = names;
+  }
+
+  /**
+   * Convert a value to a distance string
+   *
+   * @param distance value to convert
+   * @return String representation of the distance
+   */
+  public String toString(double distance) {
+    return distance + toString();
+  }
+
+  @Override
+  public String toString() {
+    return names[0];
+  }
+
+  /**
+   * Converts the given distance from the given DistanceUnit, to the given DistanceUnit
+   *
+   * @param distance Distance to convert
+   * @param from Unit to convert the distance from
+   * @param to Unit of distance to convert to
+   * @return Given distance converted to the distance in the given unit
+   */
+  public static double convert(double distance, DistanceUnit from, DistanceUnit to) {
+    if (from == to) {
+      return distance;
+    } else {
+      return distance * from.meters / to.meters;
+    }
+  }
+
+  /**
+   * Parses a given distance and converts it to the specified unit.
+   *
+   * @param distance String defining a distance (value and unit)
+   * @param defaultUnit unit assumed if none is defined
+   * @param to unit of result
+   * @return parsed distance
+   */
+  public static double parse(String distance, DistanceUnit defaultUnit, DistanceUnit to) {
+    Distance dist = Distance.parseDistance(distance, defaultUnit);
+    return convert(dist.value, dist.unit, to);
+  }
+
+  /**
+   * Parses a given distance and converts it to this unit.
+   *
+   * @param distance String defining a distance (value and unit)
+   * @param defaultUnit unit to expect if none if provided
+   * @return parsed distance
+   */
+  public double parse(String distance, DistanceUnit defaultUnit) {
+    return parse(distance, defaultUnit, this);
+  }
+
+  /** This class implements a value+unit tuple. */
+  public static class Distance implements Comparable<Distance> {
+    public final double value;
+    public final DistanceUnit unit;
+
+    public Distance(double value, DistanceUnit unit) {
+      super();
+      this.value = value;
+      this.unit = unit;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      } else if (obj instanceof Distance) {
+        Distance other = (Distance) obj;
+        return DistanceUnit.convert(value, unit, other.unit) == other.value;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Double.valueOf(value * unit.meters).hashCode();
+    }
+
+    @Override
+    public int compareTo(Distance o) {
+      return Double.compare(value, DistanceUnit.convert(o.value, o.unit, unit));
+    }
+
+    @Override
+    public String toString() {
+      return unit.toString(value);
+    }
+
+    /**
+     * Parse a {@link Distance} from a given String
+     *
+     * @param distance String defining a {@link Distance}
+     * @param defaultUnit {@link DistanceUnit} to be assumed if not unit is provided in the first
+     *     argument
+     * @return parsed {@link Distance}
+     */
+    private static Distance parseDistance(String distance, DistanceUnit defaultUnit) {
+      for (DistanceUnit unit : values()) {
+        for (String name : unit.names) {
+          if (distance.endsWith(name)) {
+            return new Distance(
+                Double.parseDouble(distance.substring(0, distance.length() - name.length())), unit);
+          }
+        }
+      }
+      return new Distance(Double.parseDouble(distance), defaultUnit);
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/DistanceUnit.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/DistanceUnit.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 public enum DistanceUnit {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/ExponentialDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/ExponentialDecayFunctionValueSourceParser.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 public class ExponentialDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/ExponentialDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/ExponentialDecayFunctionValueSourceParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 public class ExponentialDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/ExponentialDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/ExponentialDecayFunctionValueSourceParser.java
@@ -1,0 +1,31 @@
+package org.apache.solr.search.function.decayfunction;
+
+public class ExponentialDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {
+  @Override
+  DecayStrategy getDecayStrategy() {
+    return new ExponentialDecay();
+  }
+
+  @Override
+  String name() {
+    return "exp";
+  }
+}
+
+final class ExponentialDecay implements DecayStrategy {
+
+  @Override
+  public double scale(double scale, double decay) {
+    return Math.log(decay) / scale;
+  }
+
+  @Override
+  public double calculate(double value, double scale) {
+    return Math.exp(scale * value);
+  }
+
+  @Override
+  public String explain(double scale) {
+    return "exp(- <val> * " + -1 * scale + ")";
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/GaussDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/GaussDecayFunctionValueSourceParser.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 public class GaussDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/GaussDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/GaussDecayFunctionValueSourceParser.java
@@ -1,0 +1,33 @@
+package org.apache.solr.search.function.decayfunction;
+
+public class GaussDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {
+  @Override
+  DecayStrategy getDecayStrategy() {
+    return new GaussDecay();
+  }
+
+  @Override
+  String name() {
+    return "gauss";
+  }
+}
+
+final class GaussDecay implements DecayStrategy {
+
+  @Override
+  public double scale(double scale, double decay) {
+    return 0.5 * Math.pow(scale, 2.0) / Math.log(decay);
+  }
+
+  @Override
+  public double calculate(double value, double scale) {
+    // note that we already computed scale^2 in processScale() so we do
+    // not need to square it here.
+    return Math.exp(0.5 * Math.pow(value, 2.0) / scale);
+  }
+
+  @Override
+  public String explain(double scale) {
+    return "exp(-0.5*pow(<val>,2.0)/" + -1 * scale + ")";
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/GaussDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/GaussDecayFunctionValueSourceParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 public class GaussDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/LinearDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/LinearDecayFunctionValueSourceParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 public class LinearDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/LinearDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/LinearDecayFunctionValueSourceParser.java
@@ -1,0 +1,32 @@
+package org.apache.solr.search.function.decayfunction;
+
+public class LinearDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {
+
+  @Override
+  DecayStrategy getDecayStrategy() {
+    return new LinearDecay();
+  }
+
+  @Override
+  String name() {
+    return "linear";
+  }
+}
+
+final class LinearDecay implements DecayStrategy {
+
+  @Override
+  public double scale(double scale, double decay) {
+    return scale / (1.0 - decay);
+  }
+
+  @Override
+  public double calculate(double value, double scale) {
+    return Math.max(0.0, (scale - value) / scale);
+  }
+
+  @Override
+  public String explain(double scale) {
+    return "max(0.0, ((" + scale + " - <val>)/" + scale + ")";
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/function/decayfunction/LinearDecayFunctionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/decayfunction/LinearDecayFunctionValueSourceParser.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 public class LinearDecayFunctionValueSourceParser extends DecayFunctionValueSourceParser {

--- a/solr/core/src/test-files/solr/collection1/conf/schema-decayfunc.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-decayfunc.xml
@@ -1,0 +1,930 @@
+<?xml version="1.0" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- The Solr schema file. This file should be named "schema.xml" and
+     should be located where the classloader for the Solr webapp can find it.
+
+     This schema is used for testing, and as such has everything and the
+     kitchen sink thrown in. See example/solr/conf/schema.xml for a
+     more concise example.
+
+  -->
+
+<schema name="test" version="1.0">
+
+  <!-- field type definitions... note that the "name" attribute is
+       just a label to be used by field definitions.  The "class"
+       attribute and any other attributes determine the real type and
+       behavior of the fieldType.
+    -->
+
+  <fieldType name="int" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="float" class="${solr.tests.FloatFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="long" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="double" class="${solr.tests.DoubleFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+
+
+  <fieldType name="tint" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="tfloat" class="${solr.tests.FloatFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="tlong" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="tdouble" class="${solr.tests.DoubleFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  
+  <!-- Point Fields -->
+  <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+  <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+  <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+  <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
+  <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+
+  <!-- Dense Vector Fields -->
+  <fieldType name="knn_vector_cosine" class="solr.DenseVectorField" vectorDimension="4" similarityFunction="cosine"/>
+  <fieldType name="knn_vector_dot_product" class="solr.DenseVectorField" vectorDimension="4" similarityFunction="dot_product"/>
+  <fieldType name="knn_vector5" class="solr.DenseVectorField" vectorDimension="5" similarityFunction="dot_product"/>
+
+
+
+  <!-- Field type demonstrating an Analyzer failure -->
+  <fieldType name="failtype1" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="0" catenateWords="0"
+              catenateNumbers="0" catenateAll="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- Demonstrating ignoreCaseChange -->
+  <fieldType name="wdf_nocase" class="solr.TextField">
+    <analyzer type="">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="0" catenateWords="0"
+              catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="0" catenateWords="0"
+              catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="wdf_preserve" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="1" catenateWords="0"
+              catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="1"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="1" catenateWords="0"
+              catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="1"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+
+  <!-- HighlitText optimizes storage for (long) columns which will be highlit -->
+  <fieldType name="highlittext" class="solr.TextField" compressThreshold="345"/>
+
+  <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
+
+  <!-- format for date is 1995-12-31T23:59:59.999Z and only the fractional
+       seconds part (.999) is optional.
+    -->
+  <fieldType name="date" class="${solr.tests.DateFieldType}" precisionStep="0" docValues="${solr.tests.numeric.dv}"/>
+  <fieldType name="tdate" class="${solr.tests.DateFieldType}" precisionStep="6" docValues="${solr.tests.numeric.dv}"/>
+  <fieldType name="tdatedv" class="${solr.tests.DateFieldType}" precisionStep="6" docValues="true"/>
+
+  <fieldType name="dateRange" class="solr.DateRangeField"/>
+  <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+             geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
+
+  <!-- solr.TextField allows the specification of custom
+       text analyzers specified as a tokenizer and a list
+       of token filters.
+    -->
+  <fieldType name="text" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldtype name="text_payload_tv" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+      <filter class="org.apache.lucene.analysis.payloads.TokenOffsetPayloadTokenFilterFactory"/>
+    </analyzer>
+  </fieldtype>
+
+  <fieldType name="nametext" class="solr.TextField">
+    <analyzer class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
+  </fieldType>
+
+  <fieldType name="teststop" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.LetterTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory" words="stopwords.txt"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.LetterTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- fieldTypes in this section isolate tokenizers and tokenfilters for testing -->
+  <fieldType name="keywordtok" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory" pattern="keyword"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="standardtok" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="lettertok" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.LetterTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="whitetok" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="HTMLstandardtok" class="solr.TextField">
+    <analyzer>
+      <charFilter class="solr.HTMLStripCharFilterFactory"/>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="HTMLwhitetok" class="solr.TextField">
+    <analyzer>
+      <charFilter class="solr.HTMLStripCharFilterFactory"/>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="standardtokfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="standardfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="lowerfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="lowerpunctfilt" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" expand="true"/>
+      <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+              catenateNumbers="1" catenateAll="1" splitOnCaseChange="1"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" expand="true"/>
+      <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+              catenateNumbers="1" catenateAll="1" splitOnCaseChange="1"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="patternreplacefilt" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory" pattern="keyword"/>
+      <filter class="solr.PatternReplaceFilterFactory"
+              pattern="([^a-zA-Z])" replacement="_" replace="all"
+      />
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory" pattern="keyword"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="patterntok" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.PatternTokenizerFactory" pattern=","/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="porterfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <!-- fieldType name="snowballfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SnowballPorterFilterFactory"/>
+    </analyzer>
+  </fieldType -->
+  <fieldType name="engporterfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="custengporterfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="stopfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.StopFilterFactory" ignoreCase="true"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="custstopfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.StopFilterFactory" words="stopwords.txt"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="lengthfilt" class="solr.TextField">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LengthFilterFactory" min="2" max="5"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="charfilthtmlmap" class="solr.TextField">
+    <analyzer>
+      <charFilter class="solr.HTMLStripCharFilterFactory"/>
+      <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="subword" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+              catenateNumbers="1" catenateAll="0"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0"
+              catenateNumbers="0" catenateAll="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="numericsubword" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" protected="protwords.txt" splitOnNumerics="0"
+              splitOnCaseChange="0" generateWordParts="1" generateNumberParts="0" catenateWords="0" catenateNumbers="0"
+              catenateAll="0"/>
+      <filter class="solr.StopFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" protected="protwords.txt" splitOnNumerics="0"
+              splitOnCaseChange="0" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1"
+              catenateAll="0"/>
+      <filter class="solr.StopFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="protectedsubword" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" protected="protwords.txt" splitOnNumerics="0"
+              splitOnCaseChange="0" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0"
+              catenateAll="0"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+
+  <!-- more flexible in matching skus, but more chance of a false match -->
+  <fieldType name="skutype1" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+              catenateNumbers="1" catenateAll="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1"
+              catenateNumbers="1" catenateAll="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- less flexible in matching skus, but less chance of a false match -->
+  <fieldType name="skutype2" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1"
+              catenateNumbers="1" catenateAll="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1"
+              catenateNumbers="1" catenateAll="0"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- less flexible in matching skus, but less chance of a false match -->
+  <fieldType name="syn" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="old_synonyms.txt"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="old_synonyms.txt"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- Demonstrates How RemoveDuplicatesTokenFilter makes stemmed
+       synonyms "better"
+    -->
+  <fieldType name="dedup" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory"
+              synonyms="old_synonyms.txt" expand="true"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+      <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory"
+              synonyms="old_synonyms.txt" expand="true"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+      <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="unstored" class="solr.StrField" indexed="true" stored="false"/>
+
+
+  <fieldType name="textgap" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="uuid" class="solr.UUIDField"/>
+
+  <!-- Try out some point types -->
+  <fieldType name="xy" class="solr.PointType" dimension="2" subFieldType="double"  docValues="true"/>
+  <fieldType name="x" class="solr.PointType" dimension="1" subFieldType="double"/>
+  <fieldType name="tenD" class="solr.PointType" dimension="10" subFieldType="double"/>
+  <fieldType name="xyd" class="solr.PointType" dimension="2" subFieldSuffix="_d1"/>
+
+  <!-- Currency type -->
+  <fieldType name="currency" class="solr.CurrencyField" currencyConfig="currency.xml" multiValued="false"/>
+  <fieldType name="mock_currency" class="solr.CurrencyField" providerClass="solr.MockExchangeRateProvider" foo="bar"
+             multiValued="false"/>
+  <fieldType name="oer_currency"
+             class="solr.CurrencyField"
+             multiValued="false"
+             providerClass="solr.OpenExchangeRatesOrgProvider"
+             ratesFileLocation="open-exchange-rates.json"/>
+  <fieldType name="currency_CFT" class="solr.CurrencyFieldType" amountLongSuffix="_l1_ns" codeStrSuffix="_s1"
+             currencyConfig="currency.xml" multiValued="false"/>
+  <fieldType name="mock_currency_CFT" class="solr.CurrencyFieldType" amountLongSuffix="_l1_ns" codeStrSuffix="_s1"
+             providerClass="solr.MockExchangeRateProvider" foo="bar" multiValued="false"/>
+  <fieldType name="oer_currency_CFT"
+             class="solr.CurrencyFieldType"
+             amountLongSuffix="_l1_ns"
+             codeStrSuffix="_s1_ns"
+             multiValued="false"
+             providerClass="solr.OpenExchangeRatesOrgProvider"
+             ratesFileLocation="open-exchange-rates.json"/>
+
+  <!-- omitPositions example -->
+  <fieldType name="nopositions" class="solr.TextField" omitPositions="true">
+    <analyzer>
+      <tokenizer class="solr.MockTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="location" class="solr.LatLonPointSpatialField" />
+
+  <!-- 
+    Example of using PathHierarchyTokenizerFactory at index time, so
+    queries for paths match documents at that path, or in descendent paths
+  -->
+  <fieldType name="path" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.KeywordTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+  <!-- 
+    Example of using PathHierarchyTokenizerFactory at query time, so
+    queries for paths match documents at that path, or in ancestor paths
+  -->
+  <fieldType name="ancestor_path" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.KeywordTokenizerFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="payloadDelimited" class="solr.TextField">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="integer"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- CommonGrams for phrase queries -->
+  <dynamicField name="*_commongrams" type="commongrams" />
+  <fieldType name="commongrams" class="solr.TextField" indexed="true" stored="true">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.CommonGramsFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.CommonGramsQueryFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <dynamicField name="*_commongrams_stop" type="commongrams_stop" />
+  <fieldType name="commongrams_stop" class="solr.TextField" indexed="true" stored="true">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.CommonGramsFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.CommonGramsQueryFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
+    </analyzer>
+  </fieldType>
+  <copyField source="*_commongrams" dest="*_commongrams_stop" />
+  
+  <fieldType name="severityType" class="${solr.tests.EnumFieldType}" enumsConfig="enumsConfig.xml" enumName="severity"/>
+  
+  <fieldType name="binary" class="solr.BinaryField" />
+  <fieldType name="collation" class="solr.CollationField" language="en" />
+  <fieldType name="externalFile" class="solr.ExternalFileField" />
+  <fieldType name="icuCollation" class="solr.ICUCollationField" locale="en" />
+  <fieldType name="latLonPointSpatial" class="solr.LatLonPointSpatialField" />
+  <fieldType name="randomSort" class="solr.RandomSortField" />
+  <fieldType name="point" class="solr.PointType" subFieldSuffix="_coordinate" />
+
+  <fieldType name="sortable_text" class="solr.SortableTextField">
+    <analyzer>
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    </analyzer>
+  </fieldType>
+
+
+  <field name="id" type="string" indexed="true" stored="${solr.tests.id.stored:true}" multiValued="false" required="false" docValues="${solr.tests.id.docValues:false}"/>
+  <field name="_root_" type="string" indexed="true" stored="false"/>
+  <field name="_nest_path_" type="_nest_path_" /><fieldType name="_nest_path_" class="solr.NestPathField"/>
+
+  <field name="signatureField" type="string" indexed="true" stored="false"/>
+  <field name="uuid" type="uuid" stored="true"/>
+  <field name="name" type="nametext" indexed="true" stored="true"/>
+  <field name="text" type="text" indexed="true" stored="false"/>
+  <field name="subject" type="text" indexed="true" stored="true"/>
+  <field name="title" type="nametext" indexed="true" stored="true"/>
+  <field name="weight" type="float" indexed="true" stored="true" multiValued="false"/>
+  <field name="bday" type="date" indexed="true" stored="true" multiValued="false"/>
+
+  <field name="title_stemmed" type="text" indexed="true" stored="false"/>
+  <field name="title_lettertok" type="lettertok" indexed="true" stored="false"/>
+
+  <field name="syn" type="syn" indexed="true" stored="true"/>
+
+  <!-- to test property inheritance and overriding -->
+  <field name="shouldbeunstored" type="unstored"/>
+  <field name="shouldbestored" type="unstored" stored="true"/>
+  <field name="shouldbeunindexed" type="unstored" indexed="false" stored="true"/>
+
+  <!-- Test spatial PointType -->
+  <field name="home" type="xy" indexed="true" stored="true" multiValued="false"/>
+  <field name="x" type="x" indexed="true" stored="true" multiValued="false"/>
+  <field name="homed" type="xyd" indexed="true" stored="true" multiValued="false"/>
+  <field name="home_ns" type="xy" indexed="true" stored="false" multiValued="false"/>
+  <field name="work" type="xy" indexed="true" stored="true" multiValued="false"/>
+
+  <!-- Test currency -->
+  <field name="amount" type="currency" indexed="true" stored="true" multiValued="false"/>
+  <field name="mock_amount" type="mock_currency" indexed="true" stored="true"/>
+  <field name="oer_amount" type="oer_currency" indexed="true" stored="true"/>
+  <field name="amount_CFT" type="currency_CFT" indexed="true" stored="true" multiValued="false"/>
+  <field name="mock_amount_CFT" type="mock_currency_CFT" indexed="true" stored="true"/>
+  <field name="oer_amount_CFT" type="oer_currency_CFT" indexed="true" stored="true"/>
+
+  <!-- test different combinations of indexed and stored -->
+  <field name="bind" type="boolean" indexed="true" stored="false"/>
+  <field name="bsto" type="boolean" indexed="false" stored="true"/>
+  <field name="bindsto" type="boolean" indexed="true" stored="true"/>
+  <field name="isto" type="int" indexed="false" stored="true"/>
+  <field name="iind" type="int" indexed="true" stored="false"/>
+  <field name="ssto" type="string" indexed="false" stored="true"/>
+  <field name="sind" type="string" indexed="true" stored="false"/>
+  <field name="sindsto" type="string" indexed="true" stored="true"/>
+
+  <!-- test combinations of term vector settings -->
+  <field name="test_basictv" type="text" termVectors="true"/>
+  <field name="test_notv" type="text" termVectors="false"/>
+  <field name="test_postv" type="text" termVectors="true" termPositions="true"/>
+  <field name="test_offtv" type="text" termVectors="true" termOffsets="true"/>
+  <field name="test_posofftv" type="text" termVectors="true"
+         termPositions="true" termOffsets="true"/>
+  <field name="test_posoffpaytv" type="text_payload_tv" termVectors="true"
+         termPositions="true" termOffsets="true" termPayloads="true"/>
+
+  <!-- test highlit field settings -->
+  <field name="test_hlt" type="highlittext" indexed="true"/>
+  <field name="test_hlt_off" type="highlittext" indexed="true"/>
+
+  <!-- fields to test individual tokenizers and tokenfilters -->
+  <field name="teststop" type="teststop" indexed="true" stored="true"/>
+  <field name="lowertok" type="lowerfilt" indexed="true" stored="true"/>
+  <field name="keywordtok" type="keywordtok" indexed="true" stored="true"/>
+  <field name="standardtok" type="standardtok" indexed="true" stored="true"/>
+  <field name="HTMLstandardtok" type="HTMLstandardtok" indexed="true" stored="true"/>
+  <field name="lettertok" type="lettertok" indexed="true" stored="true"/>
+  <field name="whitetok" type="whitetok" indexed="true" stored="true"/>
+  <field name="HTMLwhitetok" type="HTMLwhitetok" indexed="true" stored="true"/>
+  <field name="standardtokfilt" type="standardtokfilt" indexed="true" stored="true"/>
+  <field name="standardfilt" type="standardfilt" indexed="true" stored="true"/>
+  <field name="lowerfilt" type="lowerfilt" indexed="true" stored="true"/>
+  <field name="lowerfilt1" type="lowerfilt" indexed="true" stored="true"/>
+  <field name="lowerfilt1and2" type="lowerfilt" indexed="true" stored="true"/>
+  <field name="patterntok" type="patterntok" indexed="true" stored="true"/>
+  <field name="patternreplacefilt" type="patternreplacefilt" indexed="true" stored="true"/>
+  <field name="porterfilt" type="porterfilt" indexed="true" stored="true"/>
+  <field name="engporterfilt" type="engporterfilt" indexed="true" stored="true"/>
+  <field name="custengporterfilt" type="custengporterfilt" indexed="true" stored="true"/>
+  <field name="stopfilt" type="stopfilt" indexed="true" stored="true"/>
+  <field name="custstopfilt" type="custstopfilt" indexed="true" stored="true"/>
+  <field name="lengthfilt" type="lengthfilt" indexed="true" stored="true"/>
+  <field name="dedup" type="dedup" indexed="true" stored="true"/>
+  <field name="wdf_nocase" type="wdf_nocase" indexed="true" stored="true"/>
+  <field name="wdf_preserve" type="wdf_preserve" indexed="true" stored="true"/>
+
+  <field name="numberpartfail" type="failtype1" indexed="true" stored="true"/>
+
+  <field name="nullfirst" type="string" indexed="true" stored="true" sortMissingFirst="true" multiValued="false"/>
+
+  <field name="dateRange" type="dateRange" multiValued="true"/>
+
+  <field name="cat" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="price" type="float" indexed="true" stored="true" multiValued="false"/>
+  <field name="inStock" type="boolean" indexed="true" stored="true"/>
+
+  <field name="subword" type="subword" indexed="true" stored="true"/>
+  <field name="subword_offsets" type="subword" indexed="true" stored="true" termVectors="true" termOffsets="true"/>
+  <field name="numericsubword" type="numericsubword" indexed="true" stored="true"/>
+  <field name="protectedsubword" type="protectedsubword" indexed="true" stored="true"/>
+
+  <field name="sku1" type="skutype1" indexed="true" stored="true"/>
+  <field name="sku2" type="skutype2" indexed="true" stored="true"/>
+
+  <field name="textgap" type="textgap" indexed="true" stored="true"/>
+
+  <field name="timestamp" type="date" indexed="true" stored="true" docValues="true" default="NOW" multiValued="false"/>
+  <field name="multiDefault" type="string" indexed="true" stored="true" default="muLti-Default" multiValued="true"/>
+  <field name="intDefault" type="int" indexed="true" stored="true" default="42" multiValued="false"/>
+  <field name="intDvoDefault" type="int" indexed="false" stored="false" multiValued="false"
+         useDocValuesAsStored="true" docValues="true" default="42" />
+  <field name="intRemove" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="dateRemove" type="date" indexed="true" stored="true" multiValued="true"/>
+  <field name="floatRemove" type="float" indexed="true" stored="true" multiValued="true"/>
+
+  <field name="binaryRemove" type="binary" indexed="true" stored="true" multiValued="true"/>
+  <field name="booleanRemove" type="boolean" indexed="true" stored="true" multiValued="true"/>
+  <field name="collationRemove" type="collation" indexed="true" stored="true" multiValued="true"/>
+  <field name="datePointRemove" type="pdate" indexed="true" stored="true" multiValued="true"/>
+  <field name="dateRangeRemove" type="dateRange" indexed="true" stored="true" multiValued="true"/>
+  <field name="doublePointRemove" type="pdouble" indexed="true" stored="true" multiValued="true"/>
+  <field name="externalFileRemove" type="externalFile" indexed="true" stored="true" multiValued="true"/>
+  <field name="floatPointRemove" type="pfloat" indexed="true" stored="true" multiValued="true"/>
+  <field name="icuCollationRemove" type="icuCollation" indexed="true" stored="true" multiValued="true"/>
+  <field name="intPointRemove" type="pint" indexed="true" stored="true" multiValued="true"/>
+  <field name="latLonPointSpatialRemove" type="latLonPointSpatial" indexed="true" stored="true" multiValued="true"/>
+  <field name="latLonRemove" type="location" indexed="true" stored="true" multiValued="true"/>
+  <field name="longPointRemove" type="plong" indexed="true" stored="true" multiValued="true"/>
+  <field name="point_0_coordinate" type="float" indexed="true" stored="true" multiValued="true"/>
+  <field name="point_1_coordinate" type="float" indexed="true" stored="true" multiValued="true"/>
+  <field name="pointRemove" type="point" indexed="true" stored="true" multiValued="true"/>
+  <field name="randomSortRemove" type="randomSort" indexed="true" stored="true" multiValued="true"/>
+  <field name="spatialRecursivePrefixTreeRemove" type="location_rpt" indexed="true" stored="true" multiValued="true"/>
+  <field name="stringRemove" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="textRemove" type="text" indexed="true" stored="true" multiValued="true"/>
+  <field name="uuidRemove" type="uuid" indexed="true" stored="true" multiValued="true"/>
+
+  <field name="nopositionstext" type="nopositions" indexed="true" stored="true"/>
+
+  <field name="tlong" type="tlong" indexed="true" stored="true"/>
+  <field name="_version_" type="long" indexed="false" stored="false" docValues="true" multiValued="false" useDocValuesAsStored="true"/>
+
+  <field name="title_stringNoNorms" type="string" omitNorms="true" indexed="true" stored="true"/>
+
+  <field name="store" type="location" indexed="true" stored="true" docValues="true"/>
+
+  <field name="lower" type="lowerfilt" indexed="false" stored="true" multiValued="true"/>
+  <field name="_route_" type="string" indexed="true" stored="true" multiValued="false"/>
+
+  <field name="payloadDelimited" type="payloadDelimited"/>
+
+  <field name="sortabuse_not_uninvertible" type="string" indexed="true" multiValued="false" uninvertible="false" />
+  
+  <!-- EnumType -->
+  <field name="severity" type="severityType" docValues="true" indexed="true" stored="true" multiValued="false"/>
+
+  <field name="max_chars" type="string" indexed="false" stored="true"/>
+  
+  <!-- Dense Vector-->
+  <field name="vector" type="knn_vector_cosine" indexed="true" stored="true"/>
+  <field name="vector2" type="knn_vector_dot_product" indexed="true" stored="true"/>
+  <field name="vector3" type="knn_vector_cosine" indexed="true" stored="true"/>
+  <field name="vector4" type="knn_vector_cosine" indexed="true" stored="true"/>
+  <field name="vector5" type="knn_vector5" indexed="true" stored="true"/>
+  
+  <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
+       will be used if the name matches any of the patterns.
+       RESTRICTION: the glob-like pattern in the name attribute must have
+       a "*" only at the start or the end.
+       EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
+       Longer patterns will be matched first.  if equal size patterns
+       both match, the first appearing in the schema will be used.
+  -->
+  <dynamicField name="*_i" type="int" indexed="true" stored="true"/>
+  <dynamicField name="*_i1" type="int" indexed="true" stored="true" multiValued="false" sortMissingLast="true"/>
+  <dynamicField name="*_is" type="int" indexed="true" stored="true" multiValued="true" sortMissingLast="true"/>
+  <dynamicField name="*_idv" type="int" indexed="true" stored="true" docValues="true" multiValued="false"/>
+
+
+  <dynamicField name="*_s" type="string" indexed="true" stored="true"/>
+  <dynamicField name="*_s1" type="string" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_loc1_dv" type="location" indexed="true" stored="true"  docValues="true" multiValued="false"/>
+
+  <dynamicField name="*_s1_ns" type="string" indexed="true" stored="false" multiValued="false"/>
+  <dynamicField name="*_l" type="long" indexed="true" stored="true"/>
+  <dynamicField name="*_l1" type="long" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_l1_ns" type="long" indexed="true" stored="false" multiValued="false"/>
+  <dynamicField name="*_t" type="text" indexed="true" stored="true"/>
+  <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
+  <dynamicField name="*_b1" type="boolean" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_f" type="float" indexed="true" stored="true"/>
+  <dynamicField name="*_f1" type="float" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_d" type="double" indexed="true" stored="true"/>
+  <dynamicField name="*_d1" type="double" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_d1_dv" type="double" indexed="true" docValues="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
+  <dynamicField name="*_dt1" type="date" indexed="true" stored="true" multiValued="false"/>
+
+
+  <!-- some trie-coded dynamic fields for faster range queries -->
+  <dynamicField name="*_ti" type="tint" indexed="true" stored="true"/>
+  <dynamicField name="*_ti1" type="tint" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_tl" type="tlong" indexed="true" stored="true"/>
+  <dynamicField name="*_tl1" type="tlong" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_tf" type="tfloat" indexed="true" stored="true"/>
+  <dynamicField name="*_tf1" type="tfloat" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_td" type="tdouble" indexed="true" stored="true"/>
+  <dynamicField name="*_td1" type="tdouble" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_tds" type="tdouble" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_tdt" type="tdate" indexed="true" stored="true"/>
+  <dynamicField name="*_tdt1" type="tdate" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_tdtdv" type="tdatedv" indexed="true" stored="true"/>
+  <dynamicField name="*_tdtdv1" type="tdatedv" indexed="true" stored="true" multiValued="false"/>
+  <dynamicField name="*_drf" type="dateRange" indexed="true" stored="true"/>
+
+  <dynamicField name="*_tdts" type="tdate" indexed="true" stored="true" multiValued="true"/>
+  <dynamicField name="*_tdtdvs" type="tdatedv" indexed="true" stored="true"/>
+
+  <dynamicField name="*_sI" type="string" indexed="true" stored="false"/>
+  <dynamicField name="*_sS" type="string" indexed="false" stored="true"/>
+  <dynamicField name="t_*" type="text" indexed="true" stored="true"/>
+  <dynamicField name="tv_*" type="text" indexed="true" stored="true"
+                termVectors="true" termPositions="true" termOffsets="true"/>
+  <dynamicField name="tv_mv_*" type="text" indexed="true" stored="true" multiValued="true"
+                termVectors="true" termPositions="true" termOffsets="true"/>
+  <dynamicField name="tv_no_off_*" type="text" indexed="true" stored="true"
+                termVectors="true" termPositions="true"/>
+
+  <dynamicField name="*_p" type="xyd" indexed="true" stored="true" multiValued="false"/>
+
+  <!-- special fields for dynamic copyField test -->
+  <dynamicField name="dynamic_*" type="string" indexed="true" stored="true"/>
+  <dynamicField name="*_dynamic" type="string" indexed="true" stored="true"/>
+
+  <!-- for testing to ensure that longer patterns are matched first -->
+  <dynamicField name="*aa" type="string" indexed="true" stored="true"/>
+  <dynamicField name="*aaa" type="int" indexed="false" stored="true"/>
+
+  <!-- ignored becuase not stored or indexed -->
+  <dynamicField name="*_ignored" type="text" indexed="false" stored="false"/>
+
+  <dynamicField name="*_mfacet" type="string" indexed="true" stored="false" multiValued="true"/>
+
+  <!-- Type used to index the  components for the "point" FieldType -->
+  <dynamicField name="*_coordinate" type="double" indexed="true" stored="false" omitNorms="true" docValues="false"/>
+
+  <dynamicField name="*_path" type="path" indexed="true" stored="true" omitNorms="true" multiValued="true"/>
+  <dynamicField name="*_ancestor" type="ancestor_path" indexed="true" stored="true" omitNorms="true"
+                multiValued="true"/>
+
+  <dynamicField name="*_sev_enum" type="severityType" indexed="true" stored="true" docValues="true" multiValued="true"/>
+
+  <!-- With DocValues=true -->
+  <dynamicField name="*_i_dv" type="int" indexed="true" stored="true" docValues="true"/>
+  <dynamicField name="*_l_dv" type="long" indexed="true" stored="true" docValues="true"/>
+  <dynamicField name="*_f_dv" type="float" indexed="true" stored="true" docValues="true"/>
+  <dynamicField name="*_d_dv" type="double" indexed="true" stored="true" docValues="true"/>
+  <dynamicField name="*_dt_dv" type="date" indexed="true" stored="true" docValues="true"/>
+  <dynamicField name="*_f1_dv" type="float" indexed="true" stored="true" docValues="true" multiValued="false"/>
+
+  <!--  Non-stored, DocValues=true -->
+  <dynamicField name="*_i_dvo" multiValued="false" type="int" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_d_dvo" multiValued="false" type="double" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_s_dvo" multiValued="false" type="string" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_b_dvo" multiValued="false" type="boolean" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_l_dvo" multiValued="false" type="long" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_f_dvo" multiValued="false" type="float" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_dt_dvo" multiValued="false" type="date" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+                
+  <dynamicField name="*_ii_dvo" multiValued="true" type="int" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+  <dynamicField name="*_dd_dvo" multiValued="true" type="double" docValues="true" indexed="false" stored="false"
+                useDocValuesAsStored="true"/>
+                
+  <!-- Indexed, but NOT uninvertible -->
+  <dynamicField name="*_s_not_uninvert" type="string" indexed="true" stored="false" docValues="false" uninvertible="false" />
+  <!-- docValues, but NOT uninvertible -->
+  <dynamicField name="*_s_not_uninvert_dv" type="string" indexed="true" stored="false" docValues="true" uninvertible="false" />
+
+
+  
+  <!-- Only Stored numerics -->
+  <dynamicField name="*_i_os" type="int" indexed="false" stored="true" docValues="false"/>
+  <dynamicField name="*_l_os" type="long" indexed="false" stored="true" docValues="false"/>
+  <dynamicField name="*_f_os" type="float" indexed="false" stored="true" docValues="false"/>
+  <dynamicField name="*_d_os" type="double" indexed="false" stored="true" docValues="false"/>
+  <dynamicField name="*_dt_os" type="date" indexed="false" stored="true" docValues="false"/>
+
+  <!--  Non-stored, DocValues=true, useDocValuesAsStored=false -->
+  <field name="single_i_dvn" multiValued="false" type="int" indexed="true" stored="true"/>
+  <field name="single_d_dvn" multiValued="false" type="double" indexed="true" stored="true"/>
+  <field name="single_s_dvn" multiValued="false" type="string" indexed="true" stored="true"/>
+  <field name="copy_single_i_dvn" multiValued="false" type="int" docValues="true" indexed="true" stored="false"
+         useDocValuesAsStored="false"/>
+  <field name="copy_single_d_dvn" multiValued="false" type="double" docValues="true" indexed="true" stored="false"
+         useDocValuesAsStored="false"/>
+  <field name="copy_single_s_dvn" multiValued="false" type="string" docValues="true" indexed="true" stored="false"
+         useDocValuesAsStored="false"/>
+         
+   <!-- Test point fields explicitly -->
+   <dynamicField name="*_i_p"      type="pint"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_is_p"      type="pint"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_i_ni_p"   type="pint"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_is_ni_p"   type="pint"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_l_p"      type="plong"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_ls_p"      type="plong"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_l_ni_p"   type="plong"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_ls_ni_p"   type="plong"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_f_p"      type="pfloat"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_fs_p"      type="pfloat"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_f_ni_p"   type="pfloat"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_fs_ni_p"   type="pfloat"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_d_p"      type="pdouble"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_ds_p"      type="pdouble"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_d_ni_p"   type="pdouble"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+   <dynamicField name="*_ds_ni_p"   type="pdouble"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+   <dynamicField name="*_sortable"  type="sortable_text" indexed="true" multiValued="false" stored="true" />
+
+  <dynamicField name="*_date_p"      type="pdate"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+  <dynamicField name="*_dates_p"     type="pdate"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+  <dynamicField name="*_date_ni_p"   type="pdate"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+  <dynamicField name="*_dates_ni_p"  type="pdate"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+
+  <copyField source="single_i_dvn" dest="copy_single_i_dvn"/>
+  <copyField source="single_d_dvn" dest="copy_single_d_dvn"/>
+  <copyField source="single_s_dvn" dest="copy_single_s_dvn"/>
+
+  <uniqueKey>id</uniqueKey>
+
+  <!-- copyField commands copy one field to another at the time a document
+        is added to the index.  It's used either to index the same field different
+        ways, or to add multiple fields to the same field for easier/faster searching.
+   -->
+  <copyField source="title" dest="title_stemmed"/>
+  <copyField source="title" dest="title_lettertok"/>
+  <copyField source="title" dest="title_stringNoNorms"/>
+
+  <copyField source="title" dest="text"/>
+  <copyField source="subject" dest="text"/>
+
+  <copyField source="lowerfilt1" dest="lowerfilt1and2"/>
+  <copyField source="lowerfilt" dest="lowerfilt1and2"/>
+
+  <copyField source="*_t" dest="text"/>
+
+  <copyField source="id" dest="range_facet_l"/>
+  <copyField source="id" dest="id_i1"/>
+  <copyField source="range_facet_f" dest="range_facet_d"/>
+  <copyField source="range_facet_f1" dest="range_facet_f1_dv"/>
+
+  <copyField source="id" dest="range_facet_l_dv"/>
+  <copyField source="id" dest="range_facet_i_dv"/>
+  <copyField source="range_facet_f" dest="range_facet_f_dv"/>
+  <copyField source="range_facet_f" dest="range_facet_d_dv"/>
+  <copyField source="bday" dest="range_facet_dt_dv"/>
+
+  <copyField source="trait_s" dest="trait_s_not_uninvert"/>
+  <copyField source="trait_s" dest="trait_s_not_uninvert_dv"/>
+  <copyField source="trait_s" dest="trait_s_not_indexed_sS"/>
+  
+  <!-- dynamic destination -->
+  <copyField source="*_dynamic" dest="dynamic_*"/>
+  <copyField source="*_path" dest="*_ancestor"/>
+
+  <copyField source="title" dest="max_chars" maxChars="10"/>
+  <copyField source="vector" dest="vector2"/>
+  <copyField source="vector3" dest="vector_f_p"/>
+  <copyField source="vector4" dest="vector5"/>
+
+  <!-- example of a custom similarity -->
+  <similarity class="solr.CustomSimilarityFactory">
+    <str name="echo">I am your default sim</str>
+  </similarity>
+</schema>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-decayfunc.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-decayfunc.xml
@@ -1,0 +1,533 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- This is a "kitchen sink" config file that tests can use.
+     When writting a new test, feel free to add *new* items (plugins,
+     config options, etc...) as long as they don't break any existing
+     tests.  if you need to test something esoteric please add a new
+     "solrconfig-your-esoteric-purpose.xml" config file.
+
+     Note in particular that this test is used by MinimalSchemaTest so
+     Anything added to this file needs to work correctly even if there
+     is now uniqueKey or defaultSearch Field.
+  -->
+
+<config>
+
+    <valueSourceParser name="linear"
+                       class="org.apache.solr.search.function.decayfunction.LinearDecayFunctionValueSourceParser"/>
+    <valueSourceParser name="gauss"
+                       class="org.apache.solr.search.function.decayfunction.GaussDecayFunctionValueSourceParser"/>
+    <valueSourceParser name="exp"
+                       class="org.apache.solr.search.function.decayfunction.ExponentialDecayFunctionValueSourceParser"/>
+
+
+    <!-- Used to specify an alternate directory to hold all index data.
+         It defaults to "index" if not present, and should probably
+         not be changed if replication is in use. -->
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <!--  The DirectoryFactory to use for indexes.
+        solr.StandardDirectoryFactory, the default, is filesystem based.
+        solr.RAMDirectoryFactory is memory based and not persistent. -->
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}">
+    <double name="maxWriteMBPerSecDefault">1000000</double>
+    <double name="maxWriteMBPerSecFlush">2000000</double>
+    <double name="maxWriteMBPerSecMerge">3000000</double>
+    <double name="maxWriteMBPerSecRead">4000000</double>
+    <str name="solr.hdfs.home">${solr.hdfs.home:}</str>
+    <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool>
+    <bool name="solr.hdfs.blockcache.global">${solr.hdfs.blockcache.global:true}</bool>
+    <bool name="solr.hdfs.blockcache.write.enabled">${solr.hdfs.blockcache.write.enabled:false}</bool>
+    <int name="solr.hdfs.blockcache.blocksperbank">${solr.hdfs.blockcache.blocksperbank:10}</int>
+    <int name="solr.hdfs.blockcache.slab.count">${solr.hdfs.blockcache.slab.count:1}</int>
+  </directoryFactory>
+
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+
+  <statsCache class="${solr.statsCache:}"/>
+
+  <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:-1}</maxTime>
+    </autoCommit>
+
+    <!-- autocommit pending docs if certain criteria are met
+    <autoCommit>
+      <maxDocs>10000</maxDocs>
+      <maxTime>3600000</maxTime>
+    </autoCommit>
+    -->
+
+    <updateLog enable="${enable.update.log:true}">
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+
+    <commitWithin>
+      <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
+    </commitWithin>
+
+  </updateHandler>
+
+  <query>
+    <!-- Maximum number of clauses in a boolean query... can affect
+        range or wildcard queries that expand to big boolean
+        queries.  An exception is thrown if exceeded.
+    -->
+    <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
+
+    <!-- Cache specification for Filters or DocSets - unordered set of *all* documents
+         that match a particular query.
+      -->
+    <filterCache
+      size="512"
+      initialSize="512"
+      autowarmCount="2"
+      async="${solr.filterCache.async:false}"/>
+
+    <queryResultCache
+      size="512"
+      initialSize="512"
+      autowarmCount="2"/>
+
+    <documentCache
+      size="512"
+      initialSize="512"
+      autowarmCount="0"/>
+
+    <cache name="perSegFilter"
+      class="solr.CaffeineCache"
+      size="10"
+      initialSize="0"
+      autowarmCount="10" />
+
+    <!-- If true, stored fields that are not requested will be loaded lazily.
+    -->
+    <enableLazyFieldLoading>true</enableLazyFieldLoading>
+
+    <!--
+
+    <cache name="myUserCache"
+      size="4096"
+      initialSize="1024"
+      autowarmCount="1024"
+      regenerator="MyRegenerator"
+      />
+    -->
+
+    <!--
+    <useFilterForSortedQuery>true</useFilterForSortedQuery>
+    -->
+
+    <queryResultWindowSize>10</queryResultWindowSize>
+
+    <!-- boolToFilterOptimizer converts boolean clauses with zero boost
+         into cached filters if the number of docs selected by the clause exceeds
+         the threshold (represented as a fraction of the total index)
+    -->
+    <boolTofilterOptimizer enabled="false" cacheSize="32" threshold=".05"/>
+
+    <!-- a newSearcher event is fired whenever a new searcher is being prepared
+         and there is a current searcher handling requests (aka registered). -->
+    <!-- QuerySenderListener takes an array of NamedList and executes a
+         local query request for each NamedList in sequence. -->
+    <!--
+    <listener event="newSearcher" class="solr.QuerySenderListener">
+      <arr name="queries">
+        <lst> <str name="q">solr</str> <str name="start">0</str> <str name="rows">10</str> </lst>
+        <lst> <str name="q">rocks</str> <str name="start">0</str> <str name="rows">10</str> </lst>
+      </arr>
+    </listener>
+    -->
+
+    <!-- a firstSearcher event is fired whenever a new searcher is being
+         prepared but there is no current registered searcher to handle
+         requests or to gain prewarming data from. -->
+    <!--
+    <listener event="firstSearcher" class="solr.QuerySenderListener">
+      <arr name="queries">
+        <lst> <str name="q">fast_warm</str> <str name="start">0</str> <str name="rows">10</str> </lst>
+      </arr>
+    </listener>
+    -->
+
+    <slowQueryThresholdMillis>2000</slowQueryThresholdMillis>
+
+  </query>
+
+  <queryResponseWriter name="xml" default="true"
+                       class="solr.XMLResponseWriter" />
+
+  <!-- requestHandler plugins
+  -->
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <bool name="httpCaching">true</bool>
+  </requestHandler>
+
+  <requestHandler name="/dismax" class="solr.SearchHandler" >
+    <lst name="defaults">
+     <str name="defType">dismax</str>
+     <str name="q.alt">*:*</str>
+     <float name="tie">0.01</float>
+     <str name="qf">
+        text^0.5 features_t^1.0 subject^1.4 title_stemmed^2.0
+     </str>
+     <str name="pf">
+        text^0.2 features_t^1.1 subject^1.4 title_stemmed^2.0 title^1.5
+     </str>
+     <str name="bf">
+        weight^0.5 recip(rord(id),1,1000,1000)^0.3
+     </str>
+     <str name="mm">
+        3&lt;-1 5&lt;-2 6&lt;90%
+     </str>
+     <int name="ps">100</int>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="/mock" class="org.apache.solr.core.MockQuerySenderListenerReqHandler"/>
+
+  <!-- test query parameter defaults -->
+  <requestHandler name="/defaults" class="solr.SearchHandler">
+    <lst name="defaults">
+      <int name="rows">4</int>
+      <bool name="hl">true</bool>
+      <str name="hl.fl">text,name,subject,title,whitetok</str>
+    </lst>
+  </requestHandler>
+
+  <!-- test query parameter defaults -->
+  <requestHandler name="/lazy" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <int name="rows">4</int>
+      <bool name="hl">true</bool>
+      <str name="hl.fl">text,name,subject,title,whitetok</str>
+    </lst>
+  </requestHandler>
+
+
+
+  <searchComponent name="spellcheck" class="org.apache.solr.handler.component.SpellCheckComponent">
+    <!-- This is slightly different from the field value so we can test dealing with token offset changes -->
+    <str name="queryAnalyzerFieldType">lowerpunctfilt</str>
+
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">lowerfilt</str>
+      <str name="spellcheckIndexDir">spellchecker1</str>
+      <str name="buildOnCommit">false</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">direct</str>
+      <str name="classname">DirectSolrSpellChecker</str>
+      <str name="field">lowerfilt</str>
+      <int name="minQueryLength">3</int>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">wordbreak</str>
+      <str name="classname">solr.WordBreakSolrSpellChecker</str>
+      <str name="field">lowerfilt</str>
+      <str name="combineWords">true</str>
+      <str name="breakWords">true</str>
+      <int name="maxChanges">10</int>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">multipleFields</str>
+      <str name="field">lowerfilt1and2</str>
+      <str name="spellcheckIndexDir">spellcheckerMultipleFields</str>
+      <str name="buildOnCommit">false</str>
+     </lst>
+    <!-- Example of using different distance measure -->
+    <lst name="spellchecker">
+      <str name="name">jarowinkler</str>
+      <str name="field">lowerfilt</str>
+      <!-- Use a different Distance Measure -->
+      <str name="distanceMeasure">org.apache.lucene.search.spell.JaroWinklerDistance</str>
+      <str name="spellcheckIndexDir">spellchecker2</str>
+
+    </lst>
+    <lst name="spellchecker">
+      <str name="classname">solr.FileBasedSpellChecker</str>
+      <str name="name">external</str>
+      <str name="sourceLocation">spellings.txt</str>
+      <str name="characterEncoding">UTF-8</str>
+      <str name="spellcheckIndexDir">spellchecker3</str>
+    </lst>
+    <!-- Comparator -->
+    <lst name="spellchecker">
+      <str name="name">freq</str>
+      <str name="field">lowerfilt</str>
+      <str name="spellcheckIndexDir">spellcheckerFreq</str>
+      <!-- comparatorClass be one of:
+        1. score (default)
+        2. freq (Frequency first, then score)
+        3. A fully qualified class name
+       -->
+      <str name="comparatorClass">freq</str>
+      <str name="buildOnCommit">false</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">fqcn</str>
+      <str name="field">lowerfilt</str>
+      <str name="spellcheckIndexDir">spellcheckerFQCN</str>
+      <str name="comparatorClass">org.apache.solr.spelling.SampleComparator</str>
+      <str name="buildOnCommit">false</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">perDict</str>
+      <str name="classname">org.apache.solr.handler.component.DummyCustomParamSpellChecker</str>
+      <str name="field">lowerfilt</str>
+    </lst>
+  </searchComponent>
+
+    <!-- This is now part of the implicit configuration together with terms=true and distrib=false defaults
+  <searchComponent name="termsComp" class="org.apache.solr.handler.component.TermsComponent"/>
+
+  <requestHandler name="/terms" class="org.apache.solr.handler.component.SearchHandler">
+    <arr name="components">
+      <str>termsComp</str>
+    </arr>
+  </requestHandler>
+  -->
+
+
+  <!--
+  The SpellingQueryConverter to convert raw (CommonParams.Q) queries into tokens.  Uses a simple regular expression
+   to strip off field markup, boosts, ranges, etc. but it is not guaranteed to match an exact parse from the query parser.
+   -->
+  <queryConverter name="queryConverter" class="org.apache.solr.spelling.SpellingQueryConverter"/>
+
+  <requestHandler name="/spellCheckCompRH" class="org.apache.solr.handler.component.SearchHandler">
+    <lst name="defaults">
+      <!-- omp = Only More Popular -->
+      <str name="spellcheck.onlyMorePopular">false</str>
+      <!-- exr = Extended Results -->
+      <str name="spellcheck.extendedResults">false</str>
+      <!--  The number of suggestions to return -->
+      <str name="spellcheck.count">1</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+  <requestHandler name="/spellCheckCompRH_Direct" class="org.apache.solr.handler.component.SearchHandler">
+    <lst name="defaults">
+      <str name="spellcheck.dictionary">direct</str>
+      <str name="spellcheck.onlyMorePopular">false</str>
+      <str name="spellcheck.extendedResults">false</str>
+      <str name="spellcheck.count">1</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+  <requestHandler name="/spellCheckWithWordbreak" class="org.apache.solr.handler.component.SearchHandler">
+    <lst name="defaults">
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck.dictionary">wordbreak</str>
+      <str name="spellcheck.count">20</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+  <requestHandler name="/spellCheckWithWordbreak_Direct" class="org.apache.solr.handler.component.SearchHandler">
+    <lst name="defaults">
+      <str name="spellcheck.dictionary">direct</str>
+      <str name="spellcheck.dictionary">wordbreak</str>
+      <str name="spellcheck.count">20</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+  <requestHandler name="/spellCheckCompRH1" class="org.apache.solr.handler.component.SearchHandler">
+      <lst name="defaults">
+        <str name="defType">dismax</str>
+        <str name="qf">lowerfilt1^1</str>
+      </lst>
+      <arr name="last-components">
+        <str>spellcheck</str>
+      </arr>
+ </requestHandler>
+
+  <requestHandler name="/mltrh" class="org.apache.solr.handler.component.SearchHandler">
+
+  </requestHandler>
+
+  <searchComponent name="tvComponent" class="org.apache.solr.handler.component.TermVectorComponent"/>
+
+  <requestHandler name="/tvrh" class="org.apache.solr.handler.component.SearchHandler">
+    <lst name="defaults">
+
+    </lst>
+    <arr name="last-components">
+      <str>tvComponent</str>
+    </arr>
+  </requestHandler>
+
+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
+  </requestHandler>
+
+  <searchComponent class="solr.HighlightComponent" name="highlight">
+  <highlighting>
+   <!-- Configure the standard fragmenter -->
+   <fragmenter name="gap" class="org.apache.solr.highlight.GapFragmenter" default="true">
+    <lst name="defaults">
+     <int name="hl.fragsize">100</int>
+    </lst>
+   </fragmenter>
+
+   <fragmenter name="regex" class="org.apache.solr.highlight.RegexFragmenter">
+    <lst name="defaults">
+     <int name="hl.fragsize">70</int>
+    </lst>
+   </fragmenter>
+
+   <!-- Configure the standard formatter -->
+   <formatter name="html" class="org.apache.solr.highlight.HtmlFormatter" default="true">
+    <lst name="defaults">
+     <str name="hl.simple.pre"><![CDATA[<em>]]></str>
+     <str name="hl.simple.post"><![CDATA[</em>]]></str>
+    </lst>
+   </formatter>
+
+   <!-- Configure the standard fragListBuilder -->
+   <fragListBuilder name="simple" class="org.apache.solr.highlight.SimpleFragListBuilder" default="true"/>
+
+   <!-- Configure the standard fragmentsBuilder -->
+   <fragmentsBuilder name="simple" class="org.apache.solr.highlight.SimpleFragmentsBuilder" default="true"/>
+   <fragmentsBuilder name="scoreOrder" class="org.apache.solr.highlight.ScoreOrderFragmentsBuilder"/>
+
+   <boundaryScanner name="simple" class="solr.highlight.SimpleBoundaryScanner" default="true">
+     <lst name="defaults">
+       <str name="hl.bs.maxScan">10</str>
+       <str name="hl.bs.chars">.,!? &#9;&#10;&#13;</str>
+     </lst>
+   </boundaryScanner>
+
+   <boundaryScanner name="breakIterator" class="solr.highlight.BreakIteratorBoundaryScanner">
+     <lst name="defaults">
+       <str name="hl.bs.type">WORD</str>
+       <str name="hl.bs.language">en</str>
+       <str name="hl.bs.country">US</str>
+     </lst>
+   </boundaryScanner>
+  </highlighting>
+  </searchComponent>
+
+  <requestDispatcher>
+    <requestParsers enableRemoteStreaming="true" enableStreamBody="true" multipartUploadLimitInKB="-1" />
+    <httpCaching lastModifiedFrom="openTime" etagSeed="Solr" never304="false">
+      <cacheControl>max-age=30, public</cacheControl>
+    </httpCaching>
+  </requestDispatcher>
+
+  <requestHandler name="/search-facet-def" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="facet.field">foo_s</str>
+    </lst>
+    <lst name="appends">
+      <str name="facet.query">foo_s:bar</str>
+    </lst>
+  </requestHandler>
+  <requestHandler name="/search-facet-invariants" class="solr.SearchHandler" >
+    <lst name="invariants">
+      <str name="facet.field">foo_s</str>
+      <str name="facet.query">foo_s:bar</str>
+    </lst>
+  </requestHandler>
+
+  <!-- test getting system property -->
+  <propTest attr1="${solr.test.sys.prop1}-$${literal}"
+            attr2="${non.existent.sys.prop:default-from-config}">prefix-${solr.test.sys.prop2}-suffix</propTest>
+
+  <queryParser name="foo" class="FooQParserPlugin"/>
+
+  <updateRequestProcessorChain name="uniq-fields">
+    <processor class="org.apache.solr.update.processor.UniqFieldsUpdateProcessorFactory">
+      <arr name="fieldName">
+        <str>uniq</str>
+        <str>uniq2</str>
+        <str>uniq3</str>
+      </arr>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <updateRequestProcessorChain name="distrib-dup-test-chain-explicit">
+    <!-- explicit test using processors before and after distrib -->
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_A_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.DistributedUpdateProcessorFactory" />
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_B_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <updateRequestProcessorChain name="distrib-dup-test-chain-implicit">
+    <!-- implicit test w/o distrib declared-->
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_A_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_B_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <restManager>
+    <!--
+    IMPORTANT: Due to the Lucene SecurityManager, tests can only write to their runtime directory or below.
+    But it's easier to just keep everything in memory for testing so no remnants are left behind.
+    -->
+    <str name="storageIO">org.apache.solr.rest.ManagedResourceStorage$InMemoryStorageIO</str>
+  </restManager>
+
+  <!-- warning: not a best practice; requests generally ought to be explicit to thus not require this -->
+  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh,/search-facet-def,/search-facet-invariants">
+    <lst name="defaults">
+      <str name="df">text</str>
+    </lst>
+  </initParams>
+
+  <transformer name="explain1" class="org.apache.solr.response.transform.ExplainAugmenterFactory" />
+  <transformer name="explainText" class="org.apache.solr.response.transform.ExplainAugmenterFactory" >
+    <str name="args">text</str>
+  </transformer>
+  <transformer name="explainNL" class="org.apache.solr.response.transform.ExplainAugmenterFactory" >
+    <str name="args">nl</str>
+  </transformer>
+
+</config>

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayParser.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.apache.solr.SolrTestCaseJ4;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.apache.solr.SolrTestCaseJ4;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayParser.java
@@ -1,0 +1,154 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestExponentialDecayParser extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig-decayfunc.xml", "schema-decayfunc.xml");
+  }
+
+  @Test
+  public void testIntNumericExponentialDecayParser() throws Exception {
+    clearIndex();
+    int[] vals = new int[] {0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_i1", Integer.toString(vals[i])));
+    }
+    assertU(commit());
+
+    assertJQ(
+        req(
+            "df", "id",
+            "b", "exp(test_i1,5,40,5,0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_i1==35",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_i1==40",
+        "/response/docs/[1]/score==1.0",
+        "/response/docs/[2]/test_i1==45",
+        "/response/docs/[2]/score==1.0",
+        "/response/docs/[3]/test_i1==30",
+        "/response/docs/[3]/score==0.5",
+        "/response/docs/[4]/test_i1==50",
+        "/response/docs/[4]/score==0.5",
+        "/response/docs/[5]/test_i1==25",
+        "/response/docs/[5]/score==0.25");
+
+    clearIndex();
+    vals = new int[] {0, 10, 20, 50, 80, 100};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_i1", Integer.toString(vals[i])));
+    }
+    assertU(commit());
+
+    assertJQ(
+        req(
+            "df", "id",
+            "b", "exp(test_i1,20,50,20,0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_i1==50",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_i1==20",
+        "/response/docs/[1]/score==0.70710677",
+        "/response/docs/[2]/test_i1==80",
+        "/response/docs/[2]/score==0.70710677",
+        "/response/docs/[3]/test_i1==10",
+        "/response/docs/[3]/score==0.5",
+        "/response/docs/[4]/test_i1==0",
+        "/response/docs/[4]/score==0.35355338",
+        "/response/docs/[5]/test_i1==100",
+        "/response/docs/[5]/score==0.35355338");
+  }
+
+  @Test
+  public void testDatePointFieldExponentialDecayParser() throws Exception {
+
+    clearIndex();
+    int[] vals =
+        new int[] {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_date_p", "2021-07-" + vals[i] + "T00:00:00Z"));
+    }
+    assertU(commit());
+    assertJQ(
+        req(
+            "df", "id",
+            "b",
+                "exp(test_date_p,\"+2DAY+6HOUR\",\"2021-07-20T00:00:00Z\",\"+3DAY\",0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_date_p=='2021-07-17T00:00:00Z'",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_date_p=='2021-07-18T00:00:00Z'",
+        "/response/docs/[1]/score==1.0",
+        "/response/docs/[2]/test_date_p=='2021-07-19T00:00:00Z'",
+        "/response/docs/[2]/score==1.0",
+        "/response/docs/[3]/test_date_p=='2021-07-20T00:00:00Z'",
+        "/response/docs/[3]/score==1.0",
+        "/response/docs/[4]/test_date_p=='2021-07-21T00:00:00Z'",
+        "/response/docs/[4]/score==1.0",
+        "/response/docs/[5]/test_date_p=='2021-07-22T00:00:00Z'",
+        "/response/docs/[5]/score==1.0",
+        "/response/docs/[6]/test_date_p=='2021-07-23T00:00:00Z'",
+        "/response/docs/[6]/score==1.0",
+        "/response/docs/[7]/test_date_p=='2021-07-16T00:00:00Z'",
+        "/response/docs/[7]/score==0.7348673",
+        "/response/docs/[8]/test_date_p=='2021-07-24T00:00:00Z'",
+        "/response/docs/[8]/score==0.7348673",
+        "/response/docs/[9]/test_date_p=='2021-07-15T00:00:00Z'",
+        "/response/docs/[9]/score==0.5400299}",
+        "/response/docs/[10]/test_date_p=='2021-07-25T00:00:00Z'",
+        "/response/docs/[10]/score==0.5400299}",
+        "/response/docs/[11]/test_date_p=='2021-07-14T00:00:00Z'",
+        "/response/docs/[11]/score==0.39685026",
+        "/response/docs/[12]/test_date_p=='2021-07-26T00:00:00Z'",
+        "/response/docs/[12]/score==0.39685026",
+        "/response/docs/[13]/test_date_p=='2021-07-13T00:00:00Z'",
+        "/response/docs/[13]/score==0.29163226",
+        "/response/docs/[14]/test_date_p=='2021-07-27T00:00:00Z'",
+        "/response/docs/[14]/score==0.29163226",
+        "/response/docs/[15]/test_date_p=='2021-07-12T00:00:00Z'",
+        "/response/docs/[15]/score==0.21431099");
+  }
+
+  @Test
+  public void testLatLonPointFieldExponentialDecayParser() throws Exception {
+    clearIndex();
+    assertU(adoc("id", "0", "test_loc1_dv", "52.02471051274793, -0.49007556238612354"));
+    assertU(adoc("id", "1", "test_loc1_dv", "51.927619, -0.186636"));
+    assertU(adoc("id", "2", "test_loc1_dv", "51.480043,  -0.196508"));
+
+    assertU(commit());
+    assertJQ(
+        req(
+            "df", "id",
+            "b",
+                "exp(test_loc1_dv,\"23.420770393818795km\",52.02471051274793, -0.49007556238612354,\"0km\",0.5)", // field,scale,origin_lat,origin_lon,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!lucene}*:*",
+            "sort", "score desc",
+            "rows", "3",
+            "fl", "*,score"),
+        "/response/docs/[0]/test_loc1_dv=='52.02471051274793, -0.49007556238612354'",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_loc1_dv=='51.927619, -0.186636'",
+        "/response/docs/[1]/score==0.5",
+        "/response/docs/[2]/test_loc1_dv=='51.480043,  -0.196508'",
+        "/response/docs/[2]/score==0.15113723");
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.junit.Assert;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayStrategy.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.junit.Assert;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestExponentialDecayStrategy.java
@@ -1,0 +1,23 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestExponentialDecayStrategy {
+
+  @Test
+  public void testExponentialDecayStrategy() {
+    DecayFunctionValueSourceParser parser = new ExponentialDecayFunctionValueSourceParser();
+    DecayStrategy strategy = parser.getDecayStrategy();
+    for (double scale = 0; scale < 100; scale += 0.1)
+      for (double decay = 0; decay < 1; decay += 0.01)
+        for (double value = 0; value < 100; value += 0.1) test(scale, decay, value, strategy);
+  }
+
+  private void test(double scale, double decay, double value, DecayStrategy strategy) {
+    double s = strategy.scale(scale, decay);
+    Assert.assertEquals(Math.log(decay) / scale, s, 0);
+    double v = strategy.calculate(value, s);
+    Assert.assertEquals(Math.exp(s * value), v, 0);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayParser.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.apache.solr.SolrTestCaseJ4;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayParser.java
@@ -1,0 +1,154 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestGaussDecayParser extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig-decayfunc.xml", "schema-decayfunc.xml");
+  }
+
+  @Test
+  public void testIntNumericGaussDecayParser() throws Exception {
+    clearIndex();
+    int[] vals = new int[] {0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_i1", Integer.toString(vals[i])));
+    }
+    assertU(commit());
+
+    assertJQ(
+        req(
+            "df", "id",
+            "b", "gauss(test_i1,5,40,5,0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_i1==35",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_i1==40",
+        "/response/docs/[1]/score==1.0",
+        "/response/docs/[2]/test_i1==45",
+        "/response/docs/[2]/score==1.0",
+        "/response/docs/[3]/test_i1==30",
+        "/response/docs/[3]/score==0.5",
+        "/response/docs/[4]/test_i1==50",
+        "/response/docs/[4]/score==0.5",
+        "/response/docs/[5]/test_i1==25",
+        "/response/docs/[5]/score==0.0625");
+
+    clearIndex();
+    vals = new int[] {0, 10, 20, 50, 80, 100};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_i1", Integer.toString(vals[i])));
+    }
+    assertU(commit());
+
+    assertJQ(
+        req(
+            "df", "id",
+            "b", "gauss(test_i1,20,50,20,0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_i1==50",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_i1==20",
+        "/response/docs/[1]/score==0.8408964",
+        "/response/docs/[2]/test_i1==80",
+        "/response/docs/[2]/score==0.8408964",
+        "/response/docs/[3]/test_i1==10",
+        "/response/docs/[3]/score==0.5",
+        "/response/docs/[4]/test_i1==0",
+        "/response/docs/[4]/score==0.2102241",
+        "/response/docs/[5]/test_i1==100",
+        "/response/docs/[5]/score==0.2102241");
+  }
+
+  @Test
+  public void testDatePointFieldGaussDecayParser() throws Exception {
+
+    clearIndex();
+    int[] vals =
+        new int[] {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_date_p", "2021-07-" + vals[i] + "T00:00:00Z"));
+    }
+    assertU(commit());
+    assertJQ(
+        req(
+            "df", "id",
+            "b",
+                "gauss(test_date_p,\"+2DAY+6HOUR\",\"2021-07-20T00:00:00Z\",\"+3DAY\",0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_date_p=='2021-07-17T00:00:00Z'",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_date_p=='2021-07-18T00:00:00Z'",
+        "/response/docs/[1]/score==1.0",
+        "/response/docs/[2]/test_date_p=='2021-07-19T00:00:00Z'",
+        "/response/docs/[2]/score==1.0",
+        "/response/docs/[3]/test_date_p=='2021-07-20T00:00:00Z'",
+        "/response/docs/[3]/score==1.0",
+        "/response/docs/[4]/test_date_p=='2021-07-21T00:00:00Z'",
+        "/response/docs/[4]/score==1.0",
+        "/response/docs/[5]/test_date_p=='2021-07-22T00:00:00Z'",
+        "/response/docs/[5]/score==1.0",
+        "/response/docs/[6]/test_date_p=='2021-07-23T00:00:00Z'",
+        "/response/docs/[6]/score==1.0",
+        "/response/docs/[7]/test_date_p=='2021-07-16T00:00:00Z'",
+        "/response/docs/[7]/score==0.87204176",
+        "/response/docs/[8]/test_date_p=='2021-07-24T00:00:00Z'",
+        "/response/docs/[8]/score==0.87204176",
+        "/response/docs/[9]/test_date_p=='2021-07-15T00:00:00Z'",
+        "/response/docs/[9]/score==0.5782946}",
+        "/response/docs/[10]/test_date_p=='2021-07-25T00:00:00Z'",
+        "/response/docs/[10]/score==0.5782946}",
+        "/response/docs/[11]/test_date_p=='2021-07-14T00:00:00Z'",
+        "/response/docs/[11]/score==0.29163226",
+        "/response/docs/[12]/test_date_p=='2021-07-26T00:00:00Z'",
+        "/response/docs/[12]/score==0.29163226",
+        "/response/docs/[13]/test_date_p=='2021-07-13T00:00:00Z'",
+        "/response/docs/[13]/score==0.111839846",
+        "/response/docs/[14]/test_date_p=='2021-07-27T00:00:00Z'",
+        "/response/docs/[14]/score==0.111839846",
+        "/response/docs/[15]/test_date_p=='2021-07-12T00:00:00Z'",
+        "/response/docs/[15]/score==0.032616105");
+  }
+
+  @Test
+  public void testLatLonPointFieldGaussDecayParser() throws Exception {
+    clearIndex();
+    assertU(adoc("id", "0", "test_loc1_dv", "52.02471051274793, -0.49007556238612354"));
+    assertU(adoc("id", "1", "test_loc1_dv", "51.927619, -0.186636"));
+    assertU(adoc("id", "2", "test_loc1_dv", "51.480043,  -0.196508"));
+
+    assertU(commit());
+    assertJQ(
+        req(
+            "df", "id",
+            "b",
+                "gauss(test_loc1_dv,\"23.420770393818795km\",52.02471051274793, -0.49007556238612354,\"0km\",0.5)", // field,scale,origin_lat,origin_lon,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!lucene }*:*",
+            "sort", "score desc",
+            "rows", "3",
+            "fl", "*,score"),
+        "/response/docs/[0]/test_loc1_dv=='52.02471051274793, -0.49007556238612354'",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_loc1_dv=='51.927619, -0.186636'",
+        "/response/docs/[1]/score==0.5",
+        "/response/docs/[2]/test_loc1_dv=='51.480043,  -0.196508'",
+        "/response/docs/[2]/score==0.0057930867");
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.apache.solr.SolrTestCaseJ4;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayStrategy.java
@@ -1,0 +1,23 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestGaussDecayStrategy {
+
+  @Test
+  public void testGaussDecayFunctionValueSourceParser() {
+    DecayFunctionValueSourceParser parser = new GaussDecayFunctionValueSourceParser();
+    DecayStrategy strategy = parser.getDecayStrategy();
+    for (double scale = 0; scale < 100; scale += 0.1)
+      for (double decay = 0; decay < 1; decay += 0.01)
+        for (double value = 0; value < 100; value += 0.1) test(scale, decay, value, strategy);
+  }
+
+  private void test(double scale, double decay, double value, DecayStrategy strategy) {
+    double s = strategy.scale(scale, decay);
+    Assert.assertEquals(0.5 * Math.pow(scale, 2.0) / Math.log(decay), s, 0);
+    double v = strategy.calculate(value, s);
+    Assert.assertEquals(Math.exp(0.5 * Math.pow(value, 2.0) / s), v, 0);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.junit.Assert;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestGaussDecayStrategy.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.junit.Assert;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
@@ -1,8 +1,3 @@
-package org.apache.solr.search.function.decayfunction;
-
-import org.apache.solr.SolrTestCaseJ4;
-import org.junit.BeforeClass;
-import org.junit.Test;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,6 +15,11 @@ import org.junit.Test;
  * limitations under the License.
  */
 
+package org.apache.solr.search.function.decayfunction;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestLinearDecayParser extends SolrTestCaseJ4 {
 

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
@@ -3,6 +3,22 @@ package org.apache.solr.search.function.decayfunction;
 import org.apache.solr.SolrTestCaseJ4;
 import org.junit.BeforeClass;
 import org.junit.Test;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 public class TestLinearDecayParser extends SolrTestCaseJ4 {
 

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
@@ -20,6 +20,7 @@ import org.junit.Test;
  * limitations under the License.
  */
 
+
 public class TestLinearDecayParser extends SolrTestCaseJ4 {
 
   @BeforeClass

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayParser.java
@@ -1,0 +1,155 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestLinearDecayParser extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    System.setProperty("enable.utest_date_p.log", "false"); // schema12 doesn't support _version_
+    initCore("solrconfig-decayfunc.xml", "schema-decayfunc.xml");
+  }
+
+  @Test
+  public void testIntNumericLinearDecayParser() throws Exception {
+    clearIndex();
+    int[] vals = new int[] {0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_i1", Integer.toString(vals[i])));
+    }
+    assertU(commit());
+
+    assertJQ(
+        req(
+            "df", "id",
+            "b", "linear(test_i1,5,40,5,0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_i1==35",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_i1==40",
+        "/response/docs/[1]/score==1.0",
+        "/response/docs/[2]/test_i1==45",
+        "/response/docs/[2]/score==1.0",
+        "/response/docs/[3]/test_i1==30",
+        "/response/docs/[3]/score==0.5",
+        "/response/docs/[4]/test_i1==50",
+        "/response/docs/[4]/score==0.5",
+        "/response/docs/[5]/test_i1==0",
+        "/response/docs/[5]/score==0.0");
+
+    clearIndex();
+    vals = new int[] {0, 10, 20, 50, 80, 100};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_i1", Integer.toString(vals[i])));
+    }
+    assertU(commit());
+
+    assertJQ(
+        req(
+            "df", "id",
+            "b", "linear(test_i1,20,50,20,0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_i1==50",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_i1==20",
+        "/response/docs/[1]/score==0.75",
+        "/response/docs/[2]/test_i1==80",
+        "/response/docs/[2]/score==0.75",
+        "/response/docs/[3]/test_i1==10",
+        "/response/docs/[3]/score==0.5",
+        "/response/docs/[4]/test_i1==0",
+        "/response/docs/[4]/score==0.25",
+        "/response/docs/[5]/test_i1==100",
+        "/response/docs/[5]/score==0.25");
+  }
+
+  @Test
+  public void testDatePointFieldLinearDecayParser() throws Exception {
+
+    clearIndex();
+    int[] vals =
+        new int[] {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+    for (int i = 0; i < vals.length; i++) {
+      assertU(adoc("id", Integer.toString(i), "test_date_p", "2021-07-" + vals[i] + "T00:00:00Z"));
+    }
+    assertU(commit());
+    assertJQ(
+        req(
+            "df", "id",
+            "b",
+                "linear(test_date_p,\"+2DAY+6HOUR\",\"2021-07-20T00:00:00Z\",\"+3DAY\",0.5)", // field,scale,origin,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", Integer.toString(vals.length),
+            "fl", "*,score"),
+        "/response/docs/[0]/test_date_p=='2021-07-17T00:00:00Z'",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_date_p=='2021-07-18T00:00:00Z'",
+        "/response/docs/[1]/score==1.0",
+        "/response/docs/[2]/test_date_p=='2021-07-19T00:00:00Z'",
+        "/response/docs/[2]/score==1.0",
+        "/response/docs/[3]/test_date_p=='2021-07-20T00:00:00Z'",
+        "/response/docs/[3]/score==1.0",
+        "/response/docs/[4]/test_date_p=='2021-07-21T00:00:00Z'",
+        "/response/docs/[4]/score==1.0",
+        "/response/docs/[5]/test_date_p=='2021-07-22T00:00:00Z'",
+        "/response/docs/[5]/score==1.0",
+        "/response/docs/[6]/test_date_p=='2021-07-23T00:00:00Z'",
+        "/response/docs/[6]/score==1.0",
+        "/response/docs/[7]/test_date_p=='2021-07-16T00:00:00Z'",
+        "/response/docs/[7]/score==0.7777778",
+        "/response/docs/[8]/test_date_p=='2021-07-24T00:00:00Z'",
+        "/response/docs/[8]/score==0.7777778",
+        "/response/docs/[9]/test_date_p=='2021-07-15T00:00:00Z'",
+        "/response/docs/[9]/score==0.5555556}",
+        "/response/docs/[10]/test_date_p=='2021-07-25T00:00:00Z'",
+        "/response/docs/[10]/score==0.5555556}",
+        "/response/docs/[11]/test_date_p=='2021-07-14T00:00:00Z'",
+        "/response/docs/[11]/score==0.33333334",
+        "/response/docs/[12]/test_date_p=='2021-07-26T00:00:00Z'",
+        "/response/docs/[12]/score==0.33333334",
+        "/response/docs/[13]/test_date_p=='2021-07-13T00:00:00Z'",
+        "/response/docs/[13]/score==0.11111111",
+        "/response/docs/[14]/test_date_p=='2021-07-27T00:00:00Z'",
+        "/response/docs/[14]/score==0.11111111",
+        "/response/docs/[15]/test_date_p=='2021-07-10T00:00:00Z'",
+        "/response/docs/[15]/score==0.0");
+  }
+
+  @Test
+  public void testLatLonPointFieldLinearDecayParser() throws Exception {
+    clearIndex();
+    assertU(adoc("id", "0", "test_loc1_dv", "52.02471051274793, -0.49007556238612354"));
+    assertU(adoc("id", "1", "test_loc1_dv", "51.927619, -0.186636"));
+    assertU(adoc("id", "2", "test_loc1_dv", "51.480043,  -0.196508"));
+
+    assertU(commit());
+    assertJQ(
+        req(
+            "df", "id",
+            "b",
+                "linear(test_loc1_dv,\"23.420770393818795km\",52.02471051274793, -0.49007556238612354,\"0km\",0.5)", // field,scale,origin_lat,origin_lon,offset,decay
+            "q", "{!boost b=$b v=$qq}",
+            "qq", "{!edismax }*:*",
+            "sort", "score desc",
+            "rows", "3",
+            "fl", "*,score"),
+        "/response/docs/[0]/test_loc1_dv=='52.02471051274793, -0.49007556238612354'",
+        "/response/docs/[0]/score==1.0",
+        "/response/docs/[1]/test_loc1_dv=='51.927619, -0.186636'",
+        "/response/docs/[1]/score==0.5",
+        "/response/docs/[2]/test_loc1_dv=='51.480043,  -0.196508'",
+        "/response/docs/[2]/score==0.0");
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayStrategy.java
@@ -1,0 +1,23 @@
+package org.apache.solr.search.function.decayfunction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLinearDecayStrategy {
+
+  @Test
+  public void testLinearDecayFunctionValueSourceParser() {
+    DecayFunctionValueSourceParser parser = new LinearDecayFunctionValueSourceParser();
+    DecayStrategy strategy = parser.getDecayStrategy();
+    for (double scale = 0; scale < 100; scale += 0.1)
+      for (double decay = 0; decay < 1; decay += 0.01)
+        for (double value = 0; value < 100; value += 0.1) testScale(scale, decay, value, strategy);
+  }
+
+  private void testScale(double scale, double decay, double value, DecayStrategy strategy) {
+    double s = strategy.scale(scale, decay);
+    Assert.assertEquals(scale / (1.0 - decay), s, 0);
+    double v = strategy.calculate(value, s);
+    Assert.assertEquals(Math.max(0.0, (s - value) / s), v, 0);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.junit.Assert;

--- a/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayStrategy.java
+++ b/solr/core/src/test/org/apache/solr/search/function/decayfunction/TestLinearDecayStrategy.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.solr.search.function.decayfunction;
 
 import org.junit.Assert;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16291

# Description

This is a Solr version of the Decay functions  [available in Elasticsearch ] (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-decay )

Decay functions score a document with a function that decays depending on the distance of a numeric field value of the document from a user given origin. This is similar to a range query, but with smooth edges instead of boxes.

# Solution

 implemented as ValueSourceParsers

# Tests

Test are in org.apache.solr.search.function.decayfunction for testing exponential, gauss and linear implementations

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
