### PR TITLE
SOLR-10470: setParallelCacheRefreshes should be deprecated in favor of SolrClientBuilder methods

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -98,6 +98,9 @@ Improvements
 
 * SOLR-10462: Introduce Builder setter for pollQueueTime on ConcurrentUpdateHttp2SolrClient.  Deprecated 
   direct setter setPollQueueTime on ConcurrentUpdateHttp2SolrClient. (Eric Pugh)
+
+* SOLR-10470: Introduce Builder setter for parallelCacheRefreshes on cloud SolrClients.  Deprecated
+  direct setter setParallelCacheRefreshes on cloud SolrClients. (Eric Pugh, David Smiley, Alex Deparvu)
   
 Optimizations
 ---------------------

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -97,6 +97,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     } else {
       this.stateProvider = builder.stateProvider;
     }
+    this.setParallelCacheRefreshesLocks(builder.parallelCacheRefreshesLocks);
 
     this.lbClient = new LBHttp2SolrClient.Builder(myClient).build();
   }
@@ -134,6 +135,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
 
   /** Constructs {@link CloudHttp2SolrClient} instances from provided configuration. */
   public static class Builder {
+    public int parallelCacheRefreshesLocks = 3;
     protected Collection<String> zkHosts = new ArrayList<>();
     protected List<String> solrUrls = new ArrayList<>();
     protected String zkChroot;
@@ -246,6 +248,17 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
      */
     public Builder withParallelUpdates(boolean parallelUpdates) {
       this.parallelUpdates = parallelUpdates;
+      return this;
+    }
+
+    /**
+     * Tells {@link CloudHttp2SolrClient.Builder} if caches are expired then they are refreshed
+     * after acquiring a lock. Use this to set the number of locks.
+     *
+     * <p>Defaults to 3.
+     */
+    public Builder setParallelCacheRefreshes(int parallelCacheRefreshesLocks) {
+      this.parallelCacheRefreshesLocks = parallelCacheRefreshesLocks;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -135,7 +135,6 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
 
   /** Constructs {@link CloudHttp2SolrClient} instances from provided configuration. */
   public static class Builder {
-    public int parallelCacheRefreshesLocks = 3;
     protected Collection<String> zkHosts = new ArrayList<>();
     protected List<String> solrUrls = new ArrayList<>();
     protected String zkChroot;
@@ -149,6 +148,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     private ResponseParser responseParser;
     private long retryExpiryTime =
         TimeUnit.NANOSECONDS.convert(3, TimeUnit.SECONDS); // 3 seconds or 3 million nanos
+    private int parallelCacheRefreshesLocks = 3;
 
     /**
      * Provide a series of Solr URLs to be used when configuring {@link CloudHttp2SolrClient}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -97,7 +97,10 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     } else {
       this.stateProvider = builder.stateProvider;
     }
-    this.setParallelCacheRefreshesLocks(builder.parallelCacheRefreshesLocks);
+
+    //  If caches are expired then they are refreshed after acquiring a lock. Set the number of
+    // locks.
+    this.locks = objectList(builder.parallelCacheRefreshesLocks);
 
     this.lbClient = new LBHttp2SolrClient.Builder(myClient).build();
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -252,8 +252,8 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     }
 
     /**
-     * When caches are expired then they are refreshed
-     * after acquiring a lock. Use this to set the number of locks.
+     * When caches are expired then they are refreshed after acquiring a lock. Use this to set the
+     * number of locks.
      *
      * <p>Defaults to 3.
      */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -252,7 +252,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     }
 
     /**
-     * Tells {@link CloudHttp2SolrClient.Builder} if caches are expired then they are refreshed
+     * When caches are expired then they are refreshed
      * after acquiring a lock. Use this to set the number of locks.
      *
      * <p>Defaults to 3.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -126,7 +126,7 @@ public abstract class CloudSolrClient extends SolrClient {
 
   }
 
-  private volatile List<Object> locks = objectList(3);
+  protected volatile List<Object> locks = objectList(3);
 
   /** Constructs {@link CloudSolrClient} instances from provided configuration. */
   public static class Builder extends CloudHttp2SolrClient.Builder {
@@ -1222,9 +1222,20 @@ public abstract class CloudSolrClient extends SolrClient {
   /**
    * If caches are expired they are refreshed after acquiring a lock. use this to set the number of
    * locks
+   *
+   * @deprecated use {@link CloudHttp2SolrClient.Builder#setParallelCacheRefreshes(int)} instead
    */
+  @Deprecated
   public void setParallelCacheRefreshes(int n) {
     locks = objectList(n);
+  }
+
+  /**
+   * If caches are expired they are refreshed after acquiring a lock. This method sets the number of
+   * locks. It is used by the Builder only.
+   */
+  void setParallelCacheRefreshesLocks(int parallelCacheRefreshesLocks) {
+    locks = objectList(parallelCacheRefreshesLocks);
   }
 
   protected static ArrayList<Object> objectList(int n) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -126,7 +126,7 @@ public abstract class CloudSolrClient extends SolrClient {
 
   }
 
-  protected volatile List<Object> locks = objectList(3);
+  private volatile List<Object> locks = objectList(3);
 
   /** Constructs {@link CloudSolrClient} instances from provided configuration. */
   public static class Builder extends CloudHttp2SolrClient.Builder {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -126,7 +126,7 @@ public abstract class CloudSolrClient extends SolrClient {
 
   }
 
-  private volatile List<Object> locks = objectList(3);
+  protected volatile List<Object> locks = objectList(3);
 
   /** Constructs {@link CloudSolrClient} instances from provided configuration. */
   public static class Builder extends CloudHttp2SolrClient.Builder {
@@ -1228,14 +1228,6 @@ public abstract class CloudSolrClient extends SolrClient {
   @Deprecated
   public void setParallelCacheRefreshes(int n) {
     locks = objectList(n);
-  }
-
-  /**
-   * If caches are expired they are refreshed after acquiring a lock. This method sets the number of
-   * locks. It is used by the Builder only.
-   */
-  void setParallelCacheRefreshesLocks(int parallelCacheRefreshesLocks) {
-    locks = objectList(parallelCacheRefreshesLocks);
   }
 
   protected static ArrayList<Object> objectList(int n) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-10470


# Description
setParallelCacheRefreshes should be deprecated in favor of SolrClientBuilder methods

# Solution

Please provide a short description of the approach taken to implement your solution.
