### PR TITLE
always(?) use SolrCore.getLatestSchema in RealTimeGetComponent

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -294,7 +294,7 @@ public class RealTimeGetComponent extends SearchComponent {
                     break; // document has been deleted as the resolve was going on
                   }
                   doc.visitSelfAndNestedDocs(
-                      (label, d) -> removeCopyFieldTargets(d, req.getSchema()));
+                      (label, d) -> removeCopyFieldTargets(d, core.getLatestSchema()));
                 } else {
                   throw new SolrException(
                       ErrorCode.INVALID_STATE, "Expected ADD or UPDATE_INPLACE. Got: " + oper);
@@ -382,13 +382,14 @@ public class RealTimeGetComponent extends SearchComponent {
       return;
     }
 
+    final SolrCore core = req.getCore();
+
     String idStr = params.get("getInputDocument", null);
     if (idStr == null) return;
-    BytesRef idBytes = req.getSchema().indexableUniqueKey(idStr);
+    BytesRef idBytes = core.getLatestSchema().indexableUniqueKey(idStr);
     AtomicLong version = new AtomicLong();
     SolrInputDocument doc =
-        getInputDocument(
-            req.getCore(), idBytes, idBytes, version, null, Resolution.ROOT_WITH_CHILDREN);
+        getInputDocument(core, idBytes, idBytes, version, null, Resolution.ROOT_WITH_CHILDREN);
     log.info("getInputDocument called for id={}, returning {}", idStr, doc);
     rb.rsp.add("inputDocument", doc);
     rb.rsp.add("version", version.get());


### PR DESCRIPTION
The `RealTimeGetComponent` uses `getLatestSchema` in 12 places and `getSchema` in 2 places.

Intuitively I would expect `getSchema` to be used throughout since it as per https://github.com/apache/solr/blob/releases/solr/9.0.0/solr/core/src/java/org/apache/solr/request/SolrQueryRequest.java#L86-L87 that is snapshot at request creation and so logically cannot change during processing. But based on 12:2 ratio perhaps `getLatestSchema` is equally suitable?

This pull request is to always use `getLatestSchema` _or to add clarifying comments_ w.r.t. why some places use one API and others use the other in the component.