### PR TITLE
SOLR-16316: Fix debug query clicking on the query UI does not show the debug.explain.structured option

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -109,7 +109,7 @@ Bug Fixes
 
 * SOLR-9661: Fix explanation of select() streaming expression that uses replace() operation  (Ahmet Can Kepenek via Eric Pugh) 
 
-* SOLR-16316: Fix debugQuery clicking on the Query UI does not show the debug.explain.structured option. (Shiming Li)
+* SOLR-16316: Fix debugQuery clicking on the Query UI does not show the debug.explain.structured option. (Shiming Li via Eric Pugh)
 
 Other Changes
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -109,6 +109,8 @@ Bug Fixes
 
 * SOLR-9661: Fix explanation of select() streaming expression that uses replace() operation  (Ahmet Can Kepenek via Eric Pugh) 
 
+* SOLR-16316: Fix debugQuery clicking on the Query UI does not show the debug.explain.structured option. (Shiming Li)
+
 Other Changes
 ---------------------
 * SOLR-16245: Make DenseVectorField codec agnostic (Elia Porciani via Alessandro Benedetti)

--- a/solr/webapp/web/partials/query.html
+++ b/solr/webapp/web/partials/query.html
@@ -114,7 +114,7 @@ limitations under the License.
             debugQuery
           </label>
         </legend>
-        <div class="fieldset" ng-show="isDebugQuery">
+        <div class="fieldset" ng-show="val['debugQuery']">
 
         <label for="debug_explain_structured" class="checkbox" title="Show Score explanations as nested structures.">
           <input type="checkbox" ng-model="val['debug.explain.structured']" name="debug.explain.structured" id="debug_explain_structured" value="true">


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16316
# Description

DebugQuery should display the debug.explain.structured option, which can be checked to generate debug.explain.structured=true for query parameters.


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
