### PR TITLE
speed up javac and error-prone tasks by using less resources (#11927)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'ca.cutterslade.analyze' version "1.9.0"
   id 'de.thetaphi.forbiddenapis' version '3.4' apply false
   id "de.undercouch.download" version "5.2.0" apply false
-  id "net.ltgt.errorprone" version "2.0.2" apply false
+  id "net.ltgt.errorprone" version "3.0.1" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false
   id 'com.github.node-gradle.node' version '3.4.0' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'ca.cutterslade.analyze' version "1.9.0"
   id 'de.thetaphi.forbiddenapis' version '3.4' apply false
   id "de.undercouch.download" version "5.2.0" apply false
-  id "net.ltgt.errorprone" version "3.0.1" apply false
+  id "net.ltgt.errorprone" version "2.0.2" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false
   id 'com.github.node-gradle.node' version '3.4.0' apply false
 }

--- a/gradle/generation/local-settings.gradle
+++ b/gradle/generation/local-settings.gradle
@@ -68,7 +68,7 @@ systemProp.file.encoding=UTF-8
 # The heap seems huge but gradle runs out of memory on lower values (don't know why).
 #
 # We also open up internal compiler modules for spotless/ google java format.
-org.gradle.jvmargs=-Xmx3g \\
+org.gradle.jvmargs=-Xmx3g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \\
  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \\

--- a/gradle/generation/local-settings.gradle
+++ b/gradle/generation/local-settings.gradle
@@ -68,7 +68,7 @@ systemProp.file.encoding=UTF-8
 # The heap seems huge but gradle runs out of memory on lower values (don't know why).
 #
 # We also open up internal compiler modules for spotless/ google java format.
