### PR TITLE
Lower gradle heap: 3GB is unnecessary (#11936)

### DIFF
--- a/gradle/generation/local-settings.gradle
+++ b/gradle/generation/local-settings.gradle
@@ -65,10 +65,9 @@ configure(rootProject) {
 systemProp.file.encoding=UTF-8
 
 # Set up gradle JVM defaults.
-# The heap seems huge but gradle runs out of memory on lower values (don't know why).
 #
 # We also open up internal compiler modules for spotless/ google java format.
-org.gradle.jvmargs=-Xmx3g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \\
+org.gradle.jvmargs=-Xmx1g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \\
  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \\


### PR DESCRIPTION
Ports https://github.com/apache/lucene/pull/11936 over to Solr. I've been testing this the past week or so and haven't seen any issues.

You need to clear `gradle.properties` in the Solr directory and regenerate with `./gradlew localSettings` (or let the build regenerate it for you next time.