### PR TITLE
SOLR-788: POC transfer MLT queries via {!bool}

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -21,6 +21,7 @@ import static org.apache.solr.common.params.CommonParams.SORT;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -512,7 +513,7 @@ public class MoreLikeThisComponent extends SearchComponent {
         public void consumeTerms(Query query, Term... terms) {
           if (terms.length != 1 || terms[0] == null) {
             throw new IllegalArgumentException(
-                "Expecting just a TermQuery, got " + query + ", " + terms);
+                "Expecting just a TermQuery, got " + query + ", " + Arrays.toString(terms));
           }
           params.add(ref(occur), termToQuery(terms[0]));
         }
@@ -529,7 +530,7 @@ public class MoreLikeThisComponent extends SearchComponent {
             public void consumeTerms(Query query, Term... terms) {
               if (terms.length != 1 || terms[0] == null) {
                 throw new IllegalArgumentException(
-                    "Expecting just a TermQuery, got " + query + ", " + terms);
+                    "Expecting just a TermQuery, got " + query + ", " + Arrays.toString(terms));
               }
               final Term term = terms[0];
               params.add(

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -513,11 +514,7 @@ public class MoreLikeThisComponent extends SearchComponent {
             throw new IllegalArgumentException(
                 "Expecting just a TermQuery, got " + query + ", " + terms);
           }
-          final Term term = terms[0];
-          final String paramName = "mltq" + cnt;
-          locParams.add(occur.name().toLowerCase(), "$" + paramName);
-          params.add(paramName, termToQuery(term));
-          cnt += 1;
+          params.add(ref(occur), termToQuery(terms[0]));
         }
 
         @Override
@@ -526,9 +523,7 @@ public class MoreLikeThisComponent extends SearchComponent {
             throw new IllegalArgumentException(
                 "Expecting BoostQuery, got " + parent + ", " + occur);
           }
-          final String paramName = "mltq" + cnt;
-          locParams.add(occur.name().toLowerCase(), "$" + paramName);
-          cnt += 1;
+          final String paramName = ref(occur);
           return new QueryVisitor() {
             @Override
             public void consumeTerms(Query query, Term... terms) {
@@ -544,6 +539,13 @@ public class MoreLikeThisComponent extends SearchComponent {
           };
         }
       };
+    }
+
+    private String ref(BooleanClause.Occur occur) {
+      final String paramName = "mltq" + cnt;
+      locParams.add(occur.name().toLowerCase(Locale.getDefault()), "$" + paramName);
+      cnt += 1;
+      return paramName;
     }
 
     private String termToQuery(Term term) { // shouldn't it be {!term} ??{!raw }?


### PR DESCRIPTION
Another attempt. Shard node responds MLT query via params {!bool ..}.. {!terms}. I'm not happy about this approach as well. 
Two notes:
1. existing distributed test doesn't cover mlt.boost case. 
2. I don't know but noticed some `interestingTerms` param and response. So, transferring terms is exactly what we need here. May be it's worth to explore them more and attempt to apply for the problem.  