-org.gradle.jvmargs=-Xmx3g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \\
+org.gradle.jvmargs=-Xmx3g \\
  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \\

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -19,7 +19,8 @@
 allprojects {
     def vmOpts = [
         '-XX:+UseParallelGC',
-        '-XX:TieredStopAtLevel=1'
+        '-XX:TieredStopAtLevel=1',
+        '-XX:ActiveProcessorCount=1'
     ]
 
     // Inject vm options into custom javadoc rendering. We can't refer
@@ -32,5 +33,21 @@ allprojects {
     // down but I don't think there is any harm in keeping it broad.
     tasks.withType(JavaExec) {
         jvmArgs += vmOpts
+    }
+
+    // Tweak javac to not be too resource-hungry.
+    // This applies to any JVM when javac runs forked (e.g. error-prone)
+    // Avoiding the fork entirely is best.
+    tasks.withType(JavaCompile) { JavaCompile task ->
+        if (task.path == ":lucene:core:compileMain19Java") {
+          // uses "uschindler" toolchain method, which erases "dweiss" method, but later at configure time
+          task.options.forkOptions.jvmArgs += vmOpts
+        } else if (task.options.forkOptions.javaHome != null) {
+          // uses "dweiss" toolchain method
+          task.options.forkOptions.jvmArgs += vmOpts.collect {"-J" + it}
+        } else {
+          // native or error-prone
+          task.options.forkOptions.jvmArgs += vmOpts
+        }
     }
 }

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -39,15 +39,26 @@ allprojects {
     // This applies to any JVM when javac runs forked (e.g. error-prone)
     // Avoiding the fork entirely is best.
     tasks.withType(JavaCompile) { JavaCompile task ->
-        if (task.path == ":lucene:core:compileMain19Java") {
-          // uses "uschindler" toolchain method, which erases "dweiss" method, but later at configure time
-          task.options.forkOptions.jvmArgs += vmOpts
-        } else if (task.options.forkOptions.javaHome != null) {
-          // uses "dweiss" toolchain method
-          task.options.forkOptions.jvmArgs += vmOpts.collect {"-J" + it}
-        } else {
-          // native or error-prone
-          task.options.forkOptions.jvmArgs += vmOpts
-        }
+        task.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
+            @Override
+            Iterable<String> asArguments() {
+                // Gradle bug: https://github.com/gradle/gradle/issues/22746
+                //
+                // Evaluation of this block is delayed until execution time when
+                // we know which "mode" java compiler task will pick and can set arguments
+                // accordingly.
+                //
+                // There is a side-effect to this that arguments passed via the provider
+                // are not part of up-to-date checks but these are internal JVM flags so we
+                // don't care.
+                //
+                // Pass VM options via -J only with a custom javaHome AND when java toolchains are not used.
+                if (task.options.forkOptions.javaHome != null && task.javaCompiler.getOrNull() == null) {
+                    return vmOpts.collect {"-J" + it}
+                } else {
+                    return vmOpts
+                }
+            }
+        })
     }
 }

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -19,7 +19,8 @@
 allprojects {
     def vmOpts = [
         '-XX:+UseParallelGC',
-        '-XX:TieredStopAtLevel=1'
+        '-XX:TieredStopAtLevel=1',
+        '-XX:ActiveProcessorCount=1'
     ]
 
     // Inject vm options into custom javadoc rendering. We can't refer
@@ -32,5 +33,12 @@ allprojects {
     // down but I don't think there is any harm in keeping it broad.
     tasks.withType(JavaExec) {
         jvmArgs += vmOpts
+    }
+
+    // Tweak javac to not be too resource-hungry.
+    // This applies to any JVM when javac runs forked (e.g. error-prone)
+    // Avoiding the fork entirely is best.
+    tasks.withType(JavaCompile) { JavaCompile task ->
+        task.options.forkOptions.jvmArgs += vmOpts
     }
 }

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -19,8 +19,7 @@
 allprojects {
     def vmOpts = [
         '-XX:+UseParallelGC',
-        '-XX:TieredStopAtLevel=1',
-        '-XX:ActiveProcessorCount=1'
+        '-XX:TieredStopAtLevel=1'
     ]
 
     // Inject vm options into custom javadoc rendering. We can't refer
@@ -33,12 +32,5 @@ allprojects {
     // down but I don't think there is any harm in keeping it broad.
     tasks.withType(JavaExec) {
         jvmArgs += vmOpts
-    }
-
-    // Tweak javac to not be too resource-hungry.
-    // This applies to any JVM when javac runs forked (e.g. error-prone)
-    // Avoiding the fork entirely is best.
-    tasks.withType(JavaCompile) { JavaCompile task ->
-        task.options.forkOptions.jvmArgs += vmOpts
     }
 }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -48,7 +48,7 @@ allprojects {
           [propName: 'tests.haltonfailure', value: true, description: "Halt processing on test failure."],
           // Default code cache size is 240m, but disabling C2 compiler shrinks it to 48m, which turns out to not be enough
           [propName: 'tests.jvmargs',
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=120m") },
+           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 -XX:ReservedCodeCacheSize=120m") },
            description: "Arguments passed to each forked JVM."],
           // Other settings.
           [propName: 'tests.neverUpToDate', value: true,

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -48,7 +48,7 @@ allprojects {
           [propName: 'tests.haltonfailure', value: true, description: "Halt processing on test failure."],
           // Default code cache size is 240m, but disabling C2 compiler shrinks it to 48m, which turns out to not be enough
           [propName: 'tests.jvmargs',
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=120m -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
+           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=120m") },
            description: "Arguments passed to each forked JVM."],
           // Other settings.
           [propName: 'tests.neverUpToDate', value: true,

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -48,7 +48,7 @@ allprojects {
           [propName: 'tests.haltonfailure', value: true, description: "Halt processing on test failure."],
           // Default code cache size is 240m, but disabling C2 compiler shrinks it to 48m, which turns out to not be enough
           [propName: 'tests.jvmargs',
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=120m") },
+           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=120m -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
            description: "Arguments passed to each forked JVM."],
           // Other settings.
           [propName: 'tests.neverUpToDate', value: true,

--- a/help/localSettings.txt
+++ b/help/localSettings.txt
@@ -47,7 +47,7 @@ separately from the gradle workers, for example:
 tests.jvms=3
 tests.heapsize=512m
 tests.minheapsize=512m
-tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1
+tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1 -XX:ActiveProcessorCount=1
 
 Gradle Daemon
 -------------

--- a/help/localSettings.txt
+++ b/help/localSettings.txt
@@ -47,7 +47,7 @@ separately from the gradle workers, for example:
 tests.jvms=3
 tests.heapsize=512m
 tests.minheapsize=512m
-tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1 -XX:ActiveProcessorCount=1
+tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1
 
 Gradle Daemon
 -------------


### PR DESCRIPTION
Ports over https://github.com/apache/lucene/pull/11927 and https://github.com/apache/lucene/pull/11937 to Solr

* pass jvm args to javac  #11925
* Update net.ltgt.errorprone to the latest version so that jvm args are not overwritten, add -XX:+PrintFlagsFinal for debugging
* speed up the pure javac case too

It does not help to fork additional VMs (although error-prone will do this since it messes with bootstrap classpath), so we avoid forking.

Instead it is best to tune org.gradle.jvmargs.

* use the flags consistently everywhere (tests and doc)

Co-authored-by: Robert Muir <rmuir@apache.org>