### PR TITLE
SOLR-16491: Create v2 equivalent for /admin/info/key

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -16,6 +16,19 @@
  */
 package org.apache.solr.core;
 
+import static java.util.Objects.requireNonNull;
+import static org.apache.solr.common.params.CommonParams.AUTHC_PATH;
+import static org.apache.solr.common.params.CommonParams.AUTHZ_PATH;
+import static org.apache.solr.common.params.CommonParams.COLLECTIONS_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.CONFIGSETS_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.CORES_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.INFO_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.METRICS_PATH;
+import static org.apache.solr.common.params.CommonParams.ZK_PATH;
+import static org.apache.solr.common.params.CommonParams.ZK_STATUS_PATH;
+import static org.apache.solr.core.CorePropertiesLocator.PROPERTIES_FILENAME;
+import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGIN_PROP;
+
 import com.github.benmanes.caffeine.cache.Interner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -23,6 +36,30 @@ import com.google.common.collect.Maps;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.client.CredentialsProvider;
@@ -123,44 +160,6 @@ import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Singleton;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.requireNonNull;
-import static org.apache.solr.common.params.CommonParams.AUTHC_PATH;
-import static org.apache.solr.common.params.CommonParams.AUTHZ_PATH;
-import static org.apache.solr.common.params.CommonParams.COLLECTIONS_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.CONFIGSETS_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.CORES_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.INFO_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.METRICS_PATH;
-import static org.apache.solr.common.params.CommonParams.ZK_PATH;
-import static org.apache.solr.common.params.CommonParams.ZK_STATUS_PATH;
-import static org.apache.solr.core.CorePropertiesLocator.PROPERTIES_FILENAME;
-import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGIN_PROP;
 
 /**
  * @since solr 1.3
@@ -1073,25 +1072,25 @@ public class CoreContainer {
     final CoreContainer thisCCRef = this;
     // Init the Jersey app once all CC endpoints have been registered
     containerHandlers
-            .getJerseyEndpoints()
-            .register(
-                    new AbstractBinder() {
-                      @Override
-                      protected void configure() {
-                        bindFactory(new InjectionFactories.SingletonFactory<>(thisCCRef))
-                                .to(CoreContainer.class)
-                                .in(Singleton.class);
-                      }
-                    })
-            .register(
-                    new AbstractBinder() {
-                      @Override
-                      protected void configure() {
-                        bindFactory(new InjectionFactories.SingletonFactory<>(nodeKeyPair))
-                                .to(SolrNodeKeyPair.class)
-                                .in(Singleton.class);
-                      }
-                    });
+        .getJerseyEndpoints()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bindFactory(new InjectionFactories.SingletonFactory<>(thisCCRef))
+                    .to(CoreContainer.class)
+                    .in(Singleton.class);
+              }
+            })
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bindFactory(new InjectionFactories.SingletonFactory<>(nodeKeyPair))
+                    .to(SolrNodeKeyPair.class)
+                    .in(Singleton.class);
+              }
+            });
     jerseyAppHandler = new ApplicationHandler(containerHandlers.getJerseyEndpoints());
 
     // This is a bit redundant but these are two distinct concepts for all they're accomplished at

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -16,19 +16,6 @@
  */
 package org.apache.solr.core;
 
-import static java.util.Objects.requireNonNull;
-import static org.apache.solr.common.params.CommonParams.AUTHC_PATH;
-import static org.apache.solr.common.params.CommonParams.AUTHZ_PATH;
-import static org.apache.solr.common.params.CommonParams.COLLECTIONS_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.CONFIGSETS_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.CORES_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.INFO_HANDLER_PATH;
-import static org.apache.solr.common.params.CommonParams.METRICS_PATH;
-import static org.apache.solr.common.params.CommonParams.ZK_PATH;
-import static org.apache.solr.common.params.CommonParams.ZK_STATUS_PATH;
-import static org.apache.solr.core.CorePropertiesLocator.PROPERTIES_FILENAME;
-import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGIN_PROP;
-
 import com.github.benmanes.caffeine.cache.Interner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -36,31 +23,6 @@ import com.google.common.collect.Maps;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.spec.InvalidKeySpecException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.client.CredentialsProvider;
