### PR TITLE
SOLR-10458: setFollowRedirects should be deprecated in favor of Solr Client Builder methods

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -165,11 +165,13 @@ public class HttpSolrClient extends BaseHttpSolrClient {
     }
 
     if (builder.httpClient != null) {
+      this.internalClient = false;
       this.followRedirects = builder.followRedirects;
       this.httpClient = builder.httpClient;
-      this.internalClient = false;
+
     } else {
       this.internalClient = true;
+      this.followRedirects = builder.followRedirects;
       ModifiableSolrParams params = new ModifiableSolrParams();
       params.set(HttpClientUtil.PROP_FOLLOW_REDIRECTS, followRedirects);
       params.set(HttpClientUtil.PROP_ALLOW_COMPRESSION, builder.compression);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
@@ -550,13 +550,15 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
       assertTrue(e.getMessage().contains("redirect"));
     }
 
-    try (HttpSolrClient client = new HttpSolrClient.Builder(clientUrl).withFollowRedirects(true).build()) {
+    try (HttpSolrClient client =
+        new HttpSolrClient.Builder(clientUrl).withFollowRedirects(true).build()) {
       // No exception expected
       client.query(q);
     }
 
     // And with explicit false:
-    try (HttpSolrClient client = new HttpSolrClient.Builder(clientUrl).withFollowRedirects(false).build()) {
+    try (HttpSolrClient client =
+        new HttpSolrClient.Builder(clientUrl).withFollowRedirects(false).build()) {
       SolrServerException e = expectThrows(SolrServerException.class, () -> client.query(q));
       assertTrue(e.getMessage().contains("redirect"));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-10458

# Description

Use the builder pattern for following redirects.

# Solution
update test.  Found a bug in the HttpSolrClient use of the builder pattern for this property!

# Tests

ran

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
