### PR TITLE
AuditLoggerIT should wait to join thread

### DIFF
--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -637,6 +637,7 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     public void close() throws Exception {
       shutdownCluster();
       receiverThread.interrupt();
+      receiverThread.join();
       receiver.close();
       receiverThread = null;
     }


### PR DESCRIPTION
```
  2> SEVERE: 1 thread leaked from SUITE scope at org.apache.solr.security.AuditLoggerIntegrationTest:
  2>    1) Thread[id=1232, name=auditTestCallback-918-thread-1, state=RUNNABLE, group=TGRP-AuditLoggerIntegrationTest]
  2>         at java.base@17.0.3/sun.nio.ch.Net.available(Native Method)
  2>         at java.base@17.0.3/sun.nio.ch.NioSocketImpl.available(NioSocketImpl.java:842)
  2>         at java.base@17.0.3/sun.nio.ch.NioSocketImpl$1.available(NioSocketImpl.java:807)
  2>         at java.base@17.0.3/java.net.Socket$SocketInputStream.available(Socket.java:970)
  2>         at java.base@17.0.3/sun.nio.cs.StreamDecoder.inReady(StreamDecoder.java:351)
  2>         at java.base@17.0.3/sun.nio.cs.StreamDecoder.implReady(StreamDecoder.java:359)
  2>         at java.base@17.0.3/sun.nio.cs.StreamDecoder.ready(StreamDecoder.java:195)
  2>         at java.base@17.0.3/java.io.InputStreamReader.ready(InputStreamReader.java:188)
  2>         at java.base@17.0.3/java.io.BufferedReader.ready(BufferedReader.java:463)
  2>         at app//org.apache.solr.security.AuditLoggerIntegrationTest$CallbackReceiver.run(AuditLoggerIntegrationTest.java:578)
  2>         at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
```