@@ -160,6 +122,45 @@ import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.spec.InvalidKeySpecException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.solr.common.params.CommonParams.AUTHC_PATH;
+import static org.apache.solr.common.params.CommonParams.AUTHZ_PATH;
+import static org.apache.solr.common.params.CommonParams.COLLECTIONS_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.CONFIGSETS_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.CORES_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.INFO_HANDLER_PATH;
+import static org.apache.solr.common.params.CommonParams.METRICS_PATH;
+import static org.apache.solr.common.params.CommonParams.ZK_PATH;
+import static org.apache.solr.common.params.CommonParams.ZK_STATUS_PATH;
+import static org.apache.solr.core.CorePropertiesLocator.PROPERTIES_FILENAME;
+import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGIN_PROP;
 
 /**
  * @since solr 1.3
@@ -1073,16 +1074,25 @@ public class CoreContainer {
     final CoreContainer thisCCRef = this;
     // Init the Jersey app once all CC endpoints have been registered
     containerHandlers
-        .getJerseyEndpoints()
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
-                bindFactory(new InjectionFactories.SingletonFactory<>(thisCCRef))
-                    .to(CoreContainer.class)
-                    .in(Singleton.class);
-              }
-            });
+            .getJerseyEndpoints()
+            .register(
+                    new AbstractBinder() {
+                      @Override
+                      protected void configure() {
+                        bindFactory(new InjectionFactories.SingletonFactory<>(thisCCRef))
+                                .to(CoreContainer.class)
+                                .in(Singleton.class);
+                      }
+                    })
+            .register(
+                    new AbstractBinder() {
+                      @Override
+                      protected void configure() {
+                        bindFactory(new InjectionFactories.SingletonFactory<>(cfg.getCloudConfig()))
+                                .to(CloudConfig.class)
+                                .in(Singleton.class);
+                      }
+                    });
     jerseyAppHandler = new ApplicationHandler(containerHandlers.getJerseyEndpoints());
 
     // This is a bit redundant but these are two distinct concepts for all they're accomplished at

--- a/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
@@ -16,7 +16,26 @@
  */
 package org.apache.solr.security;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHeaders;
@@ -41,26 +60,6 @@ import org.apache.solr.util.CryptoKeys;
 import org.eclipse.jetty.client.api.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.nio.ByteBuffer;
-import java.security.InvalidKeyException;
-import java.security.Principal;
-import java.security.PublicKey;
-import java.security.SignatureException;
-import java.time.Instant;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class PKIAuthenticationPlugin extends AuthenticationPlugin
     implements HttpClientBuilderPlugin {
@@ -104,7 +103,8 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
     return interceptorRegistered;
   }
 
