### PR TITLE
SOLR-16510: Fix StreamDecoratorTest.testParallelTerminatingDaemonUpdateStream Con…

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
@@ -89,7 +89,7 @@ public class StreamHandler extends RequestHandlerBase
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private String coreName;
   private SolrClientCache solrClientCache;
-  private Map<String, DaemonStream> daemons = Collections.synchronizedMap(new HashMap<>());
+  private Map<String, DaemonStream> daemons = new ConcurrentHashMap<>();
 
   @Override
   public PermissionNameProvider.Name getPermissionName(AuthorizationContext request) {


### PR DESCRIPTION
…currentModificationException
https://issues.apache.org/jira/browse/SOLR-16510

The synchronized map that was used does not protect against ConcurrentModificationException when iterating the map.values() collection. The ConcurrentHashMap does protect against this.
