### PR TITLE
SOLR-8975: Ensure poll time default of 250 is set on builder

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -858,7 +858,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
     protected String baseSolrUrl;
     protected int queueSize = 10;
     protected int threadCount;
-    protected int pollQueueTime;
+    protected int pollQueueTime = 250;
     protected ExecutorService executorService;
     protected boolean streamDeletes;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-8975

Followup to fix ConnectionReuseTest.testConnectionReuse