### PR TITLE
SOLR-16363: DirectUpdateHandler2 should not throw UnknownFormatConversionException

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -74,6 +74,8 @@ Bug Fixes
 
 * SOLR-16483: Fix IndexOutOfBounds in RecursiveNumericEvaluator (Bendegúz Ács via Kevin Risden)
 
+* SOLR-16363: DirectUpdateHandler2 should not throw UnknownFormatConversionException (Kevin Risden)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
+++ b/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
@@ -313,12 +313,12 @@ public class DirectUpdateHandler2 extends UpdateHandler
           SolrException.ErrorCode.BAD_REQUEST,
           String.format(
               Locale.ROOT,
-              "Exception writing document id %s to the index; possible analysis error: "
-                  + iae.getMessage()
-                  + (iae.getCause() instanceof BytesRefHash.MaxBytesLengthExceededException
-                      ? ". Perhaps the document has an indexed string field (solr.StrField) which is too large"
-                      : ""),
-              cmd.getPrintableId()),
+              "Exception writing document id %s to the index; possible analysis error: %s%s",
+              cmd.getPrintableId(),
+              iae.getMessage(),
+              (iae.getCause() instanceof BytesRefHash.MaxBytesLengthExceededException
+                  ? ". Perhaps the document has an indexed string field (solr.StrField) which is too large"
+                  : "")),
           iae);
     } catch (RuntimeException t) {
       throw new SolrException(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16363

Based on IntelliJ analysis, this is the only place in Solr code base where String.format has String concatenation. So this should be the only place this is a problem.