### PR TITLE
[SOLR-16489] CaffeineCache puts thread into infinite loop

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -275,7 +275,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
   @Override
   public V put(K key, V val) {
     inserts.increment();
-    V old = cache.asMap().put(key, val);
+    V old = cache.asMap().compute(key, (k,v) -> val);
     recordRamBytes(key, old, val);
     return old;
   }

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -275,7 +275,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
   @Override
   public V put(K key, V val) {
     inserts.increment();
-    V old = cache.asMap().compute(key, (k,v) -> val);
+    V old = cache.asMap().compute(key, (k, v) -> val);
     recordRamBytes(key, old, val);
     return old;
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16489

# Description

Under heavy machine load, accessing any Solr CaffeineCache can lead to threads spinning in an endless loop. In our setup we had machines spinning at 70% cpu load without receiving any request for hours.

# Solution

The problem is caused by delegating the `SolrCache#put` method to `Cache#asMap#put` Under heavy machine load with concurrent read and write access to the same key, the `ConcurrentHashMap#put` method does not terminate an endless loop.

# Tests

The behavior happens under heavy load when the cache is under congestion and read / write access is happening in different threads. We had this small fix live for a couple of weeks now without any stuck threads.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
