### PR TITLE
Remove 'compatibility' settings from gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,3 @@ apply from: file('gradle/solr/solr-forbidden-apis.gradle')
 apply from: file('gradle/ant-compat/solr.post-jar.gradle')
 
 apply from: file('gradle/node.gradle')
-
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
Was unintentionally added in c23ecd6.


# Description

A previous commit (c23ecd6) inadvertently added `sourceCompatibility` and `targetCompatibility` settings to build.gradle.  These aren't desired and need to be removed.

# Solution

This PR deletes them from the file.

# Tests

Manual testing of the build and IDE integration.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
