### PR TITLE
SOLR-16567: KnnQueryParser support for both pre-filters and post-filter

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -199,6 +199,8 @@ Bug Fixes
 
 * SOLR-16585: Fixed NPE when paginating MatchAllDocs with non-zero start offset, like q=*:*&start=10 (Michael Gibney)
 
+* SOLR-16557: Fixed problem with filtering and KNN search, especially when using post-filters (Alessandro Benedetti)
+
 ==================  9.1.0 ==================
 
 New Features

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -199,7 +199,7 @@ Bug Fixes
 
 * SOLR-16585: Fixed NPE when paginating MatchAllDocs with non-zero start offset, like q=*:*&start=10 (Michael Gibney)
 
-* SOLR-16557: Fixed problem with filtering and KNN search, especially when using post-filters (Alessandro Benedetti)
+* SOLR-16567: Fixed problem with filtering and KNN search, especially when using post-filters (Alessandro Benedetti)
 
 ==================  9.1.0 ==================
 

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -119,7 +119,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
           sortSpec = parser.getSortSpec(true);
         }
 
-        filters = QueryUtils.parseFilterQueries(req, false);
+        filters = QueryUtils.parseFilterQueries(req);
       } catch (SyntaxError e) {
         throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e);
       }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -204,7 +204,7 @@ public class QueryComponent extends SearchComponent {
         List<Query> filters = rb.getFilters();
         // if filters already exists, make a copy instead of modifying the original
         filters = filters == null ? new ArrayList<>(fqs.length) : new ArrayList<>(filters);
-        filters.addAll(QueryUtils.parseFilterQueries(req, false));
+        filters.addAll(QueryUtils.parseFilterQueries(req));
 
         // only set the filters if they are not empty otherwise
         // fq=&someotherParam= will trigger all docs filter for every request

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -19,6 +19,7 @@ package org.apache.solr.handler.component;
 import static org.apache.solr.common.params.CommonParams.DISTRIB;
 import static org.apache.solr.common.params.CommonParams.ID;
 import static org.apache.solr.common.params.CommonParams.VERSION_FIELD;
+import static org.apache.solr.search.QueryUtils.makeQueryable;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -205,7 +206,7 @@ public class RealTimeGetComponent extends SearchComponent {
         List<Query> filters = rb.getFilters();
         // if filters already exists, make a copy instead of modifying the original
         filters = filters == null ? new ArrayList<>(fqs.length) : new ArrayList<>(filters);
-        filters.addAll(QueryUtils.parseFilterQueries(req, true));
+        filters.addAll(QueryUtils.parseFilterQueries(req));
         if (!filters.isEmpty()) {
           rb.setFilters(filters);
         }
@@ -326,6 +327,7 @@ public class RealTimeGetComponent extends SearchComponent {
 
           if (rb.getFilters() != null) {
             for (Query raw : rb.getFilters()) {
+              raw = makeQueryable(raw);
               Query q = raw.rewrite(searcherInfo.getSearcher().getIndexReader());
               Scorer scorer =
                   searcherInfo

--- a/solr/core/src/java/org/apache/solr/search/QueryUtils.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryUtils.java
@@ -229,14 +229,11 @@ public class QueryUtils {
    * Parse the filter queries in Solr request
    *
    * @param req Solr request
-   * @param fixNegativeQueries if true, negative queries are rewritten by adding a MatchAllDocs
-   *     query clause
    * @return and array of Query. If the request does not contain filter queries, returns an empty
    *     list.
    * @throws SyntaxError if an error occurs during parsing
    */
-  public static List<Query> parseFilterQueries(SolrQueryRequest req, boolean fixNegativeQueries)
-      throws SyntaxError {
+  public static List<Query> parseFilterQueries(SolrQueryRequest req) throws SyntaxError {
 
     String[] filterQueriesStr = req.getParams().getParams(CommonParams.FQ);
 
@@ -247,9 +244,6 @@ public class QueryUtils {
           QParser fqp = QParser.getParser(fq, req);
           fqp.setIsFilter(true);
           Query query = fqp.getQuery();
-          if (fixNegativeQueries) {
-            query = makeQueryable(query);
-          }
           filters.add(query);
         }
       }

--- a/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
@@ -89,7 +89,7 @@ public class KnnQParser extends QParser {
       String[] filterQueries = req.getParams().getParams(CommonParams.FQ);
       if (filterQueries != null && filterQueries.length != 0) {
         try {
-          List<Query> filters = QueryUtils.parseFilterQueries(req, true);
+          List<Query> filters = QueryUtils.parseFilterQueries(req);
           SolrIndexSearcher.ProcessedFilter processedFilter =
               req.getSearcher().getProcessedFilter(filters);
           return processedFilter.filter;

--- a/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
@@ -82,10 +82,10 @@ public class KnnQParser extends QParser {
     float[] parsedVectorToSearch = parseVector(vectorToSearch, denseVectorType.getDimension());
 
     return denseVectorType.getKnnVectorQuery(
-        schemaField.getName(), parsedVectorToSearch, topK, buildPreFilter());
+        schemaField.getName(), parsedVectorToSearch, topK, getFilterQuery());
   }
 
-  private Query buildPreFilter() throws SolrException {
+  private Query getFilterQuery() throws SolrException {
     boolean isSubQuery = recurseCount != 0;
     if (!isFilter() && !isSubQuery) {
       String[] filterQueries = req.getParams().getParams(CommonParams.FQ);
@@ -93,7 +93,7 @@ public class KnnQParser extends QParser {
         List<Query> preFilters;
 
         try {
-          preFilters = acceptPreFiltersOnly(QueryUtils.parseFilterQueries(req, true));
+          preFilters = excludePostFilters(QueryUtils.parseFilterQueries(req, true));
         } catch (SyntaxError e) {
           throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
         }
@@ -122,7 +122,7 @@ public class KnnQParser extends QParser {
    * @param filters filter queries in the knn query request
    * @return the list of pre-filters
    */
-  private List<Query> acceptPreFiltersOnly(List<Query> filters) {
+  private List<Query> excludePostFilters(List<Query> filters) {
     return filters.stream()
         .filter(
             q -> {

--- a/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
@@ -53,7 +53,7 @@ public class KnnQParser extends QParser {
   }
 
   @Override
-  public Query parse() {
+  public Query parse() throws SyntaxError {
     String denseVectorField = localParams.get(QueryParsing.F);
     String vectorToSearch = localParams.get(QueryParsing.V);
     int topK = localParams.getInt(TOP_K, DEFAULT_TOP_K);
@@ -83,7 +83,7 @@ public class KnnQParser extends QParser {
         schemaField.getName(), parsedVectorToSearch, topK, getFilterQuery());
   }
 
-  private Query getFilterQuery() throws SolrException {
+  private Query getFilterQuery() throws SolrException, SyntaxError {
     boolean isSubQuery = recurseCount != 0;
     if (!isFilter() && !isSubQuery) {
       String[] filterQueries = req.getParams().getParams(CommonParams.FQ);
@@ -93,7 +93,7 @@ public class KnnQParser extends QParser {
           SolrIndexSearcher.ProcessedFilter processedFilter =
               req.getSearcher().getProcessedFilter(filters);
           return processedFilter.filter;
-        } catch (SyntaxError | IOException e) {
+        } catch (IOException e) {
           throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
         }
       }

--- a/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/neural/KnnQParser.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.search.neural;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -32,9 +34,6 @@ import org.apache.solr.search.QParser;
 import org.apache.solr.search.QueryParsing;
 import org.apache.solr.search.QueryUtils;
 import org.apache.solr.search.SyntaxError;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class KnnQParser extends QParser {
 
@@ -98,7 +97,7 @@ public class KnnQParser extends QParser {
         } catch (SyntaxError e) {
           throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
         }
-        
+
         if (preFilters.size() == 0) {
           return null;
         } else if (preFilters.size() == 1) {
@@ -116,14 +115,17 @@ public class KnnQParser extends QParser {
   }
 
   private List<Query> acceptPreFiltersOnly(List<Query> filters) {
-    return filters.stream().filter(q -> {
-      if (q instanceof ExtendedQuery) {
-        ExtendedQuery eq = (ExtendedQuery) q;
-        return eq.getCost() == 0;
-      } else {
-        return true;
-      }
-    }).collect(Collectors.toList());
+    return filters.stream()
+        .filter(
+            q -> {
+              if (q instanceof ExtendedQuery) {
+                ExtendedQuery eq = (ExtendedQuery) q;
+                return eq.getCost() == 0;
+              } else {
+                return true;
+              }
+            })
+        .collect(Collectors.toList());
   }
 
   /**
@@ -133,6 +135,7 @@ public class KnnQParser extends QParser {
    * @return a float array
    */
   private static float[] parseVector(String value, int dimension) {
+
     if (!value.startsWith("[") || !value.endsWith("]")) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST,

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -340,19 +340,19 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
     String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
 
     assertQ(
-            req(
-                    CommonParams.Q,
-                    "{!knn f=vector topK=10}" + vectorToSearch,
-                    "fq",
-                    "{!frange l=0.99}$q",
-                    "fl",
-                    "*,score"),
-            "//result[@numFound='5']",
-            "//result/doc[1]/str[@name='id'][.='1']",
-            "//result/doc[2]/str[@name='id'][.='4']",
-            "//result/doc[3]/str[@name='id'][.='2']",
-            "//result/doc[4]/str[@name='id'][.='10']",
-            "//result/doc[5]/str[@name='id'][.='3']");
+        req(
+            CommonParams.Q,
+            "{!knn f=vector topK=10}" + vectorToSearch,
+            "fq",
+            "{!frange l=0.99}$q",
+            "fl",
+            "*,score"),
+        "//result[@numFound='5']",
+        "//result/doc[1]/str[@name='id'][.='1']",
+        "//result/doc[2]/str[@name='id'][.='4']",
+        "//result/doc[3]/str[@name='id'][.='2']",
+        "//result/doc[4]/str[@name='id'][.='10']",
+        "//result/doc[5]/str[@name='id'][.='3']");
   }
 
   @Test
@@ -360,18 +360,18 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
     String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
 
     assertQ(
-            req(
-                    CommonParams.Q,
-                    "{!knn f=vector topK=4}" + vectorToSearch,
-                    "fq",
-                    "id:(3 4 9 2)",
-                    "fq",
-                    "{!frange l=0.99}$q",
-                    "fl",
-                    "id"),
-            "//result[@numFound='2']",
-            "//result/doc[1]/str[@name='id'][.='4']",
-            "//result/doc[2]/str[@name='id'][.='2']");
+        req(
+            CommonParams.Q,
+            "{!knn f=vector topK=4}" + vectorToSearch,
+            "fq",
+            "id:(3 4 9 2)",
+            "fq",
+            "{!frange l=0.99}$q",
+            "fl",
+            "id"),
+        "//result[@numFound='2']",
+        "//result/doc[1]/str[@name='id'][.='4']",
+        "//result/doc[2]/str[@name='id'][.='2']");
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -344,7 +344,7 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
             CommonParams.Q,
             "{!knn f=vector topK=10}" + vectorToSearch,
             "fq",
-            "{!frange l=0.99}$q",
+            "{!frange cache=false l=0.99}$q",
             "fl",
             "*,score"),
         "//result[@numFound='5']",

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -288,6 +288,7 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
         "//result/doc[10]/str[@name='id'][.='8']");
   }
 
+  @Test
   public void knnQueryUsedInFilter_shouldFilterResultsBeforeTheQueryExecution() {
     String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
     assertQ(
@@ -301,6 +302,23 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
         "//result[@numFound='2']",
         "//result/doc[1]/str[@name='id'][.='2']",
         "//result/doc[2]/str[@name='id'][.='4']");
+  }
+
+  @Test
+  public void knnQueryUsedInFilters_shouldFilterResultsBeforeTheQueryExecution() {
+    String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
+    assertQ(
+            req(
+                    CommonParams.Q,
+                    "id:(3 4 9 2)",
+                    "fq",
+                    "{!knn f=vector topK=4}" + vectorToSearch,
+                    "fq",
+                    "id:(4 20)",
+                    "fl",
+                    "id"),
+            "//result[@numFound='1']",
+            "//result/doc[1]/str[@name='id'][.='4']");
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -366,7 +366,7 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
             "fq",
             "id:(3 4 9 2)",
             "fq",
-            "{!frange l=0.99}$q",
+            "{!frange cache=false l=0.99}$q",
             "fl",
             "id"),
         "//result[@numFound='2']",

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -336,6 +336,45 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void knnQueryWithCostlyFq_shouldPerformKnnSearchWithPostFilter() {
+    String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
+
+    assertQ(
+            req(
+                    CommonParams.Q,
+                    "{!knn f=vector topK=10}" + vectorToSearch,
+                    "fq",
+                    "{!frange l=0.99}$q",
+                    "fl",
+                    "*,score"),
+            "//result[@numFound='5']",
+            "//result/doc[1]/str[@name='id'][.='1']",
+            "//result/doc[2]/str[@name='id'][.='4']",
+            "//result/doc[3]/str[@name='id'][.='2']",
+            "//result/doc[4]/str[@name='id'][.='10']",
+            "//result/doc[5]/str[@name='id'][.='3']");
+  }
+
+  @Test
+  public void knnQueryWithFilterQueries_shouldPerformKnnSearchWithPreFiltersAndPostFilters() {
+    String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
+
+    assertQ(
+            req(
+                    CommonParams.Q,
+                    "{!knn f=vector topK=4}" + vectorToSearch,
+                    "fq",
+                    "id:(3 4 9 2)",
+                    "fq",
+                    "{!frange l=0.99}$q",
+                    "fl",
+                    "id"),
+            "//result[@numFound='2']",
+            "//result/doc[1]/str[@name='id'][.='4']",
+            "//result/doc[2]/str[@name='id'][.='2']");
+  }
+
+  @Test
   public void knnQueryWithNegativeFilterQuery_shouldPerformKnnSearchInPreFilteredResults() {
     String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
     assertQ(

--- a/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/neural/KnnQParserTest.java
@@ -308,17 +308,17 @@ public class KnnQParserTest extends SolrTestCaseJ4 {
   public void knnQueryUsedInFilters_shouldFilterResultsBeforeTheQueryExecution() {
     String vectorToSearch = "[1.0, 2.0, 3.0, 4.0]";
     assertQ(
-            req(
-                    CommonParams.Q,
-                    "id:(3 4 9 2)",
-                    "fq",
-                    "{!knn f=vector topK=4}" + vectorToSearch,
-                    "fq",
-                    "id:(4 20)",
-                    "fl",
-                    "id"),
-            "//result[@numFound='1']",
-            "//result/doc[1]/str[@name='id'][.='4']");
+        req(
+            CommonParams.Q,
+            "id:(3 4 9 2)",
+            "fq",
+            "{!knn f=vector topK=4}" + vectorToSearch,
+            "fq",
+            "id:(4 20)",
+            "fl",
+            "id"),
+        "//result[@numFound='1']",
+        "//result/doc[1]/str[@name='id'][.='4']");
   }
 
   @Test

--- a/solr/modules/analytics/src/java/org/apache/solr/handler/AnalyticsHandler.java
+++ b/solr/modules/analytics/src/java/org/apache/solr/handler/AnalyticsHandler.java
@@ -131,7 +131,7 @@ public class AnalyticsHandler extends RequestHandlerBase
     queries.add(query);
 
     // Filter Params
-    queries.addAll(QueryUtils.parseFilterQueries(req, false));
+    queries.addAll(QueryUtils.parseFilterQueries(req));
     return req.getSearcher().getDocSet(queries);
   }
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
@@ -287,6 +287,13 @@ In
 &q={!knn f=vector topK=10}[1.0, 2.0, 3.0, 4.0]&fq=id:(1 2 3)
 
 The results are prefiltered by the fq=id:(1 2 3) and then only the documents from this subset are considered as candidates for the topK knn retrieval.
+
+If you want to run some of the filter queries as post-filters you can follow the standard approach for post-filtering in Apache Solr, using the cache and cost local parameters.
+
+e.g.
+
+[source,text]
+&q={!knn f=vector topK=10}[1.0, 2.0, 3.0, 4.0]&fq={!frange cache=false l=0.99}$q
 ====
 
 


### PR DESCRIPTION


https://issues.apache.org/jira/browse/SOLR-16567

# Description

Frange and in general post filters were abandoned for KNN search in favour of pre-filters.
This PR brings back supports for post-filters when they have a cost>0 (in line with the rest of Solr)


# Tests

tests have been added

# Checklist

Please review the following and check all that apply:

- [ X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ X] I have run `./gradlew check`.
- [ X] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