-  // TODO We only use PublicKeyHandler here to gain access to the underlying keypair; let's nuke the indirection and
+  // TODO We only use PublicKeyHandler here to gain access to the underlying keypair; let's nuke the
+  // indirection and
   //  just pass in the SolrNodeKeyPair instance directly
   public PKIAuthenticationPlugin(
       CoreContainer cores, String nodeName, PublicKeyHandler publicKeyHandler) {

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
@@ -17,18 +17,17 @@
 
 package org.apache.solr.security;
 
+import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONTENT_TYPE_V2;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.apache.solr.api.JerseyResource;
-import org.apache.solr.jersey.PermissionName;
-import org.apache.solr.jersey.SolrJerseyResponse;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-
-import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONTENT_TYPE_V2;
+import org.apache.solr.api.JerseyResource;
+import org.apache.solr.jersey.PermissionName;
+import org.apache.solr.jersey.SolrJerseyResponse;
 
 /**
  * V2 API for fetching the public key of the receiving node.
@@ -38,25 +37,25 @@ import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONT
 @Path("/node/key")
 public class PublicKeyAPI extends JerseyResource {
 
-    private final SolrNodeKeyPair nodeKeyPair;
+  private final SolrNodeKeyPair nodeKeyPair;
 
-    @Inject
-    public PublicKeyAPI(SolrNodeKeyPair nodeKeyPair) {
-        this.nodeKeyPair = nodeKeyPair;
-    }
+  @Inject
+  public PublicKeyAPI(SolrNodeKeyPair nodeKeyPair) {
+    this.nodeKeyPair = nodeKeyPair;
+  }
 
-    @GET
-    @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
-    @PermissionName(PermissionNameProvider.Name.ALL)
-    public PublicKeyResponse getPublicKey() {
-        final PublicKeyResponse response = instantiateJerseyResponse(PublicKeyResponse.class);
-        response.key = nodeKeyPair.getKeyPair().getPublicKeyStr();
-        return response;
-    }
+  @GET
+  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
+  @PermissionName(PermissionNameProvider.Name.ALL)
+  public PublicKeyResponse getPublicKey() {
+    final PublicKeyResponse response = instantiateJerseyResponse(PublicKeyResponse.class);
+    response.key = nodeKeyPair.getKeyPair().getPublicKeyStr();
+    return response;
+  }
 
-    public static class PublicKeyResponse extends SolrJerseyResponse {
-        @JsonProperty("key")
-        @Schema(description = "The public key of the receiving Solr node.")
-        public String key;
-    }
+  public static class PublicKeyResponse extends SolrJerseyResponse {
+    @JsonProperty("key")
+    @Schema(description = "The public key of the receiving Solr node.")
+    public String key;
+  }
 }

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.security;
+
+import org.apache.solr.api.JerseyResource;
+import org.apache.solr.core.CloudConfig;
+
+import javax.inject.Inject;
+
+/**
+ * V2 API for fetching the public key of the receiving node.
+ *
+ * <p>This API is analogous to the v1 /admin/info/key endpoint.
+ */
+public class PublicKeyAPI extends JerseyResource {
+
+    @Inject
+    public PublicKeyAPI(CloudConfig cloudConfig) {
+        // TODO 'CloudConfig' will be used later as a potential source for the RSA key pairs
+    }
+}

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
@@ -36,6 +36,10 @@ public class PublicKeyAPI extends JerseyResource {
     public PublicKeyAPI(CloudConfig cloudConfig) {
         // TODO 'CloudConfig' will be used later as a potential source for the RSA key pairs
     }
+
+    public PublicKeyResponse getPublicKey() {
+        return null;
+    }
     
     public static class PublicKeyResponse extends SolrJerseyResponse {
         @JsonProperty("key")

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
@@ -20,7 +20,6 @@ package org.apache.solr.security;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.solr.api.JerseyResource;
-import org.apache.solr.core.CloudConfig;
 import org.apache.solr.jersey.PermissionName;
 import org.apache.solr.jersey.SolrJerseyResponse;
 
@@ -39,9 +38,11 @@ import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONT
 @Path("/node/key")
 public class PublicKeyAPI extends JerseyResource {
 
+    private final SolrNodeKeyPair nodeKeyPair;
+
     @Inject
-    public PublicKeyAPI(CloudConfig cloudConfig) {
-        // TODO 'CloudConfig' will be used later as a potential source for the RSA key pairs
+    public PublicKeyAPI(SolrNodeKeyPair nodeKeyPair) {
+        this.nodeKeyPair = nodeKeyPair;
     }
 
     @GET
@@ -49,8 +50,7 @@ public class PublicKeyAPI extends JerseyResource {
     @PermissionName(PermissionNameProvider.Name.ALL)
     public PublicKeyResponse getPublicKey() {
         final PublicKeyResponse response = instantiateJerseyResponse(PublicKeyResponse.class);
-        response.key = "hello-world";
-
+        response.key = nodeKeyPair.getKeyPair().getPublicKeyStr();
         return response;
     }
 

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
@@ -17,8 +17,11 @@
 
 package org.apache.solr.security;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.solr.api.JerseyResource;
 import org.apache.solr.core.CloudConfig;
+import org.apache.solr.jersey.SolrJerseyResponse;
 
 import javax.inject.Inject;
 
@@ -32,5 +35,11 @@ public class PublicKeyAPI extends JerseyResource {
     @Inject
     public PublicKeyAPI(CloudConfig cloudConfig) {
         // TODO 'CloudConfig' will be used later as a potential source for the RSA key pairs
+    }
+    
+    public static class PublicKeyResponse extends SolrJerseyResponse {
+        @JsonProperty("key")
+        @Schema(description = "The public key of the receiving Solr node.")
+        public String key;
     }
 }

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyAPI.java
@@ -21,15 +21,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.solr.api.JerseyResource;
 import org.apache.solr.core.CloudConfig;
+import org.apache.solr.jersey.PermissionName;
 import org.apache.solr.jersey.SolrJerseyResponse;
 
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONTENT_TYPE_V2;
 
 /**
  * V2 API for fetching the public key of the receiving node.
  *
  * <p>This API is analogous to the v1 /admin/info/key endpoint.
  */
+@Path("/node/key")
 public class PublicKeyAPI extends JerseyResource {
 
     @Inject
@@ -37,10 +44,16 @@ public class PublicKeyAPI extends JerseyResource {
         // TODO 'CloudConfig' will be used later as a potential source for the RSA key pairs
     }
 
+    @GET
+    @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
+    @PermissionName(PermissionNameProvider.Name.ALL)
     public PublicKeyResponse getPublicKey() {
-        return null;
+        final PublicKeyResponse response = instantiateJerseyResponse(PublicKeyResponse.class);
+        response.key = "hello-world";
+
+        return response;
     }
-    
+
     public static class PublicKeyResponse extends SolrJerseyResponse {
         @JsonProperty("key")
         @Schema(description = "The public key of the receiving Solr node.")

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
@@ -20,16 +20,12 @@ package org.apache.solr.security;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.solr.api.Api;
 import org.apache.solr.api.JerseyResource;
-import org.apache.solr.common.StringUtils;
-import org.apache.solr.core.CloudConfig;
 import org.apache.solr.handler.RequestHandlerBase;
+import org.apache.solr.handler.api.V2ApiUtils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.CryptoKeys;
 
-import java.io.IOException;
-import java.net.URL;
-import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,41 +33,24 @@ import java.util.List;
 public class PublicKeyHandler extends RequestHandlerBase {
   public static final String PATH = "/admin/info/key";
 
-  final CryptoKeys.RSAKeyPair keyPair;
+  private final SolrNodeKeyPair nodeKeyPair;
 
   @VisibleForTesting
   public PublicKeyHandler() {
-    keyPair = new CryptoKeys.RSAKeyPair();
+    this(new SolrNodeKeyPair(null));
   }
 
-  public PublicKeyHandler(CloudConfig config) throws IOException, InvalidKeySpecException {
-    keyPair = createKeyPair(config);
+  public PublicKeyHandler(SolrNodeKeyPair nodeKeyPair) {
+    this.nodeKeyPair = nodeKeyPair;
   }
 
-  private CryptoKeys.RSAKeyPair createKeyPair(CloudConfig config)
-      throws IOException, InvalidKeySpecException {
-    if (config == null) {
-      return new CryptoKeys.RSAKeyPair();
-    }
-
-    String publicKey = config.getPkiHandlerPublicKeyPath();
-    String privateKey = config.getPkiHandlerPrivateKeyPath();
-
-    // If both properties unset, then we fall back to generating a new key pair
-    if (StringUtils.isEmpty(publicKey) && StringUtils.isEmpty(privateKey)) {
-      return new CryptoKeys.RSAKeyPair();
-    }
-
-    return new CryptoKeys.RSAKeyPair(new URL(privateKey), new URL(publicKey));
-  }
-
-  public String getPublicKey() {
-    return keyPair.getPublicKeyStr();
+  public CryptoKeys.RSAKeyPair getKeyPair() {
+    return nodeKeyPair.getKeyPair();
   }
 
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    rsp.add("key", keyPair.getPublicKeyStr());
+    V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, new PublicKeyAPI(nodeKeyPair).getPublicKey());
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
@@ -18,15 +18,21 @@
 package org.apache.solr.security;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
-import java.net.URL;
-import java.security.spec.InvalidKeySpecException;
+import org.apache.solr.api.Api;
+import org.apache.solr.api.JerseyResource;
 import org.apache.solr.common.StringUtils;
 import org.apache.solr.core.CloudConfig;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.CryptoKeys;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class PublicKeyHandler extends RequestHandlerBase {
   public static final String PATH = "/admin/info/key";
@@ -81,5 +87,20 @@ public class PublicKeyHandler extends RequestHandlerBase {
   @Override
   public Name getPermissionName(AuthorizationContext request) {
     return Name.ALL;
+  }
+
+  @Override
+  public Boolean registerV2() {
+    return Boolean.TRUE;
+  }
+
+  @Override
+  public Collection<Api> getApis() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public Collection<Class<? extends JerseyResource>> getJerseyResources() {
+    return List.of(PublicKeyAPI.class);
   }
 }

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
@@ -18,6 +18,9 @@
 package org.apache.solr.security;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.apache.solr.api.Api;
 import org.apache.solr.api.JerseyResource;
 import org.apache.solr.handler.RequestHandlerBase;
@@ -25,10 +28,6 @@ import org.apache.solr.handler.api.V2ApiUtils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.CryptoKeys;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class PublicKeyHandler extends RequestHandlerBase {
   public static final String PATH = "/admin/info/key";
@@ -50,7 +49,8 @@ public class PublicKeyHandler extends RequestHandlerBase {
 
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, new PublicKeyAPI(nodeKeyPair).getPublicKey());
+    V2ApiUtils.squashIntoSolrResponseWithoutHeader(
+        rsp, new PublicKeyAPI(nodeKeyPair).getPublicKey());
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/security/SolrNodeKeyPair.java
+++ b/solr/core/src/java/org/apache/solr/security/SolrNodeKeyPair.java
@@ -25,7 +25,7 @@ import org.apache.solr.core.CloudConfig;
 import org.apache.solr.util.CryptoKeys;
 
 /**
- * Creates and mediates access to the {@link CryptoKeys.RSAKeyPair} used by this Solr node.
+ * Creates and mediates access to the CryptoKeys.RSAKeyPair used by this Solr node.
  *
  * <p>Expected to be created once on each Solr node for the life of that process.
  */

--- a/solr/core/src/java/org/apache/solr/security/SolrNodeKeyPair.java
+++ b/solr/core/src/java/org/apache/solr/security/SolrNodeKeyPair.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.security;
+
+import org.apache.solr.common.StringUtils;
+import org.apache.solr.core.CloudConfig;
+import org.apache.solr.util.CryptoKeys;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * Creates and mediates access to the {@link CryptoKeys.RSAKeyPair} used by this Solr node.
+ *
+ * Expected to be created once on each Solr node for the life of that process.
+ */
+public class SolrNodeKeyPair {
+
+    private final CryptoKeys.RSAKeyPair keyPair;
+
+    public SolrNodeKeyPair(CloudConfig cloudConfig ) {
+        keyPair = createKeyPair(cloudConfig);
+    }
+
+    public CryptoKeys.RSAKeyPair getKeyPair() { return keyPair; }
+
+    private static CryptoKeys.RSAKeyPair createKeyPair(CloudConfig config) {
+        if (config == null) {
+            return new CryptoKeys.RSAKeyPair();
+        }
+
+        String publicKey = config.getPkiHandlerPublicKeyPath();
+        String privateKey = config.getPkiHandlerPrivateKeyPath();
+
+        // If both properties unset, then we fall back to generating a new key pair
+        if (StringUtils.isEmpty(publicKey) && StringUtils.isEmpty(privateKey)) {
+            return new CryptoKeys.RSAKeyPair();
+        }
+
+        try {
+            return new CryptoKeys.RSAKeyPair(new URL(privateKey), new URL(publicKey));
+        } catch (IOException | InvalidKeySpecException e) {
+            throw new RuntimeException("Bad PublicKeyHandler configuration.", e);
+        }
+    }
+}

--- a/solr/core/src/test/org/apache/solr/security/PublicKeyAPITest.java
+++ b/solr/core/src/test/org/apache/solr/security/PublicKeyAPITest.java
@@ -20,17 +20,15 @@ package org.apache.solr.security;
 import org.apache.solr.SolrTestCaseJ4;
 import org.junit.Test;
 
-/**
- * Unit test for {@link PublicKeyAPI}
- */
+/** Unit test for {@link PublicKeyAPI} */
 public class PublicKeyAPITest extends SolrTestCaseJ4 {
 
-    @Test
-    public void testRetrievesPublicKey() {
-        final SolrNodeKeyPair nodeKeyPair = new SolrNodeKeyPair(null);
+  @Test
+  public void testRetrievesPublicKey() {
+    final SolrNodeKeyPair nodeKeyPair = new SolrNodeKeyPair(null);
 
-        final PublicKeyAPI.PublicKeyResponse response = new PublicKeyAPI(nodeKeyPair).getPublicKey();
+    final PublicKeyAPI.PublicKeyResponse response = new PublicKeyAPI(nodeKeyPair).getPublicKey();
 
-        assertEquals(nodeKeyPair.getKeyPair().getPublicKeyStr(), response.key);
-    }
+    assertEquals(nodeKeyPair.getKeyPair().getPublicKeyStr(), response.key);
+  }
 }

--- a/solr/core/src/test/org/apache/solr/security/PublicKeyAPITest.java
+++ b/solr/core/src/test/org/apache/solr/security/PublicKeyAPITest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.security;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link PublicKeyAPI}
+ */
+public class PublicKeyAPITest extends SolrTestCaseJ4 {
+
+    @Test
+    public void testRetrievesPublicKey() {
+        final SolrNodeKeyPair nodeKeyPair = new SolrNodeKeyPair(null);
+
+        final PublicKeyAPI.PublicKeyResponse response = new PublicKeyAPI(nodeKeyPair).getPublicKey();
+
+        assertEquals(nodeKeyPair.getKeyPair().getPublicKeyStr(), response.key);
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16491

# Description

The /admin/info/key API used to retrieve a node's public key has no v2 equivalent.

# Solution

This PR adds a v2 equivalent using the JAX-RS framework, the new endpoint is `GET /api/node/key`.  In implementing this, some shared logic around key-creation was refactored into a separate class, `SolrNodeKeyPair`, which is created by CoreContainer and made injectable to the JAX-RS framework to that a single instance (i.e. same key) can be used by both the existing v1 RH, and the new v2 binding.

# Tests

A new simple unit test in `PublicKeyAPITest`; existing tests for  pki-auth and the PublicKeyHandler continue to pass.
 
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
