### PR TITLE
Fix the Zookeeper docs URL link so that it will not get shown

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solrcloud-shards-indexing.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solrcloud-shards-indexing.adoc
@@ -40,7 +40,7 @@ Additionally, every shard can  have multiple replicas for additional robustness.
 
 In SolrCloud there are no leaders or followers.
 Instead, every shard consists of at least one physical *replica*, exactly one of which is a *leader*.
-Leaders are automatically elected, initially on a first-come-first-served basis, and then based on the ZooKeeper process described at http://zookeeper.apache.org/doc/r{dep-version-zookeeper}/recipes.html#sc_leaderElection.
+Leaders are automatically elected, initially on a first-come-first-served basis, and then based on the ZooKeeper process described at the  http://zookeeper.apache.org/doc/r{dep-version-zookeeper}/recipes.html#sc_leaderElection[Zookeeper docs].
 
 If a leader goes down, one of the other replicas is automatically elected as the new leader.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-XXXXX

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

A full URL is shown in the docs, instead of a clickable word.

# Solution

Fix the Zookeeper docs URL link so that it will not get shown

# Tests


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
