### PR TITLE
Allow skipping failure for RAT and Source Patterns

### DIFF
--- a/gradle/globals.gradle
+++ b/gradle/globals.gradle
@@ -69,6 +69,19 @@ allprojects {
       return file(buildscript.sourceFile.absolutePath.replaceAll('.gradle$', ""))
     }
 
+    failOrWarn = { propName, message, errors ->
+      if (errors) {
+        def shouldFail = Boolean.valueOf(propertyOrDefault(propName, true))
+        def msg = message + (shouldFail ? " (skip with -P${propName}=false)" : "") + ":\n${errors.join("\n")}"
+
+        if (shouldFail) {
+          throw new GradleException(msg)
+        } else {
+          logger.warn("NOTE: ${msg}")
+        }
+      }
+    }
+
     // Utility function similar to project.exec but not emitting
     // any output unless an error code is returned from the executed command.
     quietExec = { closure ->

--- a/gradle/validation/git-status.gradle
+++ b/gradle/validation/git-status.gradle
@@ -103,19 +103,8 @@ configure(rootProject) {
           files.collect {file -> "  - ${file} ${fileStatus}" }
         }.sort()
 
-        if (offenders) {
-          def checkProp = "validation.git.failOnModified"
-          def shouldFail = Boolean.valueOf(propertyOrDefault(checkProp, true))
-          def message = "Working copy is not a clean git checkout" + 
-            (shouldFail ? " (skip with -P${checkProp}=false)" : "") +
-            ", offending files:\n${offenders.join("\n")}"
-
-          if (shouldFail) {
-            throw new GradleException(message)
-          } else {
-            logger.lifecycle("NOTE: ${message}")
-          }
-        }
+        def checkProp = "validation.git.failOnModified"
+        failOrWarn(checkProp, "Working copy is not a clean git checkout", offenders)
       }
     }
   }

--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -273,18 +273,8 @@ class RatTask extends DefaultTask {
                 errors << "Unknown license: ${resource.@name}"
             }
         }
-        if (errors) {
-            def checkProp = "validation.rat.failOnError"
-            def shouldFail = Boolean.valueOf(project.propertyOrDefault(checkProp, true))
-            def message = "Found " + errors.size() + " file(s) with errors: " +
-                    (shouldFail ? "(skip with -P${checkProp}=false)\n" : "\n") +
-                    errors.collect{ msg -> "  - ${msg}" }.join("\n")
-            if (shouldFail) {
-                throw new GradleException(message)
-            } else {
-                logger.lifecycle("NOTE: ${message}")
-            }
-        }
+        def checkProp = "validation.rat.failOnError"
+        project.failOrWarn(checkProp, "Detected license header issues", errors)
     }
 
     @TaskAction

--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -274,8 +274,16 @@ class RatTask extends DefaultTask {
             }
         }
         if (errors) {
-            throw new GradleException("Found " + errors.size() + " file(s) with errors:\n" +
-                    errors.collect{ msg -> "  - ${msg}" }.join("\n"))
+            def checkProp = "validation.rat.failOnError"
+            def shouldFail = Boolean.valueOf(project.propertyOrDefault(checkProp, true))
+            def message = "Found " + errors.size() + " file(s) with errors: " +
+                    (shouldFail ? "(skip with -P${checkProp}=false)\n" : "\n") +
+                    errors.collect{ msg -> "  - ${msg}" }.join("\n")
+            if (shouldFail) {
+                throw new GradleException(message)
+            } else {
+                logger.lifecycle("NOTE: ${message}")
+            }
         }
     }
 

--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -274,8 +274,17 @@ class ValidateSourcePatternsTask extends DefaultTask {
     progress.completed()
 
     if (found) {
-      throw new GradleException(String.format(Locale.ENGLISH, 'Found %d violations in source files (%s).',
-        found, violations.join(', ')));
+      def checkProp = "validation.sourcePatterns.failOnError"
+      def shouldFail = Boolean.valueOf(project.propertyOrDefault(checkProp, true))
+      def message = "Found ${found} violations in source files" +
+              (shouldFail ? " (skip with -P${checkProp}=false)" : "") +
+              ", offending files:\n${violations.join("\n")}"
+
+      if (shouldFail) {
+        throw new GradleException(message)
+      } else {
+        logger.lifecycle("NOTE: ${message}")
+      }
     }
   }
 }

--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -156,12 +156,10 @@ class ValidateSourcePatternsTask extends DefaultTask {
       (~$/\n\s*var\s+.*=.*<>.*/$) : 'Diamond operators should not be used with var',
     ]
 
-    def found = 0;
     def violations = new TreeSet();
     def reportViolation = { f, name ->
       logger.error('{}: {}', name, f);
       violations.add(name);
-      found++;
     }
 
     def javadocsPattern = ~$/(?sm)^\Q/**\E(.*?)\Q*/\E/$;
@@ -273,18 +271,7 @@ class ValidateSourcePatternsTask extends DefaultTask {
     }
     progress.completed()
 
-    if (found) {
-      def checkProp = "validation.sourcePatterns.failOnError"
-      def shouldFail = Boolean.valueOf(project.propertyOrDefault(checkProp, true))
-      def message = "Found ${found} violations in source files" +
-              (shouldFail ? " (skip with -P${checkProp}=false)" : "") +
-              ", offending files:\n${violations.join("\n")}"
-
-      if (shouldFail) {
-        throw new GradleException(message)
-      } else {
-        logger.lifecycle("NOTE: ${message}")
-      }
-    }
+    def checkProp = "validation.sourcePatterns.failOnError"
+    project.failOrWarn(checkProp, "Found source pattern violations", violations)
   }
 }


### PR DESCRIPTION
I'd like to be able to still run these checks and report on them, but also be able to prevent them from failing the build. Useful in CI environment where I will have the output and also want to make sure other checks get run instead of failing fast here.

This pattern was modeled on the `validation.git.failOnModified` option.