### PR TITLE
SOLR-5707: Lucene Expressions in Solr

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ExpressionValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExpressionValueSourceParser.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import static org.apache.solr.common.SolrException.ErrorCode.SERVER_ERROR;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.lucene.expressions.Bindings;
+import org.apache.lucene.expressions.Expression;
+import org.apache.lucene.expressions.js.JavascriptCompiler;
+import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.search.DoubleValuesSource;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.schema.SchemaField;
+
+/**
+ * A ValueSource parser that can be configured with (named) pre-complied Expressions that can then
+ * be evaluated at request time. :nocommit: more docs, example configs, example usage :nocommit:
+ * need "bad-solrconfig..." level test of cycle expressions, using score w/null score binding,
+ * etc..."
+ */
+public class ExpressionValueSourceParser extends ValueSourceParser {
+  public static final String SCORE_KEY = "score-name";
+  public static final String EXPRESSIONS_KEY = "expressions";
+
+  private Map<String, Expression> expressions;
+  private String scoreKey = SolrReturnFields.SCORE;
+
+  @Override
+  public void init(NamedList<?> args) {
+    initConfiguredExpression(args);
+    initScoreKey(args);
+    super.init(args);
+  }
+
+  /** Checks for optional scoreKey override */
+  private void initScoreKey(NamedList<?> args) {
+    final int scoreIdx = args.indexOf(SCORE_KEY, 0);
+    if (scoreIdx < 0) {
+      // if it's not in the list at all, use the existing default...
+      return;
+    }
+
+    Object arg = args.remove(scoreIdx);
+    // null is valid if they want to prevent default binding
+    scoreKey = (null == arg) ? null : arg.toString();
+  }
+
+  /** Parses the pre-configured expressions */
+  private void initConfiguredExpression(NamedList<?> args) {
+    Object arg = args.remove(EXPRESSIONS_KEY);
+    if (!(arg instanceof NamedList)) {
+      // :TODO: null arg may be ok if we want to later support dynamic expressions
+      throw new SolrException(
+          SERVER_ERROR, EXPRESSIONS_KEY + " must be configured as a list of named expressions");
+    }
+    @SuppressWarnings("unchecked")
+    NamedList<String> input = (NamedList<String>) arg;
+    Map<String, Expression> expr = new HashMap<>();
+    for (Map.Entry<String, String> item : input) {
+      String key = item.getKey();
+      try {
+        Expression val = JavascriptCompiler.compile(item.getValue());
+        expr.put(key, val);
+      } catch (ParseException e) {
+        throw new SolrException(
+            SERVER_ERROR, "Unable to parse javascript expression: " + item.getValue(), e);
+      }
+    }
+
+    // TODO: should we support mapping positional func args to names in bindings?
+    //
+    // ie: ...
+    // <lst name="expressions">
+    //   <lst name="my_expr">
+    //     <str name="expression">foo * bar / baz</str>
+    //     <arr name="positional-bindings">
+    //       <str>baz</str>
+    //       <str>bar</str>
+    //     </arr>
+    //   </lst>
+    //   <str name="foo">32</foo>
+    //   ...
+    // </lst>
+    //  and then:  "expr(my_expr,42,56)" == "32 * 56 / 42"
+
+    exceptionIfCycles(expr);
+    this.expressions = Collections.unmodifiableMap(expr);
+  }
+
+  @Override
+  public ValueSource parse(FunctionQParser fp) throws SyntaxError {
+    assert null != fp;
+
+    String key = fp.parseArg();
+    // TODO: allow function params for overriding bindings?
+    // TODO: support dynamic expressions:  expr("foo * bar / 32")  ??
+
+    IndexSchema schema = fp.getReq().getSchema();
+
+    SolrBindings b = new SolrBindings(scoreKey, expressions, schema);
+    return ValueSource.fromDoubleValuesSource(b.getDoubleValuesSource(key));
+  }
+
+  /** Validates that a Map of named expressions does not contain any cycles. */
+  public static void exceptionIfCycles(Map<String, Expression> expressions) {
+
+    // TODO: there's probably a more efficient way to do this
+    // TODO: be nice to just return the shortest cycles (ie: b->a->b instead of x->a->b->a)
+
+    List<String> cycles = new ArrayList<>(expressions.size());
+    Set<String> checkedKeys = new LinkedHashSet<>();
+
+    for (String key : expressions.keySet()) {
+      Set<String> visitedKeys = new LinkedHashSet<>();
+      String cycle = makeCycleErrString(key, expressions, visitedKeys, checkedKeys);
+      if (null != cycle) {
+        cycles.add(cycle);
+      }
+    }
+    if (0 < cycles.size()) {
+      throw new SolrException(
+          SERVER_ERROR,
+          "At least "
+              + cycles.size()
+              + " cycles detected in configured expressions: ["
+              + String.join("], [", cycles)
+              + "]");
+    }
+  }
+
+  /**
+   * Recursively checks for cycles, returning null if none found - otherwise the string is a
+   * representation of the cycle found (may not be the shortest cycle) This method recursively
+   * adds to visitedKeys and checkedKeys
+   */
+  private static String makeCycleErrString(
+      String key,
+      Map<String, Expression> expressions,
+      Set<String> visitedKeys,
+      Set<String> checkedKeys) {
+    if (checkedKeys.contains(key)) {
+      return null;
+    }
+    if (visitedKeys.contains(key)) {
+      checkedKeys.add(key);
+      return String.join("=>", visitedKeys) + "=>" + key;
+    }
+    visitedKeys.add(key);
+
+    Expression expr = expressions.get(key);
+    if (null != expr) {
+      for (String var : expr.variables) {
+        assert null != var;
+
+        String err = makeCycleErrString(var, expressions, visitedKeys, checkedKeys);
+        if (null != err) {
+          return err;
+        }
+      }
+    }
+
+    checkedKeys.add(key);
+    return null;
+  }
+
+  /**
+   * A bindings class that recognizes pre-configured named expression and uses schema fields to
+   * resolve variables that have not been configured as expressions.
+   *
+   * @lucene.internal
+   */
+  public static class SolrBindings extends Bindings {
+    private final String scoreKey;
+    private final Map<String, Expression> expressions;
+    private final IndexSchema schema;
+    /**
+     * @param scoreKey The binding name that should be used to represent the score, may be null
+     * @param expressions Mapping of expression names that will be consulted as the primary
+     *     bindings, get() should return null if key is not bound to an expression (will be used
+     *     read only, will *not* be defensively copied, must not contain cycles)
+     * @param schema IndexSchema for field bindings
+     */
+    public SolrBindings(String scoreKey, Map<String, Expression> expressions, IndexSchema schema) {
+      this.scoreKey = scoreKey;
+      this.expressions = expressions;
+      this.schema = schema;
+      // :TODO: add support for request time bindings (function args)
+    }
+
+    @Override
+    public DoubleValuesSource getDoubleValuesSource(String key) {
+      assert null != key;
+
+      if (Objects.equals(scoreKey, key)) {
+        return DoubleValuesSource.SCORES;
+      }
+
+      Expression expr = expressions.get(key);
+      if (null != expr) {
+        try {
+          return expr.getDoubleValuesSource(this);
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException(
+              "Invalid binding for key '" + key + "' transative binding problem: " + e.getMessage(),
+              e);
+        }
+      }
+
+      SchemaField field = schema.getFieldOrNull(key);
+      if (null != field) {
+        return field.getType().getValueSource(field, null).asDoubleValuesSource();
+      }
+
+      throw new IllegalArgumentException("No binding or schema field for key: " + key);
+    }
+  }
+}

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-expressions-vs.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-expressions-vs.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<config>
+  <luceneMatchVersion>${tests.luceneMatchVersion:LUCENE_CURRENT}</luceneMatchVersion>
+
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <requestHandler name="standard" class="solr.StandardRequestHandler"/>
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
+  
+  <valueSourceParser name="expr" class="solr.ExpressionValueSourceParser">
+    <!-- Note: uses default score binding of 'score' -->
+    <lst name="expressions">
+      <str name="sin1">sin(1)</str>
+      <str name="cos_sin1">cos(sin1)</str>
+      <str name="sqrt_int1_i">sqrt(int1_i)</str>
+      <str name="sqrt_double1_d">sqrt(double1_d)</str>
+      <str name="date1_dt_minus_1990">date1_dt - 631036800000</str>
+      <str name="one_plus_score">1 + score</str>
+      <str name="two_plus_score">1 + one_plus_score</str>
+      <str name="sqrt_int1_i_plus_one_plus_score">sqrt_int1_i + one_plus_score</str>
+      <str name="mixed_expr">one_plus_score*ln(cos_sin1)</str>
+    </lst>
+  </valueSourceParser>
+
+  <valueSourceParser name="expr_ssccoorree" class="solr.ExpressionValueSourceParser">
+    <str name="score-name">ssccoorree</str>
+    <lst name="expressions">
+      <str name="one_plus_score">1 + ssccoorree</str>
+    </lst>
+  </valueSourceParser>
+</config>

