### PR TITLE
SOLR-16362: Logs: Truncate field values in logs if a doc fails to index

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -71,6 +71,7 @@ Improvements
 
 * SOLR-16353: Make SplitShardCmd#checkDiskSpace disableable through a system property. (Haythem Khiri)
 
+* SOLR-16362: Logs: Truncate field values in logs if a doc fails to index. (Nazerke Seidan, David Smiley)
 
 Optimizations
 ---------------------

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -166,6 +166,7 @@ public class DocumentBuilder {
         // Ensure we do not flood the logs with extremely long values
         String fieldValue = field.getValue().toString();
         if (fieldValue.length() > MAX_VALUES_AS_STRING_LENGTH) {
+          assert fieldValue.endsWith("]");
           fieldValue = fieldValue.substring(0, MAX_VALUES_AS_STRING_LENGTH - 4) + "...]";
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16362

