### PR TITLE
SOLR-16257: Fix ZkStateReaderTest NPE when checking node version

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -250,9 +250,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     TimeOut timeOut = new TimeOut(5000, TimeUnit.MILLISECONDS, TimeSource.NANO_TIME);
     timeOut.waitFor(
         "Timeout on waiting for c1 to show up in cluster state",
-        () ->
-            reader.getClusterState().getCollectionRef("c1") != null
-                && reader.getClusterState().getCollectionRef("c1").get() != null);
+        () -> reader.getClusterState().getCollectionOrNull("c1") != null);
 
     ClusterState.CollectionRef ref = reader.getClusterState().getCollectionRef("c1");
     assertFalse(ref.isLazilyLoaded());
@@ -298,7 +296,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     clusterState = writer.writePendingUpdates();
     timeOut.waitFor(
         "Timeout on waiting for c1 to be removed from cluster state",
-        () -> reader.getClusterState().getCollectionRef("c1").get() == null);
+        () -> reader.getClusterState().getCollectionOrNull("c1") == null);
 
     reader.unregisterCore("c1");
     // re-add the same collection
@@ -311,9 +309,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     // reader.forceUpdateCollection("c1");
     timeOut.waitFor(
         "Timeout on waiting for c1 to show up in cluster state again",
-        () ->
-            reader.getClusterState().getCollectionRef("c1") != null
-                && reader.getClusterState().getCollectionRef("c1").get() != null);
+        () -> reader.getClusterState().getCollectionOrNull("c1") != null);
     ref = reader.getClusterState().getCollectionRef("c1");
     assertFalse(ref.isLazilyLoaded());
     assertEquals(0, ref.get().getZNodeVersion());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16257

Test failures due to NPE: https://lists.apache.org/list?builds@solr.apache.org:lte=1M:FAILED:%20%20org.apache.solr.cloud.overseer.ZkStateReaderTest.testNodeVersion

This was introduced in https://github.com/apache/solr/pull/909