--- a/solr/core/src/test/org/apache/solr/search/ExpressionValueSourceParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ExpressionValueSourceParserTest.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.lucene.expressions.Expression;
+import org.apache.lucene.expressions.js.JavascriptCompiler;
+import org.apache.lucene.queries.function.ValueSource;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.search.ExpressionValueSourceParser.SolrBindings;
+import org.apache.solr.util.DateMathParser;
+import org.junit.BeforeClass;
+
+public class ExpressionValueSourceParserTest extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeTests() throws Exception {
+    initCore("solrconfig-expressions-vs.xml", "schema15.xml");
+
+    assertU(
+        adoc("id", "1", "int1_i", "50", "double1_d", "-2.5", "date1_dt", "1996-12-19T16:39:57Z"));
+    assertU(
+        adoc("id", "2", "int1_i", "-30", "double1_d", "10.3", "date1_dt", "1999-12-19T16:39:57Z"));
+    assertU(
+        adoc("id", "3", "int1_i", "10", "double1_d", "500.3", "date1_dt", "1995-12-19T16:39:57Z"));
+    assertU(adoc("id", "4", "int1_i", "40", "double1_d", "-1", "date1_dt", "1994-12-19T16:39:57Z"));
+    assertU(
+        adoc("id", "5", "int1_i", "20", "double1_d", "2.1", "date1_dt", "1997-12-19T16:39:57Z"));
+
+    assertU(commit());
+  }
+
+  public void testValidBindings() throws ParseException {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    Map<String, Expression> exprs = new HashMap<>();
+    exprs.put("foo", JavascriptCompiler.compile("((0.3*popularity)/10.0)+(0.7*ScOrE)"));
+    exprs.put("popularity", JavascriptCompiler.compile("foo_i"));
+    SolrBindings bindings = new SolrBindings("ScOrE", exprs, schema);
+
+    assertEquals(
+        "foo_i from bindings is wrong",
+        schema
+            .getFieldType("foo_i")
+            .getValueSource(schema.getField("foo_i"), null)
+            .asDoubleValuesSource(),
+        bindings.getDoubleValuesSource("foo_i"));
+    assertNotNull("pop bindings failed", bindings.getDoubleValuesSource("popularity"));
+    assertNotNull("foo bindings failed", bindings.getDoubleValuesSource("foo"));
+    ValueSource scoreBind =
+        ValueSource.fromDoubleValuesSource(bindings.getDoubleValuesSource("ScOrE"));
+    assertNotNull("ScOrE bindings failed", scoreBind);
+
+    try {
+      bindings.getDoubleValuesSource("not_a_expr_and_not_in_schema");
+      fail("no exception from bogus binding");
+    } catch (IllegalArgumentException e) {
+      assertTrue(
+          "wrong exception message: " + e.getMessage(),
+          e.getMessage().contains("not_a_expr_and_not_in_schema"));
+    }
+
+    // change things up a bit
+
+    exprs.put("ScOrE", JavascriptCompiler.compile("42"));
+
+    bindings = new SolrBindings(null, exprs, schema);
+    assertNotNull("foo bindings failed", bindings.getDoubleValuesSource("foo"));
+  }
+
+  public void testBogusBindings() throws ParseException {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    Map<String, Expression> exprs = new HashMap<>();
+    exprs.put("foo", JavascriptCompiler.compile("((0.3*popularity)/10.0)+(0.7*ScOrE)"));
+    exprs.put("popularity", JavascriptCompiler.compile("yak"));
+    SolrBindings bindings = new SolrBindings("ScOrE", exprs, schema);
+
+    try {
+      bindings.getDoubleValuesSource("yak");
+      fail("sanity check failed: yak has a binding?");
+    } catch (IllegalArgumentException e) {
+      // NOOP
+    }
+
+    try {
+      bindings.getDoubleValuesSource("foo");
+      fail("foo should be an invalid transative binding");
+    } catch (IllegalArgumentException e) {
+      String err = e.getMessage();
+      assertTrue(
+          "wrong exception message: " + err,
+          (err.contains("foo") && err.contains("popularity") && err.contains("yak")));
+    }
+
+    // change things up a bit
+
+    bindings = new SolrBindings(null, exprs, schema);
+    try {
+      bindings.getDoubleValuesSource("ScOrE");
+      fail("ScOrE should not have bindings");
+    } catch (IllegalArgumentException e) {
+      // NOOP
+    }
+    try {
+      bindings.getDoubleValuesSource("score");
+      fail("score should not have bindings");
+    } catch (IllegalArgumentException e) {
+      // NOOP
+    }
+  }
+
+  /**
+   * @see ExpressionValueSourceParser#exceptionIfCycles(Map)
+   */
+  public void testCycleChecker() throws Exception {
+    Map<String, Expression> exprs = new HashMap<>();
+
+    exprs.put("foo", JavascriptCompiler.compile("bar * ack"));
+    ExpressionValueSourceParser.exceptionIfCycles(exprs);
+
+    exprs.put("bar", JavascriptCompiler.compile("ack * ack"));
+    ExpressionValueSourceParser.exceptionIfCycles(exprs);
+
+    exprs.put("baz", JavascriptCompiler.compile("bar * foo"));
+    ExpressionValueSourceParser.exceptionIfCycles(exprs);
+
+    // now we start to get some errors
+    exprs.put("ack", JavascriptCompiler.compile("ack * ack"));
+
+    try {
+      ExpressionValueSourceParser.exceptionIfCycles(exprs);
+      fail("no error about ack depending on ack");
+    } catch (SolrException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("ack=>ack"));
+    }
+
+    // different, deeper error
+    exprs.put("ack", JavascriptCompiler.compile("foo * 2"));
+
+    try {
+      ExpressionValueSourceParser.exceptionIfCycles(exprs);
+      fail("no error about ack/foo/bar");
+    } catch (SolrException e) {
+      String msg = e.getMessage();
+      // the thing about cycles: they might be found in either order
+      assertTrue(msg, msg.contains("foo=>ack") || msg.contains("ack=>foo"));
+      assertTrue(msg, msg.contains("bar=>ack"));
+    }
+
+    exprs.remove("bar");
+    exprs.put("wack", JavascriptCompiler.compile("sqrt(wack)"));
+
+    try {
+      ExpressionValueSourceParser.exceptionIfCycles(exprs);
+      fail("no error about ack depending on ack");
+    } catch (SolrException e) {
+      String msg = e.getMessage();
+      // the thing about cycles: they might be found in either order
+      assertTrue(msg, msg.contains("foo=>ack") || msg.contains("ack=>foo"));
+      assertTrue(msg, msg.contains("wack=>wack"));
+      assertTrue(msg, msg.contains("At least 2 cycles"));
+    }
+  }
+
+  /** tests clean error when no such binding */
+  public void testNoSuchBinding() {
+    assertQEx(
+        "should have gotten user error for invalid binding",
+        req(
+            "fl", "id",
+            "q", "{!func}field(int1_i)",
+            "sort", "expr(this_expression_is_not_bound) desc"),
+        400);
+  }
+
+  /** tests an expression referring to a score field using an overridden score binding */
+  public void testSortSsccoorree() {
+    assertQ(
+        "sort",
+        req(
+            "fl", "id",
+            "q", "{!func}field(int1_i)",
+            "sort", "expr_ssccoorree(one_plus_score) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']",
+        "//result/doc[2]/str[@name='id'][.='4']",
+        "//result/doc[3]/str[@name='id'][.='5']",
+        "//result/doc[4]/str[@name='id'][.='3']",
+        "//result/doc[5]/str[@name='id'][.='2']");
+  }
+
+  /** tests a constant expression */
+  public void testSortConstant() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "*:*", "sort", "expr(sin1) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']",
+        "//result/doc[2]/str[@name='id'][.='2']",
+        "//result/doc[3]/str[@name='id'][.='3']",
+        "//result/doc[4]/str[@name='id'][.='4']",
+        "//result/doc[5]/str[@name='id'][.='5']");
+  }
+
+  /** tests an expression referring to another expression */
+  public void testSortExpression() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "*:*", "sort", "expr(cos_sin1) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']",
+        "//result/doc[2]/str[@name='id'][.='2']",
+        "//result/doc[3]/str[@name='id'][.='3']",
+        "//result/doc[4]/str[@name='id'][.='4']",
+        "//result/doc[5]/str[@name='id'][.='5']");
+  }
+
+  /** tests an expression referring to an int field */
+  public void testSortInt() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "*:*", "sort", "expr(sqrt_int1_i) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='2']", // NaN
+        "//result/doc[2]/str[@name='id'][.='1']",
+        "//result/doc[3]/str[@name='id'][.='4']",
+        "//result/doc[4]/str[@name='id'][.='5']",
+        "//result/doc[5]/str[@name='id'][.='3']");
+  }
+
+  /** tests an expression referring to a double field */
+  public void testSortDouble() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "*:*", "sort", "expr(sqrt_double1_d) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']", // NaN
+        "//result/doc[2]/str[@name='id'][.='4']", // NaN
+        "//result/doc[3]/str[@name='id'][.='3']",
+        "//result/doc[4]/str[@name='id'][.='2']",
+        "//result/doc[5]/str[@name='id'][.='5']");
+  }
+
+  /** tests an expression referring to a date field */
+  public void testSortDate() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "*:*", "sort", "expr(date1_dt_minus_1990) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='2']",
+        "//result/doc[2]/str[@name='id'][.='5']",
+        "//result/doc[3]/str[@name='id'][.='1']",
+        "//result/doc[4]/str[@name='id'][.='3']",
+        "//result/doc[5]/str[@name='id'][.='4']");
+  }
+
+  /** tests an expression referring to a score field */
+  public void testSortScore() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "{!func}field(int1_i)", "sort", "expr(one_plus_score) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']",
+        "//result/doc[2]/str[@name='id'][.='4']",
+        "//result/doc[3]/str[@name='id'][.='5']",
+        "//result/doc[4]/str[@name='id'][.='3']",
+        "//result/doc[5]/str[@name='id'][.='2']");
+  }
+
+  /** tests an expression referring to another expression with externals */
+  public void testSortScore2() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "{!func}field(int1_i)", "sort", "expr(two_plus_score) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']",
+        "//result/doc[2]/str[@name='id'][.='4']",
+        "//result/doc[3]/str[@name='id'][.='5']",
+        "//result/doc[4]/str[@name='id'][.='3']",
+        "//result/doc[5]/str[@name='id'][.='2']");
+  }
+
+  /** tests an expression referring to two expressions with externals */
+  public void testSortScore3() {
+    assertQ(
+        "sort",
+        req(
+            "fl",
+            "id",
+            "q",
+            "{!func}field(int1_i)",
+            "sort",
+            "expr(sqrt_int1_i_plus_one_plus_score) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='2']",
+        "//result/doc[2]/str[@name='id'][.='1']",
+        "//result/doc[3]/str[@name='id'][.='4']",
+        "//result/doc[4]/str[@name='id'][.='5']",
+        "//result/doc[5]/str[@name='id'][.='3']");
+  }
+
+  /** tests an expression referring to another expression and a function */
+  public void testSortMixed() {
+    assertQ(
+        "sort",
+        req("fl", "id", "q", "{!func}field(int1_i)", "sort", "expr(mixed_expr) desc,id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='2']",
+        "//result/doc[2]/str[@name='id'][.='3']",
+        "//result/doc[3]/str[@name='id'][.='5']",
+        "//result/doc[4]/str[@name='id'][.='4']",
+        "//result/doc[5]/str[@name='id'][.='1']");
+  }
+
+  /** tests a constant expression */
+  public void testReturnConstant() {
+    final float expected = (float) Math.sin(1);
+    assertQ(
+        "return",
+        req("fl", "sin1:expr(sin1)", "q", "*:*", "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='sin1'][.='" + expected + "']",
+        "//result/doc[2]/float[@name='sin1'][.='" + expected + "']",
+        "//result/doc[3]/float[@name='sin1'][.='" + expected + "']",
+        "//result/doc[4]/float[@name='sin1'][.='" + expected + "']",
+        "//result/doc[5]/float[@name='sin1'][.='" + expected + "']");
+  }
+
+  /** tests an expression referring to another expression */
+  public void testReturnExpression() {
+    final float expected = (float) Math.cos(Math.sin(1));
+    assertQ(
+        "sort",
+        req("fl", "expr(cos_sin1)", "q", "*:*", "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='expr(cos_sin1)'][.=" + expected + "]",
+        "//result/doc[2]/float[@name='expr(cos_sin1)'][.=" + expected + "]",
+        "//result/doc[3]/float[@name='expr(cos_sin1)'][.=" + expected + "]",
+        "//result/doc[4]/float[@name='expr(cos_sin1)'][.=" + expected + "]",
+        "//result/doc[5]/float[@name='expr(cos_sin1)'][.=" + expected + "]");
+  }
+
+  /** tests an expression referring to an int field */
+  public void testReturnInt() {
+    assertQ(
+        "return",
+        req("fl", "foo:expr(sqrt_int1_i)", "q", "*:*", "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='foo'][.=" + (float) Math.sqrt(50) + "]",
+        "//result/doc[2]/float[@name='foo'][.='NaN']",
+        "//result/doc[3]/float[@name='foo'][.=" + (float) Math.sqrt(10) + "]",
+        "//result/doc[4]/float[@name='foo'][.=" + (float) Math.sqrt(40) + "]",
+        "//result/doc[5]/float[@name='foo'][.=" + (float) Math.sqrt(20) + "]");
+  }
+
+  /** tests an expression referring to a double field */
+  public void testReturnDouble() {
+    assertQ(
+        "return",
+        req("fl", "bar:expr(sqrt_double1_d)", "q", "*:*", "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='bar'][.='NaN']",
+        "//result/doc[2]/float[@name='bar'][.=" + (float) Math.sqrt(10.3d) + "]",
+        "//result/doc[3]/float[@name='bar'][.=" + (float) Math.sqrt(500.3d) + "]",
+        "//result/doc[4]/float[@name='bar'][.='NaN']",
+        "//result/doc[5]/float[@name='bar'][.=" + (float) Math.sqrt(2.1d) + "]");
+  }
+
+  /** tests an expression referring to a date field */
+  public void testReturnDate() {
+    assertQ(
+        "return",
+        req("fl", "date1_dt_minus_1990:expr(date1_dt_minus_1990)", "q", "*:*", "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='date1_dt_minus_1990'][.='"
+            + (float)
+                (DateMathParser.parseMath(null, "1996-12-19T16:39:57Z").getTime() - 631036800000D)
+            + "']",
+        "//result/doc[2]/float[@name='date1_dt_minus_1990'][.='"
+            + (float)
+                (DateMathParser.parseMath(null, "1999-12-19T16:39:57Z").getTime() - 631036800000D)
+            + "']",
+        "//result/doc[3]/float[@name='date1_dt_minus_1990'][.='"
+            + (float)
+                (DateMathParser.parseMath(null, "1995-12-19T16:39:57Z").getTime() - 631036800000D)
+            + "']",
+        "//result/doc[4]/float[@name='date1_dt_minus_1990'][.='"
+            + (float)
+                (DateMathParser.parseMath(null, "1994-12-19T16:39:57Z").getTime() - 631036800000D)
+            + "']",
+        "//result/doc[5]/float[@name='date1_dt_minus_1990'][.='"
+            + (float)
+                (DateMathParser.parseMath(null, "1997-12-19T16:39:57Z").getTime() - 631036800000D)
+            + "']");
+  }
+
+  /** tests an expression referring to score */
+  public void testReturnScores() {
+    assertQ(
+        "return",
+        // :nocommit: see ValueSourceAugmenter's nocommit for why fl needs "score"
+        req(
+            "fl", "expr(one_plus_score),score",
+            "q", "{!func}field(int1_i)",
+            "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='expr(one_plus_score)'][.='51.0']",
+        "//result/doc[2]/float[@name='expr(one_plus_score)'][.='1.0']",
+        "//result/doc[3]/float[@name='expr(one_plus_score)'][.='11.0']",
+        "//result/doc[4]/float[@name='expr(one_plus_score)'][.='41.0']",
+        "//result/doc[5]/float[@name='expr(one_plus_score)'][.='21.0']");
+  }
+
+  public void testReturnScores2() {
+    assertQ(
+        "return",
+        // :nocommit: see ValueSourceAugmenter's nocommit for why fl needs "score"
+        req(
+            "fl", "two_plus_score:expr(two_plus_score),score",
+            "q", "{!func}field(int1_i)",
+            "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='two_plus_score'][.='52.0']",
+        "//result/doc[2]/float[@name='two_plus_score'][.='2.0']",
+        "//result/doc[3]/float[@name='two_plus_score'][.='12.0']",
+        "//result/doc[4]/float[@name='two_plus_score'][.='42.0']",
+        "//result/doc[5]/float[@name='two_plus_score'][.='22.0']");
+  }
+
+  public void testReturnScores3() {
+    assertQ(
+        "return",
+        // :nocommit: see ValueSourceAugmenter's nocommit for why fl needs "score"
+        req(
+            "fl", "foo:expr(sqrt_int1_i_plus_one_plus_score),score",
+            "q", "{!func}field(int1_i)",
+            "sort", "id asc"),
+        "//*[@numFound='5']",
+        "//result/doc[1]/float[@name='foo'][.='" + (float) (Math.sqrt(50) + 1 + 50) + "']",
+        "//result/doc[2]/float[@name='foo'][.='NaN']",
+        "//result/doc[3]/float[@name='foo'][.='" + (float) (Math.sqrt(10) + 1 + 10) + "']",
+        "//result/doc[4]/float[@name='foo'][.='" + (float) (Math.sqrt(40) + 1 + 40) + "']",
+        "//result/doc[5]/float[@name='foo'][.='" + (float) (Math.sqrt(20) + 1 + 20) + "']");
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-5707

This is me taking Hoss's VSP patch from https://issues.apache.org/jira/browse/SOLR-5707 and trying to look at it again.

- [x] `./gradlew check -x test -Pvalidation.errorprone=true -Pvalidation.sourcePatterns.failOnError=false` passes :)
- [ ] nocommit are still in there
- [ ] do we NEED to deal w/ score? can we do score different now that its been years later
- [ ] does `./gradlew -p solr/core test --tests ExpressionValueSourceParserTest` pass?
- [ ] do all tests pass?
- [ ] how does this perform - this is my real goal here compared to other say boostfunctions