### PR TITLE
Revert "SOLR-16457: solr.data.home should not be set to empty string in bin/solr

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -153,8 +153,6 @@ Bug Fixes
 
 * SOLR-16229: Http2SolrClient aborts requests on exception (Daniel Rabus, Tomás Fernández Löbbe)
 
-* SOLR-16457: solr.data.home should not be set to empty string in bin/solr (Kevin Risden)
-
 * SOLR-16433: Security Manager prevents Solr SQL from working (Kevin Risden)
 
 * SOLR-16460: ClusterState.copyWith is inconsistent (noble)

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2230,7 +2230,6 @@ function start_solr() {
     fi
 
     if [ -n "${SOLR_DATA_HOME:-}" ]; then
-      SOLR_OPTS+=("-Dsolr.data.home=$SOLR_DATA_HOME")
       echo -e "    SOLR_DATA_HOME  = $SOLR_DATA_HOME"
     fi
     echo
@@ -2257,7 +2256,7 @@ function start_solr() {
     # users who don't care about useful error msgs can override in SOLR_OPTS with +OmitStackTraceInFastThrow
     "${SOLR_HOST_ARG[@]}" "-Duser.timezone=$SOLR_TIMEZONE" "-XX:-OmitStackTraceInFastThrow" \
     "-XX:OnOutOfMemoryError=$SOLR_TIP/bin/oom_solr.sh $SOLR_PORT $SOLR_LOGS_DIR" \
-    "-Djetty.home=$SOLR_SERVER_DIR" "-Dsolr.solr.home=$SOLR_HOME" "-Dsolr.install.dir=$SOLR_TIP" \
+    "-Djetty.home=$SOLR_SERVER_DIR" "-Dsolr.solr.home=$SOLR_HOME" "-Dsolr.data.home=${SOLR_DATA_HOME:-}" "-Dsolr.install.dir=$SOLR_TIP" \
     "-Dsolr.default.confdir=$DEFAULT_CONFDIR" "${LOG4J_CONFIG[@]}" "${SOLR_OPTS[@]}" "${SECURITY_MANAGER_OPTS[@]}" "${SOLR_ADMIN_UI}")
 
   mk_writable_dir "$SOLR_LOGS_DIR" "Logs"

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -45,7 +45,6 @@ ENV SOLR_USER="solr" \
     SOLR_PID_DIR=/var/solr \
     SOLR_LOGS_DIR=/var/solr/logs \
     LOG4J_PROPS=/var/solr/log4j2.xml \
-    SOLR_SERVER_DIR="/opt/solr-${SOLR_VERSION}/server" \
     SOLR_JETTY_HOST="0.0.0.0"
 
 RUN set -ex; \

--- a/solr/server/etc/security.policy
+++ b/solr/server/etc/security.policy
@@ -27,10 +27,6 @@ grant {
   // system jar resources
   permission java.io.FilePermission "${java.home}${/}-", "read";
 
-  // tmpdir
-  permission java.io.FilePermission "${java.io.tmpdir}", "read,write";
-  permission java.io.FilePermission "${java.io.tmpdir}${/}-", "read,write,delete";
-
   // Test launchers (randomizedtesting, etc.)
   permission java.io.FilePermission "${junit4.childvm.cwd}", "read";
   permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp", "read,write,delete";


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16457

This reverts commit e9100b9383a1f7e85285b381f5ee3eefda7814b4.