### PR TITLE
NO JIRA: start validateRefGuideFiles gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,7 @@ apply from: file('gradle/validation/validate-log-calls.gradle')
 apply from: file('gradle/validation/check-broken-links.gradle')
 
 apply from: file('gradle/validation/solr.config-file-sanity.gradle')
+apply from: file('gradle/validation/solr.ref-guide-files.gradle')
 
 apply from: file('gradle/validation/spotless.gradle')
 

--- a/gradle/validation/precommit.gradle
+++ b/gradle/validation/precommit.gradle
@@ -29,6 +29,7 @@ configure(rootProject) {
 
     // Solr validation tasks.
     dependsOn ":solr:validateConfigFileSanity"
+    dependsOn ":solr:validateRefGuideFiles"
 
     // Attach all these tasks from all projects that have them.
     // This uses lazy collections as they may not yet be defined.

--- a/gradle/validation/solr.ref-guide-files.gradle
+++ b/gradle/validation/solr.ref-guide-files.gradle
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+configure(project(":solr")) {
+  task validateRefGuideFiles() {
+    doFirst {
+      def (major, minor, patch) = rootProject.luceneBaseVersionProvider.get().tokenize('.')
+      def linkVersion = "${major}_${minor}_${patch}"
+
+      def antora_yml = file("solr-ref-guide/antora.yml")
+      def content = antora_yml.getText("UTF-8")
+      if (!content.contains("lucene-javadocs: 'https://lucene.apache.org/core/${linkVersion}'")) {
+        throw new GradleException("${antora_yml.absolutePath} lucene-javadocs does not link to the correct lucene version (${linkVersion})")
+      }
+    }
+  }
+}

--- a/solr/solr-ref-guide/antora.yml
+++ b/solr/solr-ref-guide/antora.yml
@@ -35,7 +35,7 @@ asciidoc:
     # 'patch-version' is the 'z' part of x.y.z semantic version
     page-solr-javadocs: 'https://solr.apache.org/docs/10_0_0'
     solr-javadocs: 'https://solr.apache.org/docs/10_0_0'
-    lucene-javadocs: 'https://lucene.apache.org/core/9_1_0'
+    lucene-javadocs: 'https://lucene.apache.org/core/9_3_0'
     java-javadocs: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/
     # Some constructed  links may be 404 TODO to check
     solr-docs-version: '10.0'


### PR DESCRIPTION
Also _9.1-->9.3 for lucene-javadocs in solr-ref-guide/antora.yml_ to match `branch_9x` and `branch_9_1` commits.