### PR TITLE
SOLR-16417: NPE if facet query hits timeout or exception

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -153,6 +153,8 @@ Bug Fixes
 
 * SOLR-16344: PlacementPlugin throws NPE for PRS collections (noble)
 
+* SOLR-16417: NPE if facet query hits timeout or exception (Kevin Risden)
+
 Other Changes
 ---------------------
 * SOLR-16351: Upgrade Carrot2 to 4.4.3, upgrade randomizedtesting to 2.8.0. (Dawid Weiss)

--- a/solr/core/src/java/org/apache/solr/response/SolrQueryResponse.java
+++ b/solr/core/src/java/org/apache/solr/response/SolrQueryResponse.java
@@ -63,7 +63,7 @@ public class SolrQueryResponse {
   public static final String RESPONSE_HEADER_PARTIAL_RESULTS_KEY = "partialResults";
   public static final String RESPONSE_HEADER_SEGMENT_TERMINATED_EARLY_KEY =
       "segmentTerminatedEarly";
-  private static final String RESPONSE_HEADER_KEY = "responseHeader";
+  public static final String RESPONSE_HEADER_KEY = "responseHeader";
   private static final String RESPONSE_KEY = "response";
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16417

* Extracts method from already implemented logic to apply error checking for refine facets and distrib intervals. 
* Use constants instead of strings in common cases.

I didn't add a test for this since I couldn't get it to reproduce easily. I know its a condition of timeAllowed for what I saw this error happen. The issue is that timeAllowed isn't easy to insert into the running query at a predetermined interval. Most of the time this just ends up breaking out at some random time in the query.