### PR TITLE
SOLR-16502: Multiple CopyField should not limit to first maxChars

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -84,6 +84,8 @@ Bug Fixes
 
 * SOLR-16274: HEAD request for managed resource returns 500 Server Error (Kevin Risden)
 
+* SOLR-16502: Multiple CopyField should not limit to first maxChars (Kevin Risden)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -84,7 +84,7 @@ Bug Fixes
 
 * SOLR-16274: HEAD request for managed resource returns 500 Server Error (Kevin Risden)
 
-* SOLR-16502: Multiple CopyField should not limit to first maxChars (Kevin Risden)
+* SOLR-16502: Multiple CopyField should not limit to first maxChars (Fredrik Rodland, Kevin Risden)
 
 Build
 ---------------------

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -306,7 +306,7 @@ public class DocumentBuilder {
   }
 
   private static boolean addCopyFields(
-      Object originalFieldValue,
+      final Object originalFieldValue,
       FieldType originalFieldType,
       List<CopyField> copyFields,
       boolean forInPlaceUpdate,

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -336,16 +336,17 @@ public class DocumentBuilder {
                 + ": "
                 + originalFieldValue);
       }
+      Object fieldValue = originalFieldValue;
       // Perhaps trim the length of a copy field
       if (originalFieldValue instanceof CharSequence && cf.getMaxChars() > 0) {
-        originalFieldValue = cf.getLimitedValue(originalFieldValue.toString());
+        fieldValue = cf.getLimitedValue(originalFieldValue.toString());
       }
 
       // TODO ban copyField populating uniqueKeyField; too problematic to support
       addField(
           out,
           destinationField,
-          originalFieldValue,
+          fieldValue,
           destinationField.getName().equals(uniqueKeyFieldName) ? false : forInPlaceUpdate);
       // record the field as having a originalFieldValue
       usedFields.add(destinationField.getName());

--- a/solr/core/src/test-files/solr/collection1/conf/schema.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema.xml
@@ -704,7 +704,9 @@
   <field name="severity" type="severityType" docValues="true" indexed="true" stored="true" multiValued="false"/>
 
   <field name="max_chars" type="string" indexed="false" stored="true"/>
-  
+  <field name="no_max_chars" type="string" indexed="false" stored="true"/>
+  <field name="large_max_chars" type="string" indexed="false" stored="true"/>
+
   <!-- Dense Vector-->
   <field name="vector" type="knn_vector_cosine" indexed="true" stored="true"/>
   <field name="vector2" type="knn_vector_dot_product" indexed="true" stored="true"/>
@@ -917,6 +919,8 @@
   <copyField source="*_path" dest="*_ancestor"/>
 
   <copyField source="title" dest="max_chars" maxChars="10"/>
+  <copyField source="title" dest="no_max_chars" />
+  <copyField source="title" dest="large_max_chars" maxChars="10000"/>
   <copyField source="vector" dest="vector2"/>
   <copyField source="vector3" dest="vector_f_p"/>
   <copyField source="vector4" dest="vector5"/>

--- a/solr/core/src/test/org/apache/solr/update/DocumentBuilderTest.java
+++ b/solr/core/src/test/org/apache/solr/update/DocumentBuilderTest.java
@@ -314,6 +314,34 @@ public class DocumentBuilderTest extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void testMultipleCopyFieldMaxChars() {
+    SolrCore core = h.getCore();
+
+    String testValue = "this is more than 10 characters";
+    String truncatedValue = "this is mo";
+
+    // maxChars with a string value
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.addField("title", testValue);
+
+    Document out = DocumentBuilder.toDocument(doc, core.getLatestSchema());
+    assertEquals(testValue, out.get("title"));
+    assertEquals(truncatedValue, out.get("max_chars"));
+    assertEquals(testValue, out.get("no_max_chars"));
+    assertEquals(testValue, out.get("large_max_chars"));
+
+    // maxChars with a ByteArrayUtf8CharSequence
+    doc = new SolrInputDocument();
+    doc.addField("title", new ByteArrayUtf8CharSequence(testValue));
+
+    out = DocumentBuilder.toDocument(doc, core.getLatestSchema());
+    assertEquals(testValue, out.get("title"));
+    assertEquals(truncatedValue, out.get("max_chars"));
+    assertEquals(testValue, out.get("no_max_chars"));
+    assertEquals(testValue, out.get("large_max_chars"));
+  }
+
+  @Test
   public void denseVector_shouldReturnOneIndexableFieldAndOneStoredFieldPerVectorElement() {
     SolrCore core = h.getCore();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16502