### PR TITLE
Refactor: remove unused "filter" in QueryCommand & getProcessedFilter

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -432,7 +432,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       newFilters.add(groupQuery);
     }
 
-    SolrIndexSearcher.ProcessedFilter pfilter = searcher.getProcessedFilter(null, newFilters);
+    SolrIndexSearcher.ProcessedFilter pfilter = searcher.getProcessedFilter(newFilters);
     if (pfilter.postFilter != null) {
       pfilter.postFilter.setLastDelegate(groupExpandCollector);
       collector = pfilter.postFilter;

--- a/solr/core/src/java/org/apache/solr/search/Grouping.java
+++ b/solr/core/src/java/org/apache/solr/search/Grouping.java
@@ -309,8 +309,7 @@ public class Grouping {
     DocListAndSet out = new DocListAndSet();
     qr.setDocListAndSet(out);
 
-    SolrIndexSearcher.ProcessedFilter pf =
-        searcher.getProcessedFilter(cmd.getFilter(), cmd.getFilterList());
+    SolrIndexSearcher.ProcessedFilter pf = searcher.getProcessedFilter(cmd.getFilterList());
     final Query filterQuery = pf.filter;
     maxDoc = searcher.maxDoc();
 

--- a/solr/core/src/java/org/apache/solr/search/QueryCommand.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryCommand.java
@@ -31,7 +31,6 @@ public class QueryCommand {
   private String queryID;
   private boolean isQueryCancellable;
   private List<Query> filterList;
-  private DocSet filter;
   private Sort sort;
   private int offset;
   private int len;
@@ -79,10 +78,6 @@ public class QueryCommand {
    * @throws IllegalArgumentException if filter is not null.
    */
   public QueryCommand setFilterList(List<Query> filterList) {
-    if (filter != null) {
-      throw new IllegalArgumentException(
-          "Either filter or filterList may be set in the QueryCommand, but not both.");
-    }
     this.filterList = filterList;
     return this;
   }
@@ -93,31 +88,11 @@ public class QueryCommand {
    * @throws IllegalArgumentException if filter is not null.
    */
   public QueryCommand setFilterList(Query f) {
-    if (filter != null) {
-      throw new IllegalArgumentException(
-          "Either filter or filterList may be set in the QueryCommand, but not both.");
-    }
     filterList = null;
     if (f != null) {
       filterList = new ArrayList<>(2);
       filterList.add(f);
     }
-    return this;
-  }
-
-  public DocSet getFilter() {
-    return filter;
-  }
-
-  /**
-   * @throws IllegalArgumentException if filterList is not null.
-   */
-  public QueryCommand setFilter(DocSet filter) {
-    if (filterList != null) {
-      throw new IllegalArgumentException(
-          "Either filter or filterList may be set in the QueryCommand, but not both.");
-    }
-    this.filter = filter;
     return this;
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1094,7 +1094,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    */
   public DocSet getDocSet(List<Query> queries) throws IOException {
 
-    ProcessedFilter pf = getProcessedFilter(null, queries);
+    ProcessedFilter pf = getProcessedFilter(queries);
 
     if (pf.postFilter == null) {
       if (pf.answer != null) {
@@ -1123,11 +1123,11 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   }
 
   /**
-   * INTERNAL: The response object from {@link #getProcessedFilter(DocSet, List)}. Holds a filter
-   * and postFilter pair that together match a set of documents. Either of them may be null, in
-   * which case the semantics are to match everything.
+   * INTERNAL: The response object from {@link #getProcessedFilter(List)}. Holds a filter and
+   * postFilter pair that together match a set of documents. Either of them may be null, in which
+   * case the semantics are to match everything.
    *
-   * @see #getProcessedFilter(DocSet, List)
+   * @see #getProcessedFilter(List)
    */
   public static class ProcessedFilter {
     // maybe null. Sometimes we have a docSet answer that represents the complete answer or result.
@@ -1137,22 +1137,17 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   }
 
   /**
-   * INTERNAL: Processes conjunction (AND) of both args into a {@link ProcessedFilter} result.
-   * Either arg may be null/empty thus doesn't restrict the matching docs. Queries typically are
+   * INTERNAL: Processes conjunction (AND) of the queries into a {@link ProcessedFilter} result.
+   * Queries may be null/empty thus doesn't restrict the matching docs. Queries typically are
    * resolved against the filter cache, and populate it.
    */
-  public ProcessedFilter getProcessedFilter(DocSet setFilter, List<Query> queries)
-      throws IOException {
+  public ProcessedFilter getProcessedFilter(List<Query> queries) throws IOException {
     ProcessedFilter pf = new ProcessedFilter();
     if (queries == null || queries.size() == 0) {
-      if (setFilter != null) {
-        pf.answer = setFilter;
-        pf.filter = setFilter.makeQuery();
-      }
       return pf;
     }
 
-    // We combine all the filter queries that come from the filter cache & setFilter into "answer".
+    // We combine all the filter queries that come from the filter cache into "answer".
     // This might become pf.answer but not if there are any non-cached filters
     DocSet answer = null;
 
@@ -1162,10 +1157,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     List<PostFilter> postFilters = null;
 
     int end = 0; // size of "sets" and "neg"; parallel arrays
-
-    if (setFilter != null) {
-      answer = setFilter;
-    } // we are done with setFilter at this point
 
     for (Query q : queries) {
       if (q instanceof ExtendedQuery) {
@@ -1546,12 +1537,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     }
 
     // we can try and look up the complete query in the cache.
-    // we can't do that if filter!=null though (we don't want to
-    // do hashCode() and equals() for a big DocSet).
     if (queryResultCache != null
-        && cmd.getFilter() == null
         && (flags & (NO_CHECK_QCACHE | NO_SET_QCACHE)) != ((NO_CHECK_QCACHE | NO_SET_QCACHE))) {
-      // all of the current flags can be reused during warming,
+      // all the current flags can be reused during warming,
       // so set all of them on the cache key.
       key =
           new QueryResultKey(q, cmd.getFilterList(), cmd.getSort(), flags, cmd.getMinExactCount());
@@ -1649,7 +1637,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       // for large filters that match few documents, this may be
       // slower than simply re-executing the query.
       if (out.docSet == null) {
-        out.docSet = getDocSet(cmd.getQuery(), cmd.getFilter());
+        out.docSet = getDocSet(cmd.getQuery());
         List<Query> filterList = cmd.getFilterList();
         if (filterList != null && !filterList.isEmpty()) {
           out.docSet = DocSetUtil.getDocSet(out.docSet.intersection(getDocSet(filterList)), this);
@@ -1802,7 +1790,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
     boolean needScores = (cmd.getFlags() & GET_SCORES) != 0;
 
-    ProcessedFilter pf = getProcessedFilter(cmd.getFilter(), cmd.getFilterList());
+    ProcessedFilter pf = getProcessedFilter(cmd.getFilterList());
     final Query query =
         QueryUtils.combineQueryAndFilter(QueryUtils.makeQueryable(cmd.getQuery()), pf.filter);
     Relation hitsRelation;
@@ -1923,7 +1911,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     int maxDoc = maxDoc();
     cmd.setMinExactCount(Integer.MAX_VALUE); // We need the full DocSet
 
-    ProcessedFilter pf = getProcessedFilter(cmd.getFilter(), cmd.getFilterList());
+    ProcessedFilter pf = getProcessedFilter(cmd.getFilterList());
     final Query query =
         QueryUtils.combineQueryAndFilter(QueryUtils.makeQueryable(cmd.getQuery()), pf.filter);
 
@@ -2030,20 +2018,19 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   }
 
   /**
-   * Returns documents matching both <code>query</code> and <code>filter</code> and sorted by <code>
-   * sort</code>. FUTURE: The returned DocList may be retrieved from a cache.
+   * Returns documents matching <code>query</code>, sorted by <code>sort</code>.
    *
-   * @param filter may be null
+   * <p>FUTURE: The returned DocList may be retrieved from a cache.
+   *
    * @param lsort criteria by which to sort (if null, query relevance is used)
    * @param offset offset into the list of documents to return
    * @param len maximum number of documents to return
    * @return DocList meeting the specified criteria, should <b>not</b> be modified by the caller.
    * @throws IOException If there is a low-level I/O error.
    */
-  public DocList getDocList(Query query, DocSet filter, Sort lsort, int offset, int len)
-      throws IOException {
+  public DocList getDocList(Query query, Sort lsort, int offset, int len) throws IOException {
     QueryCommand qc = new QueryCommand();
-    qc.setQuery(query).setFilter(filter).setSort(lsort).setOffset(offset).setLen(len);
+    qc.setQuery(query).setSort(lsort).setOffset(offset).setLen(len);
     QueryResult qr = new QueryResult();
     search(qr, qc);
     return qr.getDocList();
@@ -2155,11 +2142,12 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
   /**
    * Returns documents matching both <code>query</code> and the intersection of <code>filterList
-   * </code>, sorted by <code>sort</code>. Also returns the compete set of documents matching <code>
-   * query</code> and <code>filter</code> (regardless of <code>offset</code> and <code>len</code>).
+   * </code>, sorted by <code>sort</code>. Also returns the complete set of documents matching
+   * <code>query</code> and <code>filter</code> (regardless of <code>offset</code> and <code>len
+   * </code>).
    *
-   * <p>This method is cache aware and may retrieve <code>filter</code> from the cache or make an
-   * insertion into the cache as a result of this call.
+   * <p>This method is cache aware and may retrieve filters from the cache or make an * insertion
+   * into the cache as a result of this call.
    *
    * <p>FUTURE: The returned DocList may be retrieved from a cache.
    *
@@ -2191,13 +2179,12 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   }
 
   /**
-   * Returns documents matching both <code>query</code> and <code>filter</code> and sorted by <code>
-   * sort</code>. Also returns the compete set of documents matching <code>query</code> and <code>
-   * filter</code> (regardless of <code>offset</code> and <code>len</code>).
+   * Returns the top documents matching the <code>query</code> and sorted by <code>
+   * sort</code>, limited by <code>offset</code> and <code>len</code>. Also returns compete set of
+   * matching documents as a {@link DocSet}.
    *
    * <p>FUTURE: The returned DocList may be retrieved from a cache.
    *
-   * @param filter may be null
    * @param lsort criteria by which to sort (if null, query relevance is used)
    * @param offset offset into the list of documents to return
    * @param len maximum number of documents to return
@@ -2205,51 +2192,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    *     caller.
    * @throws IOException If there is a low-level I/O error.
    */
-  public DocListAndSet getDocListAndSet(Query query, DocSet filter, Sort lsort, int offset, int len)
+  public DocListAndSet getDocListAndSet(Query query, Sort lsort, int offset, int len)
       throws IOException {
     QueryCommand qc = new QueryCommand();
-    qc.setQuery(query)
-        .setFilter(filter)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setNeedDocSet(true);
-    QueryResult qr = new QueryResult();
-    search(qr, qc);
-    return qr.getDocListAndSet();
-  }
-
-  /**
-   * Returns documents matching both <code>query</code> and <code>filter</code> and sorted by <code>
-   * sort</code>. Also returns the compete set of documents matching <code>query</code> and <code>
-   * filter</code> (regardless of <code>offset</code> and <code>len</code>).
-   *
-   * <p>This method is cache aware and may make an insertion into the cache as a result of this
-   * call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * <p>The DocList and DocSet returned should <b>not</b> be modified.
-   *
-   * @param filter may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @param flags user supplied flags for the result set
-   * @return DocListAndSet meeting the specified criteria, should <b>not</b> be modified by the
-   *     caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  public DocListAndSet getDocListAndSet(
-      Query query, DocSet filter, Sort lsort, int offset, int len, int flags) throws IOException {
-    QueryCommand qc = new QueryCommand();
-    qc.setQuery(query)
-        .setFilter(filter)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setFlags(flags)
-        .setNeedDocSet(true);
+    qc.setQuery(query).setSort(lsort).setOffset(offset).setLen(len).setNeedDocSet(true);
     QueryResult qr = new QueryResult();
     search(qr, qc);
     return qr.getDocListAndSet();

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -2146,8 +2146,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    * <code>query</code> and <code>filter</code> (regardless of <code>offset</code> and <code>len
    * </code>).
    *
-   * <p>This method is cache aware and may retrieve filters from the cache or make an * insertion
-   * into the cache as a result of this call.
+   * <p>This method is cache aware and may retrieve filters from the cache or make an insertion into
+   * the cache as a result of this call.
    *
    * <p>FUTURE: The returned DocList may be retrieved from a cache.
    *

--- a/solr/core/src/java/org/apache/solr/search/grouping/CommandHandler.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/CommandHandler.java
@@ -149,8 +149,7 @@ public class CommandHandler {
       collectors.addAll(command.create());
     }
 
-    ProcessedFilter filter =
-        searcher.getProcessedFilter(queryCommand.getFilter(), queryCommand.getFilterList());
+    ProcessedFilter filter = searcher.getProcessedFilter(queryCommand.getFilterList());
     Query query = QueryUtils.makeQueryable(queryCommand.getQuery());
 
     if (truncateGroups) {

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -72,7 +72,6 @@ import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.DocIterator;
 import org.apache.solr.search.DocList;
-import org.apache.solr.search.DocSet;
 import org.apache.solr.search.FieldParams;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.QueryParsing;
@@ -443,7 +442,7 @@ public class SolrPluginUtils {
         sort = SortSpecParsing.parseSortSpec(commands.get(1), req).getSort();
       }
 
-      DocList results = req.getSearcher().getDocList(query, (DocSet) null, sort, start, limit);
+      DocList results = req.getSearcher().getDocList(query, sort, start, limit);
       return results;
     } catch (SyntaxError e) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Error parsing query: " + qs);

--- a/solr/core/src/test/org/apache/solr/highlight/HighlighterTest.java
+++ b/solr/core/src/test/org/apache/solr/highlight/HighlighterTest.java
@@ -41,7 +41,6 @@ import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.search.DocSet;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1399,7 +1398,7 @@ public class HighlighterTest extends SolrTestCaseJ4 {
       SolrQueryResponse resp = new SolrQueryResponse();
       ResponseBuilder rb = new ResponseBuilder(req, resp, Collections.singletonList(hlComp));
       rb.setHighlightQuery(query);
-      rb.setResults(req.getSearcher().getDocListAndSet(query, (DocSet) null, null, 0, 1));
+      rb.setResults(req.getSearcher().getDocListAndSet(query, null, 0, 1));
       // highlight:
       hlComp.prepare(rb);
       hlComp.process(rb);

--- a/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
@@ -382,7 +382,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
               Query filterQuery =
                   new TermQuery(new Term("field4_t", Integer.toString(NUM_DOCS - 1)));
               cmd.setFilterList(filterQuery);
-              assertNull(searcher.getProcessedFilter(null, cmd.getFilterList()).postFilter);
+              assertNull(searcher.getProcessedFilter(cmd.getFilterList()).postFilter);
               assertMatchesEqual(1, searcher, cmd);
               return null;
             });
@@ -404,7 +404,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
               QueryCommand cmd = createBasicQueryCommand(1, 1, "field4_t", "0");
               MockPostFilter filterQuery = new MockPostFilter(1, 101);
               cmd.setFilterList(filterQuery);
-              assertNotNull(searcher.getProcessedFilter(null, cmd.getFilterList()).postFilter);
+              assertNotNull(searcher.getProcessedFilter(cmd.getFilterList()).postFilter);
               assertMatchesEqual(1, searcher, cmd);
               return null;
             });
@@ -415,7 +415,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
               QueryCommand cmd = createBasicQueryCommand(1, 1, "field4_t", "0");
               MockPostFilter filterQuery = new MockPostFilter(100, 101);
               cmd.setFilterList(filterQuery);
-              assertNotNull(searcher.getProcessedFilter(null, cmd.getFilterList()).postFilter);
+              assertNotNull(searcher.getProcessedFilter(cmd.getFilterList()).postFilter);
               assertMatchesGreaterThan(NUM_DOCS, searcher, cmd);
               return null;
             });
@@ -430,7 +430,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
               MockPostFilter filterQuery =
                   new MockPostFilter(NUM_DOCS * 10, 101, ScoreMode.COMPLETE);
               cmd.setFilterList(filterQuery);
-              assertNotNull(searcher.getProcessedFilter(null, cmd.getFilterList()).postFilter);
+              assertNotNull(searcher.getProcessedFilter(cmd.getFilterList()).postFilter);
               assertMatchesEqual(NUM_DOCS, searcher, cmd);
               return null;
             });


### PR DESCRIPTION
1. QueryCommand: remove unused "filter"
2. SolrIndexSearcher.getProcessedFilter: remove unused setFilter param

Background:
While looking at SolrIndexSearcher.getProcessedFilter (on multiple occassions), it seemed to me the setFilter param was needless because a caller could simply provide the DocSet as a Query via DocSet.makeQuery (new in Solr 9).  Then I realized that nobody actually passes setFilter any way so I simply removed it, leading me to remove QueryCommand.filter in-kind.  Maybe it was used a long time ago; this is old code.

Not sure this needs a JIRA; it's a refactoring.  I'm thinking of only doing this in Solr 10 for back-compat sake.