### PR TITLE
NO JIRA: remove deprecated RealTimeGetComponent methods

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -630,21 +630,6 @@ public class RealTimeGetComponent extends SearchComponent {
 
   public static SolrInputDocument DELETED = new SolrInputDocument();
 
-  @Deprecated // need Resolution
-  public static SolrInputDocument getInputDocumentFromTlog(
-      SolrCore core,
-      BytesRef idBytes,
-      AtomicLong versionReturned,
-      Set<String> onlyTheseNonStoredDVs,
-      boolean resolveFullDocument) {
-    return getInputDocumentFromTlog(
-        core,
-        idBytes,
-        versionReturned,
-        onlyTheseNonStoredDVs,
-        resolveFullDocument ? Resolution.DOC : Resolution.PARTIAL);
-  }
-
   /**
    * Specialized to pick out a child doc from a nested doc from the TLog.
    *
@@ -745,12 +730,6 @@ public class RealTimeGetComponent extends SearchComponent {
     }
 
     return null;
-  }
-
-  @Deprecated // easy to use wrong
-  public static SolrInputDocument getInputDocument(
-      SolrCore core, BytesRef idBytes, Resolution lookupStrategy) throws IOException {
-    return getInputDocument(core, idBytes, idBytes, null, null, lookupStrategy);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/update/processor/DocBasedVersionConstraintsProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DocBasedVersionConstraintsProcessor.java
@@ -192,7 +192,8 @@ public class DocBasedVersionConstraintsProcessor extends UpdateRequestProcessor 
   private DocFoundAndOldUserAndSolrVersions getOldUserVersionsFromFieldCache(
       BytesRef indexedDocId) {
     SolrInputDocument oldDoc =
-        RealTimeGetComponent.getInputDocumentFromTlog(core, indexedDocId, null, null, true);
+        RealTimeGetComponent.getInputDocumentFromTlog(
+            core, indexedDocId, null, null, RealTimeGetComponent.Resolution.DOC);
     if (oldDoc == RealTimeGetComponent.DELETED) {
       return DocFoundAndOldUserAndSolrVersions.NOT_FOUND;
     }
@@ -233,7 +234,7 @@ public class DocBasedVersionConstraintsProcessor extends UpdateRequestProcessor 
     // stored fields only...
     SolrInputDocument oldDoc =
         RealTimeGetComponent.getInputDocument(
-            core, indexedDocId, RealTimeGetComponent.Resolution.DOC);
+            core, indexedDocId, indexedDocId, null, null, RealTimeGetComponent.Resolution.DOC);
     if (null == oldDoc) {
       return DocFoundAndOldUserAndSolrVersions.NOT_FOUND;
     } else {


### PR DESCRIPTION
Remove methods that were deprecated in Solr 8.8 as per https://issues.apache.org/jira/browse/SOLR-14923 tags.

No JIRA ticket or `solr/CHANGES.txt` entry required for this I think.