### PR TITLE
SOLR-13219: Fix NPE in FieldLengthFeature with non-stored/missing fields

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -137,6 +137,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* SOLR-13219: Fix NPE in FieldLengthFeature with non-stored/missing fields (Nick Veenhof, Tomasz Elendt)
+
 * SOLR-15918: Skip repetitive parent znode creation on config set upload (Mike Drob)
 
 * SOLR-15964: Transient cores: don't evict a core when it's still being used. (David Smiley)

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/FieldLengthFeature.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/FieldLengthFeature.java
@@ -19,7 +19,6 @@ package org.apache.solr.ltr.feature;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -128,17 +127,9 @@ public class FieldLengthFeature extends Feature {
 
       NumericDocValues norms = null;
 
-      public FieldLengthFeatureScorer(FeatureWeight weight, NumericDocValues norms)
-          throws IOException {
+      public FieldLengthFeatureScorer(FeatureWeight weight, NumericDocValues norms) {
         super(weight, norms);
         this.norms = norms;
-
-        // In the constructor, docId is -1, so using 0 as default lookup
-        final IndexableField idxF = searcher.doc(0).getField(field);
-        if (idxF.fieldType().omitNorms()) {
-          throw new IOException(
-              "FieldLengthFeatures can't be used if omitNorms is enabled (field=" + field + ")");
-        }
       }
 
       @Override

--- a/solr/modules/ltr/src/test-files/solr/collection1/conf/schema.xml
+++ b/solr/modules/ltr/src/test-files/solr/collection1/conf/schema.xml
@@ -22,8 +22,8 @@
     <field name="finalScore" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="finalScoreFloat" type="float" indexed="true" stored="true" multiValued="false"/>
     <field name="field" type="text_general" indexed="true" stored="false" multiValued="false"/>
-    <field name="title" type="text_general" indexed="true" stored="true"/>
-    <field name="description" type="text_general" indexed="true" stored="true"/>
+    <field name="title" type="text_general" indexed="true" stored="false"/>
+    <field name="description" type="text_general" indexed="true" stored="false"/>
     <field name="keywords" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <field name="popularity" type="int" indexed="true" stored="true" />
     <field name="dvIntPopularity" type="int" indexed="false" docValues="true" stored="false" multiValued="false"/>

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
@@ -76,7 +76,7 @@ public class TestFeatureLogging extends TestRerankBase {
 
     final SolrQuery query = new SolrQuery();
     query.setQuery("title:bloomberg");
-    query.add("fl", "title,description,id,popularity,[fv]");
+    query.add("fl", "id,popularity,[fv]");
     query.add("rows", "3");
     query.add("debugQuery", "on");
     query.add("rq", "{!ltr reRankDocs=3 model=sum1}");
@@ -84,7 +84,7 @@ public class TestFeatureLogging extends TestRerankBase {
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'title':'bloomberg bloomberg ', 'description':'bloomberg','id':'7', 'popularity':2,  '[fv]':'"
+        "/response/docs/[0]/=={'id':'7', 'popularity':2,  '[fv]':'"
             + docs0fv_default_csv
             + "'}");
 

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java
@@ -84,9 +84,7 @@ public class TestFeatureLogging extends TestRerankBase {
     restTestHarness.query("/query" + query.toQueryString());
     assertJQ(
         "/query" + query.toQueryString(),
-        "/response/docs/[0]/=={'id':'7', 'popularity':2,  '[fv]':'"
-            + docs0fv_default_csv
-            + "'}");
+        "/response/docs/[0]/=={'id':'7', 'popularity':2,  '[fv]':'" + docs0fv_default_csv + "'}");
 
     query.remove("fl");
     query.add("fl", "[fv]");

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFieldLengthFeature.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFieldLengthFeature.java
@@ -36,8 +36,18 @@ public class TestFieldLengthFeature extends TestRerankBase {
     assertU(adoc("id", "4", "title", "w4", "description", "w4"));
     assertU(adoc("id", "5", "title", "w5", "description", "w5"));
     assertU(adoc("id", "6", "title", "w1 w2", "description", "w1 w2", "x_t", "1 2"));
-    assertU(adoc("id", "7", "title", "w1 w2 w3 w4 w5", "description", "w1 w2 w3 w4 w5 w8", "x_t", "1"));
-    assertU(adoc("id", "8", "title", "w1 w1 w1 w2 w2 w8", "description", "w1 w1 w1 w2 w2", "x_t", "1 2 3"));
+    assertU(
+        adoc("id", "7", "title", "w1 w2 w3 w4 w5", "description", "w1 w2 w3 w4 w5 w8", "x_t", "1"));
+    assertU(
+        adoc(
+            "id",
+            "8",
+            "title",
+            "w1 w1 w1 w2 w2 w8",
+            "description",
+            "w1 w1 w1 w2 w2",
+            "x_t",
+            "1 2 3"));
     assertU(commit());
   }
 
@@ -159,10 +169,10 @@ public class TestFieldLengthFeature extends TestRerankBase {
     loadFeature("dynfield-length", FieldLengthFeature.class.getName(), "{\"field\":\"x_t\"}");
 
     loadModel(
-            "dynfield-model",
-            LinearModel.class.getName(),
-            new String[] {"dynfield-length"},
-            "{\"weights\":{\"dynfield-length\":1.0}}");
+        "dynfield-model",
+        LinearModel.class.getName(),
+        new String[] {"dynfield-length"},
+        "{\"weights\":{\"dynfield-length\":1.0}}");
 
     final SolrQuery query = new SolrQuery();
     query.setQuery("title:w1");

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFieldLengthFeature.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFieldLengthFeature.java
@@ -35,9 +35,9 @@ public class TestFieldLengthFeature extends TestRerankBase {
     assertU(adoc("id", "3", "title", "w3", "description", "w3"));
     assertU(adoc("id", "4", "title", "w4", "description", "w4"));
     assertU(adoc("id", "5", "title", "w5", "description", "w5"));
-    assertU(adoc("id", "6", "title", "w1 w2", "description", "w1 w2"));
-    assertU(adoc("id", "7", "title", "w1 w2 w3 w4 w5", "description", "w1 w2 w3 w4 w5 w8"));
-    assertU(adoc("id", "8", "title", "w1 w1 w1 w2 w2 w8", "description", "w1 w1 w1 w2 w2"));
+    assertU(adoc("id", "6", "title", "w1 w2", "description", "w1 w2", "x_t", "1 2"));
+    assertU(adoc("id", "7", "title", "w1 w2 w3 w4 w5", "description", "w1 w2 w3 w4 w5 w8", "x_t", "1"));
+    assertU(adoc("id", "8", "title", "w1 w1 w1 w2 w2 w8", "description", "w1 w1 w1 w2 w2", "x_t", "1 2 3"));
     assertU(commit());
   }
 
@@ -151,6 +151,38 @@ public class TestFieldLengthFeature extends TestRerankBase {
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='7'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='8'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='6'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[3]/id=='1'");
+  }
+
+  @Test
+  public void testRankingDynamicField() throws Exception {
+    loadFeature("dynfield-length", FieldLengthFeature.class.getName(), "{\"field\":\"x_t\"}");
+
+    loadModel(
+            "dynfield-model",
+            LinearModel.class.getName(),
+            new String[] {"dynfield-length"},
+            "{\"weights\":{\"dynfield-length\":1.0}}");
+
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("title:w1");
+    query.add("fl", "*, score");
+    query.add("rows", "4");
+
+    // Normal term match
+    assertJQ("/query" + query.toQueryString(), "/response/numFound/==4");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='1'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='8'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='6'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[3]/id=='7'");
+    // Normal term match
+
+    query.add("rq", "{!ltr model=dynfield-model reRankDocs=4}");
+
+    assertJQ("/query" + query.toQueryString(), "/response/numFound/==4");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='8'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/id=='6'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[2]/id=='7'");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[3]/id=='1'");
   }
 


### PR DESCRIPTION
This commit removes unnecessary check for `omitNorms` from `FieldLengthFeatureScorer` that otherwise causes `NullPointerException` in `FieldLengthFeature` for non-stored or missing fields.

https://issues.apache.org/jira/browse/SOLR-13219

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

I recently encountered a problem with using `FieldLengthFeature` with non-stored fields where feature extraction/LTR reranking would result in `NullPointerException`. I checked the `FieldLengthFeature` docs and briefly inspected the implementation to check if using this feature really requires storing fields. According to my expectations it turned out to not be required - the only required information are norms, that my field has enabled.

I searched Solr Jira and found [SOLR-13219](https://issues.apache.org/jira/browse/SOLR-13219) that seemed very similar in nature. Upon investigation I found that the two issues have indeed the same origin. The root cause seems to be the following line:

```java
final IndexableField idxF = searcher.doc(0).getField(field);
```
That returns null for non-stored or missing dynamic fields.

Honestly, I don't understand why `FieldLengthFeatureScorer `even checks whether the field omits norms or not. It's only used in `FieldLengthFeature#scorer` and this method already checks whether norms are there or not (and if they are missing a constant 0 ValueFeatureScorer is returned).

# Solution

I removed the problematic code.

# Tests

I modified `title` and `description` fields (`stored="false"`) in `schema.xml` proving that existing tests still work as long as the problematic code is removed (without it `TestFieldLength#testRanking` is failing). With this change I also had to slightly change `TestFeatureLogging#testGeneratedFeatures` test, but without changing its logic.

I also added `TestFieldLength#testRankingDynamicField` test to prove that `TestFieldLength` works correctly with dynamic fields too, and doesn't fail if one (or more) documents from rerank candidate set lack that field.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
