### PR TITLE
SOLR-15955: Put slf4j-api jar in lib/ext/

### DIFF
--- a/solr/core/build.gradle
+++ b/solr/core/build.gradle
@@ -83,22 +83,14 @@ dependencies {
   runtimeOnly('org.eclipse.jetty:jetty-alpn-java-server', {
     exclude group: "org.eclipse.jetty.alpn", module: "alpn-api"
   })
-  jettyClientImplementation('org.eclipse.jetty:jetty-http', {
-    exclude group: "org.slf4j", module: "slf4j-api"
-  })
-  jettyClientImplementation('org.eclipse.jetty:jetty-io', {
-    exclude group: "org.slf4j", module: "slf4j-api"
-  })
+  jettyClientImplementation('org.eclipse.jetty:jetty-http')
+  jettyClientImplementation('org.eclipse.jetty:jetty-io')
   implementation 'org.eclipse.jetty:jetty-rewrite'
   implementation 'org.eclipse.jetty:jetty-server'
   implementation 'org.eclipse.jetty:jetty-servlet'
-  jettyClientImplementation('org.eclipse.jetty:jetty-util', {
-    exclude group: "org.slf4j", module: "slf4j-api"
-  })
+  jettyClientImplementation('org.eclipse.jetty:jetty-util')
 
-  jettyClientImplementation('org.eclipse.jetty.http2:http2-common', {
-    exclude group: "org.slf4j", module: "slf4j-api"
-  })
+  jettyClientImplementation('org.eclipse.jetty.http2:http2-common')
   implementation 'org.eclipse.jetty.http2:http2-server'
 
   implementation('org.glassfish.jersey.containers:jersey-container-jetty-http', {

--- a/solr/server/build.gradle
+++ b/solr/server/build.gradle
@@ -76,7 +76,11 @@ dependencies {
   libExt('io.dropwizard.metrics:metrics-graphite', {
     exclude group: "com.rabbitmq", module: "amqp-client"
   })
-  libExt 'io.dropwizard.metrics:metrics-jetty10'
+  libExt('io.dropwizard.metrics:metrics-jetty10', {
+    exclude group: "org.eclipse.jetty", module: "*"
+    exclude group: "org.eclipse.jetty.http2", module: "*"
+    exclude group: "org.eclipse.jetty.toolchain", module: "*"
+  })
   libExt 'io.dropwizard.metrics:metrics-jvm'
   libExt 'io.dropwizard.metrics:metrics-jmx'
 
@@ -109,11 +113,11 @@ task assemblePackaging(type: Sync) {
     include "README.md"
   })
 
-  from(configurations.libExt - configurations.serverLib, {
+  from(configurations.libExt, {
     into "lib/ext"
   })
 
-  from(configurations.serverLib, {
+  from(configurations.serverLib - configurations.libExt, {
     into "lib/"
   })
 

--- a/solr/webapp/build.gradle
+++ b/solr/webapp/build.gradle
@@ -24,18 +24,20 @@ description = 'Solr webapp'
 
 configurations {
   war {}
-  serverLib {}
-  solrJettyClientLib {}
-  solrCore {}
+  serverLib
+  libExt
+  solrJettyClientLib
+  solrCore
 }
 
 dependencies {
   permitUnusedDeclared project(":solr:core")
-  serverLib project(path: ":solr:server", configuration: "libExt")
+  libExt project(path: ":solr:server", configuration: "libExt")
   serverLib project(path: ":solr:server", configuration: "serverLib")
   solrCore project(":solr:core")
   solrJettyClientLib project(path: ":solr:core", configuration: "jettyClientImplementation")
-  implementation(configurations.solrCore - configurations.serverLib + configurations.solrJettyClientLib)
+  // Make sure we keep the duplicate solrJettyClientLibs, but we want to remove all of the logging and metrics jars already in libExt
+  implementation(configurations.solrCore - configurations.serverLib + configurations.solrJettyClientLib - configurations.libExt)
 }
 
 war {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15955

This fixes a regression caused by the Jetty 10 upgrade.

Note: This does not make the server/lib/, server/lib/ext/ and WEB-INF/lib situation less confusing. I will introduce something separate to make that work out of the box going forward.