### PR TITLE
SOLR-16152 Print helpful error instead of NPE when using bin/solr package in standalone

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/PackageTool.java
+++ b/solr/core/src/java/org/apache/solr/util/PackageTool.java
@@ -77,6 +77,11 @@ public class PackageTool extends SolrCLI.ToolBase {
       solrBaseUrl = solrUrl.replaceAll("\\/solr$", ""); // strip out ending "/solr"
       log.info("Solr url:{}, solr base url: {}", solrUrl, solrBaseUrl);
       String zkHost = getZkHost(cli);
+      if (zkHost == null) {
+        throw new SolrException(
+            ErrorCode.INVALID_STATE,
+            "Package manager runs only in SolrCloud");
+      }
 
       log.info("ZK: {}", zkHost);
       String cmd = cli.getArgList().size() == 0 ? "help" : cli.getArgs()[0];


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16152

(NO JIRA)

Printout will be
```bash
> bin/solr package
org.apache.solr.common.SolrException: Package manager runs only in SolrCloud
	at org.apache.solr.util.PackageTool.runImpl(PackageTool.java:81)
	at org.apache.solr.util.SolrCLI$ToolBase.runTool(SolrCLI.java:170)
	at org.apache.solr.util.SolrCLI.main(SolrCLI.java:308)

ERROR: Package manager runs only in SolrCloud
```