### PR TITLE
SOLR-788: POC transfer MLT queries back and forth.

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -151,11 +151,16 @@ public class MoreLikeThisComponent extends SearchComponent {
           for (Entry<String, ?> entry : moreLikeThisReponse) {
             if (log.isDebugEnabled()) {
               log.debug("id: '{}' Query: '{}'", entry.getKey(), entry.getValue());
-            }// a little bit surprised since text formats yields bytes as base64 string
-            final String serializedQuery = entry.getValue() instanceof byte[]
-                    ? Base64.getEncoder().encodeToString((byte[]) entry.getValue()) : (String) entry.getValue();
-            ShardRequest s = buildShardQuery(rb,
-                    "{!"+QueryTransferQParserPlugin.NAME+"}"+serializedQuery, entry.getKey());
+            } // a little bit surprised since text formats yields bytes as base64 string
+            final String serializedQuery =
+                entry.getValue() instanceof byte[]
+                    ? Base64.getEncoder().encodeToString((byte[]) entry.getValue())
+                    : (String) entry.getValue();
+            ShardRequest s =
+                buildShardQuery(
+                    rb,
+                    "{!" + QueryTransferQParserPlugin.NAME + "}" + serializedQuery,
+                    entry.getKey());
             rb.addRequest(this, s);
           }
         }

--- a/solr/core/src/java/org/apache/solr/search/QParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/QParserPlugin.java
@@ -32,6 +32,7 @@ import org.apache.solr.search.mlt.MLTContentQParserPlugin;
 import org.apache.solr.search.mlt.MLTQParserPlugin;
 import org.apache.solr.search.neural.KnnQParserPlugin;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;
