### PR TITLE
NO JIRA: reduce array allocation in ExtendedDismaxQParser.UserFields

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Multimaps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1564,11 +1563,14 @@ public class ExtendedDismaxQParser extends QParser {
       if (!userFieldsMap.containsKey(MagicFieldName.QUERY.field)) {
         userFieldsMap.put("-" + MagicFieldName.QUERY.field, null);
       }
-      Collections.sort(dynUserFields);
       dynamicUserFields = dynUserFields.toArray(new DynamicField[dynUserFields.size()]);
-      Collections.sort(negDynUserFields);
+      Arrays.sort(dynamicUserFields);
+      // Avoid creating the array twice by converting to an array first and using Arrays.sort(),
+      // rather than Collections.sort() then converting to an array, since Collections.sort()
+      // copies to an array first, then sets each collection member from the array.
       negativeDynamicUserFields =
           negDynUserFields.toArray(new DynamicField[negDynUserFields.size()]);
+      Arrays.sort(negativeDynamicUserFields);
     }
 
     /**


### PR DESCRIPTION
Whilst `sed` doing the #1016 changes for SOLR-16318 some comments in `IndexSchema` cropped up and a similar approach can be used in `ExtendedDismaxQParser.UserFields` also.

No JIRA ticket and `solr/CHANGES.txt` entry required in my opinion.

https://github.com/apache/solr/blob/releases/solr/9.0.0/solr/core/src/java/org/apache/solr/schema/IndexSchema.java#L765-L767

```
// Avoid creating the array twice by converting to an array first and using Arrays.sort(),
// rather than Collections.sort() then converting to an array, since Collections.sort()
// copies to an array first, then sets each collection member from the array.
```