### PR TITLE
SOLR-16463: Workaround for serious crash on JDK17+

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -246,6 +246,8 @@ Bug Fixes
 
 * SOLR-16453: Overseer doesn't handle PRS and non-PRS messages properly (Justin Sweeney, Hitesh Khamesra)
 
+* SOLR-16463: Workaround for serious crash on JDK17+ due to JIT on caffeinecache (janhoy, Uwe Schindler)
+
 Other Changes
 ---------------------
 * SOLR-16351: Upgrade Carrot2 to 4.4.3, upgrade randomizedtesting to 2.8.0. (Dawid Weiss)

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2239,6 +2239,12 @@ function start_solr() {
     exit 1
   fi
 
+  # Workaround for JIT crash, see https://issues.apache.org/jira/browse/SOLR-16463
+  if [[ "$JAVA_VER_NUM" -ge "17" ]] ; then
+    SOLR_OPTS+=("-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put")
+    echo "Java $JAVA_VER_NUM detected. Enabled workaround for SOLR-16463"
+  fi
+
   SOLR_START_OPTS=('-server' "${JAVA_MEM_OPTS[@]}" "${GC_TUNE[@]}" "${GC_LOG_OPTS[@]}" "${IP_ACL_OPTS[@]}" \
     "${REMOTE_JMX_OPTS[@]}" "${CLOUD_MODE_OPTS[@]}" ${SOLR_LOG_LEVEL_OPT:-} -Dsolr.log.dir="$SOLR_LOGS_DIR" \
     "-Djetty.port=$SOLR_PORT" "-DSTOP.PORT=$stop_port" "-DSTOP.KEY=$STOP_KEY" \
@@ -2248,8 +2254,6 @@ function start_solr() {
     # '+CrashOnOutOfMemoryError' ensures that Solr crashes whenever
     # OOME is thrown. Program operation after OOME is unpredictable.
     "-XX:+CrashOnOutOfMemoryError" "-XX:ErrorFile=${SOLR_LOGS_DIR}/jvm_crash_%p.log" \
-    # Workaround for JIT crash, see https://issues.apache.org/jira/browse/SOLR-16463
-    "-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put" \
     "-Djetty.home=$SOLR_SERVER_DIR" "-Dsolr.solr.home=$SOLR_HOME" "-Dsolr.install.dir=$SOLR_TIP" \
     "-Dsolr.default.confdir=$DEFAULT_CONFDIR" "${LOG4J_CONFIG[@]}" "${SOLR_OPTS[@]}" "${SECURITY_MANAGER_OPTS[@]}" "${SOLR_ADMIN_UI}")
 

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2248,6 +2248,8 @@ function start_solr() {
     # '+CrashOnOutOfMemoryError' ensures that Solr crashes whenever
     # OOME is thrown. Program operation after OOME is unpredictable.
     "-XX:+CrashOnOutOfMemoryError" "-XX:ErrorFile=${SOLR_LOGS_DIR}/jvm_crash_%p.log" \
+    # Workaround for JIT crash, see https://issues.apache.org/jira/browse/SOLR-16463
+    "-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put" \
     "-Djetty.home=$SOLR_SERVER_DIR" "-Dsolr.solr.home=$SOLR_HOME" "-Dsolr.install.dir=$SOLR_TIP" \
     "-Dsolr.default.confdir=$DEFAULT_CONFDIR" "${LOG4J_CONFIG[@]}" "${SOLR_OPTS[@]}" "${SECURITY_MANAGER_OPTS[@]}" "${SOLR_ADMIN_UI}")
 

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1247,6 +1247,12 @@ IF "%GC_TUNE%"=="" (
     -XX:+ExplicitGCInvokesConcurrent
 )
 
+REM Workaround for JIT crash, see https://issues.apache.org/jira/browse/SOLR-16463
+if !JAVA_MAJOR_VERSION! GEQ 17  (
+  set SOLR_OPTS=%SOLR_OPTS% -XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put
+  echo Java %JAVA_MAJOR_VERSION% detected. Enabled workaround for SOLR-16463
+)
+
 if !JAVA_MAJOR_VERSION! GEQ 9 if NOT "%JAVA_VENDOR%" == "OpenJ9" (
   IF NOT "%GC_LOG_OPTS%"=="" (
     echo ERROR: On Java 9 you cannot set GC_LOG_OPTS, only default GC logging is available. Exiting
@@ -1326,8 +1332,6 @@ set START_OPTS=%START_OPTS% -XX:+CrashOnOutOfMemoryError
 set START_OPTS=%START_OPTS% -XX:ErrorFile=%SOLR_LOGS_DIR%\jvm_crash_%%p.log
 set START_OPTS=%START_OPTS% !GC_TUNE! %GC_LOG_OPTS%
 set START_OPTS=%START_OPTS% -DdisableAdminUI=%DISABLE_ADMIN_UI%
-REM Workaround for JIT crash, see https://issues.apache.org/jira/browse/SOLR-16463
-set START_OPTS=%START_OPTS% -XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put
 IF NOT "!CLOUD_MODE_OPTS!"=="" set "START_OPTS=%START_OPTS% !CLOUD_MODE_OPTS!"
 IF NOT "!IP_ACL_OPTS!"=="" set "START_OPTS=%START_OPTS% !IP_ACL_OPTS!"
 IF NOT "%REMOTE_JMX_OPTS%"=="" set "START_OPTS=%START_OPTS% %REMOTE_JMX_OPTS%"

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1326,6 +1326,8 @@ set START_OPTS=%START_OPTS% -XX:+CrashOnOutOfMemoryError
 set START_OPTS=%START_OPTS% -XX:ErrorFile=%SOLR_LOGS_DIR%\jvm_crash_%%p.log
 set START_OPTS=%START_OPTS% !GC_TUNE! %GC_LOG_OPTS%
 set START_OPTS=%START_OPTS% -DdisableAdminUI=%DISABLE_ADMIN_UI%
+REM Workaround for JIT crash, see https://issues.apache.org/jira/browse/SOLR-16463
+set START_OPTS=%START_OPTS% -XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put
 IF NOT "!CLOUD_MODE_OPTS!"=="" set "START_OPTS=%START_OPTS% !CLOUD_MODE_OPTS!"
 IF NOT "!IP_ACL_OPTS!"=="" set "START_OPTS=%START_OPTS% !IP_ACL_OPTS!"
 IF NOT "%REMOTE_JMX_OPTS%"=="" set "START_OPTS=%START_OPTS% %REMOTE_JMX_OPTS%"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16463

Hardcode the JVM flag in `bin/solr[.cmd]` from Solr 9.1, to workaround [https://bugs.openjdk.org/browse/JDK-8285835](https://bugs.openjdk.org/browse/JDK-8285835)