### PR TITLE
SOLR-16349 check for properties file before attempt to open

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
+++ b/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
@@ -194,10 +194,14 @@ public class CorePropertiesLocator implements CoresLocator {
   }
 
   protected CoreDescriptor buildCoreDescriptor(Path propertiesFile, CoreContainer cc) {
-
-    Path instanceDir = propertiesFile.getParent();
-    Properties coreProperties = new Properties();
+    if (Files.notExists(propertiesFile)) {
+      // This can happen in tests, see CoreContainer#reloadCoreDescriptor
+      log.info("Could not load core descriptor from {} because it does not exist", propertiesFile);
+      return null;
+    }
     try (InputStream fis = Files.newInputStream(propertiesFile)) {
+      Path instanceDir = propertiesFile.getParent();
+      Properties coreProperties = new Properties();
       coreProperties.load(new InputStreamReader(fis, StandardCharsets.UTF_8));
       String name = createName(coreProperties, instanceDir);
       Map<String, String> propMap = new HashMap<>();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16349

I'm not sure if a real production scenario would prefer a logged exception here, but the behavior is unchanged.