+import org.apache.solr.util.querytransfer.QueryTransferQParserPlugin;
 
 public abstract class QParserPlugin implements NamedListInitializedPlugin, SolrInfoBean {
   /** internal use - name of the default parser */
@@ -89,6 +90,7 @@ public abstract class QParserPlugin implements NamedListInitializedPlugin, SolrI
     map.put(HashRangeQParserPlugin.NAME, new HashRangeQParserPlugin());
     map.put(RankQParserPlugin.NAME, new RankQParserPlugin());
     map.put(KnnQParserPlugin.NAME, new KnnQParserPlugin());
+    map.put(QueryTransferQParserPlugin.NAME, new QueryTransferQParserPlugin());
 
     standardPlugins = Collections.unmodifiableMap(map);
   }

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransfer.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransfer.java
@@ -28,6 +28,12 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -36,119 +42,128 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 public class QueryTransfer {
-    static ObjectMapper mapper;
-    static {
-        SmileFactory smileFactory = new SmileFactory();
-        mapper = new ObjectMapper(smileFactory);
-        final SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addSerializer(BoostQuery.class, new StdSerializer<>(BoostQuery.class) {
+  static ObjectMapper mapper;
 
-            @Override
-            public void serialize(BoostQuery value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-                gen.writeStartArray(value, 3);
-                gen.writeString("boost1");
-                gen.writeNumber(value.getBoost());
-                gen.writeObject(value.getQuery());
-                gen.writeEndArray();
-            }
+  static {
+    SmileFactory smileFactory = new SmileFactory();
+    mapper = new ObjectMapper(smileFactory);
+    final SimpleModule simpleModule = new SimpleModule();
+    simpleModule.addSerializer(
+        BoostQuery.class,
+        new StdSerializer<>(BoostQuery.class) {
+
+          @Override
+          public void serialize(BoostQuery value, JsonGenerator gen, SerializerProvider provider)
+              throws IOException {
+            gen.writeStartArray(value, 3);
+            gen.writeString("boost1");
+            gen.writeNumber(value.getBoost());
+            gen.writeObject(value.getQuery());
+            gen.writeEndArray();
+          }
         });
 
-        simpleModule.addDeserializer(Query.class, new JsonDeserializer<>() {
-            @Override
-            public Query deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-                final ObjectCodec codec = p.getCodec();
-                final List<?> arr = codec.readValue(p, List.class);
-                return interpret(p, arr);
-            }
-            @SuppressWarnings("unchecked")
-            private Query interpret(JsonParser p, List<?> arr) throws JacksonException {
-                final String format = (String) arr.get(0);
-                switch (format) {
-                    case "term1":
-                        final String field = (String) arr.get(1);
-                        Object txt = arr.get(2);
-                        byte[] decode = txt instanceof String ? Base64.getDecoder().decode((String)txt) : (byte[])txt;
-                        Term t = new Term(field, new BytesRef(decode));
-                        return new TermQuery(t);
-                    case "boost1":
-                        final Number boost = (Number) arr.get(1);
-                        final Query query = interpret(p, (List<?>) arr.get(2));
-                        return new BoostQuery(query, boost.floatValue());
-                    case "bool1":
-                        final Map<String, ?> obj = (Map<String, ?>) arr.get(1);
-                        final BooleanQuery.Builder builder = new BooleanQuery.Builder();
-                        for(Map.Entry<String ,?> prop: obj.entrySet()) {
-                            if ("mm".equals(prop.getKey())) {
-                                builder.setMinimumNumberShouldMatch(((Number) prop.getValue()).intValue());
-                            } else {
-                                final BooleanClause.Occur occur = BooleanClause.Occur.valueOf(prop.getKey());
-                                for(Object q : (List<?>) prop.getValue()){
-                                    builder.add(interpret(p, (List<?>) q), occur);
-                                }
-                            }
-                        }
-                        return builder.build();
-                }
-                throw new InvalidFormatException(p, "Unable to interpret", arr, Query.class);
-            }
-        });
-        simpleModule.addSerializer(TermQuery.class, new StdSerializer<>(TermQuery.class) {
-            @Override
-            public void serialize(TermQuery value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-                gen.writeStartArray(value, 3);
-                gen.writeString("term1");
-                gen.writeString(value.getTerm().field());
-                final BytesRef bytes = value.getTerm().bytes();
-                gen.writeBinary(bytes.bytes, bytes.offset, bytes.length);
-                gen.writeEndArray();
-            }
-        });
-        simpleModule.addSerializer(BooleanQuery.class, new StdSerializer<>(BooleanQuery.class) {
-            @Override
-            public void serialize(BooleanQuery value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-                gen.writeStartArray(value, 2);
-                gen.writeString("bool1");
+    simpleModule.addDeserializer(
+        Query.class,
+        new JsonDeserializer<>() {
+          @Override
+          public Query deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            final ObjectCodec codec = p.getCodec();
+            final List<?> arr = codec.readValue(p, List.class);
+            return interpret(p, arr);
+          }
 
-                final Map<BooleanClause.Occur, List<Query>> byOccur = value.clauses().stream()
-                        .collect(Collectors.groupingBy(BooleanClause::getOccur,
-                                Collectors.mapping(BooleanClause::getQuery, Collectors.toList())));
-                gen.writeStartObject(value, byOccur.size() + (value.getMinimumNumberShouldMatch()==0?0:1));//cnt
-                for (Map.Entry<BooleanClause.Occur, List<Query>> occur : byOccur.entrySet()) {
-                    gen.writeArrayFieldStart(occur.getKey().name()); //TODO scalar
-                    for (Query q : occur.getValue()) {
-                        gen.writeObject(q);
+          @SuppressWarnings("unchecked")
+          private Query interpret(JsonParser p, List<?> arr) throws JacksonException {
+            final String format = (String) arr.get(0);
+            switch (format) {
+              case "term1":
+                final String field = (String) arr.get(1);
+                Object txt = arr.get(2);
+                byte[] decode =
+                    txt instanceof String ? Base64.getDecoder().decode((String) txt) : (byte[]) txt;
+                Term t = new Term(field, new BytesRef(decode));
+                return new TermQuery(t);
+              case "boost1":
+                final Number boost = (Number) arr.get(1);
+                final Query query = interpret(p, (List<?>) arr.get(2));
+                return new BoostQuery(query, boost.floatValue());
+              case "bool1":
+                final Map<String, ?> obj = (Map<String, ?>) arr.get(1);
+                final BooleanQuery.Builder builder = new BooleanQuery.Builder();
+                for (Map.Entry<String, ?> prop : obj.entrySet()) {
+                  if ("mm".equals(prop.getKey())) {
+                    builder.setMinimumNumberShouldMatch(((Number) prop.getValue()).intValue());
+                  } else {
+                    final BooleanClause.Occur occur = BooleanClause.Occur.valueOf(prop.getKey());
+                    for (Object q : (List<?>) prop.getValue()) {
+                      builder.add(interpret(p, (List<?>) q), occur);
                     }
-                    gen.writeEndArray();
+                  }
                 }
-                if (value.getMinimumNumberShouldMatch()>0) {
-                    gen.writeNumberField("mm", value.getMinimumNumberShouldMatch());
-                }
-                gen.writeEndObject();
-                gen.writeEndArray();
+                return builder.build();
             }
+            throw new InvalidFormatException(p, "Unable to interpret", arr, Query.class);
+          }
         });
-        mapper.registerModule(simpleModule);
-    }
+    simpleModule.addSerializer(
+        TermQuery.class,
+        new StdSerializer<>(TermQuery.class) {
+          @Override
+          public void serialize(TermQuery value, JsonGenerator gen, SerializerProvider provider)
+              throws IOException {
+            gen.writeStartArray(value, 3);
+            gen.writeString("term1");
+            gen.writeString(value.getTerm().field());
+            final BytesRef bytes = value.getTerm().bytes();
+            gen.writeBinary(bytes.bytes, bytes.offset, bytes.length);
+            gen.writeEndArray();
+          }
+        });
+    simpleModule.addSerializer(
+        BooleanQuery.class,
+        new StdSerializer<>(BooleanQuery.class) {
+          @Override
+          public void serialize(BooleanQuery value, JsonGenerator gen, SerializerProvider provider)
+              throws IOException {
+            gen.writeStartArray(value, 2);
+            gen.writeString("bool1");
 
-    private QueryTransfer () {
-    }
+            final Map<BooleanClause.Occur, List<Query>> byOccur =
+                value.clauses().stream()
+                    .collect(
+                        Collectors.groupingBy(
+                            BooleanClause::getOccur,
+                            Collectors.mapping(BooleanClause::getQuery, Collectors.toList())));
+            gen.writeStartObject(
+                value, byOccur.size() + (value.getMinimumNumberShouldMatch() == 0 ? 0 : 1)); // cnt
+            for (Map.Entry<BooleanClause.Occur, List<Query>> occur : byOccur.entrySet()) {
+              gen.writeArrayFieldStart(occur.getKey().name()); // TODO scalar
+              for (Query q : occur.getValue()) {
+                gen.writeObject(q);
+              }
+              gen.writeEndArray();
+            }
+            if (value.getMinimumNumberShouldMatch() > 0) {
+              gen.writeNumberField("mm", value.getMinimumNumberShouldMatch());
+            }
+            gen.writeEndObject();
+            gen.writeEndArray();
+          }
+        });
+    mapper.registerModule(simpleModule);
+  }
 
-    public static byte[] transfer(Query query) throws IOException {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        mapper.writeValue(os, query);
-        return os.toByteArray();
-    }
+  private QueryTransfer() {}
 
-    public static Query receive(byte[] unmarshal) throws IOException {
-        return mapper.readValue(unmarshal, Query.class);
-    }
+  public static byte[] transfer(Query query) throws IOException {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    mapper.writeValue(os, query);
+    return os.toByteArray();
+  }
 
+  public static Query receive(byte[] unmarshal) throws IOException {
+    return mapper.readValue(unmarshal, Query.class);
+  }
 }

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransfer.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransfer.java
@@ -1,0 +1,138 @@
+package org.apache.solr.util.querytransfer;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QueryTransfer {
+    static ObjectMapper mapper;
+    static {
+        SmileFactory smileFactory = new SmileFactory();
+        mapper = new ObjectMapper(smileFactory);
+        final SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addSerializer(BoostQuery.class, new StdSerializer<>(BoostQuery.class) {
+
+            @Override
+            public void serialize(BoostQuery value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+                gen.writeStartArray(value, 3);
+                gen.writeString("boost1");
+                gen.writeNumber(value.getBoost());
+                gen.writeObject(value.getQuery());
+                gen.writeEndArray();
+            }
+        });
+
+        simpleModule.addDeserializer(Query.class, new JsonDeserializer<>() {
+            @Override
+            public Query deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                final ObjectCodec codec = p.getCodec();
+                final List<?> arr = codec.readValue(p, List.class);
+                return interpret(p, arr);
+            }
+            @SuppressWarnings("unchecked")
+            private Query interpret(JsonParser p, List<?> arr) throws JacksonException {
+                final String format = (String) arr.get(0);
+                switch (format) {
+                    case "term1":
+                        final String field = (String) arr.get(1);
+                        Object txt = arr.get(2);
+                        byte[] decode = txt instanceof String ? Base64.getDecoder().decode((String)txt) : (byte[])txt;
+                        Term t = new Term(field, new BytesRef(decode));
+                        return new TermQuery(t);
+                    case "boost1":
+                        final Number boost = (Number) arr.get(1);
+                        final Query query = interpret(p, (List<?>) arr.get(2));
+                        return new BoostQuery(query, boost.floatValue());
+                    case "bool1":
+                        final Map<String, ?> obj = (Map<String, ?>) arr.get(1);
+                        final BooleanQuery.Builder builder = new BooleanQuery.Builder();
+                        for(Map.Entry<String ,?> prop: obj.entrySet()) {
+                            if ("mm".equals(prop.getKey())) {
+                                builder.setMinimumNumberShouldMatch(((Number) prop.getValue()).intValue());
+                            } else {
+                                final BooleanClause.Occur occur = BooleanClause.Occur.valueOf(prop.getKey());
+                                for(Object q : (List<?>) prop.getValue()){
+                                    builder.add(interpret(p, (List<?>) q), occur);
+                                }
+                            }
+                        }
+                        return builder.build();
+                }
+                throw new InvalidFormatException(p, "Unable to interpret", arr, Query.class);
+            }
+        });
+        simpleModule.addSerializer(TermQuery.class, new StdSerializer<>(TermQuery.class) {
+            @Override
+            public void serialize(TermQuery value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+                gen.writeStartArray(value, 3);
+                gen.writeString("term1");
+                gen.writeString(value.getTerm().field());
+                final BytesRef bytes = value.getTerm().bytes();
+                gen.writeBinary(bytes.bytes, bytes.offset, bytes.length);
+                gen.writeEndArray();
+            }
+        });
+        simpleModule.addSerializer(BooleanQuery.class, new StdSerializer<>(BooleanQuery.class) {
+            @Override
+            public void serialize(BooleanQuery value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+                gen.writeStartArray(value, 2);
+                gen.writeString("bool1");
+
+                final Map<BooleanClause.Occur, List<Query>> byOccur = value.clauses().stream()
+                        .collect(Collectors.groupingBy(BooleanClause::getOccur,
+                                Collectors.mapping(BooleanClause::getQuery, Collectors.toList())));
+                gen.writeStartObject(value, byOccur.size() + (value.getMinimumNumberShouldMatch()==0?0:1));//cnt
+                for (Map.Entry<BooleanClause.Occur, List<Query>> occur : byOccur.entrySet()) {
+                    gen.writeArrayFieldStart(occur.getKey().name()); //TODO scalar
+                    for (Query q : occur.getValue()) {
+                        gen.writeObject(q);
+                    }
+                    gen.writeEndArray();
+                }
+                if (value.getMinimumNumberShouldMatch()>0) {
+                    gen.writeNumberField("mm", value.getMinimumNumberShouldMatch());
+                }
+                gen.writeEndObject();
+                gen.writeEndArray();
+            }
+        });
+        mapper.registerModule(simpleModule);
+    }
+
+    private QueryTransfer () {
+    }
+
+    public static byte[] transfer(Query query) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        mapper.writeValue(os, query);
+        return os.toByteArray();
+    }
+
+    public static Query receive(byte[] unmarshal) throws IOException {
+        return mapper.readValue(unmarshal, Query.class);
+    }
+
+}

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransfer.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransfer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.util.querytransfer;
 
 import com.fasterxml.jackson.core.JacksonException;

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.util.querytransfer;
 
 import org.apache.lucene.search.Query;

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
@@ -44,7 +44,7 @@ public class QueryTransferQParserPlugin extends QParserPlugin {
         try {
           return QueryTransfer.receive(decode);
         } catch (IOException e) {
-          log.error("Unable to parse: " + qstr, e);
+          log.error(qstr, e);
           throw new SyntaxError(e);
         }
       }

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
@@ -44,7 +44,7 @@ public class QueryTransferQParserPlugin extends QParserPlugin {
         try {
           return QueryTransfer.receive(decode);
         } catch (IOException e) {
-          log.error(e.getMessage(), e);
+          log.error("Unable to parse: " + qstr, e);
           throw new SyntaxError(e);
         }
       }

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
@@ -16,6 +16,9 @@
  */
 package org.apache.solr.util.querytransfer;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Base64;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
@@ -25,29 +28,26 @@ import org.apache.solr.search.SyntaxError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.util.Base64;
-
 public class QueryTransferQParserPlugin extends QParserPlugin {
 
-    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    public static final String NAME = "qubyen64";
+  public static final String NAME = "qubyen64";
 
-    @Override
-    public QParser createParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req) {
-        return new QParser(qstr,localParams, params,req) {
-            @Override
-            public Query parse() throws SyntaxError {
-                final byte[] decode = Base64.getDecoder().decode(qstr);
-                try {
-                    return QueryTransfer.receive(decode);
-                } catch (IOException e) {
-                    log.error(e.getMessage(), e);
-                    throw new SyntaxError(e);
-                }
-            }
-        };
-    }
+  @Override
+  public QParser createParser(
+      String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req) {
+    return new QParser(qstr, localParams, params, req) {
+      @Override
+      public Query parse() throws SyntaxError {
+        final byte[] decode = Base64.getDecoder().decode(qstr);
+        try {
+          return QueryTransfer.receive(decode);
+        } catch (IOException e) {
+          log.error(e.getMessage(), e);
+          throw new SyntaxError(e);
+        }
+      }
+    };
+  }
 }

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/QueryTransferQParserPlugin.java
@@ -1,0 +1,37 @@
+package org.apache.solr.util.querytransfer;
+
+import org.apache.lucene.search.Query;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.search.QParser;
+import org.apache.solr.search.QParserPlugin;
+import org.apache.solr.search.SyntaxError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Base64;
+
+public class QueryTransferQParserPlugin extends QParserPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    public static final String NAME = "qubyen64";
+
+    @Override
+    public QParser createParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req) {
+        return new QParser(qstr,localParams, params,req) {
+            @Override
+            public Query parse() throws SyntaxError {
+                final byte[] decode = Base64.getDecoder().decode(qstr);
+                try {
+                    return QueryTransfer.receive(decode);
+                } catch (IOException e) {
+                    log.error(e.getMessage(), e);
+                    throw new SyntaxError(e);
+                }
+            }
+        };
+    }
+}

