### PR TITLE
SOLR-15342 Solrj-Zookeeper: opt-out on 9x

### DIFF
--- a/solr/solrj/build.gradle
+++ b/solr/solrj/build.gradle
@@ -41,6 +41,9 @@ dependencies {
   implementation 'org.apache.httpcomponents:httpclient'
   implementation 'org.apache.httpcomponents:httpcore'
 
+  // In 9.x, ending in 10, we depend on SolrJ modules.  Users can opt-out.
+  runtimeOnly project(':solr:solrj-zookeeper')
+
   testImplementation project(':solr:test-framework')
   testImplementation project(':solr:core')
   testImplementation project(':solr:solrj')


### PR DESCRIPTION
**On 9.x,** Solrj-Zookeeper should be "opt-out", thus a user needs to opt-out if they don't want it.  Don't change main (opt-in).

I looked at the upgrade docs for 9.1 in `solr-upgrade-notes.adoc` and I thought maybe just leave it be.  What it says isn't wrong -- yes you will need this JAR if you use this functionality.  It's unspecified wether this happens automatically or not based on Maven POM (for those that use it which is most folks for sure).  In some sense it's a detail.

In main, I can add a note for the 10.x upgrade to mention this, where it's more impactful / noticeable.