### PR TITLE
SOLR-16427: Evaluate and fix errorprone rules - part 2

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -99,7 +99,6 @@ allprojects { prj ->
             '-Xep:InputStreamSlowMultibyteRead:OFF',
             '-Xep:IntLongMath:OFF',
             '-Xep:InvalidBlockTag:OFF', // this is needed for tags like lucene.internal
-            '-Xep:JavaLangClash:OFF',
             '-Xep:JavaUtilDate:OFF',
             '-Xep:JdkObsolete:OFF',
             '-Xep:LogicalAssignment:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -119,7 +119,6 @@ allprojects { prj ->
             '-Xep:ObjectToString:OFF',
             '-Xep:ObjectsHashCodePrimitive:OFF',
             '-Xep:OperatorPrecedence:OFF',
-            '-Xep:ProtectedMembersInFinalClass:OFF',
             '-Xep:ReferenceEquality:OFF',
             '-Xep:ReturnValueIgnored:OFF',
             '-Xep:SameNameButDifferent:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -84,7 +84,6 @@ allprojects { prj ->
             '-Xep:CanIgnoreReturnValueSuggester:OFF',
             '-Xep:ClassCanBeStatic:OFF',
             '-Xep:ComplexBooleanConstant:OFF',
-            '-Xep:DoubleBraceInitialization:OFF',
             '-Xep:DoubleCheckedLocking:OFF',
             '-Xep:EmptyCatch:OFF',
             '-Xep:EqualsGetClass:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -74,7 +74,6 @@ allprojects { prj ->
             '-Xep:StaticAssignmentInConstructor:OFF', // we assign SolrTestCaseJ4.configString in many tests, difficult to untangle
             '-Xep:ComparableType:OFF', // SolrTestCaseJ4.Doc and Fld are messy
 
-            '-Xep:AlmostJavadoc:OFF',
             '-Xep:AlreadyChecked:OFF',
             '-Xep:AmbiguousMethodReference:OFF',
             '-Xep:ArgumentSelectionDefectChecker:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -99,7 +99,6 @@ allprojects { prj ->
             '-Xep:IntLongMath:OFF',
             '-Xep:InvalidBlockTag:OFF', // this is needed for tags like lucene.internal
             '-Xep:JavaUtilDate:OFF',
-            '-Xep:JdkObsolete:OFF',
             '-Xep:LogicalAssignment:OFF',
             '-Xep:MissingOverride:OFF',
             '-Xep:MissingSummary:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -99,7 +99,7 @@ allprojects { prj ->
             '-Xep:InlineFormatString:OFF', // this introduces redundancy in format strings
             '-Xep:InputStreamSlowMultibyteRead:OFF',
             '-Xep:IntLongMath:OFF',
-            '-Xep:InvalidBlockTag:OFF',
+            '-Xep:InvalidBlockTag:OFF', // this is needed for tags like lucene.internal
             '-Xep:InvalidInlineTag:OFF',
             '-Xep:InvalidParam:OFF',
             '-Xep:JavaLangClash:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -100,7 +100,6 @@ allprojects { prj ->
             '-Xep:InputStreamSlowMultibyteRead:OFF',
             '-Xep:IntLongMath:OFF',
             '-Xep:InvalidBlockTag:OFF', // this is needed for tags like lucene.internal
-            '-Xep:InvalidInlineTag:OFF',
             '-Xep:InvalidParam:OFF',
             '-Xep:JavaLangClash:OFF',
             '-Xep:JavaUtilDate:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -131,7 +131,6 @@ allprojects { prj ->
             '-Xep:UnescapedEntity:OFF',
             '-Xep:UnicodeEscape:OFF',
             '-Xep:UnnecessaryParentheses:OFF',
-            '-Xep:UnsynchronizedOverridesSynchronized:OFF',
             '-Xep:UnusedMethod:OFF',
             '-Xep:UnusedVariable:OFF',
             '-Xep:WaitNotInLoop:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -100,7 +100,6 @@ allprojects { prj ->
             '-Xep:InputStreamSlowMultibyteRead:OFF',
             '-Xep:IntLongMath:OFF',
             '-Xep:InvalidBlockTag:OFF', // this is needed for tags like lucene.internal
-            '-Xep:InvalidParam:OFF',
             '-Xep:JavaLangClash:OFF',
             '-Xep:JavaUtilDate:OFF',
             '-Xep:JdkObsolete:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -78,7 +78,6 @@ allprojects { prj ->
             '-Xep:AmbiguousMethodReference:OFF',
             '-Xep:ArgumentSelectionDefectChecker:OFF',
             '-Xep:BadImport:OFF', // style preference that we don't want to enforce
-            '-Xep:BadInstanceof:OFF',
             '-Xep:BadShiftAmount:OFF',
             '-Xep:CanIgnoreReturnValueSuggester:OFF',
             '-Xep:ClassCanBeStatic:OFF',

--- a/solr/core/src/java/org/apache/solr/analysis/ReversedWildcardFilter.java
+++ b/solr/core/src/java/org/apache/solr/analysis/ReversedWildcardFilter.java
@@ -41,7 +41,7 @@ public final class ReversedWildcardFilter extends TokenFilter {
   private final PositionIncrementAttribute posAtt;
   private State save = null;
 
-  protected ReversedWildcardFilter(TokenStream input, boolean withOriginal, char markerChar) {
+  ReversedWildcardFilter(TokenStream input, boolean withOriginal, char markerChar) {
     super(input);
     this.termAtt = addAttribute(CharTermAttribute.class);
     this.posAtt = addAttribute(PositionIncrementAttribute.class);

--- a/solr/core/src/java/org/apache/solr/api/ContainerPluginsRegistry.java
+++ b/solr/core/src/java/org/apache/solr/api/ContainerPluginsRegistry.java
@@ -55,7 +55,7 @@ import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.PluginInfo;
 import org.apache.solr.handler.admin.ContainerPluginsApi;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.SolrJacksonAnnotationInspector;
@@ -299,7 +299,7 @@ public class ContainerPluginsRegistry implements ClusterPropertiesListener, MapW
     @JsonProperty(value = "package")
     public final String pkg;
 
-    private PackageLoader.Package.Version pkgVersion;
+    private SolrPackageLoader.SolrPackage.Version pkgVersion;
     private Class<?> klas;
     Object instance;
 
@@ -328,7 +328,7 @@ public class ContainerPluginsRegistry implements ClusterPropertiesListener, MapW
       PluginInfo.ClassName klassInfo = new PluginInfo.ClassName(info.klass);
       pkg = klassInfo.pkg;
       if (pkg != null) {
-        Optional<PackageLoader.Package.Version> ver =
+        Optional<SolrPackageLoader.SolrPackage.Version> ver =
             coreContainer.getPackageLoader().getPackageVersion(pkg, info.version);
         if (ver.isEmpty()) {
           // may be we are a bit early. Do a refresh and try again
@@ -336,7 +336,7 @@ public class ContainerPluginsRegistry implements ClusterPropertiesListener, MapW
           ver = coreContainer.getPackageLoader().getPackageVersion(pkg, info.version);
         }
         if (ver.isEmpty()) {
-          PackageLoader.Package p = coreContainer.getPackageLoader().getPackage(pkg);
+          SolrPackageLoader.SolrPackage p = coreContainer.getPackageLoader().getPackage(pkg);
           if (p == null) {
             errs.add("Invalid package " + klassInfo.pkg);
             return;

--- a/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
+++ b/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
@@ -27,11 +27,11 @@ import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -313,7 +313,7 @@ public class V2HttpCall extends HttpSolrCall {
   }
 
   public static class CompositeApi extends Api {
-    private LinkedList<Api> apis = new LinkedList<>();
+    private final List<Api> apis = new ArrayList<>();
 
     public CompositeApi(Api api) {
       super(ApiBag.EMPTY_SPEC);

--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -129,7 +128,7 @@ public class JettySolrRunner {
 
   private volatile boolean startedBefore = false;
 
-  private LinkedList<FilterHolder> extraFilters;
+  private List<FilterHolder> extraFilters;
 
   private static final String excludePatterns =
       "/partials/.+,/libs/.+,/css/.+,/js/.+,/img/.+,/templates/.+";
@@ -404,7 +403,7 @@ public class JettySolrRunner {
 
               debugFilter =
                   root.addFilter(DebugFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
-              extraFilters = new LinkedList<>();
+              extraFilters = new ArrayList<>();
               for (Map.Entry<Class<? extends Filter>, String> entry :
                   config.extraFilters.entrySet()) {
                 extraFilters.add(

--- a/solr/core/src/java/org/apache/solr/cloud/DistributedClusterStateUpdater.java
+++ b/solr/core/src/java/org/apache/solr/cloud/DistributedClusterStateUpdater.java
@@ -31,9 +31,9 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.DE
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.MODIFYCOLLECTION;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -684,7 +684,7 @@ public class DistributedClusterStateUpdater {
         log.error(err);
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, err);
       }
-      mutations = new LinkedList<>();
+      mutations = new ArrayList<>();
       this.collectionName = collectionName;
       this.isCollectionCreation = isCollectionCreation;
     }
@@ -807,7 +807,7 @@ public class DistributedClusterStateUpdater {
       @Override
       public void computeUpdates(ClusterState clusterState, SolrZkClient client) {
         boolean hasJsonUpdates = false;
-        List<PerReplicaStatesOps> perReplicaStateOps = new LinkedList<>();
+        List<PerReplicaStatesOps> perReplicaStateOps = new ArrayList<>();
         for (Pair<MutatingCommand, ZkNodeProps> mutation : mutations) {
           MutatingCommand mutatingCommand = mutation.first();
           ZkNodeProps message = mutation.second();

--- a/solr/core/src/java/org/apache/solr/cloud/LockTree.java
+++ b/solr/core/src/java/org/apache/solr/cloud/LockTree.java
@@ -18,8 +18,8 @@
 package org.apache.solr.cloud;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayDeque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.cloud.OverseerMessageHandler.Lock;
@@ -54,7 +54,7 @@ public class LockTree {
 
     @Override
     public String toString() {
-      return StrUtils.join(node.constructPath(new LinkedList<>()), '/');
+      return StrUtils.join(node.constructPath(new ArrayDeque<>()), '/');
     }
   }
 
@@ -175,7 +175,7 @@ public class LockTree {
       }
     }
 
-    LinkedList<String> constructPath(LinkedList<String> collect) {
+    ArrayDeque<String> constructPath(ArrayDeque<String> collect) {
       if (name != null) collect.addFirst(name);
       if (mom != null) mom.constructPath(collect);
       return collect;

--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -22,10 +22,10 @@ import com.codahale.metrics.Timer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -314,11 +314,11 @@ public class Overseer implements SolrCloseable {
             }
           }
 
-          LinkedList<Pair<String, byte[]>> queue = null;
+          ArrayDeque<Pair<String, byte[]>> queue = null;
           try {
             // We do not need to filter any nodes here cause all processed nodes are removed once we
             // flush clusterstate
-            queue = new LinkedList<>(stateUpdateQueue.peekElements(1000, 3000L, (x) -> true));
+            queue = new ArrayDeque<>(stateUpdateQueue.peekElements(1000, 3000L, (x) -> true));
           } catch (KeeperException.SessionExpiredException e) {
             log.warn("Solr cannot talk to ZK, exiting Overseer main queue loop", e);
             return;
@@ -368,7 +368,7 @@ public class Overseer implements SolrCloseable {
               if (isClosed) break;
               // if an event comes in the next 100ms batch it together
               queue =
-                  new LinkedList<>(
+                  new ArrayDeque<>(
                       stateUpdateQueue.peekElements(
                           1000, 100, node -> !processedNodes.contains(node)));
             }

--- a/solr/core/src/java/org/apache/solr/cloud/Stats.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Stats.java
@@ -17,8 +17,8 @@
 package org.apache.solr.cloud;
 
 import com.codahale.metrics.Timer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -89,7 +89,7 @@ public class Stats {
       stat = new Stat();
       stats.put(op, stat);
     }
-    LinkedList<FailedOp> failedOps = stat.failureDetails;
+    ArrayDeque<FailedOp> failedOps = stat.failureDetails;
     synchronized (failedOps) {
       if (failedOps.size() >= MAX_STORED_FAILURES) {
         failedOps.removeFirst();
@@ -101,7 +101,7 @@ public class Stats {
   public List<FailedOp> getFailureDetails(String operation) {
     Stat stat = stats.get(operation.toLowerCase(Locale.ROOT));
     if (stat == null || stat.failureDetails.isEmpty()) return null;
-    LinkedList<FailedOp> failedOps = stat.failureDetails;
+    ArrayDeque<FailedOp> failedOps = stat.failureDetails;
     synchronized (failedOps) {
       ArrayList<FailedOp> ret = new ArrayList<>(failedOps);
       return ret;
@@ -124,13 +124,13 @@ public class Stats {
     public final AtomicInteger success;
     public final AtomicInteger errors;
     public final Timer requestTime;
-    public final LinkedList<FailedOp> failureDetails;
+    public final ArrayDeque<FailedOp> failureDetails;
 
     public Stat() {
       this.success = new AtomicInteger();
       this.errors = new AtomicInteger();
       this.requestTime = new Timer();
-      this.failureDetails = new LinkedList<>();
+      this.failureDetails = new ArrayDeque<>();
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
@@ -21,7 +21,6 @@ import static org.apache.solr.common.util.Utils.toJSONString;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.common.MapSerializable;
@@ -110,7 +109,7 @@ public class ConfigOverlay implements MapSerializable {
   public static final String NOT_EDITABLE = "''{0}'' is not an editable property";
 
   private List<String> checkEditable(String propName, boolean isXPath, boolean failOnError) {
-    LinkedList<String> hierarchy = new LinkedList<>();
+    List<String> hierarchy = new ArrayList<>();
     if (!isEditableProp(propName, isXPath, hierarchy)) {
       if (failOnError)
         throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -135,7 +135,7 @@ import org.apache.solr.metrics.SolrCoreMetricManager;
 import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.search.SolrFieldCacheBean;
@@ -283,7 +283,7 @@ public class CoreContainer {
       new DelegatingPlacementPluginFactory();
 
   private PackageStoreAPI packageStoreAPI;
-  private PackageLoader packageLoader;
+  private SolrPackageLoader packageLoader;
 
   private final Set<Path> allowPaths;
 
@@ -696,7 +696,7 @@ public class CoreContainer {
     return replayUpdatesExecutor;
   }
 
-  public PackageLoader getPackageLoader() {
+  public SolrPackageLoader getPackageLoader() {
     return packageLoader;
   }
 
@@ -780,7 +780,7 @@ public class CoreContainer {
       containerHandlers.getApiBag().registerObject(packageStoreAPI.readAPI);
       containerHandlers.getApiBag().registerObject(packageStoreAPI.writeAPI);
 
-      packageLoader = new PackageLoader(this);
+      packageLoader = new SolrPackageLoader(this);
       containerHandlers.getApiBag().registerObject(packageLoader.getPackageAPI().editAPI);
       containerHandlers.getApiBag().registerObject(packageLoader.getPackageAPI().readAPI);
       ZookeeperReadAPI zookeeperReadAPI = new ZookeeperReadAPI(this);

--- a/solr/core/src/java/org/apache/solr/core/RequestHandlers.java
+++ b/solr/core/src/java/org/apache/solr/core/RequestHandlers.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public final class RequestHandlers {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  protected final SolrCore core;
+  private final SolrCore core;
 
   final PluginBag<SolrRequestHandler> handlers;
 

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -70,7 +70,7 @@ import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.pkg.PackageListeners;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.response.QueryResponseWriter;
 import org.apache.solr.response.transform.TransformerFactory;
@@ -1119,7 +1119,7 @@ public class SolrConfig implements MapSerializable {
       return null;
     }
     Object o = p.get().get(pkg);
-    if (o == null || PackageLoader.LATEST.equals(o)) return null;
+    if (o == null || SolrPackageLoader.LATEST.equals(o)) return null;
     return o.toString();
   }
 

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -114,8 +114,8 @@ import org.apache.solr.metrics.SolrCoreMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.pkg.PackageListeners;
-import org.apache.solr.pkg.PackageLoader;
 import org.apache.solr.pkg.PackagePluginHolder;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
@@ -313,8 +313,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
     if (pkg == null) {
       return resourceLoader;
     }
-    PackageLoader.Package aPackage = coreContainer.getPackageLoader().getPackage(pkg);
-    PackageLoader.Package.Version latest = aPackage.getLatest();
+    SolrPackageLoader.SolrPackage aSolrPackage = coreContainer.getPackageLoader().getPackage(pkg);
+    SolrPackageLoader.SolrPackage.Version latest = aSolrPackage.getLatest();
     return latest.getLoader();
   }
 

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,7 +47,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -2044,8 +2044,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
   // All of the normal open searchers.  Don't access this directly.
   // protected by synchronizing on searcherLock.
-  private final LinkedList<RefCounted<SolrIndexSearcher>> _searchers = new LinkedList<>();
-  private final LinkedList<RefCounted<SolrIndexSearcher>> _realtimeSearchers = new LinkedList<>();
+  private final ArrayDeque<RefCounted<SolrIndexSearcher>> _searchers = new ArrayDeque<>();
+  private final ArrayDeque<RefCounted<SolrIndexSearcher>> _realtimeSearchers = new ArrayDeque<>();
 
   final ExecutorService searcherExecutor =
       ExecutorUtil.newMDCAwareSingleThreadExecutor(new SolrNamedThreadFactory("searcherExecutor"));
@@ -2402,7 +2402,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
         }
       }
 
-      List<RefCounted<SolrIndexSearcher>> searcherList = realtime ? _realtimeSearchers : _searchers;
+      ArrayDeque<RefCounted<SolrIndexSearcher>> searcherList =
+          realtime ? _realtimeSearchers : _searchers;
       RefCounted<SolrIndexSearcher> newSearcher = newHolder(tmp, searcherList); // refcount now at 1
 
       // Increment reference again for "realtimeSearcher" variable.  It should be at 2 after.
@@ -2733,7 +2734,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   }
 
   private RefCounted<SolrIndexSearcher> newHolder(
-      SolrIndexSearcher newSearcher, final List<RefCounted<SolrIndexSearcher>> searcherList) {
+      SolrIndexSearcher newSearcher, final ArrayDeque<RefCounted<SolrIndexSearcher>> searcherList) {
     RefCounted<SolrIndexSearcher> holder =
         new RefCounted<SolrIndexSearcher>(newSearcher) {
           @Override

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -1284,9 +1284,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
     } else {
       newUpdateHandler = createUpdateHandler(updateHandlerClass, updateHandler);
     }
-    if (newUpdateHandler instanceof SolrMetricProducer) {
-      coreMetricManager.registerMetricProducer(
-          "updateHandler", (SolrMetricProducer) newUpdateHandler);
+    if (newUpdateHandler != null) {
+      coreMetricManager.registerMetricProducer("updateHandler", newUpdateHandler);
     }
     infoRegistry.put("updateHandler", newUpdateHandler);
     return newUpdateHandler;
@@ -3427,9 +3426,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
   public void registerInfoBean(String name, SolrInfoBean solrInfoBean) {
     infoRegistry.put(name, solrInfoBean);
 
-    if (solrInfoBean instanceof SolrMetricProducer) {
-      SolrMetricProducer producer = (SolrMetricProducer) solrInfoBean;
-      coreMetricManager.registerMetricProducer(name, producer);
+    if (solrInfoBean != null) {
+      coreMetricManager.registerMetricProducer(name, solrInfoBean);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
@@ -62,7 +62,7 @@ import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.handler.component.ShardHandlerFactory;
 import org.apache.solr.logging.DeprecationLog;
 import org.apache.solr.pkg.PackageListeningClassLoader;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.response.QueryResponseWriter;
 import org.apache.solr.rest.RestManager;
@@ -894,14 +894,14 @@ public class SolrResourceLoader
     if (info.cName.pkg == null) return findClass(info.className, type);
     return _classLookup(
         info,
-        (Function<PackageLoader.Package.Version, Class<? extends T>>)
+        (Function<SolrPackageLoader.SolrPackage.Version, Class<? extends T>>)
             ver -> ver.getLoader().findClass(info.cName.className, type),
         registerCoreReloadListener);
   }
 
   private <T> T _classLookup(
       PluginInfo info,
-      Function<PackageLoader.Package.Version, T> fun,
+      Function<SolrPackageLoader.SolrPackage.Version, T> fun,
       boolean registerCoreReloadListener) {
     PluginInfo.ClassName cName = info.cName;
     if (registerCoreReloadListener) {

--- a/solr/core/src/java/org/apache/solr/core/StandardDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/StandardDirectoryFactory.java
@@ -86,7 +86,7 @@ public class StandardDirectoryFactory extends CachingDirectoryFactory {
   }
 
   @Override
-  protected void removeDirectory(CacheValue cacheValue) throws IOException {
+  protected synchronized void removeDirectory(CacheValue cacheValue) throws IOException {
     Path dirPath = Path.of(cacheValue.path);
     PathUtils.deleteDirectory(dirPath);
   }

--- a/solr/core/src/java/org/apache/solr/handler/AnalysisRequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/AnalysisRequestHandlerBase.java
@@ -386,7 +386,7 @@ public abstract class AnalysisRequestHandlerBase extends RequestHandlerBase {
       }
     }
 
-    protected void addAttributes(AttributeSource attributeSource) {
+    private void addAttributes(AttributeSource attributeSource) {
       // note: ideally we wouldn't call addAttributeImpl which is marked internal. But nonetheless
       // it's possible this method is used by some custom attributes, especially since Solr doesn't
       // provide a way to customize the AttributeFactory which is the recommended way to choose

--- a/solr/core/src/java/org/apache/solr/handler/AnalysisRequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/AnalysisRequestHandlerBase.java
@@ -22,7 +22,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -218,16 +217,12 @@ public abstract class AnalysisRequestHandlerBase extends RequestHandlerBase {
 
   // a static mapping of the reflected attribute keys to the names used in Solr 1.4
   static Map<String, String> ATTRIBUTE_MAPPING =
-      Collections.unmodifiableMap(
-          new HashMap<String, String>() {
-            {
-              put(OffsetAttribute.class.getName() + "#startOffset", "start");
-              put(OffsetAttribute.class.getName() + "#endOffset", "end");
-              put(TypeAttribute.class.getName() + "#type", "type");
-              put(TokenTrackingAttribute.class.getName() + "#position", "position");
-              put(TokenTrackingAttribute.class.getName() + "#positionHistory", "positionHistory");
-            }
-          });
+      Map.of(
+          OffsetAttribute.class.getName() + "#startOffset", "start",
+          OffsetAttribute.class.getName() + "#endOffset", "end",
+          TypeAttribute.class.getName() + "#type", "type",
+          TokenTrackingAttribute.class.getName() + "#position", "position",
+          TokenTrackingAttribute.class.getName() + "#positionHistory", "positionHistory");
 
   /**
    * Converts the list of Tokens to a list of NamedLists representing the tokens.

--- a/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
@@ -59,8 +59,8 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.PluginInfo;
 import org.apache.solr.core.SolrConfig;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.pkg.PackageLoader;
 import org.apache.solr.pkg.PackagePluginHolder;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.security.AuthorizationContext;
@@ -161,7 +161,7 @@ public class StreamHandler extends RequestHandlerBase
     }
 
     @Override
-    protected Object initNewInstance(PackageLoader.Package.Version newest, SolrCore core) {
+    protected Object initNewInstance(SolrPackageLoader.SolrPackage.Version newest, SolrCore core) {
       // This is called from super constructor, so be careful that pluginInfo.className is done
       // initializing.
       return clazz = newest.getLoader().findClass(pluginInfo.className, Expressible.class);

--- a/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -811,7 +810,7 @@ public class LukeRequestHandler extends RequestHandlerBase {
     /** This is a destructive call... the queue is empty at the end */
     public NamedList<Integer> toNamedList(IndexSchema schema) {
       // reverse the list..
-      List<TermInfo> aslist = new LinkedList<>();
+      List<TermInfo> aslist = new ArrayList<>();
       while (size() > 0) {
         aslist.add(0, pop());
       }

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -28,9 +28,9 @@ import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -402,7 +402,7 @@ public class SystemInfoHandler extends RequestHandlerBase {
   }
 
   private static List<String> getInputArgumentsRedacted(RuntimeMXBean mx) {
-    List<String> list = new LinkedList<>();
+    List<String> list = new ArrayList<>();
     for (String arg : mx.getInputArguments()) {
       if (arg.startsWith("-D")
           && arg.contains("=")

--- a/solr/core/src/java/org/apache/solr/handler/component/PhrasesIdentificationComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/PhrasesIdentificationComponent.java
@@ -491,7 +491,7 @@ public class PhrasesIdentificationComponent extends SearchComponent {
      * @return the original user input, decorated to indicate the identified phrases
      */
     public String summarize(final List<Phrase> results) {
-      final StringBuffer out = new StringBuffer(rawInput);
+      final StringBuilder out = new StringBuilder(rawInput);
 
       // sort by *reverse* position so we can go back to front
       final List<Phrase> reversed =

--- a/solr/core/src/java/org/apache/solr/handler/component/PivotFacetField.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/PivotFacetField.java
@@ -18,7 +18,6 @@ package org.apache.solr.handler.component;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -182,7 +181,7 @@ public class PivotFacetField {
     List<NamedList<Object>> convertedPivotList = null;
 
     if (valueCollection.size() > 0) {
-      convertedPivotList = new LinkedList<>();
+      convertedPivotList = new ArrayList<>();
       for (PivotFacetValue pivot : valueCollection)
         convertedPivotList.add(pivot.convertToNamedList());
     }

--- a/solr/core/src/java/org/apache/solr/handler/component/PivotFacetProcessor.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/PivotFacetProcessor.java
@@ -190,6 +190,7 @@ public class PivotFacetProcessor extends SimpleFacets {
    * @param facetQueries the list of facet queries hung under this pivot
    * @param facetRanges the list of facet ranges hung under this pivot
    */
+  @SuppressWarnings("JdkObsolete")
   private SimpleOrderedMap<List<NamedList<Object>>> processSingle(
       List<String> pivotFields,
       String refinements,

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -56,7 +56,7 @@ import org.apache.solr.metrics.MetricsMap;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.pkg.PackageAPI;
 import org.apache.solr.pkg.PackageListeners;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.CursorMark;
@@ -201,7 +201,7 @@ public class SearchHandler extends RequestHandlerBase
                 }
 
                 @Override
-                public void changed(PackageLoader.Package pkg, Ctx ctx) {
+                public void changed(SolrPackageLoader.SolrPackage pkg, Ctx ctx) {
                   // we could optimize this by listening to only relevant packages,
                   // but it is not worth optimizing as these are lightweight objects
                   components = null;

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -28,7 +28,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -462,7 +461,7 @@ public class SearchHandler extends RequestHandlerBase
       // a distributed request
 
       if (rb.outgoing == null) {
-        rb.outgoing = new LinkedList<>();
+        rb.outgoing = new ArrayList<>();
       }
       rb.finished = new ArrayList<>();
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SuggestComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SuggestComponent.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -350,7 +349,7 @@ public class SuggestComponent extends SearchComponent
             resultQueue.insertWithOverflow(res);
           }
         }
-        List<LookupResult> sortedSuggests = new LinkedList<>();
+        List<LookupResult> sortedSuggests = new ArrayList<>();
         Collections.addAll(sortedSuggests, resultQueue.getResults());
         result.add(suggesterName, token, sortedSuggests);
       }

--- a/solr/core/src/java/org/apache/solr/handler/designer/DefaultSampleDocumentsLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/DefaultSampleDocumentsLoader.java
@@ -31,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -165,7 +164,7 @@ public class DefaultSampleDocumentsLoader implements SampleDocumentsLoader {
   protected List<SolrInputDocument> loadJsonLines(
       SolrParams params, ContentStreamBase.ByteArrayStream stream, final int maxDocsToLoad)
       throws IOException {
-    List<Map<String, Object>> docs = new LinkedList<>();
+    List<Map<String, Object>> docs = new ArrayList<>();
     try (Reader r = stream.getReader()) {
       BufferedReader br = new BufferedReader(r);
       String line;
@@ -277,7 +276,7 @@ public class DefaultSampleDocumentsLoader implements SampleDocumentsLoader {
 
   protected List<SolrInputDocument> parseXmlDocs(XMLStreamReader parser, final int maxDocsToLoad)
       throws XMLStreamException {
-    List<SolrInputDocument> docs = new LinkedList<>();
+    List<SolrInputDocument> docs = new ArrayList<>();
     XMLLoader loader = new XMLLoader().init(null);
     while (true) {
       final int event;
@@ -358,7 +357,7 @@ public class DefaultSampleDocumentsLoader implements SampleDocumentsLoader {
   }
 
   private static class SampleCSVLoader extends CSVLoaderBase {
-    List<SolrInputDocument> docs = new LinkedList<>();
+    List<SolrInputDocument> docs = new ArrayList<>();
     CSVRequest req;
     int maxDocsToLoad;
     String multiValueDelimiter;

--- a/solr/core/src/java/org/apache/solr/handler/designer/DefaultSchemaSuggester.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/DefaultSchemaSuggester.java
@@ -30,11 +30,10 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -83,9 +82,9 @@ public class DefaultSchemaSuggester implements SchemaSuggester {
       "Failed to parse all sample values as %s for changing type for field %s to %s";
 
   // boolean parsing
-  private final Set<String> trueValues = new HashSet<>(Arrays.asList("true"));
-  private final Set<String> falseValues = new HashSet<>(Arrays.asList("false"));
-  private final List<DateTimeFormatter> dateTimeFormatters = new LinkedList<>();
+  private final Set<String> trueValues = Set.of("true");
+  private final Set<String> falseValues = Set.of("false");
+  private final List<DateTimeFormatter> dateTimeFormatters = new ArrayList<>();
   private boolean caseSensitive = false;
 
   @Override
@@ -208,8 +207,7 @@ public class DefaultSchemaSuggester implements SchemaSuggester {
                     f -> {
                       // skip the version field on incoming docs
                       if (!VERSION_FIELD.equals(f)) {
-                        List<Object> values =
-                            mapByField.computeIfAbsent(f, k -> new LinkedList<>());
+                        List<Object> values = mapByField.computeIfAbsent(f, k -> new ArrayList<>());
                         Collection<Object> fieldValues = doc.getFieldValues(f);
                         if (fieldValues != null && !fieldValues.isEmpty()) {
                           if (fieldValues.size() == 1) {

--- a/solr/core/src/java/org/apache/solr/handler/designer/SampleDocuments.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SampleDocuments.java
@@ -19,7 +19,7 @@ package org.apache.solr.handler.designer;
 
 import static org.apache.solr.common.params.CommonParams.JSON_MIME;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -33,7 +33,7 @@ public class SampleDocuments {
   public List<SolrInputDocument> parsed;
 
   public SampleDocuments(List<SolrInputDocument> parsed, String contentType, String fileSource) {
-    this.parsed = parsed != null ? parsed : new LinkedList<>(); // needs to be mutable
+    this.parsed = parsed != null ? parsed : new ArrayList<>(); // needs to be mutable
     this.contentType = contentType;
     this.fileSource = fileSource;
   }

--- a/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerAPI.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -874,7 +873,7 @@ public class SchemaDesignerAPI implements SchemaDesignerConstants {
   protected ManagedIndexSchema analyzeInputDocs(
       final Map<String, List<Object>> docs, ManagedIndexSchema schema, List<String> langs) {
     // collect the fields to add ... adding all fields at once is faster than one-at-a-time
-    List<SchemaField> fieldsToAdd = new LinkedList<>();
+    List<SchemaField> fieldsToAdd = new ArrayList<>();
     for (String field : docs.keySet()) {
       List<Object> sampleValues = docs.getOrDefault(field, Collections.emptyList());
 

--- a/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerConfigSetHelper.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerConfigSetHelper.java
@@ -46,7 +46,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -169,7 +168,7 @@ class SchemaDesignerConfigSetHelper implements SchemaDesignerConstants {
   }
 
   List<String> listCollectionsForConfig(String configSet) {
-    final List<String> collections = new LinkedList<>();
+    final List<String> collections = new ArrayList<>();
     Map<String, ClusterState.CollectionRef> states =
         zkStateReader().getClusterState().getCollectionStates();
     for (Map.Entry<String, ClusterState.CollectionRef> e : states.entrySet()) {
@@ -670,7 +669,7 @@ class SchemaDesignerConfigSetHelper implements SchemaDesignerConstants {
   }
 
   ManagedIndexSchema deleteNestedDocsFieldsIfNeeded(ManagedIndexSchema schema, boolean persist) {
-    List<String> toDelete = new LinkedList<>();
+    List<String> toDelete = new ArrayList<>();
     if (schema.hasExplicitField(ROOT_FIELD_NAME)) {
       toDelete.add(ROOT_FIELD_NAME);
     }

--- a/solr/core/src/java/org/apache/solr/handler/export/SortQueue.java
+++ b/solr/core/src/java/org/apache/solr/handler/export/SortQueue.java
@@ -25,8 +25,8 @@ import org.apache.lucene.util.ArrayUtil;
  */
 final class SortQueue {
 
-  protected int size = 0;
-  protected final int maxSize;
+  private int size = 0;
+  final int maxSize;
   private final SortDoc[] heap;
   private final SortDoc proto;
   private SortDoc[] cache;
@@ -64,7 +64,7 @@ final class SortQueue {
     return t1.lessThan(t2);
   }
 
-  protected void populate() {
+  private void populate() {
     cache = new SortDoc[heap.length];
     for (int i = 1; i < heap.length; i++) {
       cache[i] = heap[i] = proto.copy();
@@ -72,7 +72,7 @@ final class SortQueue {
     size = maxSize;
   }
 
-  protected void reset() {
+  void reset() {
     if (cache != null) {
       System.arraycopy(cache, 1, heap, 1, heap.length - 1);
       size = maxSize;

--- a/solr/core/src/java/org/apache/solr/highlight/DefaultSolrHighlighter.java
+++ b/solr/core/src/java/org/apache/solr/highlight/DefaultSolrHighlighter.java
@@ -953,7 +953,7 @@ public class DefaultSolrHighlighter extends SolrHighlighter implements PluginInf
     private boolean done = false;
     private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
 
-    protected TokenOrderingFilter(TokenStream input, int windowSize) {
+    private TokenOrderingFilter(TokenStream input, int windowSize) {
       super(input);
       this.windowSize = windowSize;
     }

--- a/solr/core/src/java/org/apache/solr/highlight/DefaultSolrHighlighter.java
+++ b/solr/core/src/java/org/apache/solr/highlight/DefaultSolrHighlighter.java
@@ -948,8 +948,11 @@ public class DefaultSolrHighlighter extends SolrHighlighter implements PluginInf
    */
   static final class TokenOrderingFilter extends TokenFilter {
     private final int windowSize;
+
+    @SuppressWarnings("JdkObsolete")
     private final LinkedList<OrderedToken> queue =
         new LinkedList<>(); // TODO replace with Deque, Array impl
+
     private boolean done = false;
     private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
 

--- a/solr/core/src/java/org/apache/solr/internal/csv/CharBuffer.java
+++ b/solr/core/src/java/org/apache/solr/internal/csv/CharBuffer.java
@@ -99,7 +99,24 @@ public class CharBuffer {
    *
    * @param sb the StringBuffer to append or null
    */
+  @Deprecated
+  @SuppressWarnings("JdkObsolete")
   public void append(final StringBuffer sb) {
+    if (sb == null) {
+      return;
+    }
+    provideCapacity(length + sb.length());
+    sb.getChars(0, sb.length(), c, length);
+    length += sb.length();
+  }
+
+  /**
+   * Appends <code>sb</code> to the end of this CharBuffer. This method involves copying the new
+   * data once!
+   *
+   * @param sb the StringBuffer to append or null
+   */
+  public void append(final StringBuilder sb) {
     if (sb == null) {
       return;
     }

--- a/solr/core/src/java/org/apache/solr/legacy/LegacyNumericRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/legacy/LegacyNumericRangeQuery.java
@@ -17,7 +17,7 @@
 package org.apache.solr.legacy;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Objects;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
@@ -472,7 +472,7 @@ public final class LegacyNumericRangeQuery<T extends Number> extends MultiTermQu
 
     private BytesRef currentLowerBound, currentUpperBound;
 
-    private final LinkedList<BytesRef> rangeBounds = new LinkedList<>();
+    private final ArrayDeque<BytesRef> rangeBounds = new ArrayDeque<>();
 
     NumericRangeTermsEnum(final TermsEnum tenum) {
       super(tenum);

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -43,7 +43,7 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.V2Request;
-import org.apache.solr.client.solrj.request.beans.Package;
+import org.apache.solr.client.solrj.request.beans.PackagePayload;
 import org.apache.solr.client.solrj.request.beans.PluginMeta;
 import org.apache.solr.client.solrj.response.V2Response;
 import org.apache.solr.common.NavigableObject;
@@ -58,7 +58,7 @@ import org.apache.solr.handler.admin.ContainerPluginsApi;
 import org.apache.solr.packagemanager.SolrPackage.Command;
 import org.apache.solr.packagemanager.SolrPackage.Manifest;
 import org.apache.solr.packagemanager.SolrPackage.Plugin;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.util.SolrCLI;
 import org.apache.solr.util.SolrVersion;
 import org.apache.zookeeper.KeeperException;
@@ -136,7 +136,7 @@ public class PackageManager implements Closeable {
     // Delete the package by calling the Package API and remove the Jar
 
     PackageUtils.printGreen("Executing Package API to remove this package...");
-    Package.DelVersion del = new Package.DelVersion();
+    PackagePayload.DelVersion del = new PackagePayload.DelVersion();
     del.version = version;
     del.pkg = packageName;
 
@@ -449,7 +449,7 @@ public class PackageManager implements Closeable {
             "{set:{PKG_VERSIONS:{"
                 + packageInstance.name
                 + ": '"
-                + (pegToLatest ? PackageLoader.LATEST : packageInstance.version)
+                + (pegToLatest ? SolrPackageLoader.LATEST : packageInstance.version)
                 + "'}}}");
       } catch (Exception ex) {
         throw new SolrException(ErrorCode.SERVER_ERROR, ex);
@@ -526,7 +526,7 @@ public class PackageManager implements Closeable {
             "{update:{PKG_VERSIONS:{'"
                 + packageInstance.name
                 + "' : '"
-                + (pegToLatest ? PackageLoader.LATEST : packageInstance.version)
+                + (pegToLatest ? SolrPackageLoader.LATEST : packageInstance.version)
                 + "'}}}");
       } catch (Exception ex) {
         throw new SolrException(ErrorCode.SERVER_ERROR, ex);
@@ -897,7 +897,7 @@ public class PackageManager implements Closeable {
     }
     if (version == null
         || version.equalsIgnoreCase(PackageUtils.LATEST)
-        || version.equalsIgnoreCase(PackageLoader.LATEST)) {
+        || version.equalsIgnoreCase(SolrPackageLoader.LATEST)) {
       return latest;
     } else return null;
   }
@@ -1101,7 +1101,7 @@ public class PackageManager implements Closeable {
 
   /**
    * Given a package, return a map of collections where this package is installed to the installed
-   * version (which can be {@link PackageLoader#LATEST})
+   * version (which can be {@link SolrPackageLoader#LATEST})
    */
   public Map<String, String> getDeployedCollections(String packageName) {
     List<String> allCollections;

--- a/solr/core/src/java/org/apache/solr/packagemanager/RepositoryManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/RepositoryManager.java
@@ -40,7 +40,7 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.V2Request;
-import org.apache.solr.client.solrj.request.beans.Package;
+import org.apache.solr.client.solrj.request.beans.PackagePayload;
 import org.apache.solr.client.solrj.response.V2Response;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
@@ -50,7 +50,7 @@ import org.apache.solr.filestore.PackageStoreAPI;
 import org.apache.solr.packagemanager.SolrPackage.Artifact;
 import org.apache.solr.packagemanager.SolrPackage.SolrPackageRelease;
 import org.apache.solr.pkg.PackageAPI;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.util.SolrCLI;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -211,7 +211,7 @@ public class RepositoryManager {
 
       // Call Package API to add this version of the package
       PackageUtils.printGreen("Executing Package API to register this package...");
-      Package.AddVersion add = new Package.AddVersion();
+      PackagePayload.AddVersion add = new PackagePayload.AddVersion();
       add.version = version;
       add.pkg = packageName;
       add.files =
@@ -330,7 +330,7 @@ public class RepositoryManager {
 
   /**
    * Install a version of the package. Also, run verify commands in case some collection was using
-   * {@link PackageLoader#LATEST} version of this package and got auto-updated.
+   * {@link SolrPackageLoader#LATEST} version of this package and got auto-updated.
    */
   public boolean install(String packageName, String version) throws SolrException {
     SolrPackageRelease pkg = getLastPackageRelease(packageName);
@@ -347,7 +347,8 @@ public class RepositoryManager {
     List<String> collectionsPeggedToLatest =
         collectionsDeployedIn.keySet().stream()
             .filter(
-                collection -> collectionsDeployedIn.get(collection).equals(PackageLoader.LATEST))
+                collection ->
+                    collectionsDeployedIn.get(collection).equals(SolrPackageLoader.LATEST))
             .collect(Collectors.toList());
     if (!collectionsPeggedToLatest.isEmpty()) {
       PackageUtils.printGreen(

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -608,7 +607,7 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
     switch (synonymQueryStyle) {
       case PICK_BEST:
         {
-          List<Query> sidePathSynonymQueries = new LinkedList<>();
+          List<Query> sidePathSynonymQueries = new ArrayList<>();
           sidePathQueriesIterator.forEachRemaining(sidePathSynonymQueries::add);
           return new DisjunctionMaxQuery(sidePathSynonymQueries, 0.0f);
         }

--- a/solr/core/src/java/org/apache/solr/pkg/PackageAPI.java
+++ b/solr/core/src/java/org/apache/solr/pkg/PackageAPI.java
@@ -35,7 +35,7 @@ import org.apache.solr.api.Command;
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.request.beans.Package;
+import org.apache.solr.client.solrj.request.beans.PackagePayload;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -66,13 +66,13 @@ public class PackageAPI {
 
   final CoreContainer coreContainer;
   private final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
-  private final PackageLoader packageLoader;
+  private final SolrPackageLoader packageLoader;
   Packages pkgs;
 
   public final Edit editAPI = new Edit();
   public final Read readAPI = new Read();
 
-  public PackageAPI(CoreContainer coreContainer, PackageLoader loader) {
+  public PackageAPI(CoreContainer coreContainer, SolrPackageLoader loader) {
     if (coreContainer.getPackageStoreAPI() == null) {
       throw new IllegalStateException("Must successfully load PackageStoreAPI first");
     }
@@ -192,7 +192,7 @@ public class PackageAPI {
 
     public PkgVersion() {}
 
-    public PkgVersion(Package.AddVersion addVersion) {
+    public PkgVersion(PackagePayload.AddVersion addVersion) {
       this.pkg = addVersion.pkg;
       this.version = addVersion.version;
       this.files = addVersion.files == null ? null : Collections.unmodifiableList(addVersion.files);
@@ -247,7 +247,7 @@ public class PackageAPI {
         payload.addError("Package null");
         return;
       }
-      PackageLoader.Package pkg = coreContainer.getPackageLoader().getPackage(p);
+      SolrPackageLoader.SolrPackage pkg = coreContainer.getPackageLoader().getPackage(p);
       if (pkg == null) {
         payload.addError("No such package: " + p);
         return;
@@ -269,9 +269,9 @@ public class PackageAPI {
     }
 
     @Command(name = "add")
-    public void add(PayloadObj<Package.AddVersion> payload) {
+    public void add(PayloadObj<PackagePayload.AddVersion> payload) {
       if (!checkEnabled(payload)) return;
-      Package.AddVersion add = payload.get();
+      PackagePayload.AddVersion add = payload.get();
       if (add.files.isEmpty()) {
         payload.addError("No files specified");
         return;
@@ -322,9 +322,9 @@ public class PackageAPI {
     }
 
     @Command(name = "delete")
-    public void del(PayloadObj<Package.DelVersion> payload) {
+    public void del(PayloadObj<PackagePayload.DelVersion> payload) {
       if (!checkEnabled(payload)) return;
-      Package.DelVersion delVersion = payload.get();
+      PackagePayload.DelVersion delVersion = payload.get();
       try {
         coreContainer
             .getZkController()

--- a/solr/core/src/java/org/apache/solr/pkg/PackageListeners.java
+++ b/solr/core/src/java/org/apache/solr/pkg/PackageListeners.java
@@ -71,11 +71,11 @@ public class PackageListeners {
     }
   }
 
-  synchronized void packagesUpdated(List<PackageLoader.Package> pkgs) {
+  synchronized void packagesUpdated(List<SolrPackageLoader.SolrPackage> pkgs) {
     MDCLoggingContext.setCore(core);
     Listener.Ctx ctx = new Listener.Ctx();
     try {
-      for (PackageLoader.Package pkgInfo : pkgs) {
+      for (SolrPackageLoader.SolrPackage pkgInfo : pkgs) {
         invokeListeners(pkgInfo, ctx);
       }
     } finally {
@@ -84,7 +84,7 @@ public class PackageListeners {
     }
   }
 
-  private synchronized void invokeListeners(PackageLoader.Package pkg, Listener.Ctx ctx) {
+  private synchronized void invokeListeners(SolrPackageLoader.SolrPackage pkg, Listener.Ctx ctx) {
     for (Reference<Listener> ref : listeners) {
       Listener listener = ref.get();
       if (listener == null) continue;
@@ -113,7 +113,7 @@ public class PackageListeners {
     Map<String, PackageAPI.PkgVersion> packageDetails();
 
     /** A callback when the package is updated */
-    void changed(PackageLoader.Package pkg, Ctx ctx);
+    void changed(SolrPackageLoader.SolrPackage pkg, Ctx ctx);
 
     default MapWriter getPackageVersion(PluginInfo.ClassName cName) {
       return null;
@@ -124,9 +124,9 @@ public class PackageListeners {
 
       /**
        * If there are multiple packages to be updated and there are multiple listeners, This is
-       * executed after all of the {@link Listener#changed(PackageLoader.Package, Ctx)} calls are
-       * invoked. The name is a unique identifier that can be used by consumers to avoid duplicate
-       * If no deduplication is required, use null as the name
+       * executed after all of the {@link Listener#changed(SolrPackageLoader.SolrPackage, Ctx)}
+       * calls are invoked. The name is a unique identifier that can be used by consumers to avoid
+       * duplicate If no deduplication is required, use null as the name
        */
       public void runLater(String name, Runnable runnable) {
         if (runLater == null) runLater = new LinkedHashMap<>();

--- a/solr/core/src/java/org/apache/solr/pkg/PackageListeningClassLoader.java
+++ b/solr/core/src/java/org/apache/solr/pkg/PackageListeningClassLoader.java
@@ -73,7 +73,7 @@ public class PackageListeningClassLoader implements SolrClassLoader, PackageList
     if (cName.pkg == null) {
       return fallbackClassLoader.newInstance(cname, expectedType, subpackages);
     } else {
-      PackageLoader.Package.Version version = findPackageVersion(cName, true);
+      SolrPackageLoader.SolrPackage.Version version = findPackageVersion(cName, true);
       T obj = version.getLoader().newInstance(cName.className, expectedType, subpackages);
       classNameVsPackageName.put(cName.original, cName.pkg);
       return applyResourceLoaderAware(version, obj);
@@ -85,9 +85,9 @@ public class PackageListeningClassLoader implements SolrClassLoader, PackageList
    *
    * @param cName The class name
    */
-  public PackageLoader.Package.Version findPackageVersion(
+  public SolrPackageLoader.SolrPackage.Version findPackageVersion(
       PluginInfo.ClassName cName, boolean registerListener) {
-    PackageLoader.Package.Version theVersion =
+    SolrPackageLoader.SolrPackage.Version theVersion =
         coreContainer
             .getPackageLoader()
             .getPackage(cName.pkg)
@@ -107,7 +107,7 @@ public class PackageListeningClassLoader implements SolrClassLoader, PackageList
     return p == null ? null : p::writeMap;
   }
 
-  private <T> T applyResourceLoaderAware(PackageLoader.Package.Version version, T obj) {
+  private <T> T applyResourceLoaderAware(SolrPackageLoader.SolrPackage.Version version, T obj) {
     if (obj instanceof ResourceLoaderAware) {
       SolrResourceLoader.assertAwareCompatibility(ResourceLoaderAware.class, obj);
       try {
@@ -127,7 +127,7 @@ public class PackageListeningClassLoader implements SolrClassLoader, PackageList
     if (cName.pkg == null) {
       return fallbackClassLoader.newInstance(cname, expectedType, subPackages, params, args);
     } else {
-      PackageLoader.Package.Version version = findPackageVersion(cName, true);
+      SolrPackageLoader.SolrPackage.Version version = findPackageVersion(cName, true);
       T obj =
           version.getLoader().newInstance(cName.className, expectedType, subPackages, params, args);
       classNameVsPackageName.put(cName.original, cName.pkg);
@@ -141,7 +141,7 @@ public class PackageListeningClassLoader implements SolrClassLoader, PackageList
     if (cName.pkg == null) {
       return fallbackClassLoader.findClass(cname, expectedType);
     } else {
-      PackageLoader.Package.Version version = findPackageVersion(cName, true);
+      SolrPackageLoader.SolrPackage.Version version = findPackageVersion(cName, true);
       Class<? extends T> klas = version.getLoader().findClass(cName.className, expectedType);
       classNameVsPackageName.put(cName.original, cName.pkg);
       return klas;
@@ -161,7 +161,7 @@ public class PackageListeningClassLoader implements SolrClassLoader, PackageList
   }
 
   @Override
-  public void changed(PackageLoader.Package pkg, Ctx ctx) {
+  public void changed(SolrPackageLoader.SolrPackage pkg, Ctx ctx) {
     PackageAPI.PkgVersion currVer = packageVersions.get(pkg.name);
     if (currVer == null) {
       // not watching this

--- a/solr/core/src/java/org/apache/solr/pkg/PackagePluginHolder.java
+++ b/solr/core/src/java/org/apache/solr/pkg/PackagePluginHolder.java
@@ -40,7 +40,7 @@ public class PackagePluginHolder<T> extends PluginBag.PluginHolder<T> {
 
   private final SolrCore.Provider coreProvider;
   private final SolrConfig.SolrPluginInfo pluginMeta;
-  private PackageLoader.Package.Version pkgVersion;
+  private SolrPackageLoader.SolrPackage.Version pkgVersion;
   private PluginInfo info;
 
   public PackagePluginHolder(PluginInfo info, SolrCore core, SolrConfig.SolrPluginInfo pluginMeta) {
@@ -64,7 +64,7 @@ public class PackagePluginHolder<T> extends PluginBag.PluginHolder<T> {
               }
 
               @Override
-              public void changed(PackageLoader.Package pkg, Ctx ctx) {
+              public void changed(SolrPackageLoader.SolrPackage pkg, Ctx ctx) {
                 coreProvider.withCore(c -> reload(pkg, c));
               }
 
@@ -92,15 +92,15 @@ public class PackagePluginHolder<T> extends PluginBag.PluginHolder<T> {
     }
   }
 
-  private synchronized void reload(PackageLoader.Package pkg, SolrCore core) {
+  private synchronized void reload(SolrPackageLoader.SolrPackage pkg, SolrCore core) {
     String lessThan = core.getSolrConfig().maxPackageVersion(info.pkgName);
-    PackageLoader.Package.Version newest = pkg.getLatest(lessThan);
+    SolrPackageLoader.SolrPackage.Version newest = pkg.getLatest(lessThan);
     if (newest == null) {
       log.error("No latest version available for package : {}", pkg.name());
       return;
     }
     if (lessThan != null) {
-      PackageLoader.Package.Version pkgLatest = pkg.getLatest();
+      SolrPackageLoader.SolrPackage.Version pkgLatest = pkg.getLatest();
       if (pkgLatest != newest) {
         if (log.isInfoEnabled()) {
           log.info(
@@ -134,7 +134,7 @@ public class PackagePluginHolder<T> extends PluginBag.PluginHolder<T> {
   }
 
   @SuppressWarnings({"unchecked"})
-  protected Object initNewInstance(PackageLoader.Package.Version newest, SolrCore core) {
+  protected Object initNewInstance(SolrPackageLoader.SolrPackage.Version newest, SolrCore core) {
     Object instance =
         SolrCore.createInstance(
             pluginInfo.className,

--- a/solr/core/src/java/org/apache/solr/request/PerSegmentSingleValuedFaceting.java
+++ b/solr/core/src/java/org/apache/solr/request/PerSegmentSingleValuedFaceting.java
@@ -17,7 +17,8 @@
 package org.apache.solr.request;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
@@ -122,7 +123,7 @@ class PerSegmentSingleValuedFaceting {
     // The list of pending tasks that aren't immediately submitted
     // TODO: Is there a completion service, or a delegating executor that can
     // limit the number of concurrent tasks submitted to a bigger executor?
-    LinkedList<Callable<SegFacet>> pending = new LinkedList<>();
+    Deque<Callable<SegFacet>> pending = new ArrayDeque<>();
 
     int threads = nThreads <= 0 ? Integer.MAX_VALUE : nThreads;
 

--- a/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
+++ b/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
@@ -19,9 +19,10 @@ package org.apache.solr.request;
 import java.io.Closeable;
 import java.lang.invoke.MethodHandles;
 import java.security.Principal;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,7 +43,7 @@ public class SolrRequestInfo {
   private static final int MAX_STACK_SIZE = 10;
 
   private static final ThreadLocal<Deque<SolrRequestInfo>> threadLocal =
-      ThreadLocal.withInitial(LinkedList::new);
+      ThreadLocal.withInitial(ArrayDeque::new);
 
   private int refCount = 1; // prevent closing when still used
 
@@ -204,7 +205,7 @@ public class SolrRequestInfo {
         throw new IllegalStateException("Already closed!");
       }
       if (closeHooks == null) {
-        closeHooks = new LinkedList<>();
+        closeHooks = new ArrayList<>();
       }
       closeHooks.add(hook);
     }

--- a/solr/core/src/java/org/apache/solr/response/transform/SubQueryAugmenterFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/SubQueryAugmenterFactory.java
@@ -254,7 +254,7 @@ class SubQueryAugmenter extends DocTransformer {
     /**
      * @return null if prefix doesn't match, field is absent or empty
      */
-    protected Collection<Object> mapToDocField(String param) {
+    private Collection<Object> mapToDocField(String param) {
 
       if (param.startsWith(prefixDotRowDot)) {
         final String docFieldName = param.substring(prefixDotRowDot.length());
@@ -269,7 +269,7 @@ class SubQueryAugmenter extends DocTransformer {
       return null;
     }
 
-    protected String convertFieldValue(Object val) {
+    private String convertFieldValue(Object val) {
 
       if (val instanceof IndexableField) {
         IndexableField f = (IndexableField) val;

--- a/solr/core/src/java/org/apache/solr/schema/AbstractEnumField.java
+++ b/solr/core/src/java/org/apache/solr/schema/AbstractEnumField.java
@@ -75,8 +75,8 @@ public abstract class AbstractEnumField extends PrimitiveFieldType {
     public final Map<String, Integer> enumStringToIntMap;
     public final Map<Integer, String> enumIntToStringMap;
 
-    protected final String enumsConfigFile;
-    protected final String enumName;
+    private final String enumsConfigFile;
+    private final String enumName;
 
     /**
      * Takes in a FieldType and the initArgs Map used for that type, removing the keys that specify

--- a/solr/core/src/java/org/apache/solr/schema/JsonPreAnalyzedParser.java
+++ b/solr/core/src/java/org/apache/solr/schema/JsonPreAnalyzedParser.java
@@ -21,10 +21,10 @@ import java.io.Reader;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -228,7 +228,7 @@ public class JsonPreAnalyzedParser implements PreAnalyzedParser {
     }
     TokenStream ts = f.tokenStreamValue();
     if (ts != null) {
-      List<Map<String, Object>> tokens = new LinkedList<>();
+      List<Map<String, Object>> tokens = new ArrayList<>();
       while (ts.incrementToken()) {
         Iterator<Class<? extends Attribute>> it = ts.getAttributeClassesIterator();
         String cTerm = null;

--- a/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
@@ -324,7 +324,7 @@ public final class ManagedIndexSchema extends IndexSchema {
     }
   }
 
-  protected static List<String> getActiveReplicaCoreUrls(
+  private static List<String> getActiveReplicaCoreUrls(
       ZkController zkController, String collection, String localCoreNodeName) {
     List<String> activeReplicaCoreUrls = new ArrayList<>();
     ZkStateReader zkStateReader = zkController.getZkStateReader();
@@ -1309,7 +1309,7 @@ public final class ManagedIndexSchema extends IndexSchema {
   }
 
   /** Informs analyzers used by a fieldType. */
-  protected void informResourceLoaderAwareObjectsForFieldType(FieldType fieldType) {
+  private void informResourceLoaderAwareObjectsForFieldType(FieldType fieldType) {
     // must inform any sub-components used in the
     // tokenizer chain if they are ResourceLoaderAware
     if (!fieldType.supportsAnalyzers()) return;
@@ -1442,7 +1442,7 @@ public final class ManagedIndexSchema extends IndexSchema {
    * ResourceLoaderAware interface, which need to be informed after they are loaded (as they depend
    * on this callback to complete initialization work)
    */
-  protected void informResourceLoaderAwareObjectsInChain(TokenizerChain chain) {
+  private void informResourceLoaderAwareObjectsInChain(TokenizerChain chain) {
     CharFilterFactory[] charFilters = chain.getCharFilterFactories();
     for (CharFilterFactory next : charFilters) {
       if (next instanceof ResourceLoaderAware) {

--- a/solr/core/src/java/org/apache/solr/schema/PreAnalyzedField.java
+++ b/solr/core/src/java/org/apache/solr/schema/PreAnalyzedField.java
@@ -23,8 +23,8 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
@@ -198,7 +198,7 @@ public class PreAnalyzedField extends TextField implements HasImplicitIndexAnaly
   public static class ParseResult {
     public String str;
     public byte[] bin;
-    public List<State> states = new LinkedList<>();
+    public List<State> states = new ArrayList<>();
   }
 
   /** Parse the input and return the stored part and the tokens with attributes. */
@@ -273,7 +273,7 @@ public class PreAnalyzedField extends TextField implements HasImplicitIndexAnaly
 
   /** Token stream that works from a list of saved states. */
   private static class PreAnalyzedTokenizer extends Tokenizer {
-    private final List<AttributeSource.State> cachedStates = new LinkedList<>();
+    private final List<AttributeSource.State> cachedStates = new ArrayList<>();
     private Iterator<AttributeSource.State> it = null;
     private String stringValue = null;
     private byte[] binaryValue = null;

--- a/solr/core/src/java/org/apache/solr/search/EarlyTerminatingSortingCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/EarlyTerminatingSortingCollector.java
@@ -67,9 +67,9 @@ final class EarlyTerminatingSortingCollector extends FilterCollector {
   }
 
   /** Sort used to sort the search results */
-  protected final Sort sort;
+  private final Sort sort;
   /** Number of documents to collect in each segment */
-  protected final int numDocsToCollect;
+  private final int numDocsToCollect;
 
   private final AtomicBoolean terminatedEarly = new AtomicBoolean(false);
 

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -544,7 +543,7 @@ public class ExtendedDismaxQParser extends QParser {
 
   /** Parses all function queries */
   protected List<Query> getBoostFunctions() throws SyntaxError {
-    List<Query> boostFunctions = new LinkedList<>();
+    List<Query> boostFunctions = new ArrayList<>();
     if (config.hasBoostFunctions()) {
       for (String boostFunc : config.boostFuncs) {
         if (null == boostFunc || "".equals(boostFunc)) continue;
@@ -564,7 +563,7 @@ public class ExtendedDismaxQParser extends QParser {
 
   /** Parses all boost queries */
   protected List<Query> getBoostQueries() throws SyntaxError {
-    List<Query> boostQueries = new LinkedList<>();
+    List<Query> boostQueries = new ArrayList<>();
     if (config.hasBoostParams()) {
       for (String qs : config.boostParams) {
         if (qs.trim().length() == 0) continue;

--- a/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -635,7 +634,7 @@ public class SolrDocumentFetcher {
       case SORTED_SET:
         final SortedSetDocValues values = leafReader.getSortedSetDocValues(fieldName);
         if (values != null && values.getValueCount() > 0 && values.advance(localId) == localId) {
-          final List<Object> outValues = new LinkedList<>();
+          final List<Object> outValues = new ArrayList<>();
           for (long ord = values.nextOrd();
               ord != SortedSetDocValues.NO_MORE_ORDS;
               ord = values.nextOrd()) {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetParser.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetParser.java
@@ -532,33 +532,6 @@ abstract class FacetParser<T extends FacetRequest> {
     }
   }
 
-  /* not a separate type of parser for now...
-  static class FacetBlockParentParser extends FacetParser<FacetBlockParent> {
-    public FacetBlockParentParser(FacetParser parent, String key) {
-      super(parent, key);
-      facet = new FacetBlockParent();
-    }
-
-    @Override
-    public FacetBlockParent parse(Object arg) throws SyntaxError {
-      parseCommonParams(arg);
-
-      if (arg instanceof String) {
-        // just the field name...
-        facet.parents = (String)arg;
-
-      } else if (arg instanceof Map) {
-        Map<String, Object> m = (Map<String, Object>) arg;
-        facet.parents = getString(m, "parents", null);
-
-        parseSubs( m.get("facet") );
-      }
-
-      return facet;
-    }
-  }
-  */
-
   static class FacetFieldParser extends FacetParser<FacetField> {
     public FacetFieldParser(FacetParser<?> parent, String key) {
       super(parent, key);

--- a/solr/core/src/java/org/apache/solr/search/function/OrdFieldSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/OrdFieldSource.java
@@ -124,7 +124,7 @@ public class OrdFieldSource extends ValueSource {
         }
       }
 
-      protected String toTerm(String readableValue) {
+      private String toTerm(String readableValue) {
         return readableValue;
       }
 

--- a/solr/core/src/java/org/apache/solr/search/join/ScoreModeParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/ScoreModeParser.java
@@ -24,19 +24,18 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.apache.solr.search.SyntaxError;
 
 class ScoreModeParser {
-  @SuppressWarnings("serial")
-  private static final Map<String, ScoreMode> lowerAndCapitalCase =
-      Collections.unmodifiableMap(
-          new HashMap<>() {
-            {
-              for (ScoreMode s : ScoreMode.values()) {
-                put(s.name().toLowerCase(Locale.ROOT), s);
-                put(s.name(), s);
-              }
-            }
-          });
+  private static final Map<String, ScoreMode> lowerAndCapitalCase = getLowerAndCapitalCaseMap();
 
   private ScoreModeParser() {}
+
+  private static Map<String, ScoreMode> getLowerAndCapitalCaseMap() {
+    Map<String, ScoreMode> map = new HashMap<>(ScoreMode.values().length * 2);
+    for (ScoreMode s : ScoreMode.values()) {
+      map.put(s.name().toLowerCase(Locale.ROOT), s);
+      map.put(s.name(), s);
+    }
+    return Collections.unmodifiableMap(map);
+  }
 
   /**
    * recognizes as-is {@link ScoreMode} names, and lowercase as well, otherwise throws exception

--- a/solr/core/src/java/org/apache/solr/security/AuditEvent.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditEvent.java
@@ -401,6 +401,7 @@ public class AuditEvent {
    */
   @Deprecated
   @JsonIgnore
+  @SuppressWarnings("JdkObsolete")
   public StringBuffer getRequestUrl() {
     return new StringBuffer(baseUrl);
   }

--- a/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.MultipartConfigElement;
@@ -356,7 +355,7 @@ public class SolrRequestParsers {
       boolean supportCharsetParam)
       throws IOException {
     CharsetDecoder charsetDecoder = supportCharsetParam ? null : getCharsetDecoder(charset);
-    final LinkedList<Object> buffer = supportCharsetParam ? new LinkedList<>() : null;
+    final List<Object> buffer = supportCharsetParam ? new ArrayList<>() : null;
     long len = 0L, keyPos = 0L, valuePos = 0L;
     final ByteArrayOutputStream keyStream = new ByteArrayOutputStream(),
         valueStream = new ByteArrayOutputStream();
@@ -476,9 +475,7 @@ public class SolrRequestParsers {
   }
 
   private static void decodeBuffer(
-      final LinkedList<Object> input,
-      final Map<String, String[]> map,
-      CharsetDecoder charsetDecoder) {
+      final List<Object> input, final Map<String, String[]> map, CharsetDecoder charsetDecoder) {
     for (final Iterator<Object> it = input.iterator(); it.hasNext(); ) {
       final byte[] keyBytes = (byte[]) it.next();
       it.remove();

--- a/solr/core/src/java/org/apache/solr/spelling/suggest/jaspell/JaspellTernarySearchTrie.java
+++ b/solr/core/src/java/org/apache/solr/spelling/suggest/jaspell/JaspellTernarySearchTrie.java
@@ -64,16 +64,16 @@ public class JaspellTernarySearchTrie implements Accountable {
   protected static final class TSTNode implements Accountable {
 
     /** Index values for accessing relatives array. */
-    protected static final int PARENT = 0, LOKID = 1, EQKID = 2, HIKID = 3;
+    static final int PARENT = 0, LOKID = 1, EQKID = 2, HIKID = 3;
 
     /** The key to the node. */
-    protected Object data;
+    Object data;
 
     /** The relative nodes. */
-    protected final TSTNode[] relatives = new TSTNode[4];
+    final TSTNode[] relatives = new TSTNode[4];
 
     /** The char used in the split. */
-    protected char splitchar;
+    char splitchar;
 
     /**
      * Constructor method.
@@ -81,7 +81,7 @@ public class JaspellTernarySearchTrie implements Accountable {
      * @param splitchar The char used in the split.
      * @param parent The parent node.
      */
-    protected TSTNode(char splitchar, TSTNode parent) {
+    TSTNode(char splitchar, TSTNode parent) {
       this.splitchar = splitchar;
       relatives[PARENT] = parent;
     }

--- a/solr/core/src/java/org/apache/solr/spelling/suggest/jaspell/JaspellTernarySearchTrie.java
+++ b/solr/core/src/java/org/apache/solr/spelling/suggest/jaspell/JaspellTernarySearchTrie.java
@@ -33,9 +33,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Vector;
 import java.util.zip.GZIPInputStream;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.IOUtils;
@@ -540,7 +540,7 @@ public class JaspellTernarySearchTrie implements Accountable {
         matchAlmostDiff,
         key,
         ((numReturnValues < 0) ? -1 : numReturnValues),
-        new Vector<String>(),
+        new ArrayList<>(),
         false);
   }
 
@@ -636,13 +636,13 @@ public class JaspellTernarySearchTrie implements Accountable {
    * @return A <code>List</code> with the results
    */
   public List<String> matchPrefix(CharSequence prefix, int numReturnValues) {
-    Vector<String> sortKeysResult = new Vector<>();
+    List<String> sortKeysResult = new ArrayList<>();
     TSTNode startNode = getNode(prefix);
     if (startNode == null) {
       return sortKeysResult;
     }
     if (startNode.data != null) {
-      sortKeysResult.addElement(getKey(startNode));
+      sortKeysResult.add(getKey(startNode));
     }
     return sortKeysRecursion(
         startNode.relatives[TSTNode.EQKID],
@@ -783,7 +783,7 @@ public class JaspellTernarySearchTrie implements Accountable {
    */
   protected List<String> sortKeys(TSTNode startNode, int numReturnValues) {
     return sortKeysRecursion(
-        startNode, ((numReturnValues < 0) ? -1 : numReturnValues), new Vector<String>());
+        startNode, ((numReturnValues < 0) ? -1 : numReturnValues), new ArrayList<>());
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/spelling/suggest/jaspell/JaspellTernarySearchTrie.java
+++ b/solr/core/src/java/org/apache/solr/spelling/suggest/jaspell/JaspellTernarySearchTrie.java
@@ -764,7 +764,7 @@ public class JaspellTernarySearchTrie implements Accountable {
    * the methods mentioned above provide overloaded versions that allow you to specify the maximum
    * number of return values, in which case this value is temporarily overridden.
    *
-   * <p>*@param num The number of values that will be returned when calling the methods above.
+   * @param num The number of values that will be returned when calling the methods above.
    */
   public void setNumReturnValues(int num) {
     defaultNumReturnValues = (num < 0) ? -1 : num;

--- a/solr/core/src/java/org/apache/solr/update/DefaultSolrCoreState.java
+++ b/solr/core/src/java/org/apache/solr/update/DefaultSolrCoreState.java
@@ -76,7 +76,7 @@ public final class DefaultSolrCoreState extends SolrCoreState
 
   private RefCounted<IndexWriter> refCntWriter;
 
-  protected final ReentrantLock commitLock = new ReentrantLock();
+  private final ReentrantLock commitLock = new ReentrantLock();
 
   @Deprecated
   public DefaultSolrCoreState(DirectoryFactory directoryFactory) {
@@ -254,7 +254,7 @@ public final class DefaultSolrCoreState extends SolrCoreState
     changeWriter(core, true, true);
   }
 
-  protected SolrIndexWriter createMainIndexWriter(SolrCore core, String name) throws IOException {
+  private SolrIndexWriter createMainIndexWriter(SolrCore core, String name) throws IOException {
     return SolrIndexWriter.create(
         core,
         name,

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -17,8 +17,8 @@
 package org.apache.solr.update;
 
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.apache.lucene.document.Document;
@@ -412,7 +412,7 @@ public class DocumentBuilder {
     if (!largestIsLast
         && largestField != null
         && largestFieldLen > MIN_LENGTH_TO_MOVE_LAST) { // only bother if the value isn't tiny
-      LinkedList<IndexableField> addToEnd = new LinkedList<>();
+      List<IndexableField> addToEnd = new ArrayList<>();
       Iterator<IndexableField> iterator = doc.iterator();
       while (iterator.hasNext()) {
         IndexableField field = iterator.next();

--- a/solr/core/src/java/org/apache/solr/update/MemOutputStream.java
+++ b/solr/core/src/java/org/apache/solr/update/MemOutputStream.java
@@ -17,7 +17,7 @@
 package org.apache.solr.update;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.solr.common.util.FastOutputStream;
 
@@ -25,7 +25,7 @@ import org.apache.solr.common.util.FastOutputStream;
  * @lucene.internal
  */
 public class MemOutputStream extends FastOutputStream {
-  public List<byte[]> buffers = new LinkedList<>();
+  public List<byte[]> buffers = new ArrayList<>();
 
   public MemOutputStream(byte[] tempBuffer) {
     super(null, tempBuffer, 0);

--- a/solr/core/src/java/org/apache/solr/update/StreamingSolrClients.java
+++ b/solr/core/src/java/org/apache/solr/update/StreamingSolrClients.java
@@ -29,7 +29,7 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.common.SolrException;
-import org.apache.solr.update.SolrCmdDistributor.Error;
+import org.apache.solr.update.SolrCmdDistributor.SolrError;
 import org.eclipse.jetty.client.api.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public class StreamingSolrClients {
   private Http2SolrClient httpClient;
 
   private Map<String, ConcurrentUpdateHttp2SolrClient> solrClients = new HashMap<>();
-  private List<Error> errors = Collections.synchronizedList(new ArrayList<>());
+  private List<SolrError> errors = Collections.synchronizedList(new ArrayList<>());
 
   private ExecutorService updateExecutor;
 
@@ -53,7 +53,7 @@ public class StreamingSolrClients {
     this.httpClient = updateShardHandler.getUpdateOnlyHttpClient();
   }
 
-  public List<Error> getErrors() {
+  public List<SolrError> getErrors() {
     return errors;
   }
 
@@ -116,7 +116,7 @@ public class StreamingSolrClients {
 class ErrorReportingConcurrentUpdateSolrClient extends ConcurrentUpdateHttp2SolrClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final SolrCmdDistributor.Req req;
-  private final List<Error> errors;
+  private final List<SolrError> errors;
 
   public ErrorReportingConcurrentUpdateSolrClient(Builder builder) {
     super(builder);
@@ -127,7 +127,7 @@ class ErrorReportingConcurrentUpdateSolrClient extends ConcurrentUpdateHttp2Solr
   @Override
   public void handleError(Throwable ex) {
     log.error("Error when calling {} to {}", req, req.node.getUrl(), ex);
-    Error error = new Error();
+    SolrError error = new SolrError();
     error.e = (Exception) ex;
     if (ex instanceof SolrException) {
       error.statusCode = ((SolrException) ex).code();
@@ -147,13 +147,13 @@ class ErrorReportingConcurrentUpdateSolrClient extends ConcurrentUpdateHttp2Solr
 
   static class Builder extends ConcurrentUpdateHttp2SolrClient.Builder {
     protected SolrCmdDistributor.Req req;
-    protected List<Error> errors;
+    protected List<SolrError> errors;
 
     public Builder(
         String baseSolrUrl,
         Http2SolrClient client,
         SolrCmdDistributor.Req req,
-        List<Error> errors) {
+        List<SolrError> errors) {
       super(baseSolrUrl, client);
       this.req = req;
       this.errors = errors;

--- a/solr/core/src/java/org/apache/solr/update/UpdateHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateHandler.java
@@ -18,7 +18,9 @@ package org.apache.solr.update;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.core.PluginInfo;
 import org.apache.solr.core.SolrCore;
@@ -45,9 +47,12 @@ public abstract class UpdateHandler implements SolrInfoBean {
   protected final SchemaField idField;
   protected final FieldType idFieldType;
 
-  protected Vector<SolrEventListener> commitCallbacks = new Vector<>();
-  protected Vector<SolrEventListener> softCommitCallbacks = new Vector<>();
-  protected Vector<SolrEventListener> optimizeCallbacks = new Vector<>();
+  protected List<SolrEventListener> commitCallbacks =
+      Collections.synchronizedList(new ArrayList<>());
+  protected List<SolrEventListener> softCommitCallbacks =
+      Collections.synchronizedList(new ArrayList<>());
+  protected List<SolrEventListener> optimizeCallbacks =
+      Collections.synchronizedList(new ArrayList<>());
 
   protected final UpdateLog ulog;
 

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -200,8 +201,8 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
   protected TransactionLog prevTlog;
   protected TransactionLog prevTlogOnPrecommit;
   // list of recent logs, newest first
-  protected final Deque<TransactionLog> logs = new LinkedList<>();
-  protected LinkedList<TransactionLog> newestLogsOnStartup = new LinkedList<>();
+  protected final Deque<TransactionLog> logs = new ArrayDeque<>();
+  protected Deque<TransactionLog> newestLogsOnStartup = new ArrayDeque<>();
   protected int numOldRecords; // number of records in the recent logs
 
   protected Map<BytesRef, LogPtr> map = new HashMap<>();
@@ -242,6 +243,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
     }
   }
 
+  @SuppressWarnings("JdkObsolete")
   protected LinkedList<DBQ> deleteByQueries = new LinkedList<>();
 
   // Needs to be String because hdfs.Path is incompatible with nio.Path
@@ -1700,7 +1702,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
   public RecentUpdates getRecentUpdates() {
     Deque<TransactionLog> logList;
     synchronized (this) {
-      logList = new LinkedList<>(logs);
+      logList = new ArrayDeque<>(logs);
       for (TransactionLog log : logList) {
         log.incref();
       }
@@ -1845,7 +1847,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
     boolean inSortedOrder;
 
     public LogReplayer(List<TransactionLog> translogs, boolean activeLog) {
-      this.translogs = new LinkedList<>();
+      this.translogs = new ArrayDeque<>();
       this.translogs.addAll(translogs);
       this.activeLog = activeLog;
     }

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -54,8 +54,8 @@ import org.apache.solr.update.AddUpdateCommand;
 import org.apache.solr.update.CommitUpdateCommand;
 import org.apache.solr.update.DeleteUpdateCommand;
 import org.apache.solr.update.SolrCmdDistributor;
-import org.apache.solr.update.SolrCmdDistributor.Error;
 import org.apache.solr.update.SolrCmdDistributor.Node;
+import org.apache.solr.update.SolrCmdDistributor.SolrError;
 import org.apache.solr.update.UpdateCommand;
 import org.apache.solr.update.UpdateLog;
 import org.apache.solr.update.UpdateShardHandler;
@@ -1273,15 +1273,15 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
   }
 
   public static final class DistributedUpdatesAsyncException extends SolrException {
-    public final List<Error> errors;
+    public final List<SolrError> errors;
 
-    public DistributedUpdatesAsyncException(List<Error> errors) {
+    public DistributedUpdatesAsyncException(List<SolrError> errors) {
       super(buildCode(errors), buildMsg(errors), null);
       this.errors = errors;
 
       // create a merged copy of the metadata from all wrapped exceptions
       NamedList<String> metadata = new NamedList<>();
-      for (Error error : errors) {
+      for (SolrError error : errors) {
         if (error.e instanceof SolrException) {
           SolrException e = (SolrException) error.e;
           NamedList<String> eMeta = e.getMetadata();
@@ -1296,13 +1296,13 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
     }
 
     /** Helper method for constructor */
-    private static int buildCode(List<Error> errors) {
+    private static int buildCode(List<SolrError> errors) {
       assert null != errors;
       assert 0 < errors.size();
 
       int minCode = Integer.MAX_VALUE;
       int maxCode = Integer.MIN_VALUE;
-      for (Error error : errors) {
+      for (SolrError error : errors) {
         log.trace("REMOTE ERROR: {}", error);
         minCode = Math.min(error.statusCode, minCode);
         maxCode = Math.max(error.statusCode, maxCode);
@@ -1319,7 +1319,7 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
     }
 
     /** Helper method for constructor */
-    private static String buildMsg(List<Error> errors) {
+    private static String buildMsg(List<SolrError> errors) {
       assert null != errors;
       assert 0 < errors.size();
 
@@ -1328,7 +1328,7 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
       } else {
         StringBuilder buf =
             new StringBuilder(errors.size() + " Async exceptions during distributed update: ");
-        for (Error error : errors) {
+        for (SolrError error : errors) {
           buf.append("\n");
           buf.append(error.e.getMessage());
         }

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -1261,12 +1261,12 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     // send in a background thread
 
     cmdDistrib.finish();
-    List<SolrCmdDistributor.Error> errors = cmdDistrib.getErrors();
+    List<SolrCmdDistributor.SolrError> errors = cmdDistrib.getErrors();
     // TODO - we may need to tell about more than one error...
 
-    List<SolrCmdDistributor.Error> errorsForClient = new ArrayList<>(errors.size());
+    List<SolrCmdDistributor.SolrError> errorsForClient = new ArrayList<>(errors.size());
     Set<String> replicasShouldBeInLowerTerms = new HashSet<>();
-    for (final SolrCmdDistributor.Error error : errors) {
+    for (final SolrCmdDistributor.SolrError error : errors) {
 
       if (error.req.node instanceof SolrCmdDistributor.ForwardNode) {
         // if it's a forward, any fail is a problem -

--- a/solr/core/src/java/org/apache/solr/update/processor/RoutedAliasUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/RoutedAliasUpdateProcessor.java
@@ -226,7 +226,7 @@ public class RoutedAliasUpdateProcessor extends UpdateRequestProcessor {
   public void finish() throws IOException {
     try {
       cmdDistrib.finish();
-      final List<SolrCmdDistributor.Error> errors = cmdDistrib.getErrors();
+      final List<SolrCmdDistributor.SolrError> errors = cmdDistrib.getErrors();
       if (!errors.isEmpty()) {
         throw new DistributedUpdateProcessor.DistributedUpdatesAsyncException(errors);
       }

--- a/solr/core/src/java/org/apache/solr/update/processor/TolerantUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/TolerantUpdateProcessor.java
@@ -38,7 +38,7 @@ import org.apache.solr.update.CommitUpdateCommand;
 import org.apache.solr.update.DeleteUpdateCommand;
 import org.apache.solr.update.MergeIndexesCommand;
 import org.apache.solr.update.RollbackUpdateCommand;
-import org.apache.solr.update.SolrCmdDistributor.Error;
+import org.apache.solr.update.SolrCmdDistributor.SolrError;
 import org.apache.solr.update.processor.DistributedUpdateProcessor.DistribPhase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,7 +232,7 @@ public class TolerantUpdateProcessor extends UpdateRequestProcessor {
       firstErrTracker.caught(duae);
 
       // adjust our stats based on each of the distributed errors
-      for (Error error : duae.errors) {
+      for (SolrError error : duae.errors) {
         // we can't trust the req info from the Error, because multiple original requests might have
         // been lumped together
         //

--- a/solr/core/src/java/org/apache/solr/update/processor/UpdateRequestProcessorChain.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpdateRequestProcessorChain.java
@@ -19,7 +19,6 @@ package org.apache.solr.update.processor;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -256,7 +255,7 @@ public final class UpdateRequestProcessorChain implements PluginInfoInitialized 
 
   public static UpdateRequestProcessorChain constructChain(
       UpdateRequestProcessorChain defaultUrp, ProcessorInfo processorInfo, SolrCore core) {
-    LinkedList<UpdateRequestProcessorFactory> urps = new LinkedList<>(defaultUrp.chain);
+    List<UpdateRequestProcessorFactory> urps = new ArrayList<>(defaultUrp.chain);
     List<UpdateRequestProcessorFactory> p = getReqProcessors(processorInfo.processor, core);
     List<UpdateRequestProcessorFactory> post = getReqProcessors(processorInfo.postProcessor, core);
     // processor are tried to be inserted before LogUpdateprocessor+DistributedUpdateProcessor
@@ -275,7 +274,7 @@ public final class UpdateRequestProcessorChain implements PluginInfoInitialized 
   }
 
   private static void insertBefore(
-      LinkedList<UpdateRequestProcessorFactory> urps,
+      List<UpdateRequestProcessorFactory> urps,
       List<UpdateRequestProcessorFactory> newFactories,
       Class<?> klas,
       int idx) {

--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -22,9 +22,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
@@ -295,7 +295,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
     final String BAD_VALUE = "NOT_A_DATE";
     ignoreException(BAD_VALUE);
 
-    final List<String> FIELDS = new LinkedList<>();
+    final List<String> FIELDS = new ArrayList<>();
     for (String type :
         new String[] {"tdt", "tdt1", "tdtdv", "tdtdv1", "dt_dv", "dt_dvo", "dt", "dt1", "dt_os"}) {
       FIELDS.add("malformed_" + type);
@@ -351,7 +351,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
     final String BAD_VALUE = "NOT_A_NUMBER";
     ignoreException(BAD_VALUE);
 
-    final List<String> FIELDS = new LinkedList<>();
+    final List<String> FIELDS = new ArrayList<>();
     for (String type :
         new String[] {
           "ti", "tf", "td", "tl",

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
@@ -35,13 +35,13 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Principal;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1555,7 +1555,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
 
   private static void zip(File directory, File zipfile) throws IOException {
     URI base = directory.toURI();
-    Deque<File> queue = new LinkedList<File>();
+    Deque<File> queue = new ArrayDeque<>();
     queue.push(directory);
     OutputStream out = new FileOutputStream(zipfile);
     ZipOutputStream zout = new ZipOutputStream(out);

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIExclusivity.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIExclusivity.java
@@ -18,8 +18,8 @@ package org.apache.solr.cloud;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
@@ -81,7 +81,7 @@ public class TestConfigSetsAPIExclusivity extends SolrTestCaseJ4 {
     for (ConfigSetsAPIThread thread : threads) {
       thread.join();
     }
-    List<Exception> exceptions = new LinkedList<>();
+    List<Exception> exceptions = new ArrayList<>();
     for (ConfigSetsAPIThread thread : threads) {
       exceptions.addAll(thread.getUnexpectedExceptions());
     }
@@ -107,7 +107,7 @@ public class TestConfigSetsAPIExclusivity extends SolrTestCaseJ4 {
   private abstract static class ConfigSetsAPIThread extends Thread {
     private MiniSolrCloudCluster solrCluster;
     private int trials;
-    private List<Exception> unexpectedExceptions = new LinkedList<>();
+    private List<Exception> unexpectedExceptions = new ArrayList<>();
     private List<String> allowedExceptions =
         Arrays.asList(
             new String[] {

--- a/solr/core/src/test/org/apache/solr/cloud/TestSizeLimitedDistributedMap.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestSizeLimitedDistributedMap.java
@@ -17,8 +17,8 @@
 
 package org.apache.solr.cloud;
 
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -26,7 +26,7 @@ import org.apache.solr.common.cloud.SolrZkClient;
 public class TestSizeLimitedDistributedMap extends TestDistributedMap {
 
   public void testCleanup() throws Exception {
-    final List<String> deletedItems = new LinkedList<>();
+    final List<String> deletedItems = new ArrayList<>();
     final Set<String> expectedKeys = new HashSet<>();
     int numResponsesToStore = TEST_NIGHTLY ? Overseer.NUM_RESPONSES_TO_STORE : 100;
 

--- a/solr/core/src/test/org/apache/solr/cluster/placement/Builders.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/Builders.java
@@ -17,11 +17,11 @@
 
 package org.apache.solr.cluster.placement;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.cluster.Cluster;
@@ -54,12 +54,12 @@ public class Builders {
 
   public static class ClusterBuilder {
     /** {@link NodeBuilder} for the live nodes of the cluster. */
-    private LinkedList<NodeBuilder> nodeBuilders = new LinkedList<>();
+    private List<NodeBuilder> nodeBuilders = new ArrayList<>();
 
-    private LinkedList<CollectionBuilder> collectionBuilders = new LinkedList<>();
+    private final List<CollectionBuilder> collectionBuilders = new ArrayList<>();
 
     public ClusterBuilder initializeLiveNodes(int countNodes) {
-      nodeBuilders = new LinkedList<>();
+      nodeBuilders = new ArrayList<>();
       for (int n = 0; n < countNodes; n++) {
         // Default name, can be changed
         NodeBuilder nodeBuilder = new NodeBuilder().setNodeName("node_" + n);
@@ -71,7 +71,7 @@ public class Builders {
       return this;
     }
 
-    public LinkedList<NodeBuilder> getLiveNodeBuilders() {
+    public List<NodeBuilder> getLiveNodeBuilders() {
       return nodeBuilders;
     }
 
@@ -87,7 +87,7 @@ public class Builders {
     }
 
     public List<Node> buildLiveNodes() {
-      List<Node> liveNodes = new LinkedList<>();
+      List<Node> liveNodes = new ArrayList<>();
       for (NodeBuilder nodeBuilder : nodeBuilders) {
         liveNodes.add(nodeBuilder.build());
       }
@@ -207,7 +207,7 @@ public class Builders {
 
   public static class CollectionBuilder {
     private final String collectionName;
-    private LinkedList<ShardBuilder> shardBuilders = new LinkedList<>();
+    private List<ShardBuilder> shardBuilders = new ArrayList<>();
     private Map<String, String> customProperties = new HashMap<>();
     int replicaNumber = 0; // global replica numbering for the collection
     private CollectionMetricsBuilder collectionMetricsBuilder = new CollectionMetricsBuilder();
@@ -229,7 +229,7 @@ public class Builders {
      * @return The internal shards data structure to allow test code to modify the replica
      *     distribution to nodes.
      */
-    public LinkedList<ShardBuilder> getShardBuilders() {
+    public List<ShardBuilder> getShardBuilders() {
       return shardBuilders;
     }
 
@@ -266,11 +266,11 @@ public class Builders {
      */
     public CollectionBuilder customCollectionSetup(
         List<List<String>> shardsReplicas, List<NodeBuilder> liveNodes) {
-      shardBuilders = new LinkedList<>();
+      shardBuilders = new ArrayList<>();
       int shardNumber = 1; // Shard numbering starts at 1
       for (List<String> replicasOnNodes : shardsReplicas) {
         String shardName = buildShardName(shardNumber++);
-        LinkedList<ReplicaBuilder> replicas = new LinkedList<>();
+        List<ReplicaBuilder> replicas = new ArrayList<>();
         ReplicaBuilder leader = null;
 
         for (String replicaNode : replicasOnNodes) {
@@ -361,7 +361,7 @@ public class Builders {
         List<Integer> initialSizeGBPerShard) {
       Iterator<NodeBuilder> nodeIterator = nodes.iterator();
 
-      shardBuilders = new LinkedList<>();
+      shardBuilders = new ArrayList<>();
       if (initialSizeGBPerShard != null && initialSizeGBPerShard.size() != countShards) {
         throw new RuntimeException(
             "list of shard sizes must be the same length as the countShards!");
@@ -373,7 +373,7 @@ public class Builders {
         CollectionMetricsBuilder.ShardMetricsBuilder shardMetricsBuilder =
             new CollectionMetricsBuilder.ShardMetricsBuilder(shardName);
 
-        LinkedList<ReplicaBuilder> replicas = new LinkedList<>();
+        List<ReplicaBuilder> replicas = new ArrayList<>();
         ReplicaBuilder leader = null;
         CollectionMetricsBuilder.ReplicaMetricsBuilder leaderMetrics = null;
 
@@ -466,7 +466,7 @@ public class Builders {
 
   public static class ShardBuilder {
     private String shardName;
-    private LinkedList<ReplicaBuilder> replicaBuilders = new LinkedList<>();
+    private List<ReplicaBuilder> replicaBuilders = new ArrayList<>();
     private ReplicaBuilder leaderReplicaBuilder;
 
     public ShardBuilder setShardName(String shardName) {
@@ -478,11 +478,11 @@ public class Builders {
       return shardName;
     }
 
-    public LinkedList<ReplicaBuilder> getReplicaBuilders() {
+    public List<ReplicaBuilder> getReplicaBuilders() {
       return replicaBuilders;
     }
 
-    public ShardBuilder setReplicaBuilders(LinkedList<ReplicaBuilder> replicaBuilders) {
+    public ShardBuilder setReplicaBuilders(List<ReplicaBuilder> replicaBuilders) {
       this.replicaBuilders = replicaBuilders;
       return this;
     }

--- a/solr/core/src/test/org/apache/solr/cluster/placement/impl/PlacementPluginIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/impl/PlacementPluginIntegrationTest.java
@@ -467,9 +467,7 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
                         Optional<Double> indexSizeOpt =
                             replicaMetrics.getReplicaMetric(ReplicaMetricImpl.INDEX_SIZE_GB);
                         assertTrue("indexSize", indexSizeOpt.isPresent());
-                        assertTrue(
-                            "wrong type, expected Double but was " + indexSizeOpt.get().getClass(),
-                            indexSizeOpt.get() instanceof Double);
+                        indexSizeOpt.get();
                         assertTrue(
                             "indexSize should be > 0 but was " + indexSizeOpt.get(),
                             indexSizeOpt.get() > 0);

--- a/solr/core/src/test/org/apache/solr/cluster/placement/plugins/AffinityPlacementFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/plugins/AffinityPlacementFactoryTest.java
@@ -21,7 +21,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -100,7 +99,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
     String collectionName = "basicCollection";
 
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(2);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     nodeBuilders.get(0).setCoreCount(1).setFreeDiskGB((double) (PRIORITIZED_FREE_DISK_GB + 1));
     nodeBuilders.get(1).setCoreCount(10).setFreeDiskGB((double) (PRIORITIZED_FREE_DISK_GB + 1));
 
@@ -148,7 +147,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
 
     // Cluster nodes and their attributes
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(8);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     for (int i = 0; i < nodeBuilders.size(); i++) {
       if (i == LOW_SPACE_NODE_INDEX) {
         nodeBuilders
@@ -233,7 +232,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
 
     // Cluster nodes and their attributes
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(5);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     int coresOnNode = 10;
     for (Builders.NodeBuilder nodeBuilder : nodeBuilders) {
       nodeBuilder.setCoreCount(coresOnNode).setFreeDiskGB((double) (PRIORITIZED_FREE_DISK_GB + 1));
@@ -308,7 +307,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
     // One of the NRT has fewer cores than the other
     // The TLOG/PULL replica on AZ1 doesn't have much free disk space
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(9);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     for (int i = 0; i < 9; i++) {
       final String az;
       final int numcores;
@@ -412,7 +411,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
 
     // Count cores == node index, and AZ's are: AZ0, AZ0, AZ0, AZ1, AZ1, AZ1, AZ2, AZ2, AZ2.
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(9);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     for (int i = 0; i < 9; i++) {
       nodeBuilders
           .get(i)
@@ -472,7 +471,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
 
     // Cluster nodes and their attributes
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(3);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     int coreCount = 0;
     for (Builders.NodeBuilder nodeBuilder : nodeBuilders) {
       nodeBuilder.setCoreCount(coreCount++).setFreeDiskGB((double) (PRIORITIZED_FREE_DISK_GB + 1));
@@ -944,7 +943,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
   @Test
   public void testNodeType() throws Exception {
     Builders.ClusterBuilder clusterBuilder = Builders.newClusterBuilder().initializeLiveNodes(9);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     for (int i = 0; i < 9; i++) {
       nodeBuilders.get(i).setSysprop(AffinityPlacementConfig.NODE_TYPE_SYSPROP, "type_" + (i % 3));
     }
@@ -1108,7 +1107,7 @@ public class AffinityPlacementFactoryTest extends SolrTestCaseJ4 {
 
     Builders.ClusterBuilder clusterBuilder =
         Builders.newClusterBuilder().initializeLiveNodes(numNodes);
-    LinkedList<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
+    List<Builders.NodeBuilder> nodeBuilders = clusterBuilder.getLiveNodeBuilders();
     for (int i = 0; i < numNodes; i++) {
       nodeBuilders.get(i).setCoreCount(0).setFreeDiskGB((double) numNodes);
     }

--- a/solr/core/src/test/org/apache/solr/core/PluginInfoTest.java
+++ b/solr/core/src/test/org/apache/solr/core/PluginInfoTest.java
@@ -144,7 +144,6 @@ public class PluginInfoTest extends DOMUtilTestBase {
     assertNotNull(childInfo);
     PluginInfo notExistent = pi.getChild("doesnotExist");
     assertNull(notExistent);
-    assertTrue(childInfo instanceof PluginInfo);
     assertEquals(0, (int) (Integer) childInfo.initArgs.get("index"));
     Node node2 = getNode(configWithNoChildren, "plugin");
     PluginInfo pi2 = new PluginInfo(node2, "with No Children", false, false);
@@ -160,7 +159,6 @@ public class PluginInfoTest extends DOMUtilTestBase {
     assertEquals(2, children.size());
     for (PluginInfo childInfo : children) {
       assertNotNull(childInfo);
-      assertTrue(childInfo instanceof PluginInfo);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/TestContainerPlugin.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestContainerPlugin.java
@@ -44,7 +44,7 @@ import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient.RemoteExecutionException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.V2Request;
-import org.apache.solr.client.solrj.request.beans.Package;
+import org.apache.solr.client.solrj.request.beans.PackagePayload;
 import org.apache.solr.client.solrj.request.beans.PluginMeta;
 import org.apache.solr.client.solrj.response.V2Response;
 import org.apache.solr.cloud.ClusterSingleton;
@@ -58,7 +58,7 @@ import org.apache.solr.filestore.TestDistribPackageStore;
 import org.apache.solr.filestore.TestDistribPackageStore.Fetcher;
 import org.apache.solr.pkg.PackageAPI;
 import org.apache.solr.pkg.PackageListeners;
-import org.apache.solr.pkg.PackageLoader;
+import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.pkg.TestPackages;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -97,7 +97,7 @@ public class TestContainerPlugin extends SolrCloudTestCase {
     }
 
     @Override
-    public void changed(PackageLoader.Package pkg, Ctx ctx) {
+    public void changed(SolrPackageLoader.SolrPackage pkg, Ctx ctx) {
       changeCalled.release();
     }
 
@@ -297,7 +297,7 @@ public class TestContainerPlugin extends SolrCloudTestCase {
     // We have two versions of the plugin in 2 different jar files. they are already uploaded to
     // the package store
     listener.reset();
-    Package.AddVersion add = new Package.AddVersion();
+    PackagePayload.AddVersion add = new PackagePayload.AddVersion();
     add.version = "1.0";
     add.pkg = "mypkg";
     add.files = singletonList(FILE1);

--- a/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
@@ -19,9 +19,9 @@ package org.apache.solr.handler;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
@@ -204,7 +204,7 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
       // now have the "main" test thread try to take a series of backups/snapshots
       // while adding other "real" docs
 
-      final Queue<String> namedSnapshots = new LinkedList<>();
+      final Queue<String> namedSnapshots = new ArrayDeque<>();
 
       // NOTE #1: start at i=1 for 'id' & doc counting purposes...
       // NOTE #2: abort quickly if the other thread reports a heavyCommitFailure...

--- a/solr/core/src/test/org/apache/solr/handler/XmlUpdateRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/XmlUpdateRequestHandlerTest.java
@@ -17,8 +17,8 @@
 package org.apache.solr.handler;
 
 import java.io.StringReader;
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Queue;
 import javax.xml.stream.XMLInputFactory;
@@ -213,7 +213,7 @@ public class XmlUpdateRequestHandlerTest extends SolrTestCaseJ4 {
 
   private static class MockUpdateRequestProcessor extends UpdateRequestProcessor {
 
-    private Queue<DeleteUpdateCommand> deleteCommands = new LinkedList<>();
+    private final Queue<DeleteUpdateCommand> deleteCommands = new ArrayDeque<>();
 
     public MockUpdateRequestProcessor(UpdateRequestProcessor next) {
       super(next);

--- a/solr/core/src/test/org/apache/solr/handler/component/UpdateLogCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/UpdateLogCloudTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.solr.handler.component;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -136,11 +137,8 @@ public class UpdateLogCloudTest extends SolrCloudTestCase {
       return;
     }
 
-    final LinkedList<Long> absVersions = new LinkedList<>();
-    for (Long version : versions) {
-      absVersions.add(Math.abs(version));
-    }
-    Collections.sort(absVersions);
+    final Deque<Long> absVersions =
+        versions.stream().map(Math::abs).sorted().collect(Collectors.toCollection(ArrayDeque::new));
     final Long minVersion = absVersions.getFirst();
     final Long maxVersion = absVersions.getLast();
 

--- a/solr/core/src/test/org/apache/solr/internal/csv/CharBufferTest.java
+++ b/solr/core/src/test/org/apache/solr/internal/csv/CharBufferTest.java
@@ -62,9 +62,9 @@ public class CharBufferTest extends SolrTestCaseJ4 {
     }
   }
 
-  public void testAppendStringBuffer() {
+  public void testAppendStringBuilder() {
     CharBuffer cb = new CharBuffer(1);
-    StringBuffer abcd = new StringBuffer("abcd");
+    StringBuilder abcd = new StringBuilder("abcd");
     String expected = "";
     for (int i = 0; i < 10; i++) {
       cb.append(abcd);

--- a/solr/core/src/test/org/apache/solr/pkg/TestPackages.java
+++ b/solr/core/src/test/org/apache/solr/pkg/TestPackages.java
@@ -53,7 +53,7 @@ import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.request.V2Request;
-import org.apache.solr.client.solrj.request.beans.Package;
+import org.apache.solr.client.solrj.request.beans.PackagePayload;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
@@ -129,7 +129,7 @@ public class TestPackages extends SolrCloudTestCase {
         FILE1,
         "L3q/qIGs4NaF6JiO0ZkMUFa88j0OmYc+I6O7BOdNuMct/xoZ4h73aZHZGc0+nmI1f/U3bOlMPINlSOM6LK3JpQ==");
 
-    Package.AddVersion add = new Package.AddVersion();
+    PackagePayload.AddVersion add = new PackagePayload.AddVersion();
     add.version = "1.0";
     add.pkg = "mypkg";
     add.files = Arrays.asList(new String[] {FILE1});
@@ -210,7 +210,7 @@ public class TestPackages extends SolrCloudTestCase {
         EXPR1,
         "ZOT11arAiPmPZYOHzqodiNnxO9pRyRozWZEBX8XGjU1/HJptFnZK+DI7eXnUtbNaMcbXE2Ze8hh4M/eGyhY8BQ==");
 
-    Package.AddVersion add = new Package.AddVersion();
+    PackagePayload.AddVersion add = new PackagePayload.AddVersion();
     add.version = "1.0";
     add.pkg = "mypkg";
     add.files = Arrays.asList(new String[] {FILE1, URP1, EXPR1});
@@ -399,7 +399,7 @@ public class TestPackages extends SolrCloudTestCase {
 
     assertEquals("Version 2", result.getResults().get(0).getFieldValue("TestVersionedURP.Ver_s"));
 
-    Package.DelVersion delVersion = new Package.DelVersion();
+    PackagePayload.DelVersion delVersion = new PackagePayload.DelVersion();
     delVersion.pkg = "mypkg";
     delVersion.version = "1.0";
     V2Request delete =
@@ -577,7 +577,7 @@ public class TestPackages extends SolrCloudTestCase {
     String FILE2 = "/mypkg/v.0.12/jar_b.jar";
     String FILE3 = "/mypkg/v.0.13/jar_a.jar";
 
-    Package.AddVersion add = new Package.AddVersion();
+    PackagePayload.AddVersion add = new PackagePayload.AddVersion();
     add.version = "0.12";
     add.pkg = "test_pkg";
     add.files = List.of(FILE1, FILE2);
@@ -652,7 +652,7 @@ public class TestPackages extends SolrCloudTestCase {
         Map.of(":packages:test_pkg[1]:version", "0.13", ":packages:test_pkg[1]:files[0]", FILE3));
 
     // Now we will just delete one version
-    Package.DelVersion delVersion = new Package.DelVersion();
+    PackagePayload.DelVersion delVersion = new PackagePayload.DelVersion();
     delVersion.version = "0.1"; // this version does not exist
     delVersion.pkg = "test_pkg";
     req =
@@ -759,7 +759,7 @@ public class TestPackages extends SolrCloudTestCase {
         FILE2,
         "gI6vYUDmSXSXmpNEeK1cwqrp4qTeVQgizGQkd8A4Prx2K8k7c5QlXbcs4lxFAAbbdXz9F4esBqTCiLMjVDHJ5Q==");
 
-    Package.AddVersion add = new Package.AddVersion();
+    PackagePayload.AddVersion add = new PackagePayload.AddVersion();
     add.version = "1.0";
     add.pkg = "schemapkg";
     add.files = Arrays.asList(FILE1, FILE2);
@@ -800,7 +800,7 @@ public class TestPackages extends SolrCloudTestCase {
             ":fieldType:_packageinfo_:version",
             "1.0"));
 
-    add = new Package.AddVersion();
+    add = new PackagePayload.AddVersion();
     add.version = "2.0";
     add.pkg = "schemapkg";
     add.files = Arrays.asList(FILE1);

--- a/solr/core/src/test/org/apache/solr/response/SmileWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/response/SmileWriterTest.java
@@ -210,7 +210,7 @@ public class SmileWriterTest extends SolrTestCaseJ4 {
   }
   // common-case ascii
   static String str(Random r, int sz) {
-    StringBuffer sb = new StringBuffer(sz);
+    StringBuilder sb = new StringBuilder(sz);
     for (int i = 0; i < sz; i++) {
       sb.append('\n' + r.nextInt(128 - '\n'));
     }

--- a/solr/core/src/test/org/apache/solr/search/TestRecovery.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRecovery.java
@@ -1352,6 +1352,7 @@ public class TestRecovery extends SolrTestCaseJ4 {
     }
   }
 
+  @SuppressWarnings("JdkObsolete")
   private void addDocs(int nDocs, int start, LinkedList<Long> versions) throws Exception {
     for (int i = 0; i < nDocs; i++) {
       versions.addFirst(addAndGetVersion(sdoc("id", Integer.toString(start + nDocs)), null));
@@ -1359,6 +1360,7 @@ public class TestRecovery extends SolrTestCaseJ4 {
   }
 
   @Test
+  @SuppressWarnings("JdkObsolete")
   public void testRemoveOldLogs() throws Exception {
     try {
       TestInjection.skipIndexWriterCommitOnClose = true;

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -347,9 +347,10 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
         "//result/doc[4]/str[@name='id'][.='3']");
   }
 
-  /*
-   * See {@link org.apache.solr.search.ReRankQParserPlugin.ReRankQueryRescorer.combine} for more details.
-   * */
+  /**
+   * See {@link org.apache.solr.search.ReRankQParserPlugin.ReRankQueryRescorer#combine(float,
+   * boolean, float)}} for more details.
+   */
   @Test
   public void knnQueryAsRerank_shouldAddSimilarityFunctionScore() {
     String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -43,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -392,7 +391,7 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
         assertEquals(status.intValue(), e.getStatus());
       }
       if (params != null && params.length > 0) {
-        List<String> p = new LinkedList<>(Arrays.asList(params));
+        List<String> p = new ArrayList<>(Arrays.asList(params));
         while (p.size() >= 2) {
           String val = e.getSolrParamAsString(p.get(0));
           assertEquals(p.get(1), val);
@@ -592,14 +591,11 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     @Override
     public void close() throws Exception {
       serverSocket.close();
-      assertEquals(
-          "Unexpected AuditEvents still in the queue",
-          Collections.emptyList(),
-          new LinkedList<>(queue));
+      assertTrue("Unexpected AuditEvents still in the queue", queue.isEmpty());
     }
 
     public List<AuditEvent> waitForAuditEvents(final int expected) throws InterruptedException {
-      final LinkedList<AuditEvent> results = new LinkedList<>();
+      final List<AuditEvent> results = new ArrayList<>();
       for (int i = 1; i <= expected; i++) { // NOTE: counting from 1 for error message readability
         final AuditEvent e = queue.poll(120, TimeUnit.SECONDS);
         if (null == e) {

--- a/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
@@ -397,6 +397,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
   }
 
   @Test
+  @SuppressWarnings("JdkObsolete")
   public void testAddHttpRequestToContext() throws Exception {
     HttpServletRequest request = getMock("/solr/select", null, -1);
     when(request.getMethod()).thenReturn("GET");

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -430,56 +430,17 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
 
     List<SolrInputDocument> docs = new ArrayList<>();
 
-    SolrInputDocument document1 =
-        new SolrInputDocument() {
-          {
-            final String id = id();
-            addField("id", id);
-            addField("parent_s", "X");
+    SolrInputDocument document1 = new SolrInputDocument("id", id(), "parent_s", "X");
+    List<SolrInputDocument> ch1 =
+        Arrays.asList(
+            new SolrInputDocument("id", id(), "child_s", "y"),
+            new SolrInputDocument("id", id(), "child_s", "z"));
+    Collections.shuffle(ch1, random());
+    document1.addChildDocuments(ch1);
 
-            ArrayList<SolrInputDocument> ch1 =
-                new ArrayList<>(
-                    Arrays.asList(
-                        new SolrInputDocument() {
-                          {
-                            addField("id", id());
-                            addField("child_s", "y");
-                          }
-                        },
-                        new SolrInputDocument() {
-                          {
-                            addField("id", id());
-                            addField("child_s", "z");
-                          }
-                        }));
-
-            Collections.shuffle(ch1, random());
-            addChildDocuments(ch1);
-          }
-        };
-
-    SolrInputDocument document2 =
-        new SolrInputDocument() {
-          {
-            final String id = id();
-            addField("id", id);
-            addField("parent_s", "A");
-            addChildDocument(
-                new SolrInputDocument() {
-                  {
-                    addField("id", id());
-                    addField("child_s", "b");
-                  }
-                });
-            addChildDocument(
-                new SolrInputDocument() {
-                  {
-                    addField("id", id());
-                    addField("child_s", "c");
-                  }
-                });
-          }
-        };
+    SolrInputDocument document2 = new SolrInputDocument("id", id(), "parent_s", "A");
+    document2.addChildDocument(new SolrInputDocument("id", id(), "child_s", "b"));
+    document2.addChildDocument(new SolrInputDocument("id", id(), "child_s", "c"));
 
     docs.add(document1);
     docs.add(document2);

--- a/solr/core/src/test/org/apache/solr/update/MaxSizeAutoCommitTest.java
+++ b/solr/core/src/test/org/apache/solr/update/MaxSizeAutoCommitTest.java
@@ -262,7 +262,7 @@ public class MaxSizeAutoCommitTest extends SolrTestCaseJ4 {
     public final BlockingQueue<Long> hard = new LinkedBlockingQueue<>(1000);
 
     // if non enpty, then at least one offer failed (queues full)
-    private StringBuffer fail = new StringBuffer();
+    private final StringBuilder fail = new StringBuilder();
 
     @Override
     public void newSearcher(SolrIndexSearcher newSearcher, SolrIndexSearcher currentSearcher) {
@@ -272,7 +272,7 @@ public class MaxSizeAutoCommitTest extends SolrTestCaseJ4 {
     @Override
     public void postCommit() {
       Long now = System.nanoTime();
-      if (!hard.offer(now)) fail.append(", hardCommit @ " + now);
+      if (!hard.offer(now)) fail.append(", hardCommit @ ").append(now);
     }
 
     @Override

--- a/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
+++ b/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
@@ -46,6 +46,7 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
+@SuppressWarnings("JdkObsolete")
 public class PeerSyncTest extends BaseDistributedSearchTestCase {
   protected static int numVersions = 100; // number of versions to use when syncing
   protected static final String FROM_LEADER = DistribPhase.FROMLEADER.toString();

--- a/solr/core/src/test/org/apache/solr/update/SoftAutoCommitTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SoftAutoCommitTest.java
@@ -604,7 +604,7 @@ class MockEventListener implements SolrEventListener {
   public final BlockingQueue<Long> searcher = new LinkedBlockingQueue<>(1000);
 
   // if non enpty, then at least one offer failed (queues full)
-  private StringBuffer fail = new StringBuffer();
+  private final StringBuilder fail = new StringBuilder();
 
   public MockEventListener() {
     /* NOOP */
@@ -613,19 +613,19 @@ class MockEventListener implements SolrEventListener {
   @Override
   public void newSearcher(SolrIndexSearcher newSearcher, SolrIndexSearcher currentSearcher) {
     Long now = System.nanoTime();
-    if (!searcher.offer(now)) fail.append(", newSearcher @ " + now);
+    if (!searcher.offer(now)) fail.append(", newSearcher @ ").append(now);
   }
 
   @Override
   public void postCommit() {
     Long now = System.nanoTime();
-    if (!hard.offer(now)) fail.append(", hardCommit @ " + now);
+    if (!hard.offer(now)) fail.append(", hardCommit @ ").append(now);
   }
 
   @Override
   public void postSoftCommit() {
     Long now = System.nanoTime();
-    if (!soft.offer(now)) fail.append(", softCommit @ " + now);
+    if (!soft.offer(now)) fail.append(", softCommit @ ").append(now);
   }
 
   public void clear() {

--- a/solr/core/src/test/org/apache/solr/update/processor/IgnoreLargeDocumentProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/IgnoreLargeDocumentProcessorFactoryTest.java
@@ -22,8 +22,6 @@ import static org.hamcrest.Matchers.containsString;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,9 +89,9 @@ public class IgnoreLargeDocumentProcessorFactoryTest extends SolrTestCase {
   public void testEstimateObjectSize() {
     assertEquals(estimate("abc"), 6);
     assertEquals(estimate("abcdefgh"), 16);
-    List<String> keys = Arrays.asList("int", "long", "double", "float", "str");
+    List<String> keys = List.of("int", "long", "double", "float", "str");
     assertEquals(estimate(keys), 42);
-    List<Object> values = Arrays.asList(12, 5L, 12.0, 5.0, "duck");
+    List<Object> values = List.of(12, 5L, 12.0, 5.0, "duck");
     assertEquals(estimate(values), 8);
 
     Map<String, Object> map = new HashMap<>();
@@ -125,9 +123,9 @@ public class IgnoreLargeDocumentProcessorFactoryTest extends SolrTestCase {
   public void testEstimateObjectSizeWithSingleChild() {
     assertEquals(estimate("abc"), 6);
     assertEquals(estimate("abcdefgh"), 16);
-    List<String> keys = Arrays.asList("int", "long", "double", "float", "str");
+    List<String> keys = List.of("int", "long", "double", "float", "str");
     assertEquals(estimate(keys), 42);
-    List<Object> values = Arrays.asList(12, 5L, 12.0, 5.0, "duck");
+    List<Object> values = List.of(12, 5L, 12.0, 5.0, "duck");
     assertEquals(estimate(values), 8);
     final String childDocKey = "testChildDoc";
 
@@ -166,9 +164,9 @@ public class IgnoreLargeDocumentProcessorFactoryTest extends SolrTestCase {
   public void testEstimateObjectSizeWithChildList() {
     assertEquals(estimate("abc"), 6);
     assertEquals(estimate("abcdefgh"), 16);
-    List<String> keys = Arrays.asList("int", "long", "double", "float", "str");
+    List<String> keys = List.of("int", "long", "double", "float", "str");
     assertEquals(estimate(keys), 42);
-    List<Object> values = Arrays.asList(12, 5L, 12.0, 5.0, "duck");
+    List<Object> values = List.of(12, 5L, 12.0, 5.0, "duck");
     assertEquals(estimate(values), 8);
     final String childDocKey = "testChildDoc";
 
@@ -194,12 +192,7 @@ public class IgnoreLargeDocumentProcessorFactoryTest extends SolrTestCase {
       childDocument.addField(entry.getKey(), entry.getValue());
     }
     List<SolrInputDocument> childList =
-        new ArrayList<>() {
-          {
-            add(childDocument);
-            add(new SolrInputDocument(childDocument));
-          }
-        };
+        List.of(childDocument, new SolrInputDocument(childDocument));
     document.addField(childDocKey, childList);
     mapWChild.put(childDocKey, childList);
     assertEquals(

--- a/solr/modules/analytics/src/java/org/apache/solr/analytics/facet/AnalyticsFacet.java
+++ b/solr/modules/analytics/src/java/org/apache/solr/analytics/facet/AnalyticsFacet.java
@@ -19,9 +19,10 @@ package org.apache.solr.analytics.facet;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import org.apache.solr.analytics.function.ExpressionCalculator;
 import org.apache.solr.analytics.function.ReductionCollectionManager;
@@ -143,7 +144,7 @@ public abstract class AnalyticsFacet {
    * @return the response of the facet
    */
   public Iterable<Map<String, Object>> createResponse() {
-    LinkedList<Map<String, Object>> list = new LinkedList<>();
+    List<Map<String, Object>> list = new ArrayList<>();
     reductionData.forEach(
         (facetVal, dataCol) -> {
           Map<String, Object> bucket = new HashMap<>();

--- a/solr/modules/analytics/src/java/org/apache/solr/analytics/facet/PivotNode.java
+++ b/solr/modules/analytics/src/java/org/apache/solr/analytics/facet/PivotNode.java
@@ -21,7 +21,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -160,7 +159,7 @@ public abstract class PivotNode<T> extends SortableFacet implements Consumer<Str
           });
 
       Iterable<FacetBucket> facetResultsIter = applyOptions(facetResults);
-      final LinkedList<Map<String, Object>> results = new LinkedList<>();
+      final List<Map<String, Object>> results = new ArrayList<>();
       // Export each expression in the bucket.
       for (FacetBucket bucket : facetResultsIter) {
         Map<String, Object> bucketMap = new HashMap<>();
@@ -242,7 +241,7 @@ public abstract class PivotNode<T> extends SortableFacet implements Consumer<Str
           });
 
       Iterable<FacetBucket> facetResultsIter = applyOptions(facetResults);
-      final LinkedList<Map<String, Object>> results = new LinkedList<>();
+      final List<Map<String, Object>> results = new ArrayList<>();
       // Export each expression in the bucket.
       for (FacetBucket bucket : facetResultsIter) {
         Map<String, Object> bucketMap = new HashMap<>();

--- a/solr/modules/analytics/src/java/org/apache/solr/analytics/facet/SortableFacet.java
+++ b/solr/modules/analytics/src/java/org/apache/solr/analytics/facet/SortableFacet.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.analytics.facet.compare.FacetResultsComparator;
@@ -47,7 +46,7 @@ public abstract class SortableFacet extends AnalyticsFacet {
 
   @Override
   public Iterable<Map<String, Object>> createResponse() {
-    final LinkedList<Map<String, Object>> results = new LinkedList<>();
+    final List<Map<String, Object>> results = new ArrayList<>();
     // Export each expression in the bucket.
     for (FacetBucket bucket : getBuckets()) {
       Map<String, Object> bucketMap = new HashMap<>();
@@ -91,7 +90,7 @@ public abstract class SortableFacet extends AnalyticsFacet {
       }
       facetResultsIter = Iterables.limit(facetResultsIter, sort.getLimit());
     } else if (sort.getLimit() == 0) {
-      return new LinkedList<FacetBucket>();
+      return new ArrayList<>();
     }
     return facetResultsIter;
   }

--- a/solr/modules/analytics/src/java/org/apache/solr/analytics/function/ReductionCollectionManager.java
+++ b/solr/modules/analytics/src/java/org/apache/solr/analytics/function/ReductionCollectionManager.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.solr.analytics.function.field.AnalyticsField;
@@ -67,7 +66,7 @@ public class ReductionCollectionManager {
     Arrays.sort(
         reductionDataCollectors, (a, b) -> a.getExpressionStr().compareTo(b.getExpressionStr()));
 
-    reservations = new LinkedList<>();
+    reservations = new ArrayList<>();
     for (int i = 0; i < reductionDataCollectors.length; i++) {
       reductionDataCollectors[i].submitReservations(reservation -> reservations.add(reservation));
     }

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingAnalyticsValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingAnalyticsValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.FillableTestValue.TestAnalyticsValue;
 import org.junit.Test;
@@ -28,24 +28,23 @@ public class CastingAnalyticsValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestAnalyticsValue val = new TestAnalyticsValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue("Object").setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList("Object").iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of("Object").iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingBooleanValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingBooleanValueStreamTest.java
@@ -28,24 +28,23 @@ public class CastingBooleanValueStreamTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestBooleanValueStream val = new TestBooleanValueStream();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(false, true, false);
     Iterator<String> values = Arrays.asList("false", "true", "false").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -53,25 +52,24 @@ public class CastingBooleanValueStreamTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestBooleanValueStream val = new TestBooleanValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(false, true, false);
     Iterator<Object> values =
         Arrays.<Object>asList(Boolean.FALSE, Boolean.TRUE, Boolean.FALSE).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingBooleanValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingBooleanValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.AnalyticsValueStream.ExpressionType;
 import org.apache.solr.analytics.value.FillableTestValue.TestBooleanValue;
@@ -30,56 +30,49 @@ public class CastingBooleanValueTest extends SolrTestCaseJ4 {
   public void stringCastingTest() {
     TestBooleanValue val = new TestBooleanValue();
 
-    assertTrue(val instanceof StringValue);
-    StringValue casted = (StringValue) val;
-
     val.setValue(false).setExists(true);
-    assertEquals("false", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("false", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
 
     val.setValue(true).setExists(true);
-    assertEquals("true", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("true", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
   }
 
   @Test
   public void objectCastingTest() {
     TestBooleanValue val = new TestBooleanValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue(false).setExists(true);
-    assertEquals(Boolean.FALSE, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(Boolean.FALSE, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
 
     val.setValue(true).setExists(true);
-    assertEquals(Boolean.TRUE, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(Boolean.TRUE, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
   public void booleanStreamCastingTest() {
     TestBooleanValue val = new TestBooleanValue();
 
-    assertTrue(val instanceof BooleanValueStream);
-    BooleanValueStream casted = (BooleanValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamBooleans(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((BooleanValueStream) val)
+        .streamBooleans(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(false).setExists(true);
-    Iterator<Boolean> values = Arrays.asList(false).iterator();
-    casted.streamBooleans(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Boolean> values = List.of(false).iterator();
+    ((BooleanValueStream) val)
+        .streamBooleans(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -87,24 +80,23 @@ public class CastingBooleanValueTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestBooleanValue val = new TestBooleanValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(false).setExists(true);
-    Iterator<String> values = Arrays.asList("false").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("false").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -112,24 +104,23 @@ public class CastingBooleanValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestBooleanValue val = new TestBooleanValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(false).setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList(Boolean.FALSE).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of(Boolean.FALSE).iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDateValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDateValueStreamTest.java
@@ -34,24 +34,23 @@ public class CastingDateValueStreamTest extends SolrTestCaseJ4 {
     Date date3 = Date.from(Instant.parse("2012-11-30T20:30:15Z"));
     TestDateValueStream val = new TestDateValueStream();
 
-    assertTrue(val instanceof DateValueStream);
-    DateValueStream casted = (DateValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamDates(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DateValueStream) val)
+        .streamDates(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues("1800-01-01T10:30:15Z", "1920-04-15T18:15:45Z", "2012-11-30T20:30:15Z");
     Iterator<Date> values = Arrays.asList(date1, date2, date3).iterator();
-    casted.streamDates(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next().toInstant(), value.toInstant());
-        });
+    ((DateValueStream) val)
+        .streamDates(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next().toInstant(), value.toInstant());
+            });
     assertFalse(values.hasNext());
   }
 
@@ -59,26 +58,25 @@ public class CastingDateValueStreamTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestDateValueStream val = new TestDateValueStream();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues("1800-01-01T10:30:15Z", "1920-04-15T18:15:45Z", "2012-11-30T20:30:15Z");
     Iterator<String> values =
         Arrays.asList("1800-01-01T10:30:15Z", "1920-04-15T18:15:45Z", "2012-11-30T20:30:15Z")
             .iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -89,24 +87,23 @@ public class CastingDateValueStreamTest extends SolrTestCaseJ4 {
     Date date3 = Date.from(Instant.parse("2012-11-30T20:30:15Z"));
     TestDateValueStream val = new TestDateValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues("1800-01-01T10:30:15Z", "1920-04-15T18:15:45Z", "2012-11-30T20:30:15Z");
     Iterator<Object> values = Arrays.<Object>asList(date1, date2, date3).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDateValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDateValueTest.java
@@ -18,7 +18,6 @@ package org.apache.solr.analytics.value;
 
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -35,24 +34,18 @@ public class CastingDateValueTest extends SolrTestCaseJ4 {
     Date date = Date.from(Instant.parse("1800-01-01T10:30:15Z"));
     TestDateValue val = new TestDateValue();
 
-    assertTrue(val instanceof DateValue);
-    DateValue casted = (DateValue) val;
-
     val.setValue("1800-01-01T10:30:15Z").setExists(true);
-    assertEquals(date.toInstant(), casted.getDate().toInstant());
-    assertTrue(casted.exists());
+    assertEquals(date.toInstant(), ((DateValue) val).getDate().toInstant());
+    assertTrue(((DateValue) val).exists());
   }
 
   @Test
   public void stringCastingTest() {
     TestDateValue val = new TestDateValue();
 
-    assertTrue(val instanceof StringValue);
-    StringValue casted = (StringValue) val;
-
     val.setValue("1800-01-01T10:30:15Z").setExists(true);
-    assertEquals("1800-01-01T10:30:15Z", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("1800-01-01T10:30:15Z", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
   }
 
   @Test
@@ -60,12 +53,9 @@ public class CastingDateValueTest extends SolrTestCaseJ4 {
     Date date = Date.from(Instant.parse("1800-01-01T10:30:15Z"));
     TestDateValue val = new TestDateValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue("1800-01-01T10:30:15Z").setExists(true);
-    assertEquals(date.toInstant(), ((Date) casted.getObject()).toInstant());
-    assertTrue(casted.exists());
+    assertEquals(date.toInstant(), ((Date) ((AnalyticsValue) val).getObject()).toInstant());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
@@ -73,24 +63,23 @@ public class CastingDateValueTest extends SolrTestCaseJ4 {
     Date date = Date.from(Instant.parse("1800-01-01T10:30:15Z"));
     TestDateValue val = new TestDateValue();
 
-    assertTrue(val instanceof DateValueStream);
-    DateValueStream casted = (DateValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamDates(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DateValueStream) val)
+        .streamDates(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue("1800-01-01T10:30:15Z").setExists(true);
-    Iterator<Date> values = Arrays.asList(date).iterator();
-    casted.streamDates(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next().toInstant(), value.toInstant());
-        });
+    Iterator<Date> values = List.of(date).iterator();
+    ((DateValueStream) val)
+        .streamDates(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next().toInstant(), value.toInstant());
+            });
     assertFalse(values.hasNext());
   }
 
@@ -98,24 +87,23 @@ public class CastingDateValueTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestDateValue val = new TestDateValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue("1800-01-01T10:30:15Z").setExists(true);
-    Iterator<String> values = Arrays.asList("1800-01-01T10:30:15Z").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("1800-01-01T10:30:15Z").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -124,24 +112,23 @@ public class CastingDateValueTest extends SolrTestCaseJ4 {
     Date date = Date.from(Instant.parse("1800-01-01T10:30:15Z"));
     TestDateValue val = new TestDateValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue("1800-01-01T10:30:15Z").setExists(true);
     Iterator<Object> values = List.<Object>of(date).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDoubleValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDoubleValueStreamTest.java
@@ -28,24 +28,23 @@ public class CastingDoubleValueStreamTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestDoubleValueStream val = new TestDoubleValueStream();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20.0, -3.32, 42.5);
     Iterator<String> values = Arrays.asList("20.0", "-3.32", "42.5").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -53,24 +52,23 @@ public class CastingDoubleValueStreamTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestDoubleValueStream val = new TestDoubleValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20.0, -3.32, 42.5);
     Iterator<Object> values = Arrays.<Object>asList(20.0, -3.32, 42.5).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDoubleValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingDoubleValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.AnalyticsValueStream.ExpressionType;
 import org.apache.solr.analytics.value.FillableTestValue.TestDoubleValue;
@@ -30,56 +30,49 @@ public class CastingDoubleValueTest extends SolrTestCaseJ4 {
   public void stringCastingTest() {
     TestDoubleValue val = new TestDoubleValue();
 
-    assertTrue(val instanceof StringValue);
-    StringValue casted = (StringValue) val;
-
     val.setValue(20.0).setExists(true);
-    assertEquals("20.0", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("20.0", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
 
     val.setValue(1234.0).setExists(true);
-    assertEquals("1234.0", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("1234.0", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
   }
 
   @Test
   public void objectCastingTest() {
     TestDoubleValue val = new TestDoubleValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue(20.0).setExists(true);
-    assertEquals(20.0d, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(20.0d, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
 
     val.setValue(1234.0).setExists(true);
-    assertEquals(1234.0d, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(1234.0d, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
   public void doubleStreamCastingTest() {
     TestDoubleValue val = new TestDoubleValue();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20.0).setExists(true);
-    Iterator<Double> values = Arrays.asList(20.0).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    Iterator<Double> values = List.of(20.0).iterator();
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -87,24 +80,23 @@ public class CastingDoubleValueTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestDoubleValue val = new TestDoubleValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20.0).setExists(true);
-    Iterator<String> values = Arrays.asList("20.0").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("20.0").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -112,24 +104,23 @@ public class CastingDoubleValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestDoubleValue val = new TestDoubleValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20.0).setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList(20.0d).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of(20.0d).iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingFloatValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingFloatValueStreamTest.java
@@ -28,24 +28,23 @@ public class CastingFloatValueStreamTest extends SolrTestCaseJ4 {
   public void doubleStreamCastingTest() {
     TestFloatValueStream val = new TestFloatValueStream();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20F, -3.32F, 42.5F);
     Iterator<Double> values = Arrays.asList(20.0, -3.32, 42.5).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -53,24 +52,23 @@ public class CastingFloatValueStreamTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestFloatValueStream val = new TestFloatValueStream();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20F, -3.32F, 42.5F);
     Iterator<String> values = Arrays.asList("20.0", "-3.32", "42.5").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -78,24 +76,23 @@ public class CastingFloatValueStreamTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestFloatValueStream val = new TestFloatValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20F, -3.32F, 42.5F);
     Iterator<Object> values = Arrays.<Object>asList(20F, -3.32F, 42.5F).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingFloatValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingFloatValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.AnalyticsValueStream.ExpressionType;
 import org.apache.solr.analytics.value.FillableTestValue.TestFloatValue;
@@ -30,72 +30,62 @@ public class CastingFloatValueTest extends SolrTestCaseJ4 {
   public void doubleCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof DoubleValue);
-    DoubleValue casted = (DoubleValue) val;
-
     val.setValue(20F).setExists(true);
-    assertEquals(20.0, casted.getDouble(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(20.0, ((DoubleValue) val).getDouble(), .00001);
+    assertTrue(((DoubleValue) val).exists());
 
     val.setValue(1234F).setExists(true);
-    assertEquals(1234.0, casted.getDouble(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(1234.0, ((DoubleValue) val).getDouble(), .00001);
+    assertTrue(((DoubleValue) val).exists());
   }
 
   @Test
   public void stringCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof StringValue);
-    StringValue casted = (StringValue) val;
-
     val.setValue(20F).setExists(true);
-    assertEquals("20.0", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("20.0", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
 
     val.setValue(1234F).setExists(true);
-    assertEquals("1234.0", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("1234.0", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
   }
 
   @Test
   public void objectCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue(20F).setExists(true);
-    assertEquals(20F, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(20F, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
 
     val.setValue(1234F).setExists(true);
-    assertEquals(1234F, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(1234F, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
   public void floatStreamCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof FloatValueStream);
-    FloatValueStream casted = (FloatValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamFloats(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((FloatValueStream) val)
+        .streamFloats(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20F).setExists(true);
-    Iterator<Float> values = Arrays.asList(20F).iterator();
-    casted.streamFloats(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    Iterator<Float> values = List.of(20F).iterator();
+    ((FloatValueStream) val)
+        .streamFloats(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -103,24 +93,23 @@ public class CastingFloatValueTest extends SolrTestCaseJ4 {
   public void doubleStreamCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20F).setExists(true);
-    Iterator<Double> values = Arrays.asList(20.0).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    Iterator<Double> values = List.of(20.0).iterator();
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -128,24 +117,23 @@ public class CastingFloatValueTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20F).setExists(true);
-    Iterator<String> values = Arrays.asList("20.0").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("20.0").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -153,24 +141,23 @@ public class CastingFloatValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestFloatValue val = new TestFloatValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20F).setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList(20F).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of(20F).iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingIntValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingIntValueStreamTest.java
@@ -28,24 +28,23 @@ public class CastingIntValueStreamTest extends SolrTestCaseJ4 {
   public void longStreamCastingTest() {
     TestIntValueStream val = new TestIntValueStream();
 
-    assertTrue(val instanceof LongValueStream);
-    LongValueStream casted = (LongValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamLongs(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((LongValueStream) val)
+        .streamLongs(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20, -3, 42);
     Iterator<Long> values = Arrays.asList(20L, -3L, 42L).iterator();
-    casted.streamLongs(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next().longValue(), value);
-        });
+    ((LongValueStream) val)
+        .streamLongs(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next().longValue(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -53,24 +52,23 @@ public class CastingIntValueStreamTest extends SolrTestCaseJ4 {
   public void floatStreamCastingTest() {
     TestIntValueStream val = new TestIntValueStream();
 
-    assertTrue(val instanceof FloatValueStream);
-    FloatValueStream casted = (FloatValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamFloats(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((FloatValueStream) val)
+        .streamFloats(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20, -3, 42);
     Iterator<Float> values = Arrays.asList(20F, -3F, 42F).iterator();
-    casted.streamFloats(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    ((FloatValueStream) val)
+        .streamFloats(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -78,24 +76,23 @@ public class CastingIntValueStreamTest extends SolrTestCaseJ4 {
   public void doubleStreamCastingTest() {
     TestIntValueStream val = new TestIntValueStream();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20, -3, 42);
     Iterator<Double> values = Arrays.asList(20.0, -3.0, 42.0).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -103,24 +100,23 @@ public class CastingIntValueStreamTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestIntValueStream val = new TestIntValueStream();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20, -3, 42);
     Iterator<String> values = Arrays.asList("20", "-3", "42").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -128,24 +124,23 @@ public class CastingIntValueStreamTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestIntValueStream val = new TestIntValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20, -3, 42);
     Iterator<Object> values = Arrays.<Object>asList(20, -3, 42).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingIntValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingIntValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.AnalyticsValueStream.ExpressionType;
 import org.apache.solr.analytics.value.FillableTestValue.TestIntValue;
@@ -30,104 +30,88 @@ public class CastingIntValueTest extends SolrTestCaseJ4 {
   public void longCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof LongValue);
-    LongValue casted = (LongValue) val;
-
     val.setValue(20).setExists(true);
-    assertEquals(20L, casted.getLong());
-    assertTrue(casted.exists());
+    assertEquals(20L, ((LongValue) val).getLong());
+    assertTrue(((LongValue) val).exists());
 
     val.setValue(1234).setExists(true);
-    assertEquals(1234L, casted.getLong());
-    assertTrue(casted.exists());
+    assertEquals(1234L, ((LongValue) val).getLong());
+    assertTrue(((LongValue) val).exists());
   }
 
   @Test
   public void floatCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof FloatValue);
-    FloatValue casted = (FloatValue) val;
-
     val.setValue(20).setExists(true);
-    assertEquals(20F, casted.getFloat(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(20F, ((FloatValue) val).getFloat(), .00001);
+    assertTrue(((FloatValue) val).exists());
 
     val.setValue(1234).setExists(true);
-    assertEquals(1234F, casted.getFloat(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(1234F, ((FloatValue) val).getFloat(), .00001);
+    assertTrue(((FloatValue) val).exists());
   }
 
   @Test
   public void doubleCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof DoubleValue);
-    DoubleValue casted = (DoubleValue) val;
-
     val.setValue(20).setExists(true);
-    assertEquals(20.0, casted.getDouble(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(20.0, ((DoubleValue) val).getDouble(), .00001);
+    assertTrue(((DoubleValue) val).exists());
 
     val.setValue(1234).setExists(true);
-    assertEquals(1234.0, casted.getDouble(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(1234.0, ((DoubleValue) val).getDouble(), .00001);
+    assertTrue(((DoubleValue) val).exists());
   }
 
   @Test
   public void stringCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof StringValue);
-    StringValue casted = (StringValue) val;
-
     val.setValue(20).setExists(true);
-    assertEquals("20", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("20", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
 
     val.setValue(1234).setExists(true);
-    assertEquals("1234", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("1234", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
   }
 
   @Test
   public void objectCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue(20).setExists(true);
-    assertEquals(20, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(20, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
 
     val.setValue(1234).setExists(true);
-    assertEquals(1234, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(1234, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
   public void intStreamCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof IntValueStream);
-    IntValueStream casted = (IntValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamInts(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((IntValueStream) val)
+        .streamInts(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20).setExists(true);
-    Iterator<Integer> values = Arrays.asList(20).iterator();
-    casted.streamInts(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next().intValue(), value);
-        });
+    Iterator<Integer> values = List.of(20).iterator();
+    ((IntValueStream) val)
+        .streamInts(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next().intValue(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -135,24 +119,23 @@ public class CastingIntValueTest extends SolrTestCaseJ4 {
   public void longStreamCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof LongValueStream);
-    LongValueStream casted = (LongValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamLongs(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((LongValueStream) val)
+        .streamLongs(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20).setExists(true);
-    Iterator<Long> values = Arrays.asList(20L).iterator();
-    casted.streamLongs(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next().longValue(), value);
-        });
+    Iterator<Long> values = List.of(20L).iterator();
+    ((LongValueStream) val)
+        .streamLongs(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next().longValue(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -160,24 +143,23 @@ public class CastingIntValueTest extends SolrTestCaseJ4 {
   public void floatStreamCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof FloatValueStream);
-    FloatValueStream casted = (FloatValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamFloats(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((FloatValueStream) val)
+        .streamFloats(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20).setExists(true);
-    Iterator<Float> values = Arrays.asList(20F).iterator();
-    casted.streamFloats(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    Iterator<Float> values = List.of(20F).iterator();
+    ((FloatValueStream) val)
+        .streamFloats(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -185,24 +167,23 @@ public class CastingIntValueTest extends SolrTestCaseJ4 {
   public void doubleStreamCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20).setExists(true);
-    Iterator<Double> values = Arrays.asList(20.0).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    Iterator<Double> values = List.of(20.0).iterator();
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -210,24 +191,23 @@ public class CastingIntValueTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20).setExists(true);
-    Iterator<String> values = Arrays.asList("20").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("20").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -235,24 +215,23 @@ public class CastingIntValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestIntValue val = new TestIntValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20).setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList(20).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of(20).iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingLongValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingLongValueStreamTest.java
@@ -28,24 +28,23 @@ public class CastingLongValueStreamTest extends SolrTestCaseJ4 {
   public void doubleStreamCastingTest() {
     TestLongValueStream val = new TestLongValueStream();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20L, -3L, 42L);
     Iterator<Double> values = Arrays.asList(20.0, -3.0, 42.0).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -53,24 +52,23 @@ public class CastingLongValueStreamTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestLongValueStream val = new TestLongValueStream();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20L, -3L, 42L);
     Iterator<String> values = Arrays.asList("20", "-3", "42").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -78,24 +76,23 @@ public class CastingLongValueStreamTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestLongValueStream val = new TestLongValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues(20L, -3L, 42L);
     Iterator<Object> values = Arrays.<Object>asList(20L, -3L, 42L).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingLongValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingLongValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.AnalyticsValueStream.ExpressionType;
 import org.apache.solr.analytics.value.FillableTestValue.TestLongValue;
@@ -30,72 +30,62 @@ public class CastingLongValueTest extends SolrTestCaseJ4 {
   public void doubleCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof DoubleValue);
-    DoubleValue casted = (DoubleValue) val;
-
     val.setValue(20L).setExists(true);
-    assertEquals(20.0, casted.getDouble(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(20.0, ((DoubleValue) val).getDouble(), .00001);
+    assertTrue(((DoubleValue) val).exists());
 
     val.setValue(1234L).setExists(true);
-    assertEquals(1234.0, casted.getDouble(), .00001);
-    assertTrue(casted.exists());
+    assertEquals(1234.0, ((DoubleValue) val).getDouble(), .00001);
+    assertTrue(((DoubleValue) val).exists());
   }
 
   @Test
   public void stringCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof StringValue);
-    StringValue casted = (StringValue) val;
-
     val.setValue(20L).setExists(true);
-    assertEquals("20", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("20", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
 
     val.setValue(1234L).setExists(true);
-    assertEquals("1234", casted.getString());
-    assertTrue(casted.exists());
+    assertEquals("1234", ((StringValue) val).getString());
+    assertTrue(((StringValue) val).exists());
   }
 
   @Test
   public void objectCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue(20L).setExists(true);
-    assertEquals(20L, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(20L, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
 
     val.setValue(1234L).setExists(true);
-    assertEquals(1234L, casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals(1234L, ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
   public void longStreamCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof LongValueStream);
-    LongValueStream casted = (LongValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamLongs(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((LongValueStream) val)
+        .streamLongs(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20L).setExists(true);
-    Iterator<Long> values = Arrays.asList(20L).iterator();
-    casted.streamLongs(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next().longValue(), value);
-        });
+    Iterator<Long> values = List.of(20L).iterator();
+    ((LongValueStream) val)
+        .streamLongs(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next().longValue(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -103,24 +93,23 @@ public class CastingLongValueTest extends SolrTestCaseJ4 {
   public void doubleStreamCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof DoubleValueStream);
-    DoubleValueStream casted = (DoubleValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamDoubles(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20L).setExists(true);
-    Iterator<Double> values = Arrays.asList(20.0).iterator();
-    casted.streamDoubles(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value, .00001);
-        });
+    Iterator<Double> values = List.of(20.0).iterator();
+    ((DoubleValueStream) val)
+        .streamDoubles(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value, .00001);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -128,24 +117,23 @@ public class CastingLongValueTest extends SolrTestCaseJ4 {
   public void stringStreamCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20L).setExists(true);
-    Iterator<String> values = Arrays.asList("20").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("20").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -153,24 +141,23 @@ public class CastingLongValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestLongValue val = new TestLongValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue(20L).setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList(20L).iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of(20L).iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingStringValueStreamTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingStringValueStreamTest.java
@@ -28,24 +28,23 @@ public class CastingStringValueStreamTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestStringValueStream val = new TestStringValueStream();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setValues();
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValues("abc", "def", "ghi");
     Iterator<Object> values = Arrays.<Object>asList("abc", "def", "ghi").iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingStringValueTest.java
+++ b/solr/modules/analytics/src/test/org/apache/solr/analytics/value/CastingStringValueTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.analytics.value;
 
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.analytics.value.AnalyticsValueStream.ExpressionType;
 import org.apache.solr.analytics.value.FillableTestValue.TestStringValue;
@@ -30,40 +30,36 @@ public class CastingStringValueTest extends SolrTestCaseJ4 {
   public void objectCastingTest() {
     TestStringValue val = new TestStringValue();
 
-    assertTrue(val instanceof AnalyticsValue);
-    AnalyticsValue casted = (AnalyticsValue) val;
-
     val.setValue("string 1").setExists(true);
-    assertEquals("string 1", casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals("string 1", ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
 
     val.setValue("abc").setExists(true);
-    assertEquals("abc", casted.getObject());
-    assertTrue(casted.exists());
+    assertEquals("abc", ((AnalyticsValue) val).getObject());
+    assertTrue(((AnalyticsValue) val).exists());
   }
 
   @Test
   public void stringStreamCastingTest() {
     TestStringValue val = new TestStringValue();
 
-    assertTrue(val instanceof StringValueStream);
-    StringValueStream casted = (StringValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamStrings(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue("abcd").setExists(true);
-    Iterator<String> values = Arrays.asList("abcd").iterator();
-    casted.streamStrings(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<String> values = List.of("abcd").iterator();
+    ((StringValueStream) val)
+        .streamStrings(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 
@@ -71,24 +67,23 @@ public class CastingStringValueTest extends SolrTestCaseJ4 {
   public void objectStreamCastingTest() {
     TestStringValue val = new TestStringValue();
 
-    assertTrue(val instanceof AnalyticsValueStream);
-    AnalyticsValueStream casted = (AnalyticsValueStream) val;
-
     // No values
     val.setExists(false);
-    casted.streamObjects(
-        value -> {
-          fail("There should be no values to stream");
-        });
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              fail("There should be no values to stream");
+            });
 
     // Multiple Values
     val.setValue("abcd").setExists(true);
-    Iterator<Object> values = Arrays.<Object>asList("abcd").iterator();
-    casted.streamObjects(
-        value -> {
-          assertTrue(values.hasNext());
-          assertEquals(values.next(), value);
-        });
+    Iterator<Object> values = List.<Object>of("abcd").iterator();
+    ((AnalyticsValueStream) val)
+        .streamObjects(
+            value -> {
+              assertTrue(values.hasNext());
+              assertEquals(values.next(), value);
+            });
     assertFalse(values.hasNext());
   }
 

--- a/solr/modules/extraction/src/java/org/apache/solr/handler/extraction/XLSXResponseWriter.java
+++ b/solr/modules/extraction/src/java/org/apache/solr/handler/extraction/XLSXResponseWriter.java
@@ -282,7 +282,7 @@ class XLSXWriter extends TabularResponseWriter {
   @Override
   public void writeArray(String name, Iterator<?> val, boolean raw) throws IOException {
     assert !raw;
-    StringBuffer output = new StringBuffer();
+    StringBuilder output = new StringBuilder();
     while (val.hasNext()) {
       Object v = val.next();
       if (v instanceof IndexableField) {

--- a/solr/modules/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
+++ b/solr/modules/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
@@ -41,7 +41,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -206,7 +205,7 @@ public class GCSBackupRepository implements BackupRepository {
     final String blobName = appendTrailingSeparatorIfNecessary(path.toString());
 
     final String pathStr = blobName;
-    final LinkedList<String> result = new LinkedList<>();
+    final List<String> result = new ArrayList<>();
     storage
         .list(
             bucketName,

--- a/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/DelegationTokenKerberosFilter.java
+++ b/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/DelegationTokenKerberosFilter.java
@@ -17,8 +17,8 @@
 package org.apache.solr.security.hadoop;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.LinkedList;
 import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -231,7 +231,7 @@ public class DelegationTokenKerberosFilter extends DelegationTokenAuthentication
     }
 
     private List<AuthInfo> createAuthInfo(SolrZkClient zkClient) {
-      List<AuthInfo> ret = new LinkedList<AuthInfo>();
+      List<AuthInfo> ret = new ArrayList<>();
 
       // In theory the credentials to add could change here if zookeeper hasn't been initialized
       ZkCredentialsProvider credentialsProvider =

--- a/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/HadoopAuthFilter.java
+++ b/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/HadoopAuthFilter.java
@@ -17,7 +17,7 @@
 package org.apache.solr.security.hadoop;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -215,7 +215,7 @@ public class HadoopAuthFilter extends DelegationTokenAuthenticationFilter {
     }
 
     private List<AuthInfo> createAuthInfo(SolrZkClient zkClient) {
-      List<AuthInfo> ret = new LinkedList<AuthInfo>();
+      List<AuthInfo> ret = new ArrayList<>();
 
       // In theory the credentials to add could change here if zookeeper hasn't been initialized
       ZkCredentialsProvider credentialsProvider =

--- a/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/RequestContinuesRecorderAuthenticationHandler.java
+++ b/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/RequestContinuesRecorderAuthenticationHandler.java
@@ -25,10 +25,9 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
 import org.apache.hadoop.security.authentication.server.AuthenticationToken;
 
-/*
- * {@link AuthenticationHandler} that delegates to another {@link AuthenticationHandler}
- * and records the response of managementOperation (which indicates whether the request
- * should continue or not).
+/**
+ * {@link AuthenticationHandler} that delegates to another {@link AuthenticationHandler} and records
+ * the response of managementOperation (which indicates whether the request should continue or not).
  */
 public class RequestContinuesRecorderAuthenticationHandler implements AuthenticationHandler {
   // filled in by Plugin/Filter

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/HttpParamDelegationTokenPlugin.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/HttpParamDelegationTokenPlugin.java
@@ -19,8 +19,8 @@ package org.apache.solr.security.hadoop;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -273,7 +273,7 @@ public class HttpParamDelegationTokenPlugin extends KerberosPlugin {
         throws IOException, ServletException {
       // remove the filter-specific authentication information, so it doesn't get accidentally
       // forwarded.
-      List<NameValuePair> newPairs = new LinkedList<NameValuePair>();
+      List<NameValuePair> newPairs = new ArrayList<>();
       List<NameValuePair> pairs =
           URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
       for (NameValuePair nvp : pairs) {

--- a/solr/modules/hdfs/src/test/org/apache/hadoop/fs/FileUtil.java
+++ b/solr/modules/hdfs/src/test/org/apache/hadoop/fs/FileUtil.java
@@ -888,7 +888,7 @@ public class FileUtil {
 
   private static void unTarUsingTar(File inFile, File untarDir,
       boolean gzipped) throws IOException {
-    StringBuffer untarCommand = new StringBuffer();
+    StringBuilder untarCommand = new StringBuilder();
     // not using canonical path here; this postpones relative path
     // resolution until bash is executed.
     final String source = "'" + FileUtil.makeSecureShellPath(inFile) + "'";

--- a/solr/modules/hdfs/src/test/org/apache/solr/hdfs/search/TestRecoveryHdfs.java
+++ b/solr/modules/hdfs/src/test/org/apache/solr/hdfs/search/TestRecoveryHdfs.java
@@ -718,6 +718,7 @@ public class TestRecoveryHdfs extends SolrTestCaseJ4 {
   }
 
   @Test
+  @SuppressWarnings("JdkObsolete")
   public void testRemoveOldLogs() throws Exception {
     try {
       TestInjection.skipIndexWriterCommitOnClose = true;

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/interleaving/algorithms/TeamDraftInterleaving.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/interleaving/algorithms/TeamDraftInterleaving.java
@@ -19,7 +19,7 @@ package org.apache.solr.ltr.interleaving.algorithms;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import org.apache.lucene.search.ScoreDoc;
@@ -79,7 +79,7 @@ public class TeamDraftInterleaving implements Interleaving {
    * @return the interleaved ranking list
    */
   public InterleavingResult interleave(ScoreDoc[] rerankedA, ScoreDoc[] rerankedB) {
-    LinkedList<ScoreDoc> interleavedResults = new LinkedList<>();
+    List<ScoreDoc> interleavedResults = new ArrayList<>();
     HashSet<Integer> alreadyAdded = new HashSet<>();
     ScoreDoc[] interleavedResultArray = new ScoreDoc[rerankedA.length];
     ArrayList<Set<Integer>> interleavingPicks = new ArrayList<>(2);

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/MultipleAdditiveTreesModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/MultipleAdditiveTreesModel.java
@@ -16,11 +16,12 @@
  */
 package org.apache.solr.ltr.model;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.apache.solr.ltr.feature.Feature;
@@ -221,11 +222,7 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
 
     @Override
     public String toString() {
-      final StringBuilder sb = new StringBuilder();
-      sb.append("(weight=").append(weight);
-      sb.append(",root=").append(root);
-      sb.append(")");
-      return sb.toString();
+      return "(weight=" + weight + ",root=" + root + ")";
     }
 
     public RegressionTree() {}
@@ -309,10 +306,10 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
   private static void validateNode(RegressionTreeNode regressionTreeNode) throws ModelException {
 
     // Create an empty stack and push root to it
-    Stack<RegressionTreeNode> stack = new Stack<RegressionTreeNode>();
+    Deque<RegressionTreeNode> stack = new ArrayDeque<>();
     stack.push(regressionTreeNode);
 
-    while (stack.empty() == false) {
+    while (!stack.isEmpty()) {
       RegressionTreeNode topStackNode = stack.pop();
 
       if (topStackNode.isLeaf()) {
@@ -345,15 +342,17 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
     final StringBuilder returnValueBuilder = new StringBuilder();
     while (true) {
       if (regressionTreeNode.isLeaf()) {
-        returnValueBuilder.append("val: " + regressionTreeNode.value);
+        returnValueBuilder.append("val: ").append(regressionTreeNode.value);
         return returnValueBuilder.toString();
       }
 
       // unsupported feature (tree is looking for a feature that does not exist)
       if ((regressionTreeNode.featureIndex < 0)
           || (regressionTreeNode.featureIndex >= featureVector.length)) {
-        returnValueBuilder.append(
-            "'" + regressionTreeNode.feature + "' does not exist in FV, Return Zero");
+        returnValueBuilder
+            .append("'")
+            .append(regressionTreeNode.feature)
+            .append("' does not exist in FV, Return Zero");
         return returnValueBuilder.toString();
       }
 
@@ -362,24 +361,24 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
       // that here
 
       if (featureVector[regressionTreeNode.featureIndex] <= regressionTreeNode.threshold) {
-        returnValueBuilder.append(
-            "'"
-                + regressionTreeNode.feature
-                + "':"
-                + featureVector[regressionTreeNode.featureIndex]
-                + " <= "
-                + regressionTreeNode.threshold
-                + ", Go Left | ");
+        returnValueBuilder
+            .append("'")
+            .append(regressionTreeNode.feature)
+            .append("':")
+            .append(featureVector[regressionTreeNode.featureIndex])
+            .append(" <= ")
+            .append(regressionTreeNode.threshold)
+            .append(", Go Left | ");
         regressionTreeNode = regressionTreeNode.left;
       } else {
-        returnValueBuilder.append(
-            "'"
-                + regressionTreeNode.feature
-                + "':"
-                + featureVector[regressionTreeNode.featureIndex]
-                + " > "
-                + regressionTreeNode.threshold
-                + ", Go Right | ");
+        returnValueBuilder
+            .append("'")
+            .append(regressionTreeNode.feature)
+            .append("':")
+            .append(featureVector[regressionTreeNode.featureIndex])
+            .append(" > ")
+            .append(regressionTreeNode.threshold)
+            .append(", Go Right | ");
         regressionTreeNode = regressionTreeNode.right;
       }
     }

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -2348,7 +2347,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
   }
 
   protected List<Tuple> getTuples(final SolrParams params, String baseUrl) throws IOException {
-    List<Tuple> tuples = new LinkedList<>();
+    List<Tuple> tuples = new ArrayList<>();
     try (TupleStream tupleStream = new SolrStream(baseUrl, params)) {
       tupleStream.open();
       for (; ; ) {

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/MetricsQueryTemplate.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/MetricsQueryTemplate.java
@@ -23,21 +23,20 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MetricsQueryTemplate {
-  /*
-  A regex with named groups is used to match template references to template + vars using the basic pattern:
-
-      $jq:<TEMPLATE>( <UNIQUE>, <KEYSELECTOR>, <METRIC>, <TYPE> )
-
-  For instance,
-
-      $jq:core(requests_total, endswith(".requestTimes"), count, COUNTER)
-
-  TEMPLATE = core
-  UNIQUE = requests_total (unique suffix for this metric, results in a metric named "solr_metrics_core_requests_total")
-  KEYSELECTOR = endswith(".requestTimes") (filter to select the specific key for this metric)
-  METRIC = count
-  TYPE = COUNTER
-  */
+  /**
+   * A regex with named groups is used to match template references to template + vars using the
+   * basic pattern:
+   *
+   * <p>$jq:<TEMPLATE>( <UNIQUE>, <KEYSELECTOR>, <METRIC>, <TYPE> )
+   *
+   * <p>For instance,
+   *
+   * <p>$jq:core(requests_total, endswith(".requestTimes"), count, COUNTER)
+   *
+   * <p>TEMPLATE = core UNIQUE = requests_total (unique suffix for this metric, results in a metric
+   * named "solr_metrics_core_requests_total") KEYSELECTOR = endswith(".requestTimes") (filter to
+   * select the specific key for this metric) METRIC = count TYPE = COUNTER
+   */
   private static final Pattern matchJqTemplate =
       Pattern.compile(
           "^\\$jq:(?<TEMPLATE>.*?)\\(\\s?(?<UNIQUE>[^,]*),\\s?(?<KEYSELECTOR>[^,]*)(,\\s?(?<METRIC>[^,]*)\\s?)?(,\\s?(?<TYPE>[^,]*)\\s?)?\\)$");

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/DistribStateManager.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/DistribStateManager.java
@@ -17,10 +17,10 @@
 package org.apache.solr.client.solrj.cloud;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -96,7 +96,7 @@ public interface DistribStateManager extends SolrCloseable {
    */
   default List<String> listTree(String root)
       throws NoSuchElementException, IOException, KeeperException, InterruptedException {
-    Deque<String> queue = new LinkedList<>();
+    Deque<String> queue = new ArrayDeque<>();
     List<String> tree = new ArrayList<>();
     if (!root.startsWith("/")) {
       root = "/" + root;

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/VMParamsZkCredentialsInjector.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/VMParamsZkCredentialsInjector.java
@@ -24,7 +24,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import org.apache.solr.common.SolrException;
@@ -119,16 +118,9 @@ public class VMParamsZkCredentialsInjector implements ZkCredentialsInjector {
         credentialsProps.getProperty(zkDigestReadonlyPasswordVMParamName);
 
     List<ZkCredential> zkCredentials =
-        new ArrayList<>(2) {
-          {
-            ZkCredential allUser =
-                new ZkCredential(digestAllUsername, digestAllPassword, Perms.ALL);
-            ZkCredential readUser =
-                new ZkCredential(digestReadonlyUsername, digestReadonlyPassword, Perms.READ);
-            add(allUser);
-            add(readUser);
-          }
-        };
+        List.of(
+            new ZkCredential(digestAllUsername, digestAllPassword, Perms.ALL),
+            new ZkCredential(digestReadonlyUsername, digestReadonlyPassword, Perms.READ));
     log.info(
         "Using zkCredentials: digestAllUsername: {}, digestReadonlyUsername: {}",
         digestAllUsername,

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/SocketProxy.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/SocketProxy.java
@@ -27,7 +27,6 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +57,7 @@ public class SocketProxy {
 
   private CountDownLatch closed = new CountDownLatch(1);
 
-  public List<Bridge> connections = new LinkedList<>();
+  public List<Bridge> connections = new ArrayList<>();
 
   private final int listenPort;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
@@ -20,8 +20,8 @@ package org.apache.solr.client.solrj.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayDeque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -146,7 +146,7 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
     this.shutdownClient = builder.closeHttp2Client;
     this.threadCount = builder.threadCount;
     this.queue = new CustomBlockingQueue<>(builder.queueSize, threadCount, END_UPDATE);
-    this.runners = new LinkedList<>();
+    this.runners = new ArrayDeque<>();
     this.streamDeletes = builder.streamDeletes;
     this.basePath = builder.baseSolrUrl;
     this.stallTime = Integer.getInteger("solr.cloud.client.stallTime", 15000);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Locale;
 import java.util.Queue;
 import java.util.Set;
@@ -111,7 +111,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
     this.client.setFollowRedirects(false);
     this.queue = new LinkedBlockingQueue<>(builder.queueSize);
     this.threadCount = builder.threadCount;
-    this.runners = new LinkedList<>();
+    this.runners = new ArrayDeque<>();
     this.streamDeletes = builder.streamDeletes;
     this.connectionTimeout = builder.connectionTimeoutMillis;
     this.soTimeout = builder.socketTimeoutMillis;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -32,12 +32,12 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -132,7 +132,7 @@ public class Http2SolrClient extends SolrClient {
 
   private ResponseParser parser = new BinaryResponseParser();
   private volatile RequestWriter requestWriter = new BinaryRequestWriter();
-  private List<HttpListenerFactory> listenerFactory = new LinkedList<>();
+  private List<HttpListenerFactory> listenerFactory = new ArrayList<>();
   private AsyncTracker asyncTracker = new AsyncTracker();
   /** The URL of the Solr server. */
   private String serverBaseUrl;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -31,12 +31,12 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -393,7 +393,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
                   || (streams != null && streams.size() > 1))
               && !hasNullStreamName;
 
-      LinkedList<NameValuePair> postOrPutParams = new LinkedList<>();
+      List<NameValuePair> postOrPutParams = new ArrayList<>();
 
       if (contentWriter != null) {
         String fullQueryUrl = url + wparams.toQueryString();
@@ -475,7 +475,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
       Collection<ContentStream> streams,
       ModifiableSolrParams wparams,
       boolean isMultipart,
-      LinkedList<NameValuePair> postOrPutParams,
+      List<NameValuePair> postOrPutParams,
       String fullQueryUrl)
       throws IOException {
     HttpEntityEnclosingRequestBase postOrPut =
@@ -487,7 +487,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
       postOrPut.addHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
     }
 
-    List<FormBodyPart> parts = new LinkedList<>();
+    List<FormBodyPart> parts = new ArrayList<>();
     Iterator<String> iter = wparams.getParameterNamesIterator();
     while (iter.hasNext()) {
       String p = iter.next();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/comp/MultipleFieldComparator.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/comp/MultipleFieldComparator.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.stream.expr.Explanation;
 import org.apache.solr.client.solrj.io.stream.expr.Explanation.ExpressionType;
-import org.apache.solr.client.solrj.io.stream.expr.Expressible;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
@@ -74,11 +73,11 @@ public class MultipleFieldComparator implements StreamComparator {
   public StreamExpressionParameter toExpression(StreamFactory factory) throws IOException {
     StringBuilder sb = new StringBuilder();
     for (StreamComparator comp : comps) {
-      if (comp instanceof Expressible) {
+      if (comp != null) {
         if (sb.length() > 0) {
           sb.append(",");
         }
-        sb.append(((Expressible) comp).toExpression(factory));
+        sb.append(comp.toExpression(factory));
       } else {
         throw new IOException(
             "This MultiComp contains a non-expressible comparator - it cannot be converted to an expression");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/eq/MultipleFieldEqualitor.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/eq/MultipleFieldEqualitor.java
@@ -96,17 +96,15 @@ public class MultipleFieldEqualitor implements StreamEqualitor {
     if (null == base) {
       return false;
     }
-    if (base instanceof StreamComparator) {
-      MultipleFieldComparator baseComps = (MultipleFieldComparator) base;
+    MultipleFieldComparator baseComps = (MultipleFieldComparator) base;
 
-      if (baseComps.getComps().length >= eqs.length) {
-        for (int idx = 0; idx < eqs.length; ++idx) {
-          if (!eqs[idx].isDerivedFrom(baseComps.getComps()[idx])) {
-            return false;
-          }
+    if (baseComps.getComps().length >= eqs.length) {
+      for (int idx = 0; idx < eqs.length; ++idx) {
+        if (!eqs[idx].isDerivedFrom(baseComps.getComps()[idx])) {
+          return false;
         }
-        return true;
       }
+      return true;
     }
 
     return false;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/eval/ExponentialMovingAverageEvaluator.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/eval/ExponentialMovingAverageEvaluator.java
@@ -56,7 +56,7 @@ public class ExponentialMovingAverageEvaluator extends RecursiveNumericEvaluator
     Number window = (Number) values[1];
     Number alpha;
     if (2 == values.length) {
-      if (!(observations instanceof List<?>)) {
+      if (observations == null) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -72,7 +72,7 @@ public class ExponentialMovingAverageEvaluator extends RecursiveNumericEvaluator
                 toExpression(constructingFactory),
                 observations.size()));
       }
-      if (!(window instanceof Number)) {
+      if (window == null) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -93,7 +93,7 @@ public class ExponentialMovingAverageEvaluator extends RecursiveNumericEvaluator
 
     if (3 == values.length) {
       alpha = (Number) values[2];
-      if (!(alpha instanceof Number)) {
+      if (alpha == null) {
         throw new IOException(
             String.format(
                 Locale.ROOT,

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/eval/FindDelayEvaluator.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/eval/FindDelayEvaluator.java
@@ -17,12 +17,12 @@
 package org.apache.solr.client.solrj.io.eval;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.commons.math3.util.MathArrays;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
@@ -74,10 +74,7 @@ public class FindDelayEvaluator extends RecursiveNumericEvaluator implements Two
     double[] secondArray =
         StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(
-                    ((LinkedList<?>)
-                            ((List<?>) second)
-                                .stream().collect(Collectors.toCollection(LinkedList::new)))
-                        .descendingIterator(),
+                    ((Deque<?>) new ArrayDeque<>(((List<?>) second))).descendingIterator(),
                     Spliterator.ORDERED),
                 false)
             .mapToDouble(value -> ((Number) value).doubleValue())

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/eval/TimeDifferencingEvaluator.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/eval/TimeDifferencingEvaluator.java
@@ -59,14 +59,6 @@ public class TimeDifferencingEvaluator extends RecursiveObjectEvaluator implemen
       Number lagValue = 1;
 
       if (1 == values.length) {
-        if (!(timeseriesValues instanceof List<?>)) {
-          throw new IOException(
-              String.format(
-                  Locale.ROOT,
-                  "Invalid expression %s - found type %s for the first value, expecting a List",
-                  toExpression(constructingFactory),
-                  values[0].getClass().getSimpleName()));
-        }
         if (!(timeseriesValues.size() > 1)) {
           throw new IOException(
               String.format(
@@ -78,7 +70,7 @@ public class TimeDifferencingEvaluator extends RecursiveObjectEvaluator implemen
       }
       if (2 == values.length) {
         lagValue = (Number) values[1];
-        if (!(lagValue instanceof Number)) {
+        if (lagValue == null) {
           throw new IOException(
               String.format(
                   Locale.ROOT,
@@ -114,7 +106,7 @@ public class TimeDifferencingEvaluator extends RecursiveObjectEvaluator implemen
 
       if (2 == values.length) {
         lagValue = (Number) values[1];
-        if (!(lagValue instanceof Number)) {
+        if (lagValue == null) {
           throw new IOException(
               String.format(
                   Locale.ROOT,

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
@@ -388,8 +388,7 @@ public class GatherNodesStream extends TupleStream implements Expressible {
     Set<Map.Entry<String, String>> entries = queryParams.entrySet();
     // parameters
     for (Map.Entry<String, String> param : entries) {
-      assert param.getKey() instanceof String && param.getValue() instanceof String
-          : "Bad types passed";
+      assert param.getKey() != null && param.getValue() != null : "Bad types passed";
       String value = param.getValue().toString();
 
       // SOLR-8409: This is a special case where the params contain a " character

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
@@ -556,7 +556,7 @@ public class GatherNodesStream extends TupleStream implements Expressible {
       joinSParams.set("qt", "/export");
       joinSParams.set(SORT, gather + " asc," + traverseTo + " asc");
 
-      StringBuffer nodeQuery = new StringBuffer();
+      StringBuilder nodeQuery = new StringBuilder();
 
       boolean comma = false;
       for (String node : nodes) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/ops/GroupOperation.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/ops/GroupOperation.java
@@ -20,9 +20,10 @@ import static org.apache.solr.common.params.CommonParams.SORT;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -116,7 +117,7 @@ public class GroupOperation implements ReduceOperation {
   }
 
   public Tuple reduce() {
-    LinkedList<Map<String, Object>> ll = new LinkedList<>();
+    Deque<Map<String, Object>> ll = new ArrayDeque<>();
     while (priorityQueue.size() > 0) {
       ll.addFirst(priorityQueue.poll().getFields());
       // This will clear priority queue and so it will be ready for the next group.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/CartesianProductStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/CartesianProductStream.java
@@ -17,10 +17,11 @@
 package org.apache.solr.client.solrj.io.stream;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -52,7 +53,7 @@ public class CartesianProductStream extends TupleStream implements Expressible {
   private StreamComparator orderBy;
 
   // Used to contain the sorted queue of generated tuples
-  private LinkedList<Tuple> generatedTuples;
+  private Deque<Tuple> generatedTuples;
 
   public CartesianProductStream(StreamExpression expression, StreamFactory factory)
       throws IOException {
@@ -238,7 +239,7 @@ public class CartesianProductStream extends TupleStream implements Expressible {
     return generatedTuples.pop();
   }
 
-  private LinkedList<Tuple> generateTupleList(Tuple original) throws IOException {
+  private Deque<Tuple> generateTupleList(Tuple original) throws IOException {
     Map<String, Object> evaluatedValues = new HashMap<>();
 
     for (NamedEvaluator evaluator : evaluators) {
@@ -270,7 +271,7 @@ public class CartesianProductStream extends TupleStream implements Expressible {
       generatedTupleList.sort(orderBy);
     }
 
-    return new LinkedList<>(generatedTupleList);
+    return new ArrayDeque<>(generatedTupleList);
   }
 
   private boolean iterate(
@@ -319,7 +320,7 @@ public class CartesianProductStream extends TupleStream implements Expressible {
 
   public void open() throws IOException {
     stream.open();
-    generatedTuples = new LinkedList<>();
+    generatedTuples = new ArrayDeque<>();
   }
 
   public void close() throws IOException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/ComplementStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/ComplementStream.java
@@ -117,7 +117,7 @@ public class ComplementStream extends TupleStream implements Expressible {
 
     if (includeStreams) {
       // streams
-      if (streamA instanceof Expressible) {
+      if (streamA != null) {
         expression.addParameter(((Expressible) streamA).toExpression(factory));
       } else {
         throw new IOException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/DeepRandomStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/DeepRandomStream.java
@@ -21,11 +21,12 @@ import static org.apache.solr.common.params.CommonParams.ROWS;
 import static org.apache.solr.common.params.CommonParams.SORT;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -72,7 +73,7 @@ public class DeepRandomStream extends TupleStream implements Expressible {
   protected transient Map<String, Tuple> eofTuples;
   protected transient CloudSolrClient cloudSolrClient;
   protected transient List<TupleStream> solrStreams;
-  protected transient LinkedList<TupleWrapper> tuples;
+  protected transient Deque<TupleWrapper> tuples;
   protected transient StreamContext streamContext;
 
   public DeepRandomStream() {
@@ -270,7 +271,7 @@ public class DeepRandomStream extends TupleStream implements Expressible {
   }
 
   public void open() throws IOException {
-    this.tuples = new LinkedList<>();
+    this.tuples = new ArrayDeque<>();
     this.solrStreams = new ArrayList<>();
     this.eofTuples = Collections.synchronizedMap(new HashMap<>());
     constructStreams();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/FetchStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/FetchStream.java
@@ -324,7 +324,7 @@ public class FetchStream extends TupleStream implements Expressible {
   }
 
   private String appendFields() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     if (appendKey) {
       buf.append(",");
       buf.append(rightKey);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/HavingStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/HavingStream.java
@@ -112,7 +112,7 @@ public class HavingStream extends TupleStream implements Expressible {
       expression.addParameter("<stream>");
     }
 
-    if (evaluator instanceof Expressible) {
+    if (evaluator != null) {
       expression.addParameter(evaluator.toExpression(factory));
     } else {
       throw new IOException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/InnerJoinStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/InnerJoinStream.java
@@ -32,10 +32,14 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
  * @since 6.0.0
  */
 public class InnerJoinStream extends BiJoinStream implements Expressible {
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> joinedTuples = new LinkedList<>();
 
-  private LinkedList<Tuple> joinedTuples = new LinkedList<>();
-  private LinkedList<Tuple> leftTupleGroup = new LinkedList<>();
-  private LinkedList<Tuple> rightTupleGroup = new LinkedList<>();
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> leftTupleGroup = new LinkedList<>();
+
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> rightTupleGroup = new LinkedList<>();
 
   public InnerJoinStream(TupleStream leftStream, TupleStream rightStream, StreamEqualitor eq)
       throws IOException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/IntersectStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/IntersectStream.java
@@ -117,7 +117,7 @@ public class IntersectStream extends TupleStream implements Expressible {
 
     if (includeStreams) {
       // streams
-      if (streamA instanceof Expressible) {
+      if (streamA != null) {
         expression.addParameter(((Expressible) streamA).toExpression(factory));
       } else {
         throw new IOException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JoinStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JoinStream.java
@@ -121,9 +121,8 @@ public abstract class JoinStream extends TupleStream implements Expressible {
     }
 
     // on
-    if (eq instanceof Expressible) {
-      expression.addParameter(
-          new StreamExpressionNamedParameter("on", ((Expressible) eq).toExpression(factory)));
+    if (eq != null) {
+      expression.addParameter(new StreamExpressionNamedParameter("on", eq.toExpression(factory)));
     } else {
       throw new IOException(
           "This JoinStream contains a non-expressible equalitor - it cannot be converted to an expression");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/LeftOuterJoinStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/LeftOuterJoinStream.java
@@ -33,9 +33,14 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
  */
 public class LeftOuterJoinStream extends BiJoinStream implements Expressible {
 
-  private LinkedList<Tuple> joinedTuples = new LinkedList<>();
-  private LinkedList<Tuple> leftTupleGroup = new LinkedList<>();
-  private LinkedList<Tuple> rightTupleGroup = new LinkedList<>();
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> joinedTuples = new LinkedList<>();
+
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> leftTupleGroup = new LinkedList<>();
+
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> rightTupleGroup = new LinkedList<>();
 
   public LeftOuterJoinStream(TupleStream leftStream, TupleStream rightStream, StreamEqualitor eq)
       throws IOException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/PriorityStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/PriorityStream.java
@@ -93,14 +93,14 @@ public class PriorityStream extends TupleStream implements Expressible {
 
     // stream
     if (includeStreams) {
-      if (highPriorityTasks instanceof Expressible) {
+      if (highPriorityTasks != null) {
         expression.addParameter(((Expressible) highPriorityTasks).toExpression(factory));
       } else {
         throw new IOException(
             "The SchedulerStream contains a non-expressible TupleStream - it cannot be converted to an expression");
       }
 
-      if (tasks instanceof Expressible) {
+      if (tasks != null) {
         expression.addParameter(((Expressible) tasks).toExpression(factory));
       } else {
         throw new IOException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/RankStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/RankStream.java
@@ -20,9 +20,10 @@ import static org.apache.solr.common.params.CommonParams.SORT;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.PriorityQueue;
@@ -52,7 +53,7 @@ public class RankStream extends TupleStream implements Expressible {
   private int size;
   private transient PriorityQueue<Tuple> top;
   private transient boolean finished = false;
-  private transient LinkedList<Tuple> topList;
+  private transient Deque<Tuple> topList;
 
   public RankStream(TupleStream tupleStream, int size, StreamComparator comp) throws IOException {
     init(tupleStream, size, comp);
@@ -191,7 +192,7 @@ public class RankStream extends TupleStream implements Expressible {
 
   public void open() throws IOException {
     this.top = new PriorityQueue<>(size, new ReverseComp(comp));
-    this.topList = new LinkedList<>();
+    this.topList = new ArrayDeque<>();
     stream.open();
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/ReducerStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/ReducerStream.java
@@ -169,15 +169,14 @@ public class ReducerStream extends TupleStream implements Expressible {
     }
 
     // over
-    if (eq instanceof Expressible) {
-      expression.addParameter(
-          new StreamExpressionNamedParameter("by", ((Expressible) eq).toExpression(factory)));
+    if (eq != null) {
+      expression.addParameter(new StreamExpressionNamedParameter("by", eq.toExpression(factory)));
     } else {
       throw new IOException(
           "This ReducerStream contains a non-expressible comparator - it cannot be converted to an expression");
     }
 
-    if (op instanceof Expressible) {
+    if (op != null) {
       expression.addParameter(op.toExpression(factory));
     } else {
       throw new IOException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SortStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SortStream.java
@@ -143,10 +143,9 @@ public class SortStream extends TupleStream implements Expressible {
     }
 
     // by
-    if (comparator instanceof Expressible) {
+    if (comparator != null) {
       expression.addParameter(
-          new StreamExpressionNamedParameter(
-              "by", ((Expressible) comparator).toExpression(factory)));
+          new StreamExpressionNamedParameter("by", comparator.toExpression(factory)));
     } else {
       throw new IOException(
           "This SortStream contains a non-expressible equalitor - it cannot be converted to an expression");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SortStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SortStream.java
@@ -95,7 +95,9 @@ public class SortStream extends TupleStream implements Expressible {
     worker =
         new Worker() {
 
-          private LinkedList<Tuple> tuples = new LinkedList<>();
+          @SuppressWarnings("JdkObsolete")
+          private final LinkedList<Tuple> tuples = new LinkedList<>();
+
           private Tuple eofTuple;
 
           public void readStream(TupleStream stream) throws IOException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TupleStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TupleStream.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -125,7 +124,7 @@ public abstract class TupleStream implements Closeable, Serializable, MapWriter 
   static List<Replica> getReplicas(
       String zkHost, String collection, StreamContext streamContext, SolrParams requestParams)
       throws IOException {
-    List<Replica> replicas = new LinkedList<>();
+    List<Replica> replicas = new ArrayList<>();
 
     // SolrCloud Sharding
     SolrClientCache solrClientCache =

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/UniqueStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/UniqueStream.java
@@ -127,10 +127,9 @@ public class UniqueStream extends TupleStream implements Expressible {
     }
 
     // over
-    if (originalEqualitor instanceof Expressible) {
+    if (originalEqualitor != null) {
       expression.addParameter(
-          new StreamExpressionNamedParameter(
-              "over", ((Expressible) originalEqualitor).toExpression(factory)));
+          new StreamExpressionNamedParameter("over", originalEqualitor.toExpression(factory)));
     } else {
       throw new IOException(
           "This UniqueStream contains a non-expressible equalitor - it cannot be converted to an expression");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/UpdateStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/UpdateStream.java
@@ -185,7 +185,7 @@ public class UpdateStream extends TupleStream implements Expressible {
         new StreamExpressionNamedParameter("batchSize", Integer.toString(updateBatchSize)));
 
     if (includeStreams) {
-      if (tupleSource instanceof Expressible) {
+      if (tupleSource != null) {
         expression.addParameter(((Expressible) tupleSource).toExpression(factory));
       } else {
         throw new IOException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/metrics/WeightedSumMetric.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/metrics/WeightedSumMetric.java
@@ -17,7 +17,7 @@
 package org.apache.solr.client.solrj.io.stream.metrics;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.apache.solr.client.solrj.io.Tuple;
@@ -81,7 +81,7 @@ public class WeightedSumMetric extends Metric {
     Object o = tuple.get(valueCol);
     if (c instanceof Number && o instanceof Number) {
       if (parts == null) {
-        parts = new LinkedList<>();
+        parts = new ArrayList<>();
       }
       Number count = (Number) c;
       Number value = (Number) o;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/FieldAnalysisRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/FieldAnalysisRequest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.client.solrj.request;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -183,7 +183,7 @@ public class FieldAnalysisRequest extends SolrRequest<FieldAnalysisResponse> {
    */
   public FieldAnalysisRequest addFieldName(String fieldName) {
     if (fieldNames == null) {
-      fieldNames = new LinkedList<>();
+      fieldNames = new ArrayList<>();
     }
     fieldNames.add(fieldName);
     return this;
@@ -218,7 +218,7 @@ public class FieldAnalysisRequest extends SolrRequest<FieldAnalysisResponse> {
    */
   public FieldAnalysisRequest addFieldType(String fieldTypeName) {
     if (fieldTypes == null) {
-      fieldTypes = new LinkedList<>();
+      fieldTypes = new ArrayList<>();
     }
     fieldTypes.add(fieldTypeName);
     return this;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/PackagePayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/PackagePayload.java
@@ -22,7 +22,7 @@ import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.util.ReflectMapWriter;
 
 /** Just a container class for POJOs used in Package APIs */
-public class Package {
+public class PackagePayload {
   public static class AddVersion implements ReflectMapWriter {
     @JsonProperty(value = "package", required = true)
     public String pkg;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/schema/SchemaRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/schema/SchemaRequest.java
@@ -18,7 +18,7 @@ package org.apache.solr.client.solrj.request.schema;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.client.solrj.SolrClient;
@@ -105,7 +105,7 @@ public class SchemaRequest extends AbstractSchemaRequest<SchemaResponse> {
     if (analyzerAttributes != null) analyzerNamedList.addAll(analyzerAttributes);
     List<Map<String, Object>> charFiltersAttributes = analyzerDefinition.getCharFilters();
     if (charFiltersAttributes != null) {
-      List<NamedList<Object>> charFiltersList = new LinkedList<>();
+      List<NamedList<Object>> charFiltersList = new ArrayList<>();
       for (Map<String, Object> charFilterAttributes : charFiltersAttributes)
         charFiltersList.add(new NamedList<>(charFilterAttributes));
       analyzerNamedList.add("charFilters", charFiltersList);
@@ -116,7 +116,7 @@ public class SchemaRequest extends AbstractSchemaRequest<SchemaResponse> {
     }
     List<Map<String, Object>> filtersAttributes = analyzerDefinition.getFilters();
     if (filtersAttributes != null) {
-      List<NamedList<Object>> filtersList = new LinkedList<>();
+      List<NamedList<Object>> filtersList = new ArrayList<>();
       for (Map<String, Object> filterAttributes : filtersAttributes)
         filtersList.add(new NamedList<>(filterAttributes));
       analyzerNamedList.add("filters", filtersList);
@@ -758,7 +758,7 @@ public class SchemaRequest extends AbstractSchemaRequest<SchemaResponse> {
    * call either succeed or fail together.
    */
   public static class MultiUpdate extends Update {
-    private List<Update> updateSchemaRequests = new LinkedList<>();
+    private final List<Update> updateSchemaRequests = new ArrayList<>();
 
     public MultiUpdate(List<Update> updateSchemaRequests) {
       this(updateSchemaRequests, null);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/SuggesterResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/SuggesterResponse.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.client.solrj.response;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.common.util.NamedList;
@@ -39,7 +39,7 @@ public class SuggesterResponse {
       final NamedList<Object> outerValue = suggestInfo.getVal(i);
 
       SimpleOrderedMap<?> suggestionsNode = (SimpleOrderedMap<?>) outerValue.getVal(0);
-      List<Suggestion> suggestionList = new LinkedList<>();
+      List<Suggestion> suggestionList = new ArrayList<>();
       if (suggestionsNode != null) {
         @SuppressWarnings("unchecked")
         List<SimpleOrderedMap<?>> suggestionListToParse =
@@ -77,7 +77,7 @@ public class SuggesterResponse {
     Map<String, List<String>> suggestedTermsPerDictionary = new LinkedHashMap<>();
     for (Map.Entry<String, List<Suggestion>> entry : suggestionsPerDictionary.entrySet()) {
       List<Suggestion> suggestions = entry.getValue();
-      List<String> suggestionTerms = new LinkedList<>();
+      List<String> suggestionTerms = new ArrayList<>();
       for (Suggestion s : suggestions) {
         suggestionTerms.add(s.getTerm());
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/schema/SchemaResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/schema/SchemaResponse.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.client.solrj.response.schema;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.client.solrj.request.schema.AnalyzerDefinition;
@@ -57,7 +57,7 @@ public class SchemaResponse extends SolrResponseBase {
     List<NamedList<Object>> charFiltersList =
         (List<NamedList<Object>>) analyzerNamedList.get("charFilters");
     if (charFiltersList != null) {
-      List<Map<String, Object>> charFiltersAttributesList = new LinkedList<>();
+      List<Map<String, Object>> charFiltersAttributesList = new ArrayList<>();
       for (NamedList<Object> charFilterNamedList : charFiltersList) {
         Map<String, Object> charFilterAttributes = extractAttributeMap(charFilterNamedList);
         charFiltersAttributesList.add(charFilterAttributes);
@@ -71,7 +71,7 @@ public class SchemaResponse extends SolrResponseBase {
     }
     List<NamedList<Object>> filtersList =
         (List<NamedList<Object>>) analyzerNamedList.get("filters");
-    List<Map<String, Object>> filtersAttributesList = new LinkedList<>();
+    List<Map<String, Object>> filtersAttributesList = new ArrayList<>();
     if (filtersList != null) {
       for (NamedList<Object> filterNamedList : filtersList) {
         Map<String, Object> filterAttributes = extractAttributeMap(filterNamedList);
@@ -177,7 +177,7 @@ public class SchemaResponse extends SolrResponseBase {
   @SuppressWarnings("unchecked")
   private static List<Map<String, Object>> getFields(
       @SuppressWarnings({"rawtypes"}) Map schemaNamedList) {
-    List<Map<String, Object>> fieldsAttributes = new LinkedList<>();
+    List<Map<String, Object>> fieldsAttributes = new ArrayList<>();
     List<NamedList<Object>> fieldsResponse =
         (List<NamedList<Object>>) schemaNamedList.get("fields");
     for (NamedList<Object> fieldNamedList : fieldsResponse) {
@@ -192,7 +192,7 @@ public class SchemaResponse extends SolrResponseBase {
   @SuppressWarnings("unchecked")
   private static List<Map<String, Object>> getDynamicFields(
       @SuppressWarnings({"rawtypes"}) Map schemaNamedList) {
-    List<Map<String, Object>> dynamicFieldsAttributes = new LinkedList<>();
+    List<Map<String, Object>> dynamicFieldsAttributes = new ArrayList<>();
     List<NamedList<Object>> dynamicFieldsResponse =
         (List<NamedList<Object>>) schemaNamedList.get("dynamicFields");
     for (NamedList<Object> fieldNamedList : dynamicFieldsResponse) {
@@ -207,7 +207,7 @@ public class SchemaResponse extends SolrResponseBase {
   @SuppressWarnings("unchecked")
   private static List<Map<String, Object>> getCopyFields(
       @SuppressWarnings({"rawtypes"}) Map schemaNamedList) {
-    List<Map<String, Object>> copyFieldsAttributes = new LinkedList<>();
+    List<Map<String, Object>> copyFieldsAttributes = new ArrayList<>();
     List<NamedList<Object>> copyFieldsResponse =
         (List<NamedList<Object>>) schemaNamedList.get("copyFields");
     for (NamedList<Object> copyFieldNamedList : copyFieldsResponse) {
@@ -222,7 +222,7 @@ public class SchemaResponse extends SolrResponseBase {
   @SuppressWarnings("unchecked")
   private static List<FieldTypeDefinition> getFieldTypeDefinitions(
       @SuppressWarnings({"rawtypes"}) Map schemaNamedList) {
-    List<FieldTypeDefinition> fieldTypeDefinitions = new LinkedList<>();
+    List<FieldTypeDefinition> fieldTypeDefinitions = new ArrayList<>();
     List<NamedList<Object>> fieldsResponse =
         (List<NamedList<Object>>) schemaNamedList.get("fieldTypes");
     for (NamedList<Object> fieldNamedList : fieldsResponse) {
@@ -236,7 +236,7 @@ public class SchemaResponse extends SolrResponseBase {
   @SuppressWarnings("unchecked")
   private static List<FieldTypeRepresentation> getFieldTypeRepresentations(
       @SuppressWarnings({"rawtypes"}) Map schemaNamedList) {
-    List<FieldTypeRepresentation> fieldTypeRepresentations = new LinkedList<>();
+    List<FieldTypeRepresentation> fieldTypeRepresentations = new ArrayList<>();
     List<NamedList<Object>> fieldsResponse =
         (List<NamedList<Object>>) schemaNamedList.get("fieldTypes");
     for (NamedList<Object> fieldNamedList : fieldsResponse) {

--- a/solr/solrj/src/java/org/apache/solr/common/util/JsonRecordReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JsonRecordReader.java
@@ -30,14 +30,13 @@ import static org.noggit.JSONParser.STRING;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import org.noggit.JSONParser;
 
 /** A Streaming parser for json to emit one record at a time. */
@@ -285,14 +284,14 @@ public class JsonRecordReader {
         if (event == EOF) break;
         if (event == OBJECT_START) {
           handleObjectStart(
-              parser, handler, new LinkedHashMap<>(), new Stack<>(), recordStarted, null);
+              parser, handler, new LinkedHashMap<>(), new ArrayDeque<>(), recordStarted, null);
         } else if (event == ARRAY_START) {
           for (; ; ) {
             event = parser.nextEvent();
             if (event == ARRAY_END) break;
             if (event == OBJECT_START) {
               handleObjectStart(
-                  parser, handler, new LinkedHashMap<>(), new Stack<>(), recordStarted, null);
+                  parser, handler, new LinkedHashMap<>(), new ArrayDeque<>(), recordStarted, null);
             }
           }
         }
@@ -313,7 +312,7 @@ public class JsonRecordReader {
         final JSONParser parser,
         final Handler handler,
         final Map<String, Object> values,
-        final Stack<Set<String>> stack,
+        final ArrayDeque<Set<String>> stack,
         boolean recordStarted,
         MethodFrameWrapper frameWrapper)
         throws IOException {
@@ -369,7 +368,7 @@ public class JsonRecordReader {
                 parser,
                 (record, path) -> addChildDoc2ParentDoc(record, values, getPathSuffix(path)),
                 new LinkedHashMap<>(),
-                new Stack<>(),
+                new ArrayDeque<>(),
                 true,
                 this);
           } else {
@@ -519,7 +518,7 @@ public class JsonRecordReader {
    * multiple separators appear.
    */
   private static List<String> splitEscapeQuote(String str) {
-    List<String> result = new LinkedList<>();
+    List<String> result = new ArrayList<>();
     String[] ss = str.split("/");
     for (int i = 0; i < ss.length; i++) { // i=1: skip separator at start of string
       StringBuilder sb = new StringBuilder();

--- a/solr/solrj/src/java/org/apache/solr/common/util/JsonSchemaValidator.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JsonSchemaValidator.java
@@ -17,11 +17,11 @@
 
 package org.apache.solr.common.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -47,7 +47,7 @@ public class JsonSchemaValidator {
   }
 
   public JsonSchemaValidator(Map<?, ?> jsonSchema) {
-    this.validators = new LinkedList<>();
+    this.validators = new ArrayList<>();
     for (Map.Entry<?, ?> entry : jsonSchema.entrySet()) {
       Object fname = entry.getKey();
       if (KNOWN_FNAMES.contains(fname.toString())) continue;
@@ -82,7 +82,7 @@ public class JsonSchemaValidator {
   }
 
   public List<String> validateJson(Object data) {
-    List<String> errs = new LinkedList<>();
+    List<String> errs = new ArrayList<>();
     validate(data, errs);
     return errs.isEmpty() ? null : errs;
   }

--- a/solr/solrj/src/java/org/apache/solr/common/util/PathTrie.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/PathTrie.java
@@ -243,7 +243,7 @@ public class PathTrie<T> {
       if (n == null) {
         n = children.get("*");
         if (n != null) {
-          StringBuffer sb = new StringBuffer();
+          StringBuilder sb = new StringBuilder();
           for (int i = index; i < pathSegments.size(); i++) {
             sb.append("/").append(pathSegments.get(i));
           }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/graph/GraphExpressionTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/graph/GraphExpressionTest.java
@@ -150,7 +150,7 @@ public class GraphExpressionTest extends SolrCloudTestCase {
     assertEquals(2, tuples.size());
 
     for (Tuple tuple : tuples) {
-      paths.add(tuple.getStrings("path").toString());
+      paths.add(tuple.get("path").toString());
     }
 
     assertTrue(paths.contains("[jim, dave, alex, steve]"));
@@ -177,7 +177,7 @@ public class GraphExpressionTest extends SolrCloudTestCase {
     assertEquals(2, tuples.size());
 
     for (Tuple tuple : tuples) {
-      paths.add(tuple.getStrings("path").toString());
+      paths.add(tuple.get("path").toString());
     }
 
     assertTrue(paths.contains("[jim, dave, alex, steve]"));
@@ -241,7 +241,7 @@ public class GraphExpressionTest extends SolrCloudTestCase {
     assertEquals(1, tuples.size());
 
     for (Tuple tuple : tuples) {
-      paths.add(tuple.getStrings("path").toString());
+      paths.add(tuple.get("path").toString());
     }
 
     assertTrue(paths.contains("[jim, stan, mary, steve]"));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/graph/GraphTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/graph/GraphTest.java
@@ -46,8 +46,6 @@ public class GraphTest extends SolrCloudTestCase {
 
   private static final String id = "id";
 
-  private static final int TIMEOUT = 30;
-
   @BeforeClass
   public static void setupCluster() throws Exception {
     configureCluster(2)
@@ -112,7 +110,7 @@ public class GraphTest extends SolrCloudTestCase {
     assertEquals(2, tuples.size());
 
     for (Tuple tuple : tuples) {
-      paths.add(tuple.getStrings("path").toString());
+      paths.add(tuple.get("path").toString());
     }
 
     assertTrue(paths.contains("[jim, dave, alex, steve]"));
@@ -133,7 +131,7 @@ public class GraphTest extends SolrCloudTestCase {
     assertEquals(2, tuples.size());
 
     for (Tuple tuple : tuples) {
-      paths.add(tuple.getStrings("path").toString());
+      paths.add(tuple.get("path").toString());
     }
 
     assertTrue(paths.contains("[jim, dave, alex, steve]"));
@@ -178,7 +176,7 @@ public class GraphTest extends SolrCloudTestCase {
     assertEquals(1, tuples.size());
 
     for (Tuple tuple : tuples) {
-      paths.add(tuple.getStrings("path").toString());
+      paths.add(tuple.get("path").toString());
     }
 
     assertTrue(paths.contains("[jim, stan, mary, steve]"));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/JDBCStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/JDBCStreamTest.java
@@ -24,9 +24,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4.SuppressPointFields;
 import org.apache.solr.client.solrj.io.SolrClientCache;
@@ -301,12 +301,10 @@ public class JDBCStreamTest extends SolrCloudTestCase {
       TupleStream selectStream =
           new SelectStream(
               jdbcStream,
-              new HashMap<>() {
-                {
-                  put("CODE", "code_s");
-                  put("COUNTRY_NAME", "name_s");
-                }
-              });
+              Map.of(
+                  "CODE", "code_s",
+                  "COUNTRY_NAME", "name_s"));
+
       TupleStream searchStream =
           factory.constructStream(
               "search("

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/ParallelFacetStreamOverAliasTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/ParallelFacetStreamOverAliasTest.java
@@ -21,7 +21,6 @@ import static org.apache.solr.client.solrj.io.stream.FacetStream.TIERED_PARAM;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -110,7 +109,7 @@ public class ParallelFacetStreamOverAliasTest extends SolrCloudTestCase {
     }
 
     List<String> collections = new ArrayList<>(NUM_COLLECTIONS);
-    final List<Exception> errors = new LinkedList<>();
+    final List<Exception> errors = new ArrayList<>();
     Stream.iterate(1, n -> n + 1)
         .limit(NUM_COLLECTIONS)
         .forEach(
@@ -166,7 +165,7 @@ public class ParallelFacetStreamOverAliasTest extends SolrCloudTestCase {
       // cleanup the alias and the collections behind it
       CollectionAdminRequest.deleteAlias(ALIAS_NAME).process(cluster.getSolrClient());
       if (listOfCollections != null) {
-        final List<Exception> errors = new LinkedList<>();
+        final List<Exception> errors = new ArrayList<>();
         listOfCollections.stream()
             .map(CollectionAdminRequest::deleteCollection)
             .forEach(

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -3075,7 +3074,7 @@ public class StreamingTest extends SolrCloudTestCase {
         t = stream.read();
       }
 
-      List<String> baseUrls = new LinkedList<>();
+      List<String> baseUrls = new ArrayList<>();
       ZkStateReader zkStateReader = cluster.getZkStateReader();
       List<String> resolved =
           zkStateReader.aliasesManager.getAliases().resolveAliases(MULTI_REPLICA_COLLECTIONORALIAS);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/eval/FieldValueEvaluatorTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/eval/FieldValueEvaluatorTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.solr.client.solrj.io.stream.eval;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import org.apache.solr.SolrTestCase;
@@ -40,50 +40,15 @@ public class FieldValueEvaluatorTest extends SolrTestCase {
   @Test
   public void listTypes() throws Exception {
     values.clear();
-    values.put(
-        "a",
-        new ArrayList<Boolean>() {
-          {
-            add(true);
-            add(false);
-          }
-        });
-    values.put(
-        "b",
-        new ArrayList<Double>() {
-          {
-            add(0.0);
-            add(1.1);
-          }
-        });
-    values.put(
-        "c",
-        new ArrayList<Integer>() {
-          {
-            add(0);
-            add(1);
-          }
-        });
-    values.put(
-        "d",
-        new ArrayList<Long>() {
-          {
-            add(0L);
-            add(1L);
-          }
-        });
-    values.put(
-        "e",
-        new ArrayList<String>() {
-          {
-            add("first");
-            add("second");
-          }
-        });
+    values.put("a", List.of(true, false));
+    values.put("b", List.of(0.0, 1.1));
+    values.put("c", List.of(0, 1));
+    values.put("d", List.of(0L, 1L));
+    values.put("e", List.of("first", "second"));
 
     Tuple tuple = new Tuple(values);
 
-    for (String fieldName : new String[] {"a", "b", "c", "d", "e"}) {
+    for (String fieldName : List.of("a", "b", "c", "d", "e")) {
       assertTrue(new FieldValueEvaluator(fieldName).evaluate(tuple) instanceof Collection);
       assertEquals(2, ((Collection<?>) new FieldValueEvaluator(fieldName).evaluate(tuple)).size());
     }
@@ -127,46 +92,11 @@ public class FieldValueEvaluatorTest extends SolrTestCase {
   public void iterableTypes() throws Exception {
     values.clear();
 
-    values.put(
-        "a",
-        new PriorityQueue<Boolean>() {
-          {
-            add(true);
-            add(false);
-          }
-        });
-    values.put(
-        "b",
-        new PriorityQueue<Double>() {
-          {
-            add(0.0);
-            add(1.1);
-          }
-        });
-    values.put(
-        "c",
-        new PriorityQueue<Integer>() {
-          {
-            add(0);
-            add(1);
-          }
-        });
-    values.put(
-        "d",
-        new PriorityQueue<Long>() {
-          {
-            add(0L);
-            add(1L);
-          }
-        });
-    values.put(
-        "e",
-        new PriorityQueue<String>() {
-          {
-            add("first");
-            add("second");
-          }
-        });
+    values.put("a", new PriorityQueue<>(List.of(true, false)));
+    values.put("b", new PriorityQueue<>(List.of(0.0, 1.1)));
+    values.put("c", new PriorityQueue<>(List.of(0, 1)));
+    values.put("d", new PriorityQueue<>(List.of(0L, 1L)));
+    values.put("e", new PriorityQueue<>(List.of("first", "second")));
 
     Tuple tuple = new Tuple(values);
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/eval/LengthEvaluatorTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/stream/eval/LengthEvaluatorTest.java
@@ -17,8 +17,8 @@
 package org.apache.solr.client.solrj.io.stream.eval;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.solr.SolrTestCase;
 import org.apache.solr.client.solrj.io.Tuple;
@@ -29,7 +29,6 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
 import org.junit.Test;
 
 public class LengthEvaluatorTest extends SolrTestCase {
-
   StreamFactory factory;
   Map<String, Object> values;
 
@@ -49,39 +48,19 @@ public class LengthEvaluatorTest extends SolrTestCase {
     Object result;
 
     values.clear();
-    values.put(
-        "a",
-        new ArrayList<Integer>() {
-          {
-            add(1);
-            add(2);
-            add(4);
-          }
-        });
+    values.put("a", List.of(1, 2, 4));
     result = evaluator.evaluate(new Tuple(values));
     assertTrue(result instanceof Long);
     assertEquals(3L, result);
 
     values.clear();
-    values.put(
-        "a",
-        new ArrayList<String>() {
-          {
-            add("a");
-            add("b");
-          }
-        });
+    values.put("a", List.of("a", "b"));
     result = evaluator.evaluate(new Tuple(values));
     assertTrue(result instanceof Long);
     assertEquals(2L, result);
 
     values.clear();
-    values.put(
-        "a",
-        new ArrayList<String>() {
-          {
-          }
-        });
+    values.put("a", List.of());
     result = evaluator.evaluate(new Tuple(values));
     assertTrue(result instanceof Long);
     assertEquals(0L, result);

--- a/solr/solrj/src/test/org/apache/solr/common/SolrDocumentTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/SolrDocumentTest.java
@@ -247,12 +247,9 @@ public class SolrDocumentTest extends SolrTestCase {
   }
 
   public void testMapInterface() {
-    SolrDocument doc = new SolrDocument();
-    assertTrue(doc instanceof Map);
     assertTrue(Map.class.isAssignableFrom(SolrDocument.class));
 
     SolrInputDocument indoc = new SolrInputDocument();
-    assertTrue(indoc instanceof Map);
     assertTrue(Map.class.isAssignableFrom(indoc.getClass()));
   }
 }

--- a/solr/solrj/src/test/org/apache/solr/common/util/TestFastWriter.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/TestFastWriter.java
@@ -17,13 +17,13 @@
 package org.apache.solr.common.util;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import org.apache.solr.SolrTestCase;
 
 class MemWriter extends FastWriter {
-  public List<char[]> buffers = new LinkedList<>();
+  public List<char[]> buffers = new ArrayList<>();
 
   Random r;
 

--- a/solr/solrj/src/test/org/apache/solr/common/util/TestJavaBinCodec.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/TestJavaBinCodec.java
@@ -564,7 +564,7 @@ public class TestJavaBinCodec extends SolrTestCaseJ4 {
 
   // common-case ascii
   static String str(Random r, int sz) {
-    StringBuffer sb = new StringBuffer(sz);
+    StringBuilder sb = new StringBuilder(sz);
     for (int i = 0; i < sz; i++) {
       sb.append('\n' + r.nextInt(128 - '\n'));
     }

--- a/solr/solrj/src/test/org/apache/solr/common/util/Utf8CharSequenceTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/Utf8CharSequenceTest.java
@@ -27,11 +27,7 @@ import org.apache.solr.SolrTestCaseJ4;
 public class Utf8CharSequenceTest extends SolrTestCaseJ4 {
 
   public void testLargeString() throws IOException {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < 100; i++) {
-      sb.append("Hello World!");
-    }
-    ByteArrayUtf8CharSequence utf8 = new ByteArrayUtf8CharSequence(sb.toString());
+    ByteArrayUtf8CharSequence utf8 = new ByteArrayUtf8CharSequence("Hello World!".repeat(100));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     byte[] buf = new byte[256];
     try (FastOutputStream fos = new FastOutputStream(baos, buf, 0)) {
@@ -66,18 +62,12 @@ public class Utf8CharSequenceTest extends SolrTestCaseJ4 {
     NamedList<String> nl = new NamedList<>();
     String str = " The value!";
     for (int i = 0; i < 5; i++) {
-      StringBuffer sb = new StringBuffer();
-      sb.append(i);
-      for (int j = 0; j < i; j++) {
-        sb.append(str);
-      }
-      nl.add("key" + i, sb.toString());
+      nl.add("key" + i, i + str.repeat(i));
     }
-    StringBuffer sb = new StringBuffer();
-    for (; ; ) {
+    StringBuilder sb = new StringBuilder();
+    do {
       sb.append(str);
-      if (sb.length() > 1024 * 4) break;
-    }
+    } while (sb.length() <= 1024 * 4);
     nl.add("key_long", sb.toString());
     nl.add("key5", "5" + str);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDigestZkACLAndCredentialsProvidersTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDigestZkACLAndCredentialsProvidersTestBase.java
@@ -27,8 +27,6 @@ import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -164,12 +162,9 @@ public class AbstractDigestZkACLAndCredentialsProvidersTestBase extends SolrTest
   @Test
   public void testNoCredentials() throws Exception {
     List<TestZkCredentialsInjector> testZkCredentialsInjectors =
-        new ArrayList<>() {
-          {
-            add(new TestZkCredentialsInjector(NoCredentialZkCredentialsInjector.class));
-            add(new TestZkCredentialsInjector(VMParamsZkCredentialsInjector.class));
-          }
-        };
+        List.of(
+            new TestZkCredentialsInjector(NoCredentialZkCredentialsInjector.class),
+            new TestZkCredentialsInjector(VMParamsZkCredentialsInjector.class));
 
     testInjectors(
         testZkCredentialsInjectors,
@@ -188,18 +183,13 @@ public class AbstractDigestZkACLAndCredentialsProvidersTestBase extends SolrTest
   @Test
   public void testWrongCredentials() throws Exception {
     List<TestZkCredentialsInjector> testZkCredentialsInjectors =
-        new ArrayList<>() {
-          {
-            add(new TestZkCredentialsInjector(WrongAllCredentialZkCredentialsInjector.class));
-            add(
-                new TestZkCredentialsInjector(
-                    VMParamsZkCredentialsInjector.class,
-                    Arrays.asList(
-                        DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME,
-                        DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME),
-                    Arrays.asList(ALL_USERNAME, ALL_PASSWORD + "Wrong")));
-          }
-        };
+        List.of(
+            new TestZkCredentialsInjector(WrongAllCredentialZkCredentialsInjector.class),
+            new TestZkCredentialsInjector(
+                VMParamsZkCredentialsInjector.class,
+                List.of(
+                    DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME),
+                List.of(ALL_USERNAME, ALL_PASSWORD + "Wrong")));
 
     testInjectors(
         testZkCredentialsInjectors,
@@ -218,18 +208,13 @@ public class AbstractDigestZkACLAndCredentialsProvidersTestBase extends SolrTest
   @Test
   public void testAllCredentials() throws Exception {
     List<TestZkCredentialsInjector> testZkCredentialsInjectors =
-        new ArrayList<>() {
-          {
-            add(new TestZkCredentialsInjector(AllCredentialZkCredentialsInjector.class));
-            add(
-                new TestZkCredentialsInjector(
-                    VMParamsZkCredentialsInjector.class,
-                    Arrays.asList(
-                        DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME,
-                        DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME),
-                    Arrays.asList(ALL_USERNAME, ALL_PASSWORD)));
-          }
-        };
+        List.of(
+            new TestZkCredentialsInjector(AllCredentialZkCredentialsInjector.class),
+            new TestZkCredentialsInjector(
+                VMParamsZkCredentialsInjector.class,
+                List.of(
+                    DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME),
+                List.of(ALL_USERNAME, ALL_PASSWORD)));
 
     testInjectors(
         testZkCredentialsInjectors, true, true, true, true, true, true, true, true, true, true);
@@ -238,18 +223,13 @@ public class AbstractDigestZkACLAndCredentialsProvidersTestBase extends SolrTest
   @Test
   public void testReadonlyCredentials() throws Exception {
     List<TestZkCredentialsInjector> testZkCredentialsInjectors =
-        new ArrayList<>() {
-          {
-            add(new TestZkCredentialsInjector(ConnectWithReadonlyCredsInjector.class));
-            add(
-                new TestZkCredentialsInjector(
-                    VMParamsZkCredentialsInjector.class,
-                    Arrays.asList(
-                        DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME,
-                        DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME),
-                    Arrays.asList(READONLY_USERNAME, READONLY_PASSWORD)));
-          }
-        };
+        List.of(
+            new TestZkCredentialsInjector(ConnectWithReadonlyCredsInjector.class),
+            new TestZkCredentialsInjector(
+                VMParamsZkCredentialsInjector.class,
+                List.of(
+                    DEFAULT_DIGEST_USERNAME_VM_PARAM_NAME, DEFAULT_DIGEST_PASSWORD_VM_PARAM_NAME),
+                List.of(READONLY_USERNAME, READONLY_PASSWORD)));
     testInjectors(
         testZkCredentialsInjectors,
         true,
@@ -493,46 +473,32 @@ public class AbstractDigestZkACLAndCredentialsProvidersTestBase extends SolrTest
       implements ZkCredentialsInjector {
     @Override
     public List<ZkCredential> getZkCredentials() {
-      return new ArrayList<>() {
-        {
-          add(new ZkCredential(ALL_USERNAME, ALL_PASSWORD, ZkCredential.Perms.ALL));
-          add(new ZkCredential(READONLY_USERNAME, READONLY_PASSWORD, ZkCredential.Perms.READ));
-        }
-      };
+      return List.of(
+          new ZkCredential(ALL_USERNAME, ALL_PASSWORD, ZkCredential.Perms.ALL),
+          new ZkCredential(READONLY_USERNAME, READONLY_PASSWORD, ZkCredential.Perms.READ));
     }
   }
 
   public static class ConnectWithReadonlyCredsInjector implements ZkCredentialsInjector {
     @Override
     public List<ZkCredential> getZkCredentials() {
-      return new ArrayList<>() {
-        {
-          // uses readonly creds to connect to zookeeper, hence "all"
-          add(new ZkCredential(READONLY_USERNAME, READONLY_PASSWORD, ZkCredential.Perms.ALL));
-        }
-      };
+      return List.of(
+          new ZkCredential(READONLY_USERNAME, READONLY_PASSWORD, ZkCredential.Perms.ALL));
     }
   }
 
   public static class AllCredentialZkCredentialsInjector implements ZkCredentialsInjector {
     @Override
     public List<ZkCredential> getZkCredentials() {
-      return new ArrayList<>() {
-        {
-          add(new ZkCredential(ALL_USERNAME, ALL_PASSWORD, ZkCredential.Perms.ALL));
-        }
-      };
+      return List.of(new ZkCredential(ALL_USERNAME, ALL_PASSWORD, ZkCredential.Perms.ALL));
     }
   }
 
   public static class WrongAllCredentialZkCredentialsInjector implements ZkCredentialsInjector {
     @Override
     public List<ZkCredential> getZkCredentials() {
-      return new ArrayList<>() {
-        {
-          add(new ZkCredential(ALL_USERNAME, ALL_PASSWORD + "Wrong", ZkCredential.Perms.ALL));
-        }
-      };
+      return List.of(
+          new ZkCredential(ALL_USERNAME, ALL_PASSWORD + "Wrong", ZkCredential.Perms.ALL));
     }
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -1134,6 +1134,7 @@ public class MiniSolrCloudCluster {
       return this;
     }
 
+    @SuppressWarnings("InvalidParam")
     /**
      * Force the cluster Collection and config state API execution as well as the cluster state
      * update strategy to be either Overseer based or distributed. <b>This method can be useful when

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractCollectionsAPIDistributedZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractCollectionsAPIDistributedZkTestBase.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -588,7 +587,7 @@ public abstract class AbstractCollectionsAPIDistributedZkTestBase extends SolrCl
   private void checkNoTwoShardsUseTheSameIndexDir() {
     Map<String, Set<String>> indexDirToShardNamesMap = new HashMap<>();
 
-    List<MBeanServer> servers = new LinkedList<>();
+    List<MBeanServer> servers = new ArrayList<>();
     servers.add(ManagementFactory.getPlatformMBeanServer());
     servers.addAll(MBeanServerFactory.findMBeanServer(null));
     for (final MBeanServer server : servers) {

--- a/solr/test-framework/src/java/org/apache/solr/handler/component/TrackingShardHandlerFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/handler/component/TrackingShardHandlerFactory.java
@@ -16,9 +16,9 @@
  */
 package org.apache.solr.handler.component;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -198,7 +198,7 @@ public class TrackingShardHandlerFactory extends HttpShardHandlerFactory {
    *     org.apache.solr.handler.component.TrackingShardHandlerFactory#setTrackingQueue(java.util.List,
    *     java.util.Queue)
    */
-  public static class RequestTrackingQueue extends LinkedList<ShardRequestAndParams> {
+  public static class RequestTrackingQueue extends ArrayDeque<ShardRequestAndParams> {
     private final Map<String, List<ShardRequestAndParams>> requests = new ConcurrentHashMap<>();
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16427

Builds on https://github.com/apache/solr/pull/1037

Enables the following errorprone rules:
* `AlmostJavadoc` - Fixed a few javadoc issues
* `BadInstanceof` - this is most of the changes
* `DoubleBraceInitialization` - Most of these moved to `List.of`, `Map.of`, or `Set.of`
* `InvalidInlineTag` - Fixed a few javadoc issues
* `InvalidParam` - Fixed a few javadoc issues
* `JavaLangClash` - `Package` was used twice in Solr code - renamed to `SolrPackage` and `PackagePayload`. Also renamed `PackageLoader` to `SolrPackageLoader`. Renamed `Error` class in `SolrCmdDistributor` to `SolrError` to avoid clashing with Java.
* `JdkObsolete` - There are some suppressions for this for `LinkedList` usages. Most went to `ArrayList` or `ArrayDeque`
* `ProtectedMembersInFinalClass` - fixed the visibility of these methods
* `UnsynchronizedOverridesSynchronized` found one issue in `StandardDirectoryFactory` where `removeDirectory` missed synchronized