### PR TITLE
SOLR-16581: Upgrade OWASP dependency check to 7.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ import java.time.format.DateTimeFormatter
 plugins {
   id "base"
   id "com.palantir.consistent-versions" version "2.11.0"
-  id "org.owasp.dependencycheck" version "7.2.0"
+  id "org.owasp.dependencycheck" version "7.4.1"
   id 'ca.cutterslade.analyze' version "1.9.0"
   id 'de.thetaphi.forbiddenapis' version '3.4' apply false
   id "de.undercouch.download" version "5.2.0" apply false

--- a/gradle/validation/owasp-dependency-check.gradle
+++ b/gradle/validation/owasp-dependency-check.gradle
@@ -25,9 +25,9 @@ def resources = scriptResources(buildscript)
 configure(rootProject) {
   dependencyCheck {
     failBuildOnCVSS = propertyOrDefault("validation.owasp.threshold", 7) as Integer
-    formats = ['HTML', 'JSON']
+    formats = ['ALL']
     skipProjects = [':solr:solr-ref-guide']
-    skipConfigurations = ['unifiedClasspath']
+    skipConfigurations = ['unifiedClasspath', 'permitUnusedDeclared']
     suppressionFile = file("${resources}/exclusions.xml")
   }
 

--- a/gradle/validation/owasp-dependency-check/exclusions.xml
+++ b/gradle/validation/owasp-dependency-check/exclusions.xml
@@ -51,4 +51,25 @@
     <packageUrl regex="true">^pkg:maven/org\.carrot2\.shaded/carrot2\-guava@.*$</packageUrl>
     <cpe>cpe:/a:google:guava</cpe>
   </suppress>
+  <suppress>
+    <notes><![CDATA[Apache Calcite Avatica has separate releases from Apache Calcite]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/.*@.*$</packageUrl>
+    <cpe>cpe:/a:apache:calcite</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[jetty-servlet-api has separate releases from Jetty itself]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@.*$</packageUrl>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[hadoop-shaded-guava-1.1.1.jar is not Apache Hadoop 1.1.1]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop\-shaded\-guava@.*$</packageUrl>
+    <cpe>cpe:/a:apache:hadoop:1.1.1</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[hadoop-client-runtime-3.*.jar is not Apache Hadoop 1.1.1]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop/hadoop\-client\-runtime@3.*$</packageUrl>
+    <cpe>cpe:/a:apache:hadoop:1.1.1</cpe>
+  </suppress>
 </suppressions>

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -141,6 +141,8 @@ Build
 
 * SOLR-16578: Upgrade to errorprone 2.16 (Kevin Risden)
 
+* SOLR-16581: Upgrade OWASP dependency check to 7.4.1 (Kevin Risden)
+
 Other Changes
 ---------------------
 * SOLR-16545: Upgrade Carrot2 to 4.5.0 (Dawid Weiss)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16581

Dependency Check 7.4.0 added a Jenkins format (https://github.com/jeremylong/DependencyCheck/releases/tag/v7.4.0) which makes it better than the regular HTML output for the ci jobs (ie: https://ci-builds.apache.org/job/Solr/job/OWASP-main/).