### PR TITLE
[SOLR-16515] Remove synchronized access to cachedOrdMaps in SlowCompositeReaderWrapper

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -64,7 +64,8 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+
+* SOLR-16515: Remove synchronized access to cachedOrdMaps in SlowCompositeReaderWrapper (Dennis Berger, Torsten Bøgh Köster, Marco Petris)
 
 Bug Fixes
 ---------------------

--- a/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
+++ b/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
@@ -223,7 +223,7 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
     CacheHelper cacheHelper = getReaderCacheHelper();
 
     Function<? super String, ? extends OrdinalMap> producer =
-        (f) -> {
+        (notUsed) -> {
           try {
             OrdinalMap mapping =
                 OrdinalMap.build(
@@ -297,7 +297,9 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
     Function<? super String, ? extends OrdinalMap> producer =
         (notUsed) -> {
           try {
-            OrdinalMap mapping = OrdinalMap.build(cacheHelper.getKey(), values, PackedInts.DEFAULT);
+            OrdinalMap mapping =
+                OrdinalMap.build(
+                    cacheHelper == null ? null : cacheHelper.getKey(), values, PackedInts.DEFAULT);
             return mapping;
           } catch (IOException e) {
             throw new RuntimeException(e);

--- a/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
+++ b/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiDocValues;
+import org.apache.lucene.index.MultiDocValues.MultiSortedDocValues;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.NumericDocValues;
@@ -46,7 +47,6 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
@@ -173,54 +173,39 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
     return MultiDocValues.getSortedNumericValues(in, field); // TODO cache?
   }
 
-  private interface MultiDocValuesAccessor<T> {
-    T getSortedValues(LeafReader reader, String field) throws IOException;
-
-    T[] createSortedValuesArray(int size);
-
-    T createMultiSortedValues(T[] values, int[] docStarts, OrdinalMap mapping, long totalCost);
-
-    DocValuesType getDocValuesType();
-
-    T getEmptySortedValues();
-
-    OrdinalMap buildMap(CacheKey key, T[] values) throws IOException;
-  }
-
-  private <T extends DocIdSetIterator> T getMultiSortedDocValues(
-          MultiDocValuesAccessor<T> multiDocValuesAccessor, String field) throws IOException {
+  @Override
+  public SortedDocValues getSortedDocValues(String field) throws IOException {
     ensureOpen();
 
-    // Integration of what was previously in MultiDocValues.getSortedValues/getSortedSetValues:
+    // Integration of what was previously in MultiDocValues.getSortedValues:
     // The purpose of this integration is to be able to construct a value producer which can always
     // produce a value that is actually needed. The reason for the producer is to avoid getAndSet
     // pitfalls in this multithreaded context.
     // So all cases that do not lead to a cacheable value are handled upfront.
-    // We kept the semantics of MultiDocValues.getSortedValues/getSortedSetValues.
+    // We kept the semantics of MultiDocValues.getSortedValues.
     final List<LeafReaderContext> leaves = in.leaves();
     final int size = leaves.size();
 
     if (size == 0) {
       return null;
     } else if (size == 1) {
-      return multiDocValuesAccessor.getSortedValues(leaves.get(0).reader(), field);
+      return leaves.get(0).reader().getSortedDocValues(field);
     }
 
     boolean anyReal = false;
-    final T[] values = multiDocValuesAccessor.createSortedValuesArray(size);
+    final SortedDocValues[] values = new SortedDocValues[size];
     final int[] starts = new int[size + 1];
     long totalCost = 0;
     for (int i = 0; i < size; i++) {
       LeafReaderContext context = in.leaves().get(i);
       final LeafReader reader = context.reader();
       final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
-      if (fieldInfo != null
-          && fieldInfo.getDocValuesType() != multiDocValuesAccessor.getDocValuesType()) {
+      if (fieldInfo != null && fieldInfo.getDocValuesType() != DocValuesType.SORTED) {
         return null;
       }
-      T v = multiDocValuesAccessor.getSortedValues(reader, field);
+      SortedDocValues v = reader.getSortedDocValues(field);
       if (v == null) {
-        v = multiDocValuesAccessor.getEmptySortedValues();
+        v = DocValues.emptySorted();
       } else {
         anyReal = true;
       }
@@ -240,8 +225,10 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
     Function<? super String, ? extends OrdinalMap> producer =
         (notUsed) -> {
           try {
-            return multiDocValuesAccessor.buildMap(
-                cacheHelper == null ? null : cacheHelper.getKey(), values);
+            OrdinalMap mapping =
+                OrdinalMap.build(
+                    cacheHelper == null ? null : cacheHelper.getKey(), values, PackedInts.DEFAULT);
+            return mapping;
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -255,88 +242,79 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
       map = producer.apply("notUsed");
     }
 
-    return multiDocValuesAccessor.createMultiSortedValues(values, starts, map, totalCost);
-  }
-
-  @Override
-  public SortedDocValues getSortedDocValues(String field) throws IOException {
-    MultiDocValuesAccessor<SortedDocValues> sortedDocValuesAccessor =
-        new MultiDocValuesAccessor<>() {
-          @Override
-          public SortedDocValues getSortedValues(LeafReader reader, String field)
-              throws IOException {
-            return reader.getSortedDocValues(field);
-          }
-
-          @Override
-          public SortedDocValues[] createSortedValuesArray(int size) {
-            return new SortedDocValues[size];
-          }
-
-          @Override
-          public SortedDocValues createMultiSortedValues(
-              SortedDocValues[] values, int[] docStarts, OrdinalMap mapping, long totalCost) {
-            return new MultiDocValues.MultiSortedDocValues(values, docStarts, mapping, totalCost);
-          }
-
-          @Override
-          public DocValuesType getDocValuesType() {
-            return DocValuesType.SORTED;
-          }
-
-          @Override
-          public SortedDocValues getEmptySortedValues() {
-            return DocValues.emptySorted();
-          }
-
-          @Override
-          public OrdinalMap buildMap(CacheKey key, SortedDocValues[] values) throws IOException {
-            return OrdinalMap.build(key, values, PackedInts.DEFAULT);
-          }
-        };
-    return getMultiSortedDocValues(sortedDocValuesAccessor, field);
+    return new MultiSortedDocValues(values, starts, map, totalCost);
   }
 
   @Override
   public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
-    MultiDocValuesAccessor<SortedSetDocValues> sortedSetDocValuesAccessor =
-        new MultiDocValuesAccessor<>() {
+    ensureOpen();
 
-          @Override
-          public SortedSetDocValues getSortedValues(LeafReader reader, String field)
-              throws IOException {
-            return reader.getSortedSetDocValues(field);
-          }
+    // Integration of what was previously in MultiDocValues.getSortedSetValues:
+    // The purpose of this integration is to be able to construct a value producer which can always
+    // produce a value that is actually needed. The reason for the producer is to avoid getAndSet
+    // pitfalls in this multithreaded context.
+    // So all cases that do not lead to a cacheable value are handled upfront.
+    // We kept the semantics of MultiDocValues.getSortedSetValues.
+    final List<LeafReaderContext> leaves = in.leaves();
+    final int size = leaves.size();
 
-          @Override
-          public SortedSetDocValues[] createSortedValuesArray(int size) {
-            return new SortedSetDocValues[size];
-          }
+    if (size == 0) {
+      return null;
+    } else if (size == 1) {
+      return leaves.get(0).reader().getSortedSetDocValues(field);
+    }
 
-          @Override
-          public SortedSetDocValues createMultiSortedValues(
-              SortedSetDocValues[] values, int[] docStarts, OrdinalMap mapping, long totalCost) {
-            return new MultiDocValues.MultiSortedSetDocValues(
-                values, docStarts, mapping, totalCost);
-          }
+    boolean anyReal = false;
+    final SortedSetDocValues[] values = new SortedSetDocValues[size];
+    final int[] starts = new int[size + 1];
+    long totalCost = 0;
+    for (int i = 0; i < size; i++) {
+      LeafReaderContext context = in.leaves().get(i);
+      final LeafReader reader = context.reader();
+      final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+      if (fieldInfo != null && fieldInfo.getDocValuesType() != DocValuesType.SORTED_SET) {
+        return null;
+      }
+      SortedSetDocValues v = reader.getSortedSetDocValues(field);
+      if (v == null) {
+        v = DocValues.emptySortedSet();
+      } else {
+        anyReal = true;
+      }
+      totalCost += v.cost();
+      values[i] = v;
+      starts[i] = context.docBase;
+    }
+    starts[size] = maxDoc();
+    if (anyReal == false) {
+      return null;
+    }
 
-          @Override
-          public DocValuesType getDocValuesType() {
-            return DocValuesType.SORTED_SET;
-          }
+    // at this point in time we are able to formulate the producer
+    OrdinalMap map = null;
+    CacheHelper cacheHelper = getReaderCacheHelper();
 
-          @Override
-          public SortedSetDocValues getEmptySortedValues() {
-            return DocValues.emptySortedSet();
-          }
-
-          @Override
-          public OrdinalMap buildMap(CacheKey key, SortedSetDocValues[] values) throws IOException {
-            return OrdinalMap.build(key, values, PackedInts.DEFAULT);
+    Function<? super String, ? extends OrdinalMap> producer =
+        (notUsed) -> {
+          try {
+            OrdinalMap mapping =
+                OrdinalMap.build(
+                    cacheHelper == null ? null : cacheHelper.getKey(), values, PackedInts.DEFAULT);
+            return mapping;
+          } catch (IOException e) {
+            throw new RuntimeException(e);
           }
         };
 
-    return getMultiSortedDocValues(sortedSetDocValuesAccessor, field);
+    // either we use a cached result that gets produced eventually during caching,
+    // or we produce directly without caching
+    if (cacheHelper != null) {
+      map = cachedOrdMaps.computeIfAbsent(field + cacheHelper.getKey(), producer);
+    } else {
+      map = producer.apply("notUsed");
+    }
+
+    return new MultiDocValues.MultiSortedSetDocValues(values, starts, map, totalCost);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
+++ b/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
@@ -17,9 +17,10 @@
 package org.apache.solr.index;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.CompositeReader;
 import org.apache.lucene.index.DirectoryReader;
@@ -49,6 +50,7 @@ import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
+import org.apache.lucene.util.packed.PackedInts;
 
 /**
  * This class forces a composite reader (eg a {@link MultiReader} or {@link DirectoryReader}) to
@@ -73,10 +75,9 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
 
   final Map<String, Terms> cachedTerms = new ConcurrentHashMap<>();
 
-  // TODO: consider ConcurrentHashMap ?
   // TODO: this could really be a weak map somewhere else on the coreCacheKey,
   // but do we really need to optimize slow-wrapper any more?
-  final Map<String, OrdinalMap> cachedOrdMaps = new HashMap<>();
+  final Map<String, OrdinalMap> cachedOrdMaps = new ConcurrentHashMap<>();
 
   /**
    * This method is sugar for getting an {@link LeafReader} from an {@link IndexReader} of any kind.
@@ -175,23 +176,23 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
   @Override
   public SortedDocValues getSortedDocValues(String field) throws IOException {
     ensureOpen();
-    OrdinalMap map = null;
-    synchronized (cachedOrdMaps) {
-      map = cachedOrdMaps.get(field);
-      if (map == null) {
-        // uncached, or not a multi dv
-        SortedDocValues dv = MultiDocValues.getSortedValues(in, field);
-        if (dv instanceof MultiSortedDocValues) {
-          map = ((MultiSortedDocValues) dv).mapping;
-          IndexReader.CacheHelper cacheHelper = getReaderCacheHelper();
-          if (cacheHelper != null && map.owner == cacheHelper.getKey()) {
-            cachedOrdMaps.put(field, map);
-          }
-        }
-        return dv;
-      }
+
+    // Integration of what was previously in MultiDocValues.getSortedValues:
+    // The purpose of this integration is to be able to construct a value producer which can always
+    // produce a value that is actually needed. The reason for the producer is to avoid getAndSet
+    // pitfalls in this multithreaded context.
+    // So all cases that do not lead to a cacheable value are handled upfront.
+    // We kept the semantics of MultiDocValues.getSortedValues.
+    final List<LeafReaderContext> leaves = in.leaves();
+    final int size = leaves.size();
+
+    if (size == 0) {
+      return null;
+    } else if (size == 1) {
+      return leaves.get(0).reader().getSortedDocValues(field);
     }
-    int size = in.leaves().size();
+
+    boolean anyReal = false;
     final SortedDocValues[] values = new SortedDocValues[size];
     final int[] starts = new int[size + 1];
     long totalCost = 0;
@@ -205,40 +206,68 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
       SortedDocValues v = reader.getSortedDocValues(field);
       if (v == null) {
         v = DocValues.emptySorted();
+      } else {
+        anyReal = true;
       }
       totalCost += v.cost();
       values[i] = v;
       starts[i] = context.docBase;
     }
     starts[size] = maxDoc();
+    if (anyReal == false) {
+      return null;
+    }
+
+    // at this point in time we are able to formulate the producer
+    OrdinalMap map = null;
+    CacheHelper cacheHelper = getReaderCacheHelper();
+
+    Function<? super String, ? extends OrdinalMap> producer =
+        (f) -> {
+          try {
+            OrdinalMap mapping =
+                OrdinalMap.build(
+                    cacheHelper == null ? null : cacheHelper.getKey(), values, PackedInts.DEFAULT);
+            return mapping;
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    // either we use a cached result that gets produced eventually during caching,
+    // or we produce directly without caching
+    if (cacheHelper != null) {
+      map = cachedOrdMaps.computeIfAbsent(field + cacheHelper.getKey(), producer);
+    } else {
+      map = producer.apply("notUsed");
+    }
+
     return new MultiSortedDocValues(values, starts, map, totalCost);
   }
 
   @Override
   public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
     ensureOpen();
-    OrdinalMap map = null;
-    synchronized (cachedOrdMaps) {
-      map = cachedOrdMaps.get(field);
-      if (map == null) {
-        // uncached, or not a multi dv
-        SortedSetDocValues dv = MultiDocValues.getSortedSetValues(in, field);
-        if (dv instanceof MultiDocValues.MultiSortedSetDocValues) {
-          map = ((MultiDocValues.MultiSortedSetDocValues) dv).mapping;
-          IndexReader.CacheHelper cacheHelper = getReaderCacheHelper();
-          if (cacheHelper != null && map.owner == cacheHelper.getKey()) {
-            cachedOrdMaps.put(field, map);
-          }
-        }
-        return dv;
-      }
+
+    // Integration of what was previously in MultiDocValues.getSortedSetValues:
+    // The purpose of this integration is to be able to construct a value producer which can always
+    // produce a value that is actually needed. The reason for the producer is to avoid getAndSet
+    // pitfalls in this multithreaded context.
+    // So all cases that do not lead to a cacheable value are handled upfront.
+    // We kept the semantics of MultiDocValues.getSortedSetValues.
+    final List<LeafReaderContext> leaves = in.leaves();
+    final int size = leaves.size();
+
+    if (size == 0) {
+      return null;
+    } else if (size == 1) {
+      return leaves.get(0).reader().getSortedSetDocValues(field);
     }
 
-    assert map != null;
-    int size = in.leaves().size();
+    boolean anyReal = false;
     final SortedSetDocValues[] values = new SortedSetDocValues[size];
     final int[] starts = new int[size + 1];
-    long cost = 0;
+    long totalCost = 0;
     for (int i = 0; i < size; i++) {
       LeafReaderContext context = in.leaves().get(i);
       final LeafReader reader = context.reader();
@@ -249,13 +278,41 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
       SortedSetDocValues v = reader.getSortedSetDocValues(field);
       if (v == null) {
         v = DocValues.emptySortedSet();
+      } else {
+        anyReal = true;
       }
+      totalCost += v.cost();
       values[i] = v;
       starts[i] = context.docBase;
-      cost += v.cost();
     }
     starts[size] = maxDoc();
-    return new MultiDocValues.MultiSortedSetDocValues(values, starts, map, cost);
+    if (anyReal == false) {
+      return null;
+    }
+
+    // at this point in time we are able to formulate the producer
+    OrdinalMap map = null;
+    CacheHelper cacheHelper = getReaderCacheHelper();
+
+    Function<? super String, ? extends OrdinalMap> producer =
+        (notUsed) -> {
+          try {
+            OrdinalMap mapping = OrdinalMap.build(cacheHelper.getKey(), values, PackedInts.DEFAULT);
+            return mapping;
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    // either we use a cached result that gets produced eventually during caching,
+    // or we produce directly without caching
+    if (cacheHelper != null) {
+      map = cachedOrdMaps.computeIfAbsent(field + cacheHelper.getKey(), producer);
+    } else {
+      map = producer.apply("notUsed");
+    }
+
+    return new MultiDocValues.MultiSortedSetDocValues(values, starts, map, totalCost);
   }
 
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16515

The `SlowCompositeReaderWrapper` uses synchronized read and write access to its internal `cachedOrdMaps`. By using a `ConcurrentHashMap` instead of a `LinkedHashMap` as the  underlying `cachedOrdMaps` implementation and the `ConcurrentHashMap#computeIfAbsent` method to compute cache values, we were able to reduce locking contention significantly.

### Background

Under heavy load we discovered that application halts inside of Solr are becoming a serious problem in high traffic environments. Using Java Flight Recordings we discovered high accumulated applications halts on the `cachedOrdMaps` in `SlowCompositeReaderWrapper`. Without this fix we were able to utilize our machines only up to 25% cpu usage. With the fix applied, a utilization up to 80% is perfectly doable.

### Description

Our Solr instances utilizes the `collapse` component heavily. The instances run with 32 cores and 32gb Java heap on a rather small index (4gb). The instances scale out at 50% cpu load. We take Java Flight Recorder snapshots of 60 seconds
as soon the cpu usage exceeds 50%.

<img width="997" alt="solr-issues-scrw-locking" src="https://user-images.githubusercontent.com/557264/196221280-7eeac492-d204-497a-907e-bc261cd90530.png">

During our 60s Java Flight Recorder snapshot, the ~2k Jetty threads accumulated more than 16h locking time inside the `SlowCompositeReaderWrapper` (see screenshot). With this fix applied, the locking access is reduced to cache write accesses only. We validated this using another JFR snapshot:

<img width="983" alt="solr-issues-scrw-after" src="https://user-images.githubusercontent.com/557264/196221323-3ab53d23-cf23-4aee-a395-b518d4b42e54.png">

### Solution

We propose the following improvement inside the `SlowCompositeReaderWrapper` removing blocking `synchronized` access to the internal `cachedOrdMaps`. The implementation keeps the semantics of the `getSortedDocValues` and `getSortedSetDocValues` methods but moves the expensive part of `OrdinalMap#build` into a producer. We use the producer to access the `ConcurrentHashMap` using the `ConcurrentHashMap#computeIfAbsent` method only.

The current implementation uses the `synchronized` block not only to lock access to the `cachedOrdMaps` but also to protect the critical section between getting, building and putting the `OrdinalMap` into the cache. Inside the critical section the decision is formed, whether a cacheable value should be composed and added to the cache. 

To support non-blocking read access to the cache, we move the building part of the critical section into a producer `Function`. The check whether we have a cacheable value is made upfront. To properly make that decision we had to take logic from `MultiDocValues#getSortedSetValues` and `MultiDocValues#getSortedValues` (the `SlowCompositeReaderWrapper` already contained duplicated code from those methods).

### Summary

This change removes most blocking access inside the `SlowCompositeReaderWrapper` and despite it's name it's now capable of a much higher request throughput.

This change has been composed together by Dennis Berger, Torsten Bøgh Köster and Marco Petris.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
