### PR TITLE
SOLR-15955: Fix dependency in hadoop-auth

### DIFF
--- a/solr/modules/hadoop-auth/build.gradle
+++ b/solr/modules/hadoop-auth/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
   implementation 'org.slf4j:slf4j-api'
 
-  compileOnlyApi 'org.eclipse.jetty.toolchain:jetty-servlet-api'
+  api 'org.eclipse.jetty.toolchain:jetty-servlet-api'
 
   implementation 'com.fasterxml.jackson.core:jackson-core'
   implementation 'com.google.guava:guava'
@@ -103,7 +103,7 @@ dependencies {
     exclude group: "org.apache.yetus", module: "audience-annotations"
   })
   // required for instantiating a Zookeeper server in tests or embedded
-  runtimeOnly ('org.xerial.snappy:snappy-java')
+  testRuntimeOnly ('org.xerial.snappy:snappy-java')
 }
 
 


### PR DESCRIPTION
This dependency is not compileTimeOnly. I think this was only done because of the weird old way of handling jetty dependencies.

After https://issues.apache.org/jira/browse/SOLR-16158 this should no longer be an issue.