### PR TITLE
SOLR-16582: Allow configuration of solrcore response logging by path

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -179,6 +179,7 @@ import org.eclipse.jetty.io.RuntimeIOException;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 
 /**
  * SolrCore got its name because it represents the "core" of Solr -- one index and everything needed
@@ -2875,7 +2876,12 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
     if (rsp.getToLog().size() > 0) {
       if (requestLog.isInfoEnabled()) {
-        requestLog.info(rsp.getToLogAsString());
+        Object path = rsp.getToLog().get("path");
+        if (path instanceof String) {
+          requestLog.info(MarkerFactory.getMarker((String) path), rsp.getToLogAsString());
+        } else{
+          requestLog.info(rsp.getToLogAsString());
+        }
       }
 
       /* slowQueryThresholdMillis defaults to -1 in SolrConfig -- not enabled.*/

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2879,7 +2879,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
         Object path = rsp.getToLog().get("path");
         if (path instanceof String) {
           requestLog.info(MarkerFactory.getMarker((String) path), rsp.getToLogAsString());
-        } else{
+        } else {
           requestLog.info(rsp.getToLogAsString());
         }
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16582

# Description

Logs can somethings be a bit too noisy on SolrCore#execute which prints info on each response.

In our usage, `/get` and `/replication` are too verbose that we want to skip logging those 2 while keeping response logging for rest of the requests.

It would be nice to add a "marker" with the path of the request so that user can tune logging behavior per request handler (path).

# Solution

If the path is available in `SolrCore#execute`, then log the response with the path as marker.

Logging for such can then be configured such as
```
<Logger name="org.apache.solr.core.SolrCore.Request" level="info">
  <Filters>
    <MarkerFilter marker="/get" onMatch="DENY" onMismatch="NEUTRAL"/>
    <MarkerFilter marker="/replication" onMatch="DENY" onMismatch="NEUTRAL"/>
  </Filters>
</Logger>
```
# Tests

No tests added for this

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
