### PR TITLE
Gradle should fail clearly on too-new JDK

### DIFF
--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -47,14 +47,22 @@ public class WrapperDownloader {
   public static void main(String[] args) {
     if (args.length != 1) {
       System.err.println("Usage: java WrapperDownloader.java <destination>");
-      System.exit(1);
+      System.exit(2);
     }
 
     try {
+      checkVersion();
       new WrapperDownloader().run(Paths.get(args[0]));
     } catch (Exception e) {
       System.err.println("ERROR: " + e.getMessage());
-      System.exit(1);
+      System.exit(3);
+    }
+  }
+
+  public static void checkVersion() {
+    int major = Runtime.getRuntime().version().feature();
+    if (major < 11 || major > 18) {
+      throw new IllegalStateException("java version must be between 11 and 18, your version: " + major);
     }
   }
 

--- a/gradlew
+++ b/gradlew
@@ -152,9 +152,13 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
 fi
 GRADLE_WRAPPER_JAR="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
-if ! "$JAVACMD" --source 11 "$APP_HOME/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR" ; then
-    echo "\nSomething went wrong. Make sure you're using Java 11 or later."
-    exit $?
+"$JAVACMD" $JAVA_OPTS --source 11 "$APP_HOME/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR"
+WRAPPER_STATUS=$?
+if [ "$WRAPPER_STATUS" -eq 1 ]; then
+    echo "ERROR: Something went wrong. Make sure you're using Java 11 - 18."
+    exit $WRAPPER_STATUS
+elif [ "$WRAPPER_STATUS" -ne 0 ]; then
+    exit $WRAPPER_STATUS
 fi
 
 CLASSPATH=$GRADLE_WRAPPER_JAR

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -91,6 +91,9 @@ IF NOT EXIST "%DIRNAME%\gradle.properties" SET GRADLE_DAEMON_CTRL=--no-daemon
 if "%ERRORLEVEL%"=="0" goto mainEnd
 
 :fail
+@rem https://github.com/apache/lucene/pull/819
+echo Error: Something went wrong. Make sure you're using Java 11 - 18.
+
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
 if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1


### PR DESCRIPTION
Gradle will give a very confusing error using the
wrong JDK, let's make it absolutely clear.

Port the following to Solr with minor adjustments (minimum JDK 11)
* https://github.com/apache/lucene/pull/819
* https://github.com/apache/lucene/pull/11889

Co-authored-by: Dawid Weiss <dawid.weiss@carrotsearch.com>
Co-authored-by: Robert Muir <rmuir@apache.org>