### PR TITLE
SOLR-14251 Add option skipFreeSpaceCheck to split shard operation

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -194,8 +194,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
     RTimerTree t;
     if (ccc.getCoreContainer().getNodeConfig().getMetricsConfig().isEnabled()) {
       // check disk space for shard split
-      if (Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true"))
-          || !message.getBool(SKIP_FREE_SPACE_CHECK, false)) {
+      if (!message.getBool(SKIP_FREE_SPACE_CHECK, !Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true")))) {
         // 1. verify that there is enough space on disk to create sub-shards
         log.debug(
             "SplitShardCmd: verify that there is enough space on disk to create sub-shards for slice: {}",

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -194,23 +194,15 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
     RTimerTree t;
     if (ccc.getCoreContainer().getNodeConfig().getMetricsConfig().isEnabled()) {
       // check disk space for shard split
-      if (Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true"))) {
+      if (Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true"))
+          || !message.getBool(SKIP_FREE_SPACE_CHECK, false)) {
         // 1. verify that there is enough space on disk to create sub-shards
         log.debug(
             "SplitShardCmd: verify that there is enough space on disk to create sub-shards for slice: {}",
             parentShardLeader);
         t = timings.sub("checkDiskSpace");
-        boolean skipFreeSpaceCheck = message.getBool(SKIP_FREE_SPACE_CHECK, false);
-        if (skipFreeSpaceCheck) {
-          log.debug("Skipping check for sufficient disk space", message);
-        } else {
-          checkDiskSpace(
-              collectionName,
-              slice.get(),
-              parentShardLeader,
-              splitMethod,
-              ccc.getSolrCloudManager());
-        }
+        checkDiskSpace(
+            collectionName, slice.get(), parentShardLeader, splitMethod, ccc.getSolrCloudManager());
         t.stop();
       }
     }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -194,7 +194,9 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
     RTimerTree t;
     if (ccc.getCoreContainer().getNodeConfig().getMetricsConfig().isEnabled()) {
       // check disk space for shard split
-      if (!message.getBool(SKIP_FREE_SPACE_CHECK, !Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true")))) {
+      if (!message.getBool(
+          SKIP_FREE_SPACE_CHECK,
+          !Boolean.parseBoolean(System.getProperty(SHARDSPLIT_CHECKDISKSPACE_ENABLED, "true")))) {
         // 1. verify that there is enough space on disk to create sub-shards
         log.debug(
             "SplitShardCmd: verify that there is enough space on disk to create sub-shards for slice: {}",

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -202,10 +202,14 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         t = timings.sub("checkDiskSpace");
         boolean skipFreeSpaceCheck = message.getBool(SKIP_FREE_SPACE_CHECK, false);
         if (skipFreeSpaceCheck) {
-            log.debug("Skipping check for sufficient disk space", message);
+          log.debug("Skipping check for sufficient disk space", message);
         } else {
           checkDiskSpace(
-                  collectionName, slice.get(), parentShardLeader, splitMethod, ccc.getSolrCloudManager());
+              collectionName,
+              slice.get(),
+              parentShardLeader,
+              splitMethod,
+              ccc.getSolrCloudManager());
         }
         t.stop();
       }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -27,6 +27,7 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.CR
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.DELETESHARD;
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonAdminParams.NUM_SUB_SHARDS;
+import static org.apache.solr.common.params.CommonAdminParams.SKIP_FREE_SPACE_CHECK;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -199,8 +200,13 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
             "SplitShardCmd: verify that there is enough space on disk to create sub-shards for slice: {}",
             parentShardLeader);
         t = timings.sub("checkDiskSpace");
-        checkDiskSpace(
-            collectionName, slice.get(), parentShardLeader, splitMethod, ccc.getSolrCloudManager());
+        boolean skipFreeSpaceCheck = message.getBool(SKIP_FREE_SPACE_CHECK, false);
+        if (skipFreeSpaceCheck) {
+            log.debug("Skipping check for sufficient disk space", message);
+        } else {
+          checkDiskSpace(
+                  collectionName, slice.get(), parentShardLeader, splitMethod, ccc.getSolrCloudManager());
+        }
         t.stop();
       }
     }

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -100,11 +100,11 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.SY
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonAdminParams.IN_PLACE_MOVE;
 import static org.apache.solr.common.params.CommonAdminParams.NUM_SUB_SHARDS;
+import static org.apache.solr.common.params.CommonAdminParams.SKIP_FREE_SPACE_CHECK;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_BY_PREFIX;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_FUZZ;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_METHOD;
 import static org.apache.solr.common.params.CommonAdminParams.WAIT_FOR_FINAL_STATE;
-import static org.apache.solr.common.params.CommonAdminParams.SKIP_FREE_SPACE_CHECK;
 import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.common.params.CommonParams.TIMING;
 import static org.apache.solr.common.params.CommonParams.VALUE_LONG;

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -104,6 +104,7 @@ import static org.apache.solr.common.params.CommonAdminParams.SPLIT_BY_PREFIX;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_FUZZ;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_METHOD;
 import static org.apache.solr.common.params.CommonAdminParams.WAIT_FOR_FINAL_STATE;
+import static org.apache.solr.common.params.CommonAdminParams.SKIP_FREE_SPACE_CHECK;
 import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.common.params.CommonParams.TIMING;
 import static org.apache.solr.common.params.CommonParams.VALUE_LONG;
@@ -930,7 +931,8 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
                   NUM_SUB_SHARDS,
                   SPLIT_FUZZ,
                   SPLIT_BY_PREFIX,
-                  FOLLOW_ALIASES);
+                  FOLLOW_ALIASES,
+                  SKIP_FREE_SPACE_CHECK);
           return copyPropertiesWithPrefix(req.getParams(), map, PROPERTY_PREFIX);
         }),
     DELETESHARD_OP(

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
@@ -195,6 +195,9 @@ This slows down the replication process and consumes more disk space on replica 
 +
 A float value which must be smaller than `0.5` that allows to vary the sub-shard ranges by this percentage of total shard range, odd shards being larger and even shards being smaller.
 
+`skipFreeSpaceCheck`::
+A boolean value to skip checking for free disk space before shard splitting. Can be useful in case of shared file systems like HDFS. Defaults to `false`.
+
 `property._name_=_value_`::
 +
 [%autowidth,frame=none]

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
@@ -36,6 +36,6 @@ public interface CommonAdminParams {
   String TIMEOUT = "timeout";
   /** Inexact shard splitting factor. */
   String SPLIT_FUZZ = "splitFuzz";
-  /** Skip free space checking before shard splitting. **/
+  /** Skip free space checking before shard splitting. * */
   String SKIP_FREE_SPACE_CHECK = "skipFreeSpaceCheck";
 }

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
@@ -36,4 +36,6 @@ public interface CommonAdminParams {
   String TIMEOUT = "timeout";
   /** Inexact shard splitting factor. */
   String SPLIT_FUZZ = "splitFuzz";
+  /** Skip free space checking before shard splitting. **/
+  String SKIP_FREE_SPACE_CHECK = "skipFreeSpaceCheck";
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14251

# Description

Adding an option to the SPLIT_SHARD_OP command to make it possible to skip free space checking before splitting shards. This is a workaround as the check logic is broken for shared filesystems.

# Solution

The option skips the disk space check as a workaround.

# Tests

None.

# Checklist

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