--- a/solr/core/src/java/org/apache/solr/util/querytransfer/package-info.java
+++ b/solr/core/src/java/org/apache/solr/util/querytransfer/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Utility for serializing Lucene Queries */
+package org.apache.solr.util.querytransfer;

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
@@ -91,7 +91,7 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
         id,
         "9",
         "lowerfilt",
-        "The quick red fox jumped over the lazy big and large brown dogs.",
+        "The quick red fox smart:bear jumped over the lazy big and large brown dogs.",
         "lowerfilt1",
         "x");
     index(id, "10", "lowerfilt", "blue", "lowerfilt1", "x");
@@ -100,84 +100,84 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
         id,
         "13",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "14",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "15",
         "lowerfilt",
-        "The fat red fox jumped over the lazy brown dogs.",
+        "The fat red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "16",
         "lowerfilt",
-        "The slim red fox jumped over the lazy brown dogs.",
+        "The slim red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "17",
         "lowerfilt",
-        "The quote red fox jumped moon over the lazy brown dogs moon. Of course moon. Foxes and moon come back to the foxes and moon",
+        "The quote red fox smart:bear jumped moon over the lazy brown dogs moon. Of course moon. Foxes and moon come back to the foxes and moon",
         "lowerfilt1",
         "y");
     index(
         id,
         "18",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "19",
         "lowerfilt",
-        "The hose red fox jumped over the lazy brown dogs.",
+        "The hose red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "20",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "21",
         "lowerfilt",
-        "The court red fox jumped over the lazy brown dogs.",
+        "The court red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "22",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "23",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
         id,
         "24",
         "lowerfilt",
-        "The file red fox jumped over the lazy brown dogs.",
+        "The file red fox smart:bear jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(id, "25", "lowerfilt", "rod fix", "lowerfilt1", "y");

--- a/solr/core/src/test/org/apache/solr/handler/component/MoreLikeThisComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/MoreLikeThisComponentTest.java
@@ -81,7 +81,7 @@ public class MoreLikeThisComponentTest extends SolrTestCaseJ4 {
             "id",
             "44",
             "name",
-            "Harrison Ford",
+            "Harrison Ford a:little bit:fraud",
             "subword",
             "Star Wars",
             "subword",

--- a/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
+++ b/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.solr.util.querytransfer;
 
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -31,71 +36,69 @@ import org.apache.solr.search.QParserPlugin;
 import org.apache.solr.search.SyntaxError;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.Base64;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-
 public class QueryTransferTest extends SolrTestCase {
-    @Test
-    public void testTermQuery() throws IOException, SyntaxError {
-        final TermQuery termQuery = randomTermQuery();
-        assertTransfer(termQuery);
-    }
+  @Test
+  public void testTermQuery() throws IOException, SyntaxError {
+    final TermQuery termQuery = randomTermQuery();
+    assertTransfer(termQuery);
+  }
 
-    private static TermQuery randomTermQuery() {
-        return new TermQuery(new Term(TestUtil.randomSimpleString(random()), TestUtil.randomUnicodeString(random())));
-    }
+  private static TermQuery randomTermQuery() {
+    return new TermQuery(
+        new Term(TestUtil.randomSimpleString(random()), TestUtil.randomUnicodeString(random())));
+  }
 
-    @Test
-    public void testBoostQuery() throws IOException, SyntaxError {
-        final TermQuery termQuery = randomTermQuery();
-        final BoostQuery boostQuery = randomBoostQuery(termQuery);
-        assertTransfer(boostQuery);
-    }
+  @Test
+  public void testBoostQuery() throws IOException, SyntaxError {
+    final TermQuery termQuery = randomTermQuery();
+    final BoostQuery boostQuery = randomBoostQuery(termQuery);
+    assertTransfer(boostQuery);
+  }
 
-    final BooleanClause.Occur[] occurs = BooleanClause.Occur.values();
-    @Test
-    public void testBoolQuery() throws IOException, SyntaxError {
-        final BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        Set<Query> noDupes = new HashSet<>();
-        int clauses = 1+random().nextInt(5);
-        for (int i =0; i<clauses; i++) {
-            Query termQuery = randomTermQuery();
-            if (random().nextBoolean()) {
-                termQuery = randomBoostQuery(termQuery);
-            }
-            if (noDupes.add(termQuery)) {
-                builder.add(termQuery, occurs[random().nextInt(occurs.length)]);
-            }
-        }
-        if (random().nextBoolean()) {
-            builder.setMinimumNumberShouldMatch(random().nextInt(5));
-        }
-        assertTransfer(builder.build());
-    }
-    private static BoostQuery randomBoostQuery(Query termQuery) {
-        return new BoostQuery(termQuery, random().nextFloat() * random().nextInt(10));
-    }
+  final BooleanClause.Occur[] occurs = BooleanClause.Occur.values();
 
-    private static void assertTransfer(Query termQuery) throws IOException, SyntaxError {
-        final Query mltQ = mltRemoteReduce(termQuery);
-        assertEquals(termQuery, mltQ);
-        assertNotSame(termQuery, mltQ);
+  @Test
+  public void testBoolQuery() throws IOException, SyntaxError {
+    final BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    Set<Query> noDupes = new HashSet<>();
+    int clauses = 1 + random().nextInt(5);
+    for (int i = 0; i < clauses; i++) {
+      Query termQuery = randomTermQuery();
+      if (random().nextBoolean()) {
+        termQuery = randomBoostQuery(termQuery);
+      }
+      if (noDupes.add(termQuery)) {
+        builder.add(termQuery, occurs[random().nextInt(occurs.length)]);
+      }
     }
+    if (random().nextBoolean()) {
+      builder.setMinimumNumberShouldMatch(random().nextInt(5));
+    }
+    assertTransfer(builder.build());
+  }
 
-    private static Query mltRemoteReduce(Query termQuery) throws IOException, SyntaxError {
-        final byte[] blob = QueryTransfer.transfer(termQuery);
-        final LocalSolrQueryRequest req = new LocalSolrQueryRequest(null, new NamedList<>());
-        final String qstr = Base64.getEncoder().encodeToString(blob);
-        final Query mltQ;
-        try (QParserPlugin plugin = new QueryTransferQParserPlugin()) {
-            mltQ = plugin.createParser(qstr, new MapSolrParams(Map.of()),
-                    new MapSolrParams(Map.of()), req).getQuery();
-            req.close();
-        }
-        return mltQ;
+  private static BoostQuery randomBoostQuery(Query termQuery) {
+    return new BoostQuery(termQuery, random().nextFloat() * random().nextInt(10));
+  }
+
+  private static void assertTransfer(Query termQuery) throws IOException, SyntaxError {
+    final Query mltQ = mltRemoteReduce(termQuery);
+    assertEquals(termQuery, mltQ);
+    assertNotSame(termQuery, mltQ);
+  }
+
+  private static Query mltRemoteReduce(Query termQuery) throws IOException, SyntaxError {
+    final byte[] blob = QueryTransfer.transfer(termQuery);
+    final LocalSolrQueryRequest req = new LocalSolrQueryRequest(null, new NamedList<>());
+    final String qstr = Base64.getEncoder().encodeToString(blob);
+    final Query mltQ;
+    try (QParserPlugin plugin = new QueryTransferQParserPlugin()) {
+      mltQ =
+          plugin
+              .createParser(qstr, new MapSolrParams(Map.of()), new MapSolrParams(Map.of()), req)
+              .getQuery();
+      req.close();
     }
+    return mltQ;
+  }
 }

--- a/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
+++ b/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
@@ -8,6 +8,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.solr.SolrTestCase;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.request.LocalSolrQueryRequest;
@@ -22,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 
-public class QueryTransferTest extends LuceneTestCase {
+public class QueryTransferTest extends SolrTestCase {
     @Test
     public void testTermQuery() throws IOException, SyntaxError {
         final TermQuery termQuery = randomTermQuery();

--- a/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
+++ b/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.util.querytransfer;
 
 import org.apache.lucene.index.Term;
@@ -6,7 +22,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.SolrTestCase;
 import org.apache.solr.common.params.MapSolrParams;

--- a/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
+++ b/solr/core/src/test/org/apache/solr/util/querytransfer/QueryTransferTest.java
@@ -1,0 +1,85 @@
+package org.apache.solr.util.querytransfer;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.solr.common.params.MapSolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.LocalSolrQueryRequest;
+import org.apache.solr.search.QParserPlugin;
+import org.apache.solr.search.SyntaxError;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+public class QueryTransferTest extends LuceneTestCase {
+    @Test
+    public void testTermQuery() throws IOException, SyntaxError {
+        final TermQuery termQuery = randomTermQuery();
+        assertTransfer(termQuery);
+    }
+
+    private static TermQuery randomTermQuery() {
+        return new TermQuery(new Term(TestUtil.randomSimpleString(random()), TestUtil.randomUnicodeString(random())));
+    }
+
+    @Test
+    public void testBoostQuery() throws IOException, SyntaxError {
+        final TermQuery termQuery = randomTermQuery();
+        final BoostQuery boostQuery = randomBoostQuery(termQuery);
+        assertTransfer(boostQuery);
+    }
+
+    final BooleanClause.Occur[] occurs = BooleanClause.Occur.values();
+    @Test
+    public void testBoolQuery() throws IOException, SyntaxError {
+        final BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        Set<Query> noDupes = new HashSet<>();
+        int clauses = 1+random().nextInt(5);
+        for (int i =0; i<clauses; i++) {
+            Query termQuery = randomTermQuery();
+            if (random().nextBoolean()) {
+                termQuery = randomBoostQuery(termQuery);
+            }
+            if (noDupes.add(termQuery)) {
+                builder.add(termQuery, occurs[random().nextInt(occurs.length)]);
+            }
+        }
+        if (random().nextBoolean()) {
+            builder.setMinimumNumberShouldMatch(random().nextInt(5));
+        }
+        assertTransfer(builder.build());
+    }
+    private static BoostQuery randomBoostQuery(Query termQuery) {
+        return new BoostQuery(termQuery, random().nextFloat() * random().nextInt(10));
+    }
+
+    private static void assertTransfer(Query termQuery) throws IOException, SyntaxError {
+        final Query mltQ = mltRemoteReduce(termQuery);
+        assertEquals(termQuery, mltQ);
+        assertNotSame(termQuery, mltQ);
+    }
+
+    private static Query mltRemoteReduce(Query termQuery) throws IOException, SyntaxError {
+        final byte[] blob = QueryTransfer.transfer(termQuery);
+        final LocalSolrQueryRequest req = new LocalSolrQueryRequest(null, new NamedList<>());
+        final String qstr = Base64.getEncoder().encodeToString(blob);
+        final Query mltQ;
+        try (QParserPlugin plugin = new QueryTransferQParserPlugin()) {
+            mltQ = plugin.createParser(qstr, new MapSolrParams(Map.of()),
+                    new MapSolrParams(Map.of()), req).getQuery();
+            req.close();
+        }
+        return mltQ;
+    }
+}


### PR DESCRIPTION
The way how distributed MLT works now lacks of perfection, you know. 
Here's not a real proposal, it just demonstrates current state. 

1. MLT respond with Query instance. However, it might be list of terms, or so. I keep it as-is
2. These queries should be responded to query coordinator. In HEAD it's just `BoolQ.toString()` that's a pity. There are two options instead: Lucene query can be structured as named list, or as a blob. I started from the former approach, but then decided to dump it to blob with Jackson+Smile. So, in the patch MLT query successfully arrives to coordinator. 
3. Then, we need to spread it across shards. And now it's prototyped in a little bit weird way. Since, it's deadly hard to send shard request with payload in body, I have to encode it to base64 and hook it up by dedicated QParser. Yeah... 

So, where to tweak it further?
  