### PR TITLE
Update caches-warming.adoc with a note about maxRamMB

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
@@ -170,6 +170,9 @@ The more fields you store in your documents, the higher the memory usage of this
                autowarmCount="0"/>
 ----
 
+[NOTE]
+Do not use the `maxRamMB` setting for the `documentCache`. The amount of memory required for the cached documents will not be calculated properly, which can lead to the cache using much more memory than anticipated.
+
 === User Defined Caches
 
 You can also define named caches for your own application code to use.


### PR DESCRIPTION
Add a note about documentCache not supporting maxRamMB setting properly.

Since Lucene's RamUsageEstimator doesn't understand the Document objects, it will default to 256 bytes. Depending on the real document size this can be wildly inaccurate and cause the cache to use several magnitudes more memory than expected.

