### PR TITLE
Disable lift god classes

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -3,10 +3,10 @@
 # https://help.sonatype.com/lift/configuration-reference
 
 jdkVersion = "11"
+disableTools = [ "refactor-first" ]
 ignoreFiles = '''
 **/test/**
 **/*.min.js
 solr/webapp/web/libs/*.js
 '''
 build = "./gradlew jar"
-


### PR DESCRIPTION
See https://github.com/apache/solr/pull/1068#issuecomment-1279338815 and other recent PRs where Lift is repeatedly saying:

```
314 God Classes were detected by Lift in this project. [Visit the Lift web console](https://lift.sonatype.com/results/github.com/apache/solr/01GF5VM3TQ2XTE65VJSF5B3J4S?tab=technical-debt&utm_source=github.com&utm_campaign=lift-comment&utm_content=apache%20solr) for more details.
```

Disabled using .lift.toml based on https://help.sonatype.com/lift/prioritizing-technical-debt#PrioritizingTechnicalDebt-CanItweakthistool?