### PR TITLE
SOLR-16438: Support optional split.setPreferredLeaders prop in shard split command.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -41,8 +41,6 @@ New Features
 
 * SOLR-16409: Admin UI - Expose all highlighting parameters in the Query UI (Jeanie Lam via Eric Pugh)
 
-* SOLR-16438: Support optional split.setPreferredLeaders prop in shard split command. (Bruno Roustant)
-
 Improvements
 ---------------------
 
@@ -83,6 +81,9 @@ Improvements
   (Houston Putman)
 
 * SOLR-16565: posting the same file to the package store should not throw an error (noble)
+
+* SOLR-16438: Support optional split.setPreferredLeaders prop in shard split command. (Bruno Roustant)
+
 Optimizations
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -41,6 +41,8 @@ New Features
 
 * SOLR-16409: Admin UI - Expose all highlighting parameters in the Query UI (Jeanie Lam via Eric Pugh)
 
+* SOLR-16438: Support optional split.setPreferredLeaders prop in shard split command. (Bruno Roustant)
+
 Improvements
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DistributedCollectionConfigSetCommandRunner.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DistributedCollectionConfigSetCommandRunner.java
@@ -163,9 +163,9 @@ public class DistributedCollectionConfigSetCommandRunner {
   }
 
   /**
-   * When {@link org.apache.solr.handler.admin.CollectionsHandler#invokeAction} does not enqueue to
-   * overseer queue and instead calls this method, this method is expected to do the equivalent of
-   * what Overseer does in {@link
+   * When {@link org.apache.solr.handler.admin.CollectionsHandler#invokeOperation} does not enqueue
+   * to overseer queue and instead calls this method, this method is expected to do the equivalent
+   * of what Overseer does in {@link
    * org.apache.solr.cloud.OverseerConfigSetMessageHandler#processMessage}.
    *
    * <p>The steps leading to that call in the Overseer execution path are (and the equivalent is
@@ -235,9 +235,9 @@ public class DistributedCollectionConfigSetCommandRunner {
   }
 
   /**
-   * When {@link org.apache.solr.handler.admin.CollectionsHandler#invokeAction} does not enqueue to
-   * overseer queue and instead calls this method, this method is expected to do the equivalent of
-   * what Overseer does in {@link
+   * When {@link org.apache.solr.handler.admin.CollectionsHandler#invokeOperation} does not enqueue
+   * to overseer queue and instead calls this method, this method is expected to do the equivalent
+   * of what Overseer does in {@link
    * org.apache.solr.cloud.api.collections.OverseerCollectionMessageHandler#processMessage}.
    *
    * <p>The steps leading to that call in the Overseer execution path are (and the equivalent is

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -195,7 +195,9 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
     }
 
     boolean setPreferredLeaders =
-        message.getBool(CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS, Boolean.getBoolean(AUTO_PREFERRED_LEADERS));
+        message.getBool(
+            CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS,
+            Boolean.getBoolean(AUTO_PREFERRED_LEADERS));
 
     // 1. Verify that there is enough disk space to create sub-shards.
     RTimerTree t;

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -28,6 +28,7 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.DE
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonAdminParams.NUM_SUB_SHARDS;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,6 +45,7 @@ import org.apache.solr.client.solrj.cloud.DistribStateManager;
 import org.apache.solr.client.solrj.cloud.NodeStateProvider;
 import org.apache.solr.client.solrj.cloud.SolrCloudManager;
 import org.apache.solr.client.solrj.cloud.VersionedData;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.cloud.DistributedClusterStateUpdater;
 import org.apache.solr.cloud.Overseer;
@@ -112,20 +114,21 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
    * <ul>
    *   <li>1. Verify that there is enough disk space to create sub-shards.
    *   <li>2. If splitByPrefix is true, make request to get prefix ranges.
-   *   <li>3. If this split was attempted previously and there are lingering sub-shards, delete
-   *       them.
-   *   <li>4. Create sub-shards in CONSTRUCTION state.
-   *   <li>5. Add an initial replica to each sub-shard.
-   *   <li>6. Request that parent shard wait for children to become ACTIVE.
-   *   <li>7. Execute split: either LINK or REWRITE.
-   *   <li>8. Apply buffered updates to the sub-shards so they are up-to-date with parent.
-   *   <li>9. Determine node placement for additional replicas (but do not create yet).
-   *   <li>10. If replicationFactor is more than 1, set shard state for sub-shards to RECOVERY; else
+   *   <li>3. Fill the sub-shards ranges.
+   *   <li>4. If this split was attempted previously and there are lingering INACTIVE sub-shards,
+   *       delete them.
+   *   <li>5. Create sub-shards in CONSTRUCTION state.
+   *   <li>6. Add an initial replica to each sub-shard.
+   *   <li>7. Request that parent shard wait for children to become ACTIVE.
+   *   <li>8. Execute split: either LINK or REWRITE.
+   *   <li>9. Apply buffered updates to the sub-shards so they are up-to-date with parent.
+   *   <li>10. Determine node placement for additional replicas (but do not create yet).
+   *   <li>11. If replicationFactor is more than 1, set shard state for sub-shards to RECOVERY; else
    *       mark ACTIVE.
-   *   <li>11. Create additional replicas of sub-shards.
+   *   <li>12. Create additional replicas of sub-shards.
+   *   <li>13. If setPreferredLeaders param is true, set the preferred leader property on one
+   *       replica of each sub-shard. Distribute preferred leaders evenly among the nodes.
    * </ul>
-   *
-   * <br>
    *
    * <p>There is a shard split doc (dev-docs/shard-split/shard-split.adoc) on how shard split works;
    * illustrated with diagrams.
@@ -190,19 +193,23 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Interrupted.");
     }
 
+    boolean setPreferredLeaders =
+        message.getBool(CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS, false);
+
+    // 1. Verify that there is enough disk space to create sub-shards.
     RTimerTree t;
-    if (ccc.getCoreContainer().getNodeConfig().getMetricsConfig().isEnabled()) {
-      // check disk space for shard split
-      if (Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true"))) {
-        // 1. verify that there is enough space on disk to create sub-shards
+    if (ccc.getCoreContainer().getNodeConfig().getMetricsConfig().isEnabled()
+        && Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true"))) {
+      if (log.isDebugEnabled()) {
         log.debug(
-            "SplitShardCmd: verify that there is enough space on disk to create sub-shards for slice: {}",
+            "Check disk space before splitting shard {} on replica {}",
+            slice.get(),
             parentShardLeader);
-        t = timings.sub("checkDiskSpace");
-        checkDiskSpace(
-            collectionName, slice.get(), parentShardLeader, splitMethod, ccc.getSolrCloudManager());
-        t.stop();
       }
+      t = timings.sub("checkDiskSpace");
+      checkDiskSpace(
+          collectionName, slice.get(), parentShardLeader, splitMethod, ccc.getSolrCloudManager());
+      t.stop();
     }
 
     // let's record the ephemeralOwner of the parent leader node
@@ -281,8 +288,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
 
       ShardHandler shardHandler = ccc.newShardHandler();
 
-      // 2. if split request has splitByPrefix set to true, make request to SplitOp to get prefix
-      // ranges of sub-shards
+      // 2. If splitByPrefix is true, make request to get prefix ranges.
       if (message.getBool(CommonAdminParams.SPLIT_BY_PREFIX, false)) {
         t = timings.sub("getRanges");
 
@@ -326,8 +332,8 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         t.stop();
       }
 
+      // 3. Fill the sub-shards ranges.
       t = timings.sub("fillRanges");
-
       String rangesStr =
           fillRanges(
               ccc.getSolrCloudManager(),
@@ -340,8 +346,8 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
               firstNrtReplica);
       t.stop();
 
-      // 3. if this shard has attempted a split before and failed, there will be lingering INACTIVE
-      // sub-shards.  Clean these up before proceeding
+      // 4. If this split was attempted previously and there are lingering INACTIVE sub-shards,
+      // delete them.
       boolean oldShardsDeleted = false;
       for (String subSlice : subSlices) {
         Slice oSlice = collection.getSlice(subSlice);
@@ -372,16 +378,14 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
           }
         }
       }
-
       if (oldShardsDeleted) {
         // refresh the locally cached cluster state
         // we know we have the latest because otherwise deleteshard would have failed
         clusterState = zkStateReader.getClusterState();
       }
 
-      // 4. create the child sub-shards in CONSTRUCTION state
+      // 5. Create sub-shards in CONSTRUCTION state.
       String nodeName = parentShardLeader.getNodeName();
-
       t = timings.sub("createSubSlicesAndLeadersInState");
       for (int i = 0; i < subRanges.size(); i++) {
         String subSlice = subSlices.get(i);
@@ -417,7 +421,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
             CollectionHandlingUtils.waitForNewShard(
                 collectionName, subSlice, ccc.getZkStateReader());
 
-        // 5. and add the initial replica for each sub-shard
+        // 6. Add an initial replica to each sub-shard.
         log.debug(
             "Adding first replica {} as part of slice {} of collection {} on {}",
             subShardName,
@@ -457,7 +461,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
       }
       t.stop();
 
-      // 6. request that parent shard wait for children to become active
+      // 7. Request that parent shard wait for children to become ACTIVE.
       t = timings.sub("waitForSubSliceLeadersAlive");
       {
         final ShardRequestTracker shardRequestTracker =
@@ -487,12 +491,6 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
       }
       t.stop();
 
-      log.debug(
-          "Successfully created all sub-shards for collection {} parent shard: {} on: {}",
-          collectionName,
-          slice,
-          parentShardLeader);
-
       if (log.isInfoEnabled()) {
         log.info(
             "Splitting shard {} as part of slice {} of collection {} on {}",
@@ -502,7 +500,8 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
             parentShardLeader);
       }
 
-      // 7. execute actual split
+      // 8. Execute split: either LINK or REWRITE.
+      t = timings.sub("splitParentCore");
       ModifiableSolrParams params = new ModifiableSolrParams();
       params.set(CoreAdminParams.ACTION, CoreAdminParams.CoreAdminAction.SPLIT.toString());
       params.set(CommonAdminParams.SPLIT_METHOD, splitMethod.toLower());
@@ -512,8 +511,6 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         params.add(CoreAdminParams.TARGET_CORE, subShardName);
       }
       params.set(CoreAdminParams.RANGES, rangesStr);
-
-      t = timings.sub("splitParentCore");
       {
         final ShardRequestTracker shardRequestTracker =
             CollectionHandlingUtils.asyncRequestTracker(asyncId, ccc);
@@ -524,12 +521,11 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         handleFailureOnAsyncRequest(results, msgOnError);
       }
       t.stop();
-
       if (log.isDebugEnabled()) {
         log.debug("Index on shard: {} split into {} successfully", nodeName, subShardNames.size());
       }
 
-      // 8. apply buffered updates on sub-shards
+      // 9. Apply buffered updates to the sub-shards, so they are up-to-date with parent.
       t = timings.sub("applyBufferedUpdates");
       {
         final ShardRequestTracker shardRequestTracker =
@@ -555,9 +551,9 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         handleFailureOnAsyncRequest(results, msgOnError);
       }
       t.stop();
-
       log.debug("Successfully applied buffered updates on : {}", subShardNames);
 
+      // 10. Determine node placement for additional replicas (but do not create yet).
       // TODO: change this to handle sharding a slice into > 2 sub-shards.
 
       // we have already created one subReplica for each subShard on the parent node.
@@ -730,8 +726,8 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
       // this ensures that the logic inside ReplicaMutator to update sub-shard state to 'active'
       // always gets a chance to execute. See SOLR-7673
 
-      // 10. if replicationFactor > 1, set shard state for sub-shards to RECOVERY; otherwise mark
-      // ACTIVE
+      // 11. If replicationFactor is more than 1, set shard state for sub-shards to RECOVERY; else
+      // mark ACTIVE.
       if (repFactor == 1) {
         // A commit is needed so that documents are visible when the sub-shard replicas come up
         // (Note: This commit used to be after the state switch, but was brought here before the
@@ -781,14 +777,12 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         }
       }
 
+      // 12. Create additional replicas of sub-shards.
       t = timings.sub("createCoresForReplicas");
-      // 11. now actually create replica cores on sub shard nodes
       for (Map<String, Object> replica : replicas) {
         new AddReplicaCmd(ccc).addReplica(clusterState, new ZkNodeProps(replica), results, null);
       }
-
       assert TestInjection.injectSplitFailureAfterReplicaCreation();
-
       {
         final ShardRequestTracker syncRequestTracker =
             CollectionHandlingUtils.syncRequestTracker(ccc);
@@ -797,8 +791,44 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         handleFailureOnAsyncRequest(results, msgOnError);
       }
       t.stop();
-
       log.info("Successfully created all replica shards for all sub-slices {}", subSlices);
+
+      // 13. If setPreferredLeaders param is true, set the preferred leader property on one replica
+      // of each sub-shard. Distribute preferred leaders evenly among the nodes.
+      if (setPreferredLeaders && repFactor > 1) {
+        t = timings.sub("setPreferredLeaders");
+        log.info("Setting the preferred leaders");
+        clusterState = zkStateReader.getClusterState();
+        collection = clusterState.getCollection(collectionName);
+
+        // Keep the leader on the current node for the first sub-shard.
+        Map<String, Integer> numLeadersPerNode = new HashMap<>();
+        {
+          String subSliceName = subSlices.get(0);
+          Replica replica = collection.getSlice(subSliceName).getLeader();
+          setPreferredLeaderProp(collectionName, subSliceName, replica.getName());
+          numLeadersPerNode.put(replica.getNodeName(), 1);
+        }
+
+        // Distribute the preferred leaders for the other sub-shards evenly among the nodes.
+        for (String subSliceName : subSlices.subList(1, subSlices.size())) {
+          Slice subSlice = collection.getSlice(subSliceName);
+          Replica selectedReplica = null;
+          int minNumLeaders = Integer.MAX_VALUE;
+          for (Replica replica : subSlice.getReplicas()) {
+            int numLeaders = numLeadersPerNode.getOrDefault(replica.getNodeName(), 0);
+            if (numLeaders < minNumLeaders) {
+              selectedReplica = replica;
+              minNumLeaders = numLeaders;
+            }
+          }
+          assert selectedReplica != null;
+          setPreferredLeaderProp(collectionName, subSliceName, selectedReplica.getName());
+          numLeadersPerNode.compute(
+              selectedReplica.getNodeName(), (__, n) -> n == null ? 1 : n + 1);
+        }
+        t.stop();
+      }
 
       // The final commit was added in SOLR-4997 so that documents are visible
       // when the sub-shard replicas come up
@@ -810,6 +840,9 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
 
       if (withTiming) {
         results.add(CommonParams.TIMING, timings.asNamedList());
+      }
+      if (log.isInfoEnabled()) {
+        log.info("Timings for split operations: {}", timings.asNamedList());
       }
       success = true;
       // don't unlock the shard yet - only do this if the final switch-over in ReplicaMutator
@@ -831,6 +864,15 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         unlockForSplit(ccc.getSolrCloudManager(), collectionName, parentSlice.getName());
       }
     }
+  }
+
+  private void setPreferredLeaderProp(String collectionName, String shardName, String replicaName)
+      throws IOException {
+    log.info("Setting replica {} as the preferred leader of shard {}", replicaName, shardName);
+    CollectionAdminRequest.AddReplicaProp addProp =
+        CollectionAdminRequest.addReplicaProperty(
+            collectionName, shardName, replicaName, "preferredleader", "true");
+    ccc.getSolrCloudManager().request(addProp);
   }
 
   /**
@@ -1206,6 +1248,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
 
   public static boolean lockForSplit(SolrCloudManager cloudManager, String collection, String shard)
       throws Exception {
+    log.debug("Getting lock for shard {} split", shard);
     String path = ZkStateReader.COLLECTIONS_ZKNODE + "/" + collection + "/" + shard + "-splitting";
     final DistribStateManager stateManager = cloudManager.getDistribStateManager();
     synchronized (stateManager) {
@@ -1229,12 +1272,14 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
                 + shard,
             e);
       }
+      log.debug("Obtained lock for shard {} split", shard);
       return true;
     }
   }
 
   public static void unlockForSplit(SolrCloudManager cloudManager, String collection, String shard)
       throws Exception {
+    log.debug("Releasing lock for shard {} split", shard);
     if (shard != null) {
       String path =
           ZkStateReader.COLLECTIONS_ZKNODE + "/" + collection + "/" + shard + "-splitting";

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -27,6 +27,7 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.CR
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.DELETESHARD;
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonAdminParams.NUM_SUB_SHARDS;
+import static org.apache.solr.handler.admin.CollectionsHandler.AUTO_PREFERRED_LEADERS;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -194,7 +195,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
     }
 
     boolean setPreferredLeaders =
-        message.getBool(CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS, false);
+        message.getBool(CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS, Boolean.getBoolean(AUTO_PREFERRED_LEADERS));
 
     // 1. Verify that there is enough disk space to create sub-shards.
     RTimerTree t;

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -105,6 +105,7 @@ import static org.apache.solr.common.params.CommonAdminParams.NUM_SUB_SHARDS;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_BY_PREFIX;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_FUZZ;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_METHOD;
+import static org.apache.solr.common.params.CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS;
 import static org.apache.solr.common.params.CommonAdminParams.WAIT_FOR_FINAL_STATE;
 import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.common.params.CommonParams.TIMING;
@@ -130,6 +131,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -302,7 +304,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
     // Make sure the cores is enabled
-    CoreContainer cores = checkErrors();
+    checkCoreContainer();
 
     // Pick the action
     SolrParams params = req.getParams();
@@ -325,24 +327,24 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     }
 
     CollectionOperation operation = CollectionOperation.get(action);
-    invokeAction(req, rsp, cores, action, operation);
+    for (CollectionOperation op : operation.getCombinedOps(req, this)) {
+      invokeOperation(req, rsp, op);
+      if (rsp.getException() != null) {
+        log.warn("Operation {} failed with exception, skipping subsequent operations", op);
+        break;
+      }
+    }
     rsp.setHttpCaching(false);
   }
 
-  protected CoreContainer checkErrors() {
-    CoreContainer cores = getCoreContainer();
-    AdminAPIBase.validateZooKeeperAwareCoreContainer(cores);
-    return cores;
+  protected void checkCoreContainer() {
+    AdminAPIBase.validateZooKeeperAwareCoreContainer(getCoreContainer());
   }
 
   @SuppressWarnings({"unchecked"})
-  void invokeAction(
-      SolrQueryRequest req,
-      SolrQueryResponse rsp,
-      CoreContainer cores,
-      CollectionAction action,
-      CollectionOperation operation)
+  void invokeOperation(SolrQueryRequest req, SolrQueryResponse rsp, CollectionOperation operation)
       throws Exception {
+    log.debug("Invoking {}", operation);
     if (!coreContainer.isZooKeeperAware()) {
       throw new SolrException(
           BAD_REQUEST, "Invalid request. collections can be accessed only in SolrCloud mode");
@@ -373,10 +375,10 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     // Even if Overseer does wait for the collection to be created, it sees a different cluster
     // state than this node, so this wait is required to make sure the local node Zookeeper watches
     // fired and now see the collection.
-    if (action.equals(CollectionAction.CREATE) && asyncId == null) {
-      if (rsp.getException() == null) {
-        waitForActiveCollection(zkProps.getStr(NAME), cores, overseerResponse);
-      }
+    if (operation.equals(CollectionOperation.CREATE_OP)
+        && asyncId == null
+        && rsp.getException() == null) {
+      waitForActiveCollection(zkProps.getStr(NAME), getCoreContainer(), overseerResponse);
     }
   }
 
@@ -888,7 +890,6 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         SPLITSHARD,
         DEFAULT_COLLECTION_OP_TIMEOUT * 5,
         (req, rsp, h) -> {
-          String name = req.getParams().required().get(COLLECTION_PROP);
           // TODO : add support for multiple shards
           String shard = req.getParams().get(SHARD_ID_PROP);
           String rangesStr = req.getParams().get(CoreAdminParams.RANGES);
@@ -933,8 +934,75 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
                   NUM_SUB_SHARDS,
                   SPLIT_FUZZ,
                   SPLIT_BY_PREFIX,
-                  FOLLOW_ALIASES);
+                  FOLLOW_ALIASES,
+                  SPLIT_SET_PREFERRED_LEADERS);
           return copyPropertiesWithPrefix(req.getParams(), map, PROPERTY_PREFIX);
+        },
+        SplitShardHelper.OP_COMBINER),
+    /**
+     * Waits for a shard split to complete. Waits until the shard state is switched to INACTIVE (in
+     * ReplicaMutator.checkAndCompleteShardSplit). At the same time, the sub-shards states become
+     * ACTIVE.
+     */
+    WAIT_FOR_SHARD_SPLIT_OP(
+        null,
+        (req, rsp, h) -> {
+          String collectionName = req.getParams().get(COLLECTION_PROP);
+          String shardName = req.getParams().get(SHARD_ID_PROP);
+          log.info("Waiting for shard {} split to complete", shardName);
+          long startTime = System.nanoTime();
+          h.coreContainer
+              .getZkController()
+              .getZkStateReader()
+              .waitForState(
+                  collectionName,
+                  1,
+                  TimeUnit.HOURS,
+                  collection -> {
+                    Slice splitSlice = collection.getSlice(shardName);
+                    boolean splitComplete =
+                        splitSlice == null || splitSlice.getState().equals(Slice.State.INACTIVE);
+                    if (splitComplete) {
+                      if (log.isInfoEnabled()) {
+                        log.info(
+                            "Shard {} split completed in {} ms",
+                            shardName,
+                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
+                      }
+                    }
+                    return splitComplete;
+                  });
+          return null;
+        }),
+    /** Waits for the shard preferred leader to become the leader. */
+    WAIT_FOR_PREFERRED_LEADER_OP(
+        null,
+        (req, rsp, h) -> {
+          String collectionName = req.getParams().get(COLLECTION_PROP);
+          String shardName = req.getParams().get(SHARD_ID_PROP);
+          log.info("Waiting for shard {} preferred leader to become the leader", shardName);
+          long startTime = System.nanoTime();
+          h.coreContainer
+              .getZkController()
+              .getZkStateReader()
+              .waitForState(
+                  collectionName,
+                  5,
+                  TimeUnit.MINUTES,
+                  collection -> {
+                    boolean isLeader =
+                        SplitShardHelper.isPreferredLeaderCurrentLeader(collection, shardName, h);
+                    if (isLeader) {
+                      if (log.isInfoEnabled()) {
+                        log.info(
+                            "Shard {} preferred leader is leader in {} ms",
+                            shardName,
+                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
+                      }
+                    }
+                    return isLeader;
+                  });
+          return null;
         }),
     DELETESHARD_OP(
         DELETESHARD,
@@ -1852,28 +1920,90 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     public final CollectionOp fun;
     final CollectionAction action;
     final long timeOut;
+    final CollectionOpCombiner opCombiner;
 
     CollectionOperation(CollectionAction action, CollectionOp fun) {
-      this(action, DEFAULT_COLLECTION_OP_TIMEOUT, fun);
+      this(action, DEFAULT_COLLECTION_OP_TIMEOUT, fun, CollectionOpCombiner.SINGLE_OP);
     }
 
-    CollectionOperation(CollectionAction action, long timeOut, CollectionOp fun) {
+    CollectionOperation(
+        CollectionAction action, long timeOut, CollectionOp fun, CollectionOpCombiner opCombiner) {
       this.action = action;
       this.timeOut = timeOut;
       this.fun = fun;
+      this.opCombiner = opCombiner;
+      if (action != null) {
+        OperationMap.map.put(action, this);
+      }
     }
 
     public static CollectionOperation get(CollectionAction action) {
-      for (CollectionOperation op : values()) {
-        if (op.action == action) return op;
+      CollectionOperation op = OperationMap.map.get(action);
+      if (op == null) {
+        throw new SolrException(ErrorCode.SERVER_ERROR, "No such action " + action);
       }
-      throw new SolrException(ErrorCode.SERVER_ERROR, "No such action " + action);
+      return op;
+    }
+
+    List<CollectionOperation> getCombinedOps(SolrQueryRequest req, CollectionsHandler h) {
+      return opCombiner.getCombinedOps(this, req, h);
     }
 
     @Override
     public Map<String, Object> execute(
         SolrQueryRequest req, SolrQueryResponse rsp, CollectionsHandler h) throws Exception {
       return fun.execute(req, rsp, h);
+    }
+
+    private static class OperationMap {
+      static final Map<CollectionAction, CollectionOperation> map =
+          new EnumMap<>(CollectionAction.class);
+    }
+
+    private static class SplitShardHelper {
+      static final CollectionOpCombiner OP_COMBINER =
+          (op, req, h) -> {
+            if (!req.getParams().getBool(SPLIT_SET_PREFERRED_LEADERS, false)) {
+              return Collections.singletonList(op);
+            }
+            // The split.setPreferredLeader prop is true.
+            List<CollectionOperation> opSequence = new ArrayList<>();
+            String collectionName = req.getParams().get(COLLECTION_PROP);
+            String shardName = req.getParams().get(SHARD_ID_PROP);
+            DocCollection collection =
+                h.coreContainer
+                    .getZkController()
+                    .getZkStateReader()
+                    .getClusterState()
+                    .getCollection(collectionName);
+            // Ensure we split a preferred leader to help cluster balancing.
+            if (!isPreferredLeaderCurrentLeader(collection, shardName, h)) {
+              // A replica of the shard is defined as preferred leader, but is not the current
+              // leader yet.
+              opSequence.add(REBALANCELEADERS_OP); // Rebalance the leader on shard.
+              opSequence.add(WAIT_FOR_PREFERRED_LEADER_OP); // Wait for the rebalancing completion.
+            }
+            opSequence.add(op); // Split the shard and set the sub-shards preferred leaders.
+            opSequence.add(WAIT_FOR_SHARD_SPLIT_OP); // Wait for the shard split completion.
+            opSequence.add(REBALANCELEADERS_OP); // Rebalance the leaders on the sub-shards.
+            return opSequence;
+          };
+
+      static boolean isPreferredLeaderCurrentLeader(
+          DocCollection collection, String shardName, CollectionsHandler h) {
+        Slice slice = collection.getSlice(shardName);
+        if (slice == null) {
+          throw new SolrException(
+              ErrorCode.BAD_REQUEST, "Shard '" + shardName + "' does not exist, no action taken.");
+        }
+        for (Replica replica : slice.getReplicas()) {
+          if (replica.getBool(PROPERTY_PREFIX + "preferredleader", false)) {
+            return replica.equals(slice.getLeader());
+          }
+        }
+        // No replicas have the preferred leader property.
+        return true;
+      }
     }
   }
 
@@ -2059,6 +2189,14 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
   interface CollectionOp {
     Map<String, Object> execute(SolrQueryRequest req, SolrQueryResponse rsp, CollectionsHandler h)
         throws Exception;
+  }
+
+  interface CollectionOpCombiner {
+
+    CollectionOpCombiner SINGLE_OP = (op, req, h) -> Collections.singletonList(op);
+
+    List<CollectionOperation> getCombinedOps(
+        CollectionOperation op, SolrQueryRequest req, CollectionsHandler h);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -243,6 +243,14 @@ import org.slf4j.LoggerFactory;
 public class CollectionsHandler extends RequestHandlerBase implements PermissionNameProvider {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  /**
+   * Boolean system property to automatically set the preferred leaders
+   * at collection creation and during shard split. Default false.
+   * Otherwise, the caller needs to set it for each
+   * {@link CollectionAdminRequest#splitShard(String) SplitShard} request.
+   */
+  public static final String AUTO_PREFERRED_LEADERS = "solr.autoPreferredLeaders";
+
   protected final CoreContainer coreContainer;
   private final Optional<DistributedCollectionConfigSetCommandRunner>
       distributedCollectionConfigSetCommandRunner;
@@ -1963,7 +1971,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     private static class SplitShardHelper {
       static final CollectionOpCombiner OP_COMBINER =
           (op, req, h) -> {
-            if (!req.getParams().getBool(SPLIT_SET_PREFERRED_LEADERS, false)) {
+            if (!req.getParams().getBool(SPLIT_SET_PREFERRED_LEADERS, Boolean.getBoolean(AUTO_PREFERRED_LEADERS))) {
               return Collections.singletonList(op);
             }
             // The split.setPreferredLeader prop is true.

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -244,10 +244,9 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   /**
-   * Boolean system property to automatically set the preferred leaders
-   * at collection creation and during shard split. Default false.
-   * Otherwise, the caller needs to set it for each
-   * {@link CollectionAdminRequest#splitShard(String) SplitShard} request.
+   * Boolean system property to automatically set the preferred leaders at collection creation and
+   * during shard split. Default false. Otherwise, the caller needs to set it for each {@link
+   * CollectionAdminRequest#splitShard(String) SplitShard} request.
    */
   public static final String AUTO_PREFERRED_LEADERS = "solr.autoPreferredLeaders";
 
@@ -1971,7 +1970,8 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     private static class SplitShardHelper {
       static final CollectionOpCombiner OP_COMBINER =
           (op, req, h) -> {
-            if (!req.getParams().getBool(SPLIT_SET_PREFERRED_LEADERS, Boolean.getBoolean(AUTO_PREFERRED_LEADERS))) {
+            if (!req.getParams()
+                .getBool(SPLIT_SET_PREFERRED_LEADERS, Boolean.getBoolean(AUTO_PREFERRED_LEADERS))) {
               return Collections.singletonList(op);
             }
             // The split.setPreferredLeader prop is true.

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -1205,6 +1205,7 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     }
 
     if ((isLeader && !localIsLeader) || (isSubShardLeader && !localIsLeader)) {
+      log.error("ClusterState says we are the leader, but locally we don't think so");
       throw new SolrException(
           SolrException.ErrorCode.SERVICE_UNAVAILABLE,
           "ClusterState says we are the leader ("

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -1205,7 +1205,6 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     }
 
     if ((isLeader && !localIsLeader) || (isSubShardLeader && !localIsLeader)) {
-      log.error("ClusterState says we are the leader, but locally we don't think so");
       throw new SolrException(
           SolrException.ErrorCode.SERVICE_UNAVAILABLE,
           "ClusterState says we are the leader ("

--- a/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
@@ -336,8 +336,7 @@ public class SplitShardTest extends SolrCloudTestCase {
       int docCount = model.size();
 
       CollectionAdminRequest.SplitShard splitShard =
-          CollectionAdminRequest.splitShard(collectionName)
-              .setShardName("shard1");
+          CollectionAdminRequest.splitShard(collectionName).setShardName("shard1");
       // Set the preferred leaders param either with a request param, or with a system property.
       if (random().nextBoolean()) {
         splitShard.shouldSetPreferredLeaders(setPreferredLeaders);
@@ -346,8 +345,11 @@ public class SplitShardTest extends SolrCloudTestCase {
       }
       try {
         splitShard.process(client);
-        waitForState("Timed out waiting for sub shards to be active.",
-            collectionName, activeClusterShape(2, 3 * repFactor)); // 2 repFactor for the new split shards, 1 repFactor for old replicas
+        waitForState(
+            "Timed out waiting for sub shards to be active.",
+            collectionName,
+            // 2 repFactor for the new split shards, 1 repFactor for old replicas
+            activeClusterShape(2, 3 * repFactor));
       } finally {
         System.clearProperty(AUTO_PREFERRED_LEADERS);
       }

--- a/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
@@ -19,17 +19,18 @@ package org.apache.solr.cloud;
 
 import static org.hamcrest.core.StringContains.containsString;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -41,10 +42,9 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
+import org.apache.solr.common.params.CollectionAdminParams;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,27 +54,51 @@ public class SplitShardTest extends SolrCloudTestCase {
 
   private final String COLLECTION_NAME = "splitshardtest-collection";
 
-  @BeforeClass
-  public static void setupCluster() throws Exception {
-    System.setProperty("metricsEnabled", "true");
-    configureCluster(1).addConfig("conf", configset("cloud-minimal")).configure();
-  }
-
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-
   @After
   @Override
   public void tearDown() throws Exception {
     super.tearDown();
     cluster.deleteAllCollections();
+    shutdownCluster();
   }
 
   @Test
-  public void doTest() throws IOException, SolrServerException {
+  public void testSplitOneHostTwoSubShardsTwoReplicas() throws Exception {
+    setupCluster(1);
+    innerTestSplitTwoSubShardsTwoReplicas();
+  }
+
+  @Test
+  public void testSplitTwoHostsTwoSubShardsTwoReplicas() throws Exception {
+    setupCluster(2);
+    innerTestSplitTwoSubShardsTwoReplicas();
+  }
+
+  @Test
+  public void testSplitThreeHostsTwoSubShardsTwoReplicas() throws Exception {
+    setupCluster(3);
+    innerTestSplitTwoSubShardsTwoReplicas();
+  }
+
+  private void innerTestSplitTwoSubShardsTwoReplicas() throws Exception {
+    CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 1, 2)
+        .process(cluster.getSolrClient());
+
+    cluster.waitForActiveCollection(COLLECTION_NAME, 1, 2);
+
+    CollectionAdminRequest.SplitShard splitShard =
+        CollectionAdminRequest.splitShard(COLLECTION_NAME)
+            .setNumSubShards(2)
+            .setShardName("shard1");
+    splitShard.process(cluster.getSolrClient());
+    waitForState(
+        "Timed out waiting for sub shards to be active", COLLECTION_NAME, activeClusterShape(2, 6));
+  }
+
+  @Test
+  public void testSplitOneHostFiveSubShardsOneReplica() throws Exception {
+    setupCluster(1);
+
     CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 2, 1)
         .process(cluster.getSolrClient());
 
@@ -125,7 +149,8 @@ public class SplitShardTest extends SolrCloudTestCase {
   }
 
   @Test
-  public void multipleOptionsSplitTest() {
+  public void multipleOptionsSplitTest() throws Exception {
+    setupCluster(1);
     CollectionAdminRequest.SplitShard splitShard =
         CollectionAdminRequest.splitShard(COLLECTION_NAME)
             .setNumSubShards(5)
@@ -140,6 +165,7 @@ public class SplitShardTest extends SolrCloudTestCase {
 
   @Test
   public void testSplitFuzz() throws Exception {
+    setupCluster(1);
     String collectionName = "splitFuzzCollection";
     CollectionAdminRequest.createCollection(collectionName, "conf", 2, 1)
         .process(cluster.getSolrClient());
@@ -171,7 +197,11 @@ public class SplitShardTest extends SolrCloudTestCase {
     assertEquals("wrong range in s1_1", expected1, delta1);
   }
 
-  CloudSolrClient createCollection(String collectionName, int repFactor) throws Exception {
+  private void setupCluster(int nodeCount) throws Exception {
+    configureCluster(nodeCount).addConfig("conf", configset("cloud-minimal")).configure();
+  }
+
+  private CloudSolrClient createCollection(String collectionName, int repFactor) throws Exception {
 
     CollectionAdminRequest.createCollection(collectionName, "conf", 1, repFactor)
         .process(cluster.getSolrClient());
@@ -183,7 +213,7 @@ public class SplitShardTest extends SolrCloudTestCase {
     return client;
   }
 
-  long getNumDocs(CloudSolrClient client) throws Exception {
+  private long getNumDocs(CloudSolrClient client) throws Exception {
     String collectionName = client.getDefaultCollection();
     DocCollection collection = client.getClusterState().getCollection(collectionName);
     Collection<Slice> slices = collection.getSlices();
@@ -220,13 +250,35 @@ public class SplitShardTest extends SolrCloudTestCase {
     return totCount;
   }
 
-  void doLiveSplitShard(String collectionName, int repFactor, int nThreads) throws Exception {
+  @Test
+  public void testConcurrentSplitOneHostRepFactorOne() throws Exception {
+    setupCluster(1);
+    // Debugging tips: if this fails, it may be easier to debug by lowering the number fo threads to
+    // 1 and looping the test until you get another failure.
+    // You may need to further instrument things like DistributedZkUpdateProcessor to display the
+    // cluster state for the collection, etc. Using more threads increases the chance to hit a
+    // concurrency bug, but too many threads can overwhelm single-threaded buffering replay after
+    // the low level index split and result in subShard leaders that can't catch up and become
+    // active (a known issue that still needs to be resolved.)
+    splitWithConcurrentUpdates("livesplit-1-1", 1, 4, false);
+  }
+
+  @Test
+  public void testConcurrentSplitThreeHostsRepFactorTwo() throws Exception {
+    setupCluster(3);
+    splitWithConcurrentUpdates("livesplit-3-2", 2, 4, true);
+  }
+
+  private void splitWithConcurrentUpdates(
+      String collectionName, int repFactor, int nThreads, boolean preferredLeaders)
+      throws Exception {
     final CloudSolrClient client = createCollection(collectionName, repFactor);
 
     final ConcurrentHashMap<String, Long> model =
         new ConcurrentHashMap<>(); // what the index should contain
     final AtomicBoolean doIndex = new AtomicBoolean(true);
-    final AtomicInteger docsIndexed = new AtomicInteger();
+    final AtomicInteger numDocsAdded = new AtomicInteger();
+    final AtomicInteger numDocsDeleted = new AtomicInteger();
     Thread[] indexThreads = new Thread[nThreads];
     try {
 
@@ -234,23 +286,38 @@ public class SplitShardTest extends SolrCloudTestCase {
         indexThreads[i] =
             new Thread(
                 () -> {
+                  Random random = random();
+                  List<Integer> threadDocIndexes = new ArrayList<>();
                   while (doIndex.get()) {
                     try {
                       // Thread.sleep(10);  // cap indexing rate at 100 docs per second, per thread
-                      int currDoc = docsIndexed.incrementAndGet();
+                      int currDoc = numDocsAdded.incrementAndGet();
                       String docId = "doc_" + currDoc;
 
                       // Try all docs in the same update request
-                      UpdateRequest updateReq = new UpdateRequest();
-                      updateReq.add(sdoc("id", docId));
+                      UpdateRequest addReq = new UpdateRequest();
+                      addReq.add(sdoc("id", docId));
                       // UpdateResponse ursp = updateReq.commit(client, collectionName);
                       // uncomment this if you want a commit each time
-                      UpdateResponse ursp = updateReq.process(client, collectionName);
+                      UpdateResponse ursp = addReq.process(client, collectionName);
                       assertEquals(0, ursp.getStatus()); // for now, don't accept any failures
                       if (ursp.getStatus() == 0) {
                         // in the future, keep track of a version per document and reuse ids to keep
                         // index from growing too large
                         model.put(docId, 1L);
+                        threadDocIndexes.add(currDoc);
+                      }
+
+                      if (currDoc % 20 == 0) {
+                        int docIndex =
+                            threadDocIndexes.remove(random.nextInt(threadDocIndexes.size()));
+                        docId = "doc_" + docIndex;
+                        UpdateRequest deleteReq = new UpdateRequest();
+                        deleteReq.deleteById(docId);
+                        ursp = deleteReq.process(client, collectionName);
+                        assertEquals(0, ursp.getStatus()); // for now, don't accept any failures
+                        model.remove(docId);
+                        numDocsDeleted.incrementAndGet();
                       }
                     } catch (Exception e) {
                       fail(e.getMessage());
@@ -268,7 +335,9 @@ public class SplitShardTest extends SolrCloudTestCase {
       int docCount = model.size();
 
       CollectionAdminRequest.SplitShard splitShard =
-          CollectionAdminRequest.splitShard(collectionName).setShardName("shard1");
+          CollectionAdminRequest.splitShard(collectionName)
+              .setShardName("shard1")
+              .shouldSetPreferredLeaders(preferredLeaders);
       splitShard.process(client);
       waitForState(
           "Timed out waiting for sub shards to be active.",
@@ -306,19 +375,42 @@ public class SplitShardTest extends SolrCloudTestCase {
       log.error("MISSING DOCUMENTS: {}", leftover);
     }
 
-    assertEquals("Documents are missing!", docsIndexed.get(), numDocs);
-    log.info("Number of documents indexed and queried : {}", numDocs);
-  }
+    assertEquals(
+        "Documents are missing!"
+            + " numDocsAdded="
+            + numDocsAdded.get()
+            + " numDocsDeleted="
+            + numDocsDeleted.get()
+            + " numDocs="
+            + numDocs,
+        numDocsAdded.get() - numDocsDeleted.get(),
+        numDocs);
+    if (log.isInfoEnabled()) {
+      log.info("{} docs added, {} docs deleted", numDocsAdded.get(), numDocsDeleted.get());
+    }
 
-  @Test
-  public void testLiveSplit() throws Exception {
-    // Debugging tips: if this fails, it may be easier to debug by lowering the number fo threads to
-    // 1 and looping the test until you get another failure. You may need to further instrument
-    // things like DistributedZkUpdateProcessor to display the cluster state for the collection,
-    // etc. Using more threads increases the chance to hit a concurrency bug, but too many threads
-    // can overwhelm single-threaded buffering replay after the low level index split and result in
-    // subShard leaders that can't catch up and become active (a known issue that still needs to be
-    // resolved.)
-    doLiveSplitShard("livesplit1", 1, 4);
+    if (preferredLeaders) {
+      DocCollection collection =
+          cluster.getSolrClient().getClusterState().getCollection(collectionName);
+      for (Slice slice : collection.getSlices()) {
+        if (!slice.getState().equals(Slice.State.ACTIVE)) {
+          continue;
+        }
+        boolean preferredLeaderFound = false;
+        for (Replica replica : slice.getReplicas()) {
+          if (replica.getBool(CollectionAdminParams.PROPERTY_PREFIX + "preferredleader", false)) {
+            preferredLeaderFound = true;
+            assertEquals(
+                "Replica "
+                    + replica.getName()
+                    + " is the preferred leader but not the leader of shard "
+                    + slice.getName(),
+                slice.getLeader(),
+                replica);
+          }
+        }
+        assertTrue("No preferred leader found for shard " + slice.getName(), preferredLeaderFound);
+      }
+    }
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -17,6 +17,7 @@
 package org.apache.solr.cloud.api.collections;
 
 import static org.apache.solr.common.cloud.ZkStateReader.REPLICATION_FACTOR;
+import static org.apache.solr.common.params.CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -52,6 +53,7 @@ import org.apache.solr.cloud.BasicDistributedZkTest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.cloud.StoppableIndexingThread;
 import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.CompositeIdRouter;
 import org.apache.solr.common.cloud.DocCollection;
@@ -711,7 +713,13 @@ public class ShardSplitTest extends BasicDistributedZkTest {
         trySplit(collectionName, null, SHARD1, 1);
         fail("expected to fail due to locking but succeeded");
       } catch (Exception e) {
-        log.info("Expected failure: {}", e);
+        // Verify the exception caught.
+        // If the split command sets the preferred leader, that checks that the exception is not a
+        // TimeoutException because we don't want the split combined operation to wait for the split
+        // completion if the split fails.
+        assertTrue("Unexpected exception " + e, e instanceof SolrException);
+        assertEquals(SolrException.ErrorCode.INVALID_STATE.code, ((SolrException) e).code());
+        log.info("Expected failure:", e);
       }
 
       // make sure the lock still exists
@@ -1252,6 +1260,9 @@ public class ShardSplitTest extends BasicDistributedZkTest {
     }
     if (splitKey != null) {
       params.set("split.key", splitKey);
+    }
+    if (random().nextBoolean()) {
+      params.set(SPLIT_SET_PREFERRED_LEADERS, true);
     }
     QueryRequest request = new QueryRequest(params);
     request.setPath("/admin/collections");

--- a/solr/core/src/test/org/apache/solr/handler/admin/TestCollectionAPIs.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/TestCollectionAPIs.java
@@ -36,7 +36,6 @@ import org.apache.solr.api.ApiBag;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ZkNodeProps;
-import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.params.SolrParams;
@@ -44,7 +43,6 @@ import org.apache.solr.common.util.CommandOperation;
 import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.common.util.Pair;
 import org.apache.solr.common.util.Utils;
-import org.apache.solr.core.CoreContainer;
 import org.apache.solr.handler.ClusterAPI;
 import org.apache.solr.handler.CollectionsAPI;
 import org.apache.solr.request.LocalSolrQueryRequest;
@@ -310,23 +308,16 @@ public class TestCollectionAPIs extends SolrTestCaseJ4 {
     MockCollectionsHandler() {}
 
     @Override
-    protected CoreContainer checkErrors() {
-      return null;
-    }
+    protected void checkCoreContainer() {}
 
     @Override
     protected void copyFromClusterProp(Map<String, Object> props, String prop) {}
 
     @Override
-    void invokeAction(
-        SolrQueryRequest req,
-        SolrQueryResponse rsp,
-        CoreContainer cores,
-        CollectionParams.CollectionAction action,
-        CollectionOperation operation)
+    void invokeOperation(SolrQueryRequest req, SolrQueryResponse rsp, CollectionOperation operation)
         throws Exception {
       Map<String, Object> result = null;
-      if (action == CollectionParams.CollectionAction.COLLECTIONPROP) {
+      if (operation.equals(CollectionOperation.COLLECTIONPROP_OP)) {
         // Fake this action, since we don't want to write to ZooKeeper in this test
         result = new HashMap<>();
         result.put(NAME, req.getParams().required().get(NAME));

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
@@ -262,6 +262,16 @@ One simple way to populate `id_prefix` is a copyField in the schema:
   </fieldtype>
 ----
 
+`split.setPreferredLeaders`::
++
+[%autowidth,frame=none]
+|===
+|Optional |Default: `false`
+|===
++
+If `true`, the SPLITSHARD command sets the preferred leader property on one replica of each sub-shard,
+automatically when splitting a shard. The preferred leaders are distributed evenly among the nodes.
+
 Current implementation details and limitations:
 
 * Prefix size is calculated using number of documents with the prefix.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
@@ -271,6 +271,8 @@ One simple way to populate `id_prefix` is a copyField in the schema:
 +
 If `true`, the SPLITSHARD command sets the preferred leader property on one replica of each sub-shard,
 automatically when splitting a shard. The preferred leaders are distributed evenly among the nodes.
+It is also possible to change the default value of this parameter to `true` by setting the system property
+`solr.autoPreferredLeaders` to `true`.
 
 Current implementation details and limitations:
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
@@ -1567,6 +1567,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Boolean splitByPrefix;
     protected Integer numSubShards;
     protected Float splitFuzz;
+    protected Boolean setPreferredLeaders;
 
     private Properties properties;
 
@@ -1643,6 +1644,11 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
       return this;
     }
 
+    public SplitShard shouldSetPreferredLeaders(Boolean setPreferredLeaders) {
+      this.setPreferredLeaders = setPreferredLeaders;
+      return this;
+    }
+
     @Override
     public SolrParams getParams() {
       ModifiableSolrParams params = (ModifiableSolrParams) super.getParams();
@@ -1663,13 +1669,14 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
       if (splitFuzz != null) {
         params.set(CommonAdminParams.SPLIT_FUZZ, String.valueOf(splitFuzz));
       }
-
       if (splitByPrefix != null) {
         params.set(CommonAdminParams.SPLIT_BY_PREFIX, splitByPrefix);
       }
-
       if (properties != null) {
         addProperties(params, properties);
+      }
+      if (setPreferredLeaders != null) {
+        params.set(CommonAdminParams.SPLIT_SET_PREFERRED_LEADERS, setPreferredLeaders);
       }
       return params;
     }

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
@@ -38,8 +38,8 @@ public interface CommonAdminParams {
   String SPLIT_FUZZ = "splitFuzz";
   /**
    * Boolean param to set the preferred leader property on one replica of each sub-shard,
-   * automatically when splitting a shard. The preferred leaders are distributed evenly
-   * among the nodes.
+   * automatically when splitting a shard. The preferred leaders are distributed evenly among the
+   * nodes.
    */
   String SPLIT_SET_PREFERRED_LEADERS = "split.setPreferredLeaders";
 }

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
@@ -36,4 +36,10 @@ public interface CommonAdminParams {
   String TIMEOUT = "timeout";
   /** Inexact shard splitting factor. */
   String SPLIT_FUZZ = "splitFuzz";
+  /**
+   * Boolean param to set the preferred leader property on one replica of each sub-shard,
+   * automatically when splitting a shard. The preferred leaders are distributed evenly
+   * among the nodes.
+   */
+  String SPLIT_SET_PREFERRED_LEADERS = "split.setPreferredLeaders";
 }


### PR DESCRIPTION
- Introduce the optional split.setPreferredLeaders prop on CollectionAdminRequest#SplitShard.
- Make SplitShardCommand support it and set the preferredLeader property on other replicas of each created sub-shard. Distributing the preferred leaders evenly.
-  Introduce combined operations in CollectionsHandler, so that a CollectionOperation (e.g. SPLITSHARD_OP) can look at the request and (e.g. if split.setPreferredLeaders is set) create a sequence of operations to execute (e.g. split, wait for completion, rebalance leaders).