### PR TITLE
Modifying github actions to run on all branches including ones with slashes

### DIFF
--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -3,7 +3,7 @@ name: Gradle Precommit
 on: 
   pull_request:
     branches:
-    - '*'
+    - '**'
 
 jobs:
   test:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16516

# Description

This change modifies the Github Actions to execute on any PR opened against any branch, including branches with a `/` in the branch name. This can be useful for organizations that have forked the Solr repo and want to run checks against additional branches.

# Solution

This is a simple change to the pattern used to be `**` instead of `*` to include branches with slashes. More info here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
