### PR TITLE
SOLR-10452: setQueryParams should be deprecated in favor of SolrClientBuilder methods

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -98,6 +98,10 @@ Improvements
 
 * SOLR-10462: Introduce Builder setter for pollQueueTime on ConcurrentUpdateHttp2SolrClient.  Deprecated 
   direct setter setPollQueueTime on ConcurrentUpdateHttp2SolrClient. (Eric Pugh)
+
+* SOLR-10452: Introduce Builder setter withTheseParamNamesInTheUrl for queryParams, renaming them to urlParamNames
+  to clarify they are parameter names, not the values. Deprecated direct setter setQueryParams and addQueryParams 
+  on SolrClients. (Eric Pugh, David Smiley, Alex Deparvu)
   
 Optimizations
 ---------------------

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -148,7 +148,7 @@ public class UpdateShardHandler implements SolrInfoBean {
           .idleTimeout(cfg.getDistributedSocketTimeout())
           .maxConnectionsPerHost(cfg.getMaxUpdateConnectionsPerHost());
     }
-    updateOnlyClientBuilder.withQueryParams(queryParams);
+    updateOnlyClientBuilder.withTheseParamNamesInTheUrl(queryParams);
     updateOnlyClient = updateOnlyClientBuilder.build();
     updateOnlyClient.addListenerFactory(updateHttpListenerFactory);
 

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -138,6 +138,9 @@ public class UpdateShardHandler implements SolrInfoBean {
         HttpClientUtil.createClient(
             clientParams, defaultConnectionManager, false, httpRequestExecutor);
 
+    Set<String> queryParams = new HashSet<>(2);
+    queryParams.add(DistributedUpdateProcessor.DISTRIB_FROM);
+    queryParams.add(DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM);
     Http2SolrClient.Builder updateOnlyClientBuilder = new Http2SolrClient.Builder();
     if (cfg != null) {
       updateOnlyClientBuilder
@@ -145,12 +148,9 @@ public class UpdateShardHandler implements SolrInfoBean {
           .idleTimeout(cfg.getDistributedSocketTimeout())
           .maxConnectionsPerHost(cfg.getMaxUpdateConnectionsPerHost());
     }
+    updateOnlyClientBuilder.withQueryParams(queryParams);
     updateOnlyClient = updateOnlyClientBuilder.build();
     updateOnlyClient.addListenerFactory(updateHttpListenerFactory);
-    Set<String> queryParams = new HashSet<>(2);
-    queryParams.add(DistributedUpdateProcessor.DISTRIB_FROM);
-    queryParams.add(DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM);
-    updateOnlyClient.setQueryParams(queryParams);
 
     ThreadFactory recoveryThreadFactory = new SolrNamedThreadFactory("recoveryExecutor");
     if (cfg != null && cfg.getMaxRecoveryThreads() > 0) {

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -137,7 +137,7 @@ public class UpdateShardHandler implements SolrInfoBean {
         HttpClientUtil.createClient(
             clientParams, defaultConnectionManager, false, httpRequestExecutor);
 
-    Set<String> queryParams =
+    Set<String> urlParamNames =
         Set.of(
             DistributedUpdateProcessor.DISTRIB_FROM,
             DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM);
@@ -148,7 +148,7 @@ public class UpdateShardHandler implements SolrInfoBean {
           .idleTimeout(cfg.getDistributedSocketTimeout())
           .maxConnectionsPerHost(cfg.getMaxUpdateConnectionsPerHost());
     }
-    updateOnlyClientBuilder.withTheseParamNamesInTheUrl(queryParams);
+    updateOnlyClientBuilder.withTheseParamNamesInTheUrl(urlParamNames);
     updateOnlyClient = updateOnlyClientBuilder.build();
     updateOnlyClient.addListenerFactory(updateHttpListenerFactory);
 

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -20,7 +20,6 @@ import static org.apache.solr.util.stats.InstrumentedHttpRequestExecutor.KNOWN_M
 
 import com.google.common.annotations.VisibleForTesting;
 import java.lang.invoke.MethodHandles;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -138,9 +137,10 @@ public class UpdateShardHandler implements SolrInfoBean {
         HttpClientUtil.createClient(
             clientParams, defaultConnectionManager, false, httpRequestExecutor);
 
-    Set<String> queryParams = new HashSet<>(2);
-    queryParams.add(DistributedUpdateProcessor.DISTRIB_FROM);
-    queryParams.add(DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM);
+    Set<String> queryParams =
+        Set.of(
+            DistributedUpdateProcessor.DISTRIB_FROM,
+            DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM);
     Http2SolrClient.Builder updateOnlyClientBuilder = new Http2SolrClient.Builder();
     if (cfg != null) {
       updateOnlyClientBuilder

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -108,7 +108,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
             .withConnectionTimeout(builder.connectionTimeoutMillis)
             .withSocketTimeout(builder.socketTimeoutMillis)
             .withFollowRedirects(false)
-            .withQueryParams(builder.queryParams)
+            .withTheseParamNamesInTheUrl(builder.queryParams)
             .build();
     this.queue = new LinkedBlockingQueue<>(builder.queueSize);
     this.threadCount = builder.threadCount;
@@ -149,7 +149,8 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
    * Expert Method.
    *
    * @param queryParams set of param keys to only send via the query string
-   * @deprecated use {@link ConcurrentUpdateSolrClient.Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link ConcurrentUpdateSolrClient.Builder#withTheseParamNamesInTheUrl(Set)}
+   *     instead
    */
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -141,8 +141,16 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
     }
   }
 
+  /**
+   * @deprecated  use {@link #getUrlParamNames()}
+   */
+  @Deprecated
   public Set<String> getQueryParams() {
-    return this.client.getQueryParams();
+    return getUrlParamNames();
+  }
+
+  public Set<String> getUrlParamNames() {
+    return this.client.getUrlParamNames();
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -108,7 +108,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
             .withConnectionTimeout(builder.connectionTimeoutMillis)
             .withSocketTimeout(builder.socketTimeoutMillis)
             .withFollowRedirects(false)
-            .withTheseParamNamesInTheUrl(builder.queryParams)
+            .withTheseParamNamesInTheUrl(builder.urlParamNames)
             .build();
     this.queue = new LinkedBlockingQueue<>(builder.queueSize);
     this.threadCount = builder.threadCount;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -108,6 +108,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
             .withConnectionTimeout(builder.connectionTimeoutMillis)
             .withSocketTimeout(builder.socketTimeoutMillis)
             .withFollowRedirects(false)
+            .withQueryParams(builder.queryParams)
             .build();
     this.queue = new LinkedBlockingQueue<>(builder.queueSize);
     this.threadCount = builder.threadCount;
@@ -148,7 +149,9 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
    * Expert Method.
    *
    * @param queryParams set of param keys to only send via the query string
+   * @deprecated use {@link ConcurrentUpdateSolrClient.Builder#withQueryParams(Set)} instead
    */
+  @Deprecated
   public void setQueryParams(Set<String> queryParams) {
     this.client.setQueryParams(queryParams);
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -142,7 +142,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
   }
 
   /**
-   * @deprecated  use {@link #getUrlParamNames()}
+   * @deprecated use {@link #getUrlParamNames()}
    */
   @Deprecated
   public Set<String> getQueryParams() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/DelegationTokenHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/DelegationTokenHttpSolrClient.java
@@ -17,11 +17,9 @@
 package org.apache.solr.client.solrj.impl;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TreeSet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -37,7 +35,6 @@ public class DelegationTokenHttpSolrClient extends HttpSolrClient {
    */
   protected DelegationTokenHttpSolrClient(Builder builder) {
     super(builder);
-    setQueryParams(new TreeSet<>(Arrays.asList(DELEGATION_TOKEN_PARAM)));
   }
 
   @Override
@@ -50,6 +47,7 @@ public class DelegationTokenHttpSolrClient extends HttpSolrClient {
     return super.createMethod(request, collection);
   }
 
+  @Deprecated
   @Override
   public void setQueryParams(Set<String> urlParamNames) {
     urlParamNames = urlParamNames == null ? Set.of(DELEGATION_TOKEN_PARAM) : urlParamNames;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/DelegationTokenHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/DelegationTokenHttpSolrClient.java
@@ -51,13 +51,13 @@ public class DelegationTokenHttpSolrClient extends HttpSolrClient {
   }
 
   @Override
-  public void setQueryParams(Set<String> queryParams) {
-    queryParams = queryParams == null ? Set.of(DELEGATION_TOKEN_PARAM) : queryParams;
-    if (!queryParams.contains(DELEGATION_TOKEN_PARAM)) {
-      queryParams = new HashSet<>(queryParams);
-      queryParams.add(DELEGATION_TOKEN_PARAM);
-      queryParams = Collections.unmodifiableSet(queryParams);
+  public void setQueryParams(Set<String> urlParamNames) {
+    urlParamNames = urlParamNames == null ? Set.of(DELEGATION_TOKEN_PARAM) : urlParamNames;
+    if (!urlParamNames.contains(DELEGATION_TOKEN_PARAM)) {
+      urlParamNames = new HashSet<>(urlParamNames);
+      urlParamNames.add(DELEGATION_TOKEN_PARAM);
+      urlParamNames = Collections.unmodifiableSet(urlParamNames);
     }
-    super.setQueryParams(queryParams);
+    super.setQueryParams(urlParamNames);
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -128,7 +128,7 @@ public class Http2SolrClient extends SolrClient {
   private static final List<String> errPath = Arrays.asList("metadata", "error-class");
 
   private HttpClient httpClient;
-  protected volatile Set<String> urlParamNames = Set.of();
+  private volatile Set<String> urlParamNames = Set.of();
   private int idleTimeout;
   private int requestTimeout;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -128,7 +128,7 @@ public class Http2SolrClient extends SolrClient {
   private static final List<String> errPath = Arrays.asList("metadata", "error-class");
 
   private HttpClient httpClient;
-  protected Set<String> queryParams = Set.of();
+  protected Set<String> urlParamNames = Set.of();
   private int idleTimeout;
   private int requestTimeout;
 
@@ -186,7 +186,7 @@ public class Http2SolrClient extends SolrClient {
       requestTimeout = builder.requestTimeout;
     }
     httpClient.setFollowRedirects(builder.followRedirects);
-    this.queryParams = builder.queryParams;
+    this.urlParamNames = builder.urlParamNames;
     assert ObjectReleaseTracker.track(this);
   }
 
@@ -680,7 +680,7 @@ public class Http2SolrClient extends SolrClient {
                 contentWriter.getContentType(), ByteBuffer.wrap(baos.getbuf(), 0, baos.size())));
       } else if (streams == null || isMultipart) {
         // send server list and request list as query string params
-        ModifiableSolrParams queryParams = calculateQueryParams(this.queryParams, wparams);
+        ModifiableSolrParams queryParams = calculateQueryParams(this.urlParamNames, wparams);
         queryParams.add(calculateQueryParams(solrRequest.getQueryParams(), wparams));
         Request req = httpClient.newRequest(url + queryParams.toQueryString()).method(method);
         return fillContentStream(req, streams, wparams, isMultipart);
@@ -992,7 +992,7 @@ public class Http2SolrClient extends SolrClient {
     private ExecutorService executor;
     protected RequestWriter requestWriter;
     protected ResponseParser responseParser;
-    private Set<String> queryParams = Set.of();
+    private Set<String> urlParamNames = Set.of();
 
     public Builder() {}
 
@@ -1084,13 +1084,13 @@ public class Http2SolrClient extends SolrClient {
     /**
      * Expert Method
      *
-     * @param queryParams set of param keys that are only sent via the query string. Note that the
+     * @param urlParamNames set of param keys that are only sent via the query string. Note that the
      *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
      *     query params.
      * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
      */
-    public Builder withTheseParamNamesInTheUrl(Set<String> queryParams) {
-      this.queryParams = queryParams;
+    public Builder withTheseParamNamesInTheUrl(Set<String> urlParamNames) {
+      this.urlParamNames = urlParamNames;
       return this;
     }
 
@@ -1130,22 +1130,30 @@ public class Http2SolrClient extends SolrClient {
     }
   }
 
+  /**
+   * @deprecated  use {@link #getUrlParamNames()}
+   */
+  @Deprecated
   public Set<String> getQueryParams() {
-    return queryParams;
+    return getUrlParamNames();
+  }
+
+  public Set<String> getUrlParamNames() {
+    return urlParamNames;
   }
 
   /**
    * Expert Method
    *
-   * @param queryParams set of param keys that are only sent via the query string. Note that the
+   * @param urlParamNames set of param keys that are only sent via the query string. Note that the
    *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
    *     query params.
    * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
    * @deprecated use {@link Http2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
-  public void setQueryParams(Set<String> queryParams) {
-    this.queryParams = queryParams;
+  public void setUrlParamNames(Set<String> urlParamNames) {
+    this.urlParamNames = urlParamNames;
   }
 
   private ModifiableSolrParams calculateQueryParams(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -128,7 +128,7 @@ public class Http2SolrClient extends SolrClient {
   private static final List<String> errPath = Arrays.asList("metadata", "error-class");
 
   private HttpClient httpClient;
-  protected Set<String> urlParamNames = Set.of();
+  protected volatile Set<String> urlParamNames = Set.of();
   private int idleTimeout;
   private int requestTimeout;
 
@@ -1131,7 +1131,7 @@ public class Http2SolrClient extends SolrClient {
   }
 
   /**
-   * @deprecated  use {@link #getUrlParamNames()}
+   * @deprecated use {@link #getUrlParamNames()}
    */
   @Deprecated
   public Set<String> getQueryParams() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -186,6 +186,7 @@ public class Http2SolrClient extends SolrClient {
       requestTimeout = builder.requestTimeout;
     }
     httpClient.setFollowRedirects(builder.followRedirects);
+    this.queryParams = builder.queryParams;
     assert ObjectReleaseTracker.track(this);
   }
 
@@ -991,6 +992,7 @@ public class Http2SolrClient extends SolrClient {
     private ExecutorService executor;
     protected RequestWriter requestWriter;
     protected ResponseParser responseParser;
+    private volatile Set<String> queryParams = Collections.emptySet();
 
     public Builder() {}
 
@@ -1080,6 +1082,18 @@ public class Http2SolrClient extends SolrClient {
     }
 
     /**
+     * Expert Method
+     *
+     * @param queryParams set of param keys that are only sent via the query string. Note that the param will
+     *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
+     * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
+     */
+    public Builder setQueryParams(Set<String> queryParams) {
+      this.queryParams = queryParams;
+      return this;
+    }
+
+    /**
      * Set maxConnectionsPerHost for http1 connections, maximum number http2 connections is limited
      * by 4
      */
@@ -1122,10 +1136,12 @@ public class Http2SolrClient extends SolrClient {
   /**
    * Expert Method
    *
-   * @param queryParams set of param keys to only send via the query string Note that the param will
+   * @param queryParams set of param keys that are only sent via the query string. Note that the param will
    *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
    * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
+   * @deprecated use {@link Http2SolrClient.Builder#setQueryParams(Set)} instead
    */
+  @Deprecated
   public void setQueryParams(Set<String> queryParams) {
     this.queryParams = queryParams;
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -128,7 +128,7 @@ public class Http2SolrClient extends SolrClient {
   private static final List<String> errPath = Arrays.asList("metadata", "error-class");
 
   private HttpClient httpClient;
-  protected volatile Set<String> queryParams = Collections.emptySet();
+  protected Set<String> queryParams = Set.of();
   private int idleTimeout;
   private int requestTimeout;
 
@@ -992,7 +992,7 @@ public class Http2SolrClient extends SolrClient {
     private ExecutorService executor;
     protected RequestWriter requestWriter;
     protected ResponseParser responseParser;
-    private volatile Set<String> queryParams = Collections.emptySet();
+    private Set<String> queryParams = Set.of();
 
     public Builder() {}
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -1089,7 +1089,7 @@ public class Http2SolrClient extends SolrClient {
      *     query params.
      * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
      */
-    public Builder withQueryParams(Set<String> queryParams) {
+    public Builder withTheseParamNamesInTheUrl(Set<String> queryParams) {
       this.queryParams = queryParams;
       return this;
     }
@@ -1141,7 +1141,7 @@ public class Http2SolrClient extends SolrClient {
    *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
    *     query params.
    * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
-   * @deprecated use {@link Http2SolrClient.Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link Http2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -1089,7 +1089,7 @@ public class Http2SolrClient extends SolrClient {
      *     query params.
      * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
      */
-    public Builder setQueryParams(Set<String> queryParams) {
+    public Builder withQueryParams(Set<String> queryParams) {
       this.queryParams = queryParams;
       return this;
     }
@@ -1141,7 +1141,7 @@ public class Http2SolrClient extends SolrClient {
    *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
    *     query params.
    * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
-   * @deprecated use {@link Http2SolrClient.Builder#setQueryParams(Set)} instead
+   * @deprecated use {@link Http2SolrClient.Builder#withQueryParams(Set)} instead
    */
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -128,7 +128,7 @@ public class Http2SolrClient extends SolrClient {
   private static final List<String> errPath = Arrays.asList("metadata", "error-class");
 
   private HttpClient httpClient;
-  private volatile Set<String> queryParams = Collections.emptySet();
+  protected volatile Set<String> queryParams = Collections.emptySet();
   private int idleTimeout;
   private int requestTimeout;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -1084,8 +1084,9 @@ public class Http2SolrClient extends SolrClient {
     /**
      * Expert Method
      *
-     * @param queryParams set of param keys that are only sent via the query string. Note that the param will
-     *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
+     * @param queryParams set of param keys that are only sent via the query string. Note that the
+     *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
+     *     query params.
      * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
      */
     public Builder setQueryParams(Set<String> queryParams) {
@@ -1136,8 +1137,9 @@ public class Http2SolrClient extends SolrClient {
   /**
    * Expert Method
    *
-   * @param queryParams set of param keys that are only sent via the query string. Note that the param will
-   *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
+   * @param queryParams set of param keys that are only sent via the query string. Note that the
+   *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
+   *     query params.
    * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
    * @deprecated use {@link Http2SolrClient.Builder#setQueryParams(Set)} instead
    */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -1051,6 +1052,15 @@ public class HttpSolrClient extends BaseHttpSolrClient {
       if (this.invariantParams.get(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM) == null) {
         return new HttpSolrClient(this);
       } else {
+        queryParams =
+            queryParams == null
+                ? Set.of(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM)
+                : queryParams;
+        if (!queryParams.contains(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM)) {
+          queryParams = new HashSet<>(queryParams);
+          queryParams.add(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM);
+          queryParams = Collections.unmodifiableSet(queryParams);
+        }
         return new DelegationTokenHttpSolrClient(this);
       }
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -148,7 +148,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
   private volatile boolean useMultiPartPost;
   private final boolean internalClient;
 
-  private volatile Set<String> queryParams = Collections.emptySet();
+  private volatile Set<String> queryParams = Set.of();
   private volatile Integer connectionTimeout;
   private volatile Integer soTimeout;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -188,7 +188,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
     this.connectionTimeout = builder.connectionTimeoutMillis;
     this.soTimeout = builder.socketTimeoutMillis;
     this.useMultiPartPost = builder.useMultiPartPost;
-    this.urlParamNames = builder.queryParams;
+    this.urlParamNames = builder.urlParamNames;
   }
 
   /**
@@ -1052,14 +1052,14 @@ public class HttpSolrClient extends BaseHttpSolrClient {
       if (this.invariantParams.get(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM) == null) {
         return new HttpSolrClient(this);
       } else {
-        queryParams =
-            queryParams == null
+        urlParamNames =
+            urlParamNames == null
                 ? Set.of(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM)
-                : queryParams;
-        if (!queryParams.contains(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM)) {
-          queryParams = new HashSet<>(queryParams);
-          queryParams.add(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM);
-          queryParams = Collections.unmodifiableSet(queryParams);
+                : urlParamNames;
+        if (!urlParamNames.contains(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM)) {
+          urlParamNames = new HashSet<>(urlParamNames);
+          urlParamNames.add(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM);
+          urlParamNames = Collections.unmodifiableSet(urlParamNames);
         }
         return new DelegationTokenHttpSolrClient(this);
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -191,7 +191,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
   }
 
   /**
-   * @deprecated  use {@link #getUrlParamNames()}
+   * @deprecated use {@link #getUrlParamNames()}
    */
   @Deprecated
   public Set<String> getQueryParams() {
@@ -205,8 +205,9 @@ public class HttpSolrClient extends BaseHttpSolrClient {
   /**
    * Expert Method
    *
-   * @param urlParamNames set of param keys to only send via the query string Note that the param will
-   *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
+   * @param urlParamNames set of param keys to only send via the query string Note that the param
+   *     will be sent as a query string if the key is part of this Set or the SolrRequest's query
+   *     params.
    *     <p>{@link SolrClient} setters can be unsafe when the involved {@link SolrClient} is used in
    *     multiple threads simultaneously. To avoid this, use {@link
    *     Builder#withTheseParamNamesInTheUrl(Set)}.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -1059,8 +1059,8 @@ public class HttpSolrClient extends BaseHttpSolrClient {
         if (!urlParamNames.contains(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM)) {
           urlParamNames = new HashSet<>(urlParamNames);
           urlParamNames.add(DelegationTokenHttpSolrClient.DELEGATION_TOKEN_PARAM);
-          urlParamNames = Collections.unmodifiableSet(urlParamNames);
         }
+        urlParamNames = Set.copyOf(urlParamNames);
         return new DelegationTokenHttpSolrClient(this);
       }
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -200,9 +200,10 @@ public class HttpSolrClient extends BaseHttpSolrClient {
    * @param queryParams set of param keys to only send via the query string Note that the param will
    *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
    *     <p>{@link SolrClient} setters can be unsafe when the involved {@link SolrClient} is used in
-   *     multiple threads simultaneously. To avoid this, use {@link Builder#withQueryParams(Set)}.
+   *     multiple threads simultaneously. To avoid this, use {@link
+   *     Builder#withTheseParamNamesInTheUrl(Set)}.
    * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
-   * @deprecated use {@link Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -148,7 +148,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
   private volatile boolean useMultiPartPost;
   private final boolean internalClient;
 
-  private volatile Set<String> queryParams = Set.of();
+  private volatile Set<String> urlParamNames = Set.of();
   private volatile Integer connectionTimeout;
   private volatile Integer soTimeout;
 
@@ -187,17 +187,25 @@ public class HttpSolrClient extends BaseHttpSolrClient {
     this.connectionTimeout = builder.connectionTimeoutMillis;
     this.soTimeout = builder.socketTimeoutMillis;
     this.useMultiPartPost = builder.useMultiPartPost;
-    this.queryParams = builder.queryParams;
+    this.urlParamNames = builder.queryParams;
   }
 
+  /**
+   * @deprecated  use {@link #getUrlParamNames()}
+   */
+  @Deprecated
   public Set<String> getQueryParams() {
-    return queryParams;
+    return getUrlParamNames();
+  }
+
+  public Set<String> getUrlParamNames() {
+    return urlParamNames;
   }
 
   /**
    * Expert Method
    *
-   * @param queryParams set of param keys to only send via the query string Note that the param will
+   * @param urlParamNames set of param keys to only send via the query string Note that the param will
    *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
    *     <p>{@link SolrClient} setters can be unsafe when the involved {@link SolrClient} is used in
    *     multiple threads simultaneously. To avoid this, use {@link
@@ -206,8 +214,8 @@ public class HttpSolrClient extends BaseHttpSolrClient {
    * @deprecated use {@link Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
-  public void setQueryParams(Set<String> queryParams) {
-    this.queryParams = queryParams;
+  public void setQueryParams(Set<String> urlParamNames) {
+    this.urlParamNames = urlParamNames;
   }
 
   /**
@@ -436,7 +444,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
 
       } else if (streams == null || isMultipart) {
         // send server list and request list as query string params
-        ModifiableSolrParams queryParams = calculateQueryParams(this.queryParams, wparams);
+        ModifiableSolrParams queryParams = calculateQueryParams(this.urlParamNames, wparams);
         queryParams.add(calculateQueryParams(request.getQueryParams(), wparams));
         String fullQueryUrl = url + queryParams.toQueryString();
         HttpEntityEnclosingRequestBase postOrPut =

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -144,8 +144,13 @@ public class LBHttp2SolrClient extends LBSolrClient {
     return http2SolrClient.getRequestWriter();
   }
 
+  @Override
+  public Set<String> getUrlParamNames() {
+    return http2SolrClient.getUrlParamNames();
+  }
+
   /**
-   * @deprecated use {@link LBHttp2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
+   * @deprecated You should instead set this on the passed in Http2SolrClient used by the Builder.
    */
   @Override
   @Deprecated
@@ -158,7 +163,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
    * This method should be removed as being able to add a query parameter isn't compatible with the
    * idea that query params are an immutable property of a solr client.
    *
-   * @deprecated use {@link LBHttp2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
+   * @deprecated you should instead set this on the passed in Http2SolrClient used by the Builder.
    */
   @Override
   @Deprecated
@@ -315,7 +320,6 @@ public class LBHttp2SolrClient extends LBSolrClient {
     private final Http2SolrClient http2SolrClient;
     private final String[] baseSolrUrls;
     private int aliveCheckInterval = CHECK_INTERVAL;
-    private Set<String> queryParams = Set.of();
 
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
       this.http2SolrClient = http2Client;
@@ -337,24 +341,9 @@ public class LBHttp2SolrClient extends LBSolrClient {
       return this;
     }
 
-    /**
-     * Expert Method
-     *
-     * @param queryParams set of param keys that are only sent via the query string. Note that the
-     *     param will be sent as a query string if the key is part of this Set or the SolrRequest's
-     *     query params.
-     * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
-     */
-    public LBHttp2SolrClient.Builder withTheseParamNamesInTheUrl(Set<String> queryParams) {
-      this.queryParams = queryParams;
-      return this;
-    }
-
     public LBHttp2SolrClient build() {
       LBHttp2SolrClient solrClient =
           new LBHttp2SolrClient(this.http2SolrClient, Arrays.asList(this.baseSolrUrls));
-      solrClient.urlParamNames = this.queryParams;
-      this.http2SolrClient.urlParamNames = this.queryParams;
       solrClient.aliveCheckInterval = this.aliveCheckInterval;
       return solrClient;
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -23,6 +23,7 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -139,12 +140,10 @@ public class LBHttp2SolrClient extends LBSolrClient {
     this.http2SolrClient.setRequestWriter(writer);
   }
 
-  @Override
   public RequestWriter getRequestWriter() {
     return http2SolrClient.getRequestWriter();
   }
 
-  @Override
   public Set<String> getUrlParamNames() {
     return http2SolrClient.getUrlParamNames();
   }
@@ -152,10 +151,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
   /**
    * @deprecated You should instead set this on the passed in Http2SolrClient used by the Builder.
    */
-  @Override
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {
-    super.setQueryParams(queryParams);
     this.http2SolrClient.setUrlParamNames(queryParams);
   }
 
@@ -165,11 +162,11 @@ public class LBHttp2SolrClient extends LBSolrClient {
    *
    * @deprecated you should instead set this on the passed in Http2SolrClient used by the Builder.
    */
-  @Override
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {
-    super.addQueryParams(queryOnlyParam);
-    this.http2SolrClient.setUrlParamNames(getQueryParams());
+    Set<String> urlParamNames = new HashSet<>(this.http2SolrClient.getUrlParamNames());
+    urlParamNames.add(queryOnlyParam);
+    this.http2SolrClient.setUrlParamNames(urlParamNames);
   }
 
   public Cancellable asyncReq(Req req, AsyncListener<Rsp> asyncListener) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -23,7 +23,6 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -316,7 +315,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
     private final Http2SolrClient http2SolrClient;
     private final String[] baseSolrUrls;
     private int aliveCheckInterval = CHECK_INTERVAL;
-    private volatile Set<String> queryParams = Collections.emptySet();
+    private Set<String> queryParams = Set.of();
 
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
       this.http2SolrClient = http2Client;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -313,13 +313,13 @@ public class LBHttp2SolrClient extends LBSolrClient {
   public static class Builder {
 
     public static final int CHECK_INTERVAL = 60 * 1000; // 1 minute between checks
-    private final Http2SolrClient http2Client;
+    private final Http2SolrClient http2SolrClient;
     private final String[] baseSolrUrls;
     private int aliveCheckInterval = CHECK_INTERVAL;
     private volatile Set<String> queryParams = Collections.emptySet();
 
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
-      this.http2Client = http2Client;
+      this.http2SolrClient = http2Client;
       this.baseSolrUrls = baseSolrUrls;
     }
 
@@ -353,9 +353,9 @@ public class LBHttp2SolrClient extends LBSolrClient {
 
     public LBHttp2SolrClient build() {
       LBHttp2SolrClient solrClient =
-          new LBHttp2SolrClient(this.http2Client, Arrays.asList(this.baseSolrUrls));
+          new LBHttp2SolrClient(this.http2SolrClient, Arrays.asList(this.baseSolrUrls));
       solrClient.queryParams = this.queryParams;
-      this.http2Client.queryParams = this.queryParams;
+      this.http2SolrClient.queryParams = this.queryParams;
       solrClient.aliveCheckInterval = this.aliveCheckInterval;
       return solrClient;
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -83,25 +83,25 @@ import org.slf4j.MDC;
  * @since solr 8.0
  */
 public class LBHttp2SolrClient extends LBSolrClient {
-  private final Http2SolrClient http2SolrClient;
+  private final Http2SolrClient solrClient;
 
   /**
    * @deprecated Use {@link LBHttp2SolrClient.Builder} instead
    */
   @Deprecated
-  public LBHttp2SolrClient(Http2SolrClient http2SolrClient, String... baseSolrUrls) {
+  public LBHttp2SolrClient(Http2SolrClient solrClient, String... baseSolrUrls) {
     super(Arrays.asList(baseSolrUrls));
-    this.http2SolrClient = http2SolrClient;
+    this.solrClient = solrClient;
   }
 
-  private LBHttp2SolrClient(Http2SolrClient http2SolrClient, List<String> baseSolrUrls) {
+  private LBHttp2SolrClient(Http2SolrClient solrClient, List<String> baseSolrUrls) {
     super(baseSolrUrls);
-    this.http2SolrClient = http2SolrClient;
+    this.solrClient = solrClient;
   }
 
   @Override
   protected SolrClient getClient(String baseUrl) {
-    return http2SolrClient;
+    return solrClient;
   }
 
   /**
@@ -116,12 +116,12 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Override
   public void setParser(ResponseParser parser) {
     super.setParser(parser);
-    this.http2SolrClient.setParser(parser);
+    this.solrClient.setParser(parser);
   }
 
   @Override
   public ResponseParser getParser() {
-    return http2SolrClient.getParser();
+    return solrClient.getParser();
   }
 
   /**
@@ -137,16 +137,16 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Override
   public void setRequestWriter(RequestWriter writer) {
     super.setRequestWriter(writer);
-    this.http2SolrClient.setRequestWriter(writer);
+    this.solrClient.setRequestWriter(writer);
   }
 
   @Override
   public RequestWriter getRequestWriter() {
-    return http2SolrClient.getRequestWriter();
+    return solrClient.getRequestWriter();
   }
 
   public Set<String> getUrlParamNames() {
-    return http2SolrClient.getUrlParamNames();
+    return solrClient.getUrlParamNames();
   }
 
   /**
@@ -154,7 +154,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
    */
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {
-    this.http2SolrClient.setUrlParamNames(queryParams);
+    this.solrClient.setUrlParamNames(queryParams);
   }
 
   /**
@@ -165,9 +165,9 @@ public class LBHttp2SolrClient extends LBSolrClient {
    */
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {
-    Set<String> urlParamNames = new HashSet<>(this.http2SolrClient.getUrlParamNames());
+    Set<String> urlParamNames = new HashSet<>(this.solrClient.getUrlParamNames());
     urlParamNames.add(queryOnlyParam);
-    this.http2SolrClient.setUrlParamNames(urlParamNames);
+    this.solrClient.setUrlParamNames(urlParamNames);
   }
 
   public Cancellable asyncReq(Req req, AsyncListener<Rsp> asyncListener) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -83,25 +83,25 @@ import org.slf4j.MDC;
  * @since solr 8.0
  */
 public class LBHttp2SolrClient extends LBSolrClient {
-  private final Http2SolrClient httpClient;
+  private final Http2SolrClient http2SolrClient;
 
   /**
    * @deprecated Use {@link LBHttp2SolrClient.Builder} instead
    */
   @Deprecated
-  public LBHttp2SolrClient(Http2SolrClient httpClient, String... baseSolrUrls) {
+  public LBHttp2SolrClient(Http2SolrClient http2SolrClient, String... baseSolrUrls) {
     super(Arrays.asList(baseSolrUrls));
-    this.httpClient = httpClient;
+    this.http2SolrClient = http2SolrClient;
   }
 
-  private LBHttp2SolrClient(Http2SolrClient httpClient, List<String> baseSolrUrls) {
+  private LBHttp2SolrClient(Http2SolrClient http2SolrClient, List<String> baseSolrUrls) {
     super(baseSolrUrls);
-    this.httpClient = httpClient;
+    this.http2SolrClient = http2SolrClient;
   }
 
   @Override
   protected SolrClient getClient(String baseUrl) {
-    return httpClient;
+    return http2SolrClient;
   }
 
   /**
@@ -116,12 +116,12 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Override
   public void setParser(ResponseParser parser) {
     super.setParser(parser);
-    this.httpClient.setParser(parser);
+    this.http2SolrClient.setParser(parser);
   }
 
   @Override
   public ResponseParser getParser() {
-    return httpClient.getParser();
+    return http2SolrClient.getParser();
   }
 
   /**
@@ -137,12 +137,12 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Override
   public void setRequestWriter(RequestWriter writer) {
     super.setRequestWriter(writer);
-    this.httpClient.setRequestWriter(writer);
+    this.http2SolrClient.setRequestWriter(writer);
   }
 
   @Override
   public RequestWriter getRequestWriter() {
-    return httpClient.getRequestWriter();
+    return http2SolrClient.getRequestWriter();
   }
 
   /**
@@ -152,7 +152,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {
     super.setQueryParams(queryParams);
-    this.httpClient.setQueryParams(queryParams);
+    this.http2SolrClient.setQueryParams(queryParams);
   }
 
   /**
@@ -165,7 +165,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {
     super.addQueryParams(queryOnlyParam);
-    this.httpClient.setQueryParams(getQueryParams());
+    this.http2SolrClient.setQueryParams(getQueryParams());
   }
 
   public Cancellable asyncReq(Req req, AsyncListener<Rsp> asyncListener) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -145,7 +145,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
   }
 
   /**
-   * @deprecated use {@link LBHttp2SolrClient.Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link LBHttp2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Override
   @Deprecated
@@ -158,7 +158,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
    * This method should be removed as being able to add a query parameter isn't compatible with the
    * idea that query params are an immutable property of a solr client.
    *
-   * @deprecated use {@link LBHttp2SolrClient.Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link LBHttp2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Override
   @Deprecated
@@ -345,7 +345,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
      *     query params.
      * @see org.apache.solr.client.solrj.SolrRequest#getQueryParams
      */
-    public LBHttp2SolrClient.Builder withQueryParams(Set<String> queryParams) {
+    public LBHttp2SolrClient.Builder withTheseParamNamesInTheUrl(Set<String> queryParams) {
       this.queryParams = queryParams;
       return this;
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -140,6 +140,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
     this.http2SolrClient.setRequestWriter(writer);
   }
 
+  @Override
   public RequestWriter getRequestWriter() {
     return http2SolrClient.getRequestWriter();
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -151,7 +151,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {
     super.setQueryParams(queryParams);
-    this.http2SolrClient.setQueryParams(queryParams);
+    this.http2SolrClient.setUrlParamNames(queryParams);
   }
 
   /**
@@ -164,7 +164,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {
     super.addQueryParams(queryOnlyParam);
-    this.http2SolrClient.setQueryParams(getQueryParams());
+    this.http2SolrClient.setUrlParamNames(getQueryParams());
   }
 
   public Cancellable asyncReq(Req req, AsyncListener<Rsp> asyncListener) {
@@ -353,8 +353,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
     public LBHttp2SolrClient build() {
       LBHttp2SolrClient solrClient =
           new LBHttp2SolrClient(this.http2SolrClient, Arrays.asList(this.baseSolrUrls));
-      solrClient.queryParams = this.queryParams;
-      this.http2SolrClient.queryParams = this.queryParams;
+      solrClient.urlParamNames = this.queryParams;
+      this.http2SolrClient.urlParamNames = this.queryParams;
       solrClient.aliveCheckInterval = this.aliveCheckInterval;
       return solrClient;
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -124,7 +124,7 @@ public class LBHttpSolrClient extends LBSolrClient {
           httpSolrClientBuilder.withRequestWriter(requestWriter);
         }
         if (queryParams != null) {
-          httpSolrClientBuilder.withQueryParams(queryParams);
+          httpSolrClientBuilder.withTheseParamNamesInTheUrl(queryParams);
         }
         client = httpSolrClientBuilder.build();
       }
@@ -141,7 +141,7 @@ public class LBHttpSolrClient extends LBSolrClient {
         clientBuilder.withRequestWriter(requestWriter);
       }
       if (queryParams != null) {
-        clientBuilder.withQueryParams(queryParams);
+        clientBuilder.withTheseParamNamesInTheUrl(queryParams);
       }
       client = clientBuilder.build();
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -123,8 +123,8 @@ public class LBHttpSolrClient extends LBSolrClient {
         if (requestWriter != null) {
           httpSolrClientBuilder.withRequestWriter(requestWriter);
         }
-        if (queryParams != null) {
-          httpSolrClientBuilder.withTheseParamNamesInTheUrl(queryParams);
+        if (urlParamNames != null) {
+          httpSolrClientBuilder.withTheseParamNamesInTheUrl(urlParamNames);
         }
         client = httpSolrClientBuilder.build();
       }
@@ -140,8 +140,8 @@ public class LBHttpSolrClient extends LBSolrClient {
       if (requestWriter != null) {
         clientBuilder.withRequestWriter(requestWriter);
       }
-      if (queryParams != null) {
-        clientBuilder.withTheseParamNamesInTheUrl(queryParams);
+      if (urlParamNames != null) {
+        clientBuilder.withTheseParamNamesInTheUrl(urlParamNames);
       }
       client = clientBuilder.build();
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -17,7 +17,9 @@
 package org.apache.solr.client.solrj.impl;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.client.solrj.SolrClient;
@@ -76,6 +78,7 @@ public class LBHttpSolrClient extends LBSolrClient {
   private final boolean clientIsInternal;
   private final ConcurrentHashMap<String, HttpSolrClient> urlToClient = new ConcurrentHashMap<>();
   private final HttpSolrClient.Builder httpSolrClientBuilder;
+  private volatile Set<String> urlParamNames = new HashSet<>();
 
   private Integer connectionTimeout;
   private volatile Integer soTimeout;
@@ -176,6 +179,26 @@ public class LBHttpSolrClient extends LBSolrClient {
   /** Return the HttpClient this instance uses. */
   public HttpClient getHttpClient() {
     return httpClient;
+  }
+
+  @Deprecated
+  public Set<String> getQueryParams() {
+    return urlParamNames;
+  }
+
+  /**
+   * Expert Method.
+   *
+   * @param urlParamNames set of param keys to only send via the query string
+   */
+  @Deprecated
+  public void setQueryParams(Set<String> urlParamNames) {
+    this.urlParamNames = urlParamNames;
+  }
+
+  @Deprecated
+  public void addQueryParams(String urlParamNames) {
+    this.urlParamNames.add(urlParamNames);
   }
 
   /** Constructs {@link LBHttpSolrClient} instances from provided configuration. */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -335,7 +335,7 @@ public abstract class LBSolrClient extends SolrClient {
    * Expert Method.
    *
    * @param urlParamNames set of param keys to only send via the query string
-   * @deprecated use {@link LBHttpSolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
+   * @deprecated You should instead set this on the passed in Http2SolrClient used by the Builder.
    */
   @Deprecated
   public void setQueryParams(Set<String> urlParamNames) {
@@ -346,7 +346,7 @@ public abstract class LBSolrClient extends SolrClient {
    * This method should be removed as being able to add a query parameter isn't compatible with the
    * idea that query params are an immutable property of a solr client.
    *
-   * @deprecated use {@link LBHttpSolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
+   * @deprecated You should instead set this on the passed in Http2SolrClient used by the Builder.
    */
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -84,8 +84,6 @@ public abstract class LBSolrClient extends SolrClient {
   protected volatile ResponseParser parser;
   protected volatile RequestWriter requestWriter;
 
-  protected Set<String> urlParamNames = new HashSet<>();
-
   static {
     solrQuery.setRows(0);
     /**
@@ -317,40 +315,6 @@ public abstract class LBSolrClient extends SolrClient {
 
   protected ServerWrapper createServerWrapper(String baseUrl) {
     return new ServerWrapper(baseUrl);
-  }
-
-  /**
-   * @deprecated use {@link #getUrlParamNames()}
-   */
-  @Deprecated
-  public Set<String> getQueryParams() {
-    return getUrlParamNames();
-  }
-
-  public Set<String> getUrlParamNames() {
-    return urlParamNames;
-  }
-
-  /**
-   * Expert Method.
-   *
-   * @param urlParamNames set of param keys to only send via the query string
-   * @deprecated You should instead set this on the passed in Http2SolrClient used by the Builder.
-   */
-  @Deprecated
-  public void setQueryParams(Set<String> urlParamNames) {
-    this.urlParamNames = urlParamNames;
-  }
-
-  /**
-   * This method should be removed as being able to add a query parameter isn't compatible with the
-   * idea that query params are an immutable property of a solr client.
-   *
-   * @deprecated You should instead set this on the passed in Http2SolrClient used by the Builder.
-   */
-  @Deprecated
-  public void addQueryParams(String queryOnlyParam) {
-    this.urlParamNames.add(queryOnlyParam);
   }
 
   public static String normalize(String server) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -320,7 +320,7 @@ public abstract class LBSolrClient extends SolrClient {
   }
 
   /**
-   * @deprecated  use {@link #getUrlParamNames()}
+   * @deprecated use {@link #getUrlParamNames()}
    */
   @Deprecated
   public Set<String> getQueryParams() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -327,11 +327,20 @@ public abstract class LBSolrClient extends SolrClient {
    * Expert Method.
    *
    * @param queryParams set of param keys to only send via the query string
+   * @deprecated use {@link LBHttpSolrClient.Builder#withQueryParams(Set)} instead
    */
+  @Deprecated
   public void setQueryParams(Set<String> queryParams) {
     this.queryParams = queryParams;
   }
 
+  /**
+   * This method should be removed as being able to add a query parameter isn't compatible with the
+   * idea that query params are an immutable property of a solr client.
+   *
+   * @deprecated use {@link LBHttpSolrClient.Builder#withQueryParams(Set)} instead
+   */
+  @Deprecated
   public void addQueryParams(String queryOnlyParam) {
     this.queryParams.add(queryOnlyParam);
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -84,7 +84,7 @@ public abstract class LBSolrClient extends SolrClient {
   protected volatile ResponseParser parser;
   protected volatile RequestWriter requestWriter;
 
-  protected Set<String> queryParams = new HashSet<>();
+  protected Set<String> urlParamNames = new HashSet<>();
 
   static {
     solrQuery.setRows(0);
@@ -319,19 +319,27 @@ public abstract class LBSolrClient extends SolrClient {
     return new ServerWrapper(baseUrl);
   }
 
+  /**
+   * @deprecated  use {@link #getUrlParamNames()}
+   */
+  @Deprecated
   public Set<String> getQueryParams() {
-    return queryParams;
+    return getUrlParamNames();
+  }
+
+  public Set<String> getUrlParamNames() {
+    return urlParamNames;
   }
 
   /**
    * Expert Method.
    *
-   * @param queryParams set of param keys to only send via the query string
+   * @param urlParamNames set of param keys to only send via the query string
    * @deprecated use {@link LBHttpSolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
-  public void setQueryParams(Set<String> queryParams) {
-    this.queryParams = queryParams;
+  public void setQueryParams(Set<String> urlParamNames) {
+    this.urlParamNames = urlParamNames;
   }
 
   /**
@@ -342,7 +350,7 @@ public abstract class LBSolrClient extends SolrClient {
    */
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {
-    this.queryParams.add(queryOnlyParam);
+    this.urlParamNames.add(queryOnlyParam);
   }
 
   public static String normalize(String server) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -327,7 +327,7 @@ public abstract class LBSolrClient extends SolrClient {
    * Expert Method.
    *
    * @param queryParams set of param keys to only send via the query string
-   * @deprecated use {@link LBHttpSolrClient.Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link LBHttpSolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
   public void setQueryParams(Set<String> queryParams) {
@@ -338,7 +338,7 @@ public abstract class LBSolrClient extends SolrClient {
    * This method should be removed as being able to add a query parameter isn't compatible with the
    * idea that query params are an immutable property of a solr client.
    *
-   * @deprecated use {@link LBHttpSolrClient.Builder#withQueryParams(Set)} instead
+   * @deprecated use {@link LBHttpSolrClient.Builder#withTheseParamNamesInTheUrl(Set)} instead
    */
   @Deprecated
   public void addQueryParams(String queryOnlyParam) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -35,7 +35,7 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
   protected Integer connectionTimeoutMillis = 15000;
   protected Integer socketTimeoutMillis = 120000;
   protected boolean followRedirects = false;
-  protected Set<String> queryParams;
+  protected Set<String> urlParamNames;
 
   /** The solution for the unchecked cast warning. */
   public abstract B getThis();
@@ -71,7 +71,7 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
    */
   public B withTheseParamNamesInTheUrl(Set<String> queryParams) {
-    this.queryParams = queryParams;
+    this.urlParamNames = queryParams;
     return getThis();
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -70,7 +70,7 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    * @param queryParams set of param keys to only send via the query string Note that the param will
    *     be sent as a query string if the key is part of this Set or the SolrRequest's query params.
    */
-  public B withQueryParams(Set<String> queryParams) {
+  public B withTheseParamNamesInTheUrl(Set<String> queryParams) {
     this.queryParams = queryParams;
     return getThis();
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
@@ -781,7 +781,8 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
 
     final String clientUrl = jetty.getBaseUrl().toString() + "/debug/foo";
     HttpSolrClient.Builder builder = new HttpSolrClient.Builder(clientUrl);
-    try (HttpSolrClient client = builder.withQueryParams(Set.of("serverOnly")).build()) {
+    try (HttpSolrClient client =
+        builder.withTheseParamNamesInTheUrl(Set.of("serverOnly")).build()) {
       // test without request query params
       DebugServlet.clear();
       UpdateRequest req = new UpdateRequest();
@@ -789,7 +790,7 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req));
       verifyServletState(client, req);
     }
-    try (HttpSolrClient client = builder.withQueryParams(Set.of()).build()) {
+    try (HttpSolrClient client = builder.withTheseParamNamesInTheUrl(Set.of()).build()) {
       // test without server query params
       DebugServlet.clear();
       UpdateRequest req2 = new UpdateRequest();
@@ -798,7 +799,8 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req2));
       verifyServletState(client, req2);
     }
-    try (HttpSolrClient client = builder.withQueryParams(Set.of("serverOnly", "both")).build()) {
+    try (HttpSolrClient client =
+        builder.withTheseParamNamesInTheUrl(Set.of("serverOnly", "both")).build()) {
       // test with both request and server query params
       DebugServlet.clear();
       UpdateRequest req3 = new UpdateRequest();
@@ -807,7 +809,8 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req3));
       verifyServletState(client, req3);
     }
-    try (HttpSolrClient client = builder.withQueryParams(Set.of("serverOnly", "both")).build()) {
+    try (HttpSolrClient client =
+        builder.withTheseParamNamesInTheUrl(Set.of("serverOnly", "both")).build()) {
       // test with both request and server query params with single stream
       DebugServlet.clear();
       UpdateRequest req4 = new UpdateRequest();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -747,14 +746,6 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
     }
   }
 
-  private Set<String> setOf(String... keys) {
-    Set<String> set = new TreeSet<>();
-    if (keys != null) {
-      Collections.addAll(set, keys);
-    }
-    return set;
-  }
-
   private void setReqParamsOf(UpdateRequest req, String... keys) {
     if (keys != null) {
       for (String k : keys) {
@@ -790,7 +781,7 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
 
     final String clientUrl = jetty.getBaseUrl().toString() + "/debug/foo";
     HttpSolrClient.Builder builder = new HttpSolrClient.Builder(clientUrl);
-    try (HttpSolrClient client = builder.withQueryParams(setOf("serverOnly")).build()) {
+    try (HttpSolrClient client = builder.withQueryParams(Set.of("serverOnly")).build()) {
       // test without request query params
       DebugServlet.clear();
       UpdateRequest req = new UpdateRequest();
@@ -798,36 +789,36 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req));
       verifyServletState(client, req);
     }
-    try (HttpSolrClient client = builder.withQueryParams(setOf()).build()) {
+    try (HttpSolrClient client = builder.withQueryParams(Set.of()).build()) {
       // test without server query params
       DebugServlet.clear();
       UpdateRequest req2 = new UpdateRequest();
-      req2.setQueryParams(setOf("requestOnly"));
+      req2.setQueryParams(Set.of("requestOnly"));
       setReqParamsOf(req2, "requestOnly", "notRequest");
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req2));
       verifyServletState(client, req2);
     }
-    try (HttpSolrClient client = builder.withQueryParams(setOf("serverOnly", "both")).build()) {
+    try (HttpSolrClient client = builder.withQueryParams(Set.of("serverOnly", "both")).build()) {
       // test with both request and server query params
       DebugServlet.clear();
       UpdateRequest req3 = new UpdateRequest();
-      req3.setQueryParams(setOf("requestOnly", "both"));
+      req3.setQueryParams(Set.of("requestOnly", "both"));
       setReqParamsOf(req3, "serverOnly", "requestOnly", "both", "neither");
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req3));
       verifyServletState(client, req3);
     }
-    try (HttpSolrClient client = builder.withQueryParams(setOf("serverOnly", "both")).build()) {
+    try (HttpSolrClient client = builder.withQueryParams(Set.of("serverOnly", "both")).build()) {
       // test with both request and server query params with single stream
       DebugServlet.clear();
       UpdateRequest req4 = new UpdateRequest();
       req4.add(new SolrInputDocument());
-      req4.setQueryParams(setOf("requestOnly", "both"));
+      req4.setQueryParams(Set.of("requestOnly", "both"));
       setReqParamsOf(req4, "serverOnly", "requestOnly", "both", "neither");
       expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.request(req4));
       // NOTE: single stream requests send all the params
       // as part of the query string.  So add "neither" to the request
       // so it passes the verification step.
-      req4.setQueryParams(setOf("requestOnly", "both", "neither"));
+      req4.setQueryParams(Set.of("requestOnly", "both", "neither"));
       verifyServletState(client, req4);
     }
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -619,14 +618,6 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
   }
 
-  private Set<String> setOf(String... keys) {
-    Set<String> set = new TreeSet<>();
-    if (keys != null) {
-      Collections.addAll(set, keys);
-    }
-    return set;
-  }
-
   private void setReqParamsOf(UpdateRequest req, String... keys) {
     if (keys != null) {
       for (String k : keys) {
@@ -664,7 +655,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     UpdateRequest req = new UpdateRequest();
 
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withQueryParams(setOf("serverOnly")).build()) {
+        new Http2SolrClient.Builder(clientUrl).withQueryParams(Set.of("serverOnly")).build()) {
       // test without request query params
       DebugServlet.clear();
       setReqParamsOf(req, "serverOnly", "notServer");
@@ -679,9 +670,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       DebugServlet.clear();
     }
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withQueryParams(setOf()).build()) {
+        new Http2SolrClient.Builder(clientUrl).withQueryParams(Set.of()).build()) {
       req = new UpdateRequest();
-      req.setQueryParams(setOf("requestOnly"));
+      req.setQueryParams(Set.of("requestOnly"));
       setReqParamsOf(req, "requestOnly", "notRequest");
       try {
         client.request(req);
@@ -694,10 +685,10 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
-            .withQueryParams(setOf("serverOnly", "both"))
+            .withQueryParams(Set.of("serverOnly", "both"))
             .build()) {
       req = new UpdateRequest();
-      req.setQueryParams(setOf("requestOnly", "both"));
+      req.setQueryParams(Set.of("requestOnly", "both"));
       setReqParamsOf(req, "serverOnly", "requestOnly", "both", "neither");
       try {
         client.request(req);
@@ -707,14 +698,14 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
-            .withQueryParams(setOf("serverOnly", "both"))
+            .withQueryParams(Set.of("serverOnly", "both"))
             .build()) {
 
       // test with both request and server query params with single stream
       DebugServlet.clear();
       req = new UpdateRequest();
       req.add(new SolrInputDocument());
-      req.setQueryParams(setOf("requestOnly", "both"));
+      req.setQueryParams(Set.of("requestOnly", "both"));
       setReqParamsOf(req, "serverOnly", "requestOnly", "both", "neither");
       try {
         client.request(req);
@@ -723,7 +714,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       // NOTE: single stream requests send all the params
       // as part of the query string.  So add "neither" to the request
       // so it passes the verification step.
-      req.setQueryParams(setOf("requestOnly", "both", "neither"));
+      req.setQueryParams(Set.of("requestOnly", "both", "neither"));
       verifyServletState(client, req);
     }
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -189,7 +189,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     super.tearDown();
   }
 
-  private Http2SolrClient.Builder getHttp2SolrClient(
+  private Http2SolrClient.Builder getHttp2SolrClientBuilder(
       String url, int connectionTimeOut, int socketTimeout) {
     return new Http2SolrClient.Builder(url)
         .connectionTimeout(connectionTimeOut)
@@ -200,7 +200,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testTimeout() throws Exception {
     SolrQuery q = new SolrQuery("*:*");
     try (Http2SolrClient client =
-        getHttp2SolrClient(
+        getHttp2SolrClientBuilder(
                 jetty.getBaseUrl().toString() + "/slow/foo", DEFAULT_CONNECTION_TIMEOUT, 2000)
             .build()) {
       client.query(q, SolrRequest.METHOD.GET);
@@ -214,7 +214,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void test0IdleTimeout() throws Exception {
     SolrQuery q = new SolrQuery("*:*");
     try (Http2SolrClient client =
-        getHttp2SolrClient(
+        getHttp2SolrClientBuilder(
                 jetty.getBaseUrl().toString() + "/debug/foo", DEFAULT_CONNECTION_TIMEOUT, 0)
             .build()) {
       try {
@@ -228,7 +228,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testRequestTimeout() throws Exception {
     SolrQuery q = new SolrQuery("*:*");
     try (Http2SolrClient client =
-        getHttp2SolrClient(
+        getHttp2SolrClientBuilder(
                 jetty.getBaseUrl().toString() + "/slow/foo", DEFAULT_CONNECTION_TIMEOUT, 0)
             .requestTimeout(500)
             .build()) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -655,7 +655,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     UpdateRequest req = new UpdateRequest();
 
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withQueryParams(Set.of("serverOnly")).build()) {
+        new Http2SolrClient.Builder(clientUrl)
+            .withTheseParamNamesInTheUrl(Set.of("serverOnly"))
+            .build()) {
       // test without request query params
       DebugServlet.clear();
       setReqParamsOf(req, "serverOnly", "notServer");
@@ -670,7 +672,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       DebugServlet.clear();
     }
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withQueryParams(Set.of()).build()) {
+        new Http2SolrClient.Builder(clientUrl).withTheseParamNamesInTheUrl(Set.of()).build()) {
       req = new UpdateRequest();
       req.setQueryParams(Set.of("requestOnly"));
       setReqParamsOf(req, "requestOnly", "notRequest");
@@ -685,7 +687,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
-            .withQueryParams(Set.of("serverOnly", "both"))
+            .withTheseParamNamesInTheUrl(Set.of("serverOnly", "both"))
             .build()) {
       req = new UpdateRequest();
       req.setQueryParams(Set.of("requestOnly", "both"));
@@ -698,7 +700,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
-            .withQueryParams(Set.of("serverOnly", "both"))
+            .withTheseParamNamesInTheUrl(Set.of("serverOnly", "both"))
             .build()) {
 
       // test with both request and server query params with single stream

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -635,7 +635,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       if (values != null) {
         for (String value : values) {
           boolean shouldBeInQueryString =
-              client.getQueryParams().contains(name)
+              client.getUrlParamNames().contains(name)
                   || (request.getQueryParams() != null && request.getQueryParams().contains(name));
           assertEquals(
               shouldBeInQueryString, DebugServlet.queryString.contains(name + "=" + value));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -664,7 +664,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     UpdateRequest req = new UpdateRequest();
     setReqParamsOf(req, "serverOnly", "notServer");
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).setQueryParams(setOf("serverOnly")).build()) {
+        new Http2SolrClient.Builder(clientUrl).withQueryParams(setOf("serverOnly")).build()) {
       // test without request query params
       DebugServlet.clear();
 
@@ -678,7 +678,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       DebugServlet.clear();
     }
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).setQueryParams(setOf()).build()) {
+        new Http2SolrClient.Builder(clientUrl).withQueryParams(setOf()).build()) {
       req = new UpdateRequest();
       req.setQueryParams(setOf("requestOnly"));
       setReqParamsOf(req, "requestOnly", "notRequest");
@@ -693,7 +693,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
-            .setQueryParams(setOf("serverOnly", "both"))
+            .withQueryParams(setOf("serverOnly", "both"))
             .build()) {
       req = new UpdateRequest();
       req.setQueryParams(setOf("requestOnly", "both"));
@@ -706,7 +706,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
-            .setQueryParams(setOf("serverOnly", "both"))
+            .withQueryParams(setOf("serverOnly", "both"))
             .build()) {
 
       // test with both request and server query params with single stream

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -662,11 +662,12 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
 
     final String clientUrl = jetty.getBaseUrl().toString() + "/debug/foo";
     UpdateRequest req = new UpdateRequest();
-    setReqParamsOf(req, "serverOnly", "notServer");
+
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl).withQueryParams(setOf("serverOnly")).build()) {
       // test without request query params
       DebugServlet.clear();
+      setReqParamsOf(req, "serverOnly", "notServer");
 
       try {
         client.request(req);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -26,11 +26,9 @@ import org.junit.Test;
 public class LBHttp2SolrClientTest extends SolrTestCase {
 
   /**
-   * Test method for {@link LBHttp2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} and {@link
-   * LBHttp2SolrClient#addQueryParams(String)}.
-   *
-   * <p>Validate that the query param keys passed in are used in the base <code>Http2SolrClient
-   * </code> instance.
+   * Test method for {@link LBHttp2SolrClient.Builder} that validates that the query param keys
+   * passed in by the base <code>Http2SolrClient
+   * </code> instance are used by the LBHttp2SolrClient.
    *
    * <p>TODO: Eliminate the addQueryParams aspect of test as it is not compatible with goal of
    * immutable SolrClient
@@ -41,16 +39,14 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
     Set<String> queryParams = new HashSet<>(2);
     queryParams.add("param1");
 
-    try (Http2SolrClient http2Client = new Http2SolrClient.Builder(url).build();
-        LBHttp2SolrClient testClient =
-            new LBHttp2SolrClient.Builder(http2Client, url)
-                .withTheseParamNamesInTheUrl(queryParams)
-                .build()) {
+    try (Http2SolrClient http2Client =
+            new Http2SolrClient.Builder(url).withTheseParamNamesInTheUrl(queryParams).build();
+        LBHttp2SolrClient testClient = new LBHttp2SolrClient.Builder(http2Client, url).build()) {
 
       assertArrayEquals(
           "Wrong queryParams found in lb client.",
           queryParams.toArray(),
-          testClient.getQueryParams().toArray());
+          testClient.getUrlParamNames().toArray());
       assertArrayEquals(
           "Wrong queryParams found in base client.",
           queryParams.toArray(),

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -29,7 +29,7 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
    * Test method for {@link LBHttp2SolrClient.Builder#withQueryParams(Set)} and {@link
    * LBHttp2SolrClient#addQueryParams(String)}.
    *
-   * <p>Validate that the query params passed in are used in the base <code>Http2SolrClient</code>
+   * <p>Validate that the query param keys passed in are used in the base <code>Http2SolrClient</code>
    * instance.
    *
    * <p>TODO: Eliminate the addQueryParams aspect of test as it is not compatible with goal of
@@ -56,8 +56,8 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
           queryParams.toArray(),
           http2Client.getQueryParams().toArray());
 
-      testClient.addQueryParams("param2=that");
-      queryParams.add("param2=that");
+      testClient.addQueryParams("param2");
+      queryParams.add("param2");
       assertArrayEquals(
           "Wrong queryParams found in lb client.",
           queryParams.toArray(),

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -54,7 +54,7 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
       assertArrayEquals(
           "Wrong queryParams found in base client.",
           queryParams.toArray(),
-          http2Client.getQueryParams().toArray());
+          http2Client.getUrlParamNames().toArray());
 
       testClient.addQueryParams("param2");
       queryParams.add("param2");
@@ -65,7 +65,7 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
       assertArrayEquals(
           "Wrong queryParams found in base client.",
           queryParams.toArray(),
-          http2Client.getQueryParams().toArray());
+          http2Client.getUrlParamNames().toArray());
     }
   }
 }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -35,11 +35,15 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
   @Test
   public void testLBHttp2SolrClientSetQueryParams() throws IOException {
     String url = "http://127.0.0.1:8080";
+    Set<String> queryParams = new HashSet<>(2);
+    queryParams.add("param1=this");
+
     try (Http2SolrClient http2Client = new Http2SolrClient.Builder(url).build();
-        LBHttp2SolrClient testClient = new LBHttp2SolrClient.Builder(http2Client, url).build()) {
-      Set<String> queryParams = new HashSet<>(2);
-      queryParams.add("param1=this");
-      testClient.setQueryParams(new HashSet<>(queryParams));
+        LBHttp2SolrClient testClient =
+            new LBHttp2SolrClient.Builder(http2Client, url)
+                .withQueryParams(new HashSet<>(queryParams))
+                .build()) {
+
       assertArrayEquals(
           "Wrong queryParams found in lb client.",
           queryParams.toArray(),

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class LBHttp2SolrClientTest extends SolrTestCase {
 
   /**
-   * Test method for {@link LBHttp2SolrClient.Builder#withQueryParams(Set)} and {@link
+   * Test method for {@link LBHttp2SolrClient.Builder#withTheseParamNamesInTheUrl(Set)} and {@link
    * LBHttp2SolrClient#addQueryParams(String)}.
    *
    * <p>Validate that the query param keys passed in are used in the base <code>Http2SolrClient
@@ -43,7 +43,9 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
 
     try (Http2SolrClient http2Client = new Http2SolrClient.Builder(url).build();
         LBHttp2SolrClient testClient =
-            new LBHttp2SolrClient.Builder(http2Client, url).withQueryParams(queryParams).build()) {
+            new LBHttp2SolrClient.Builder(http2Client, url)
+                .withTheseParamNamesInTheUrl(queryParams)
+                .build()) {
 
       assertArrayEquals(
           "Wrong queryParams found in lb client.",

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -26,11 +26,14 @@ import org.junit.Test;
 public class LBHttp2SolrClientTest extends SolrTestCase {
 
   /**
-   * Test method for {@link LBHttp2SolrClient#setQueryParams(Set)} and {@link
+   * Test method for {@link LBHttp2SolrClient.Builder#withQueryParams(Set)} and {@link
    * LBHttp2SolrClient#addQueryParams(String)}.
    *
    * <p>Validate that the query params passed in are used in the base <code>Http2SolrClient</code>
    * instance.
+   *
+   * <p>TODO: Eliminate the addQueryParams aspect of test as it is not compatible with goal of
+   * immutable SolrClient
    */
   @Test
   public void testLBHttp2SolrClientSetQueryParams() throws IOException {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -29,8 +29,8 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
    * Test method for {@link LBHttp2SolrClient.Builder#withQueryParams(Set)} and {@link
    * LBHttp2SolrClient#addQueryParams(String)}.
    *
-   * <p>Validate that the query param keys passed in are used in the base <code>Http2SolrClient</code>
-   * instance.
+   * <p>Validate that the query param keys passed in are used in the base <code>Http2SolrClient
+   * </code> instance.
    *
    * <p>TODO: Eliminate the addQueryParams aspect of test as it is not compatible with goal of
    * immutable SolrClient
@@ -43,9 +43,7 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
 
     try (Http2SolrClient http2Client = new Http2SolrClient.Builder(url).build();
         LBHttp2SolrClient testClient =
-            new LBHttp2SolrClient.Builder(http2Client, url)
-                .withQueryParams(queryParams)
-                .build()) {
+            new LBHttp2SolrClient.Builder(http2Client, url).withQueryParams(queryParams).build()) {
 
       assertArrayEquals(
           "Wrong queryParams found in lb client.",

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -39,9 +39,10 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
     Set<String> queryParams = new HashSet<>(2);
     queryParams.add("param1");
 
-    try (Http2SolrClient http2Client =
+    try (Http2SolrClient http2SolrClient =
             new Http2SolrClient.Builder(url).withTheseParamNamesInTheUrl(queryParams).build();
-        LBHttp2SolrClient testClient = new LBHttp2SolrClient.Builder(http2Client, url).build()) {
+        LBHttp2SolrClient testClient =
+            new LBHttp2SolrClient.Builder(http2SolrClient, url).build()) {
 
       assertArrayEquals(
           "Wrong queryParams found in lb client.",
@@ -50,7 +51,7 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
       assertArrayEquals(
           "Wrong queryParams found in base client.",
           queryParams.toArray(),
-          http2Client.getUrlParamNames().toArray());
+          http2SolrClient.getUrlParamNames().toArray());
 
       testClient.addQueryParams("param2");
       queryParams.add("param2");
@@ -61,7 +62,7 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
       assertArrayEquals(
           "Wrong queryParams found in base client.",
           queryParams.toArray(),
-          http2Client.getUrlParamNames().toArray());
+          http2SolrClient.getUrlParamNames().toArray());
     }
   }
 }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.client.solrj.impl;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.solr.SolrTestCase;
@@ -34,34 +33,34 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
    * immutable SolrClient
    */
   @Test
-  public void testLBHttp2SolrClientSetQueryParams() throws IOException {
+  public void testLBHttp2SolrClientSetQueryParams() {
     String url = "http://127.0.0.1:8080";
-    Set<String> queryParams = new HashSet<>(2);
-    queryParams.add("param1");
+    Set<String> urlParamNames = new HashSet<>(2);
+    urlParamNames.add("param1");
 
     try (Http2SolrClient http2SolrClient =
-            new Http2SolrClient.Builder(url).withTheseParamNamesInTheUrl(queryParams).build();
+            new Http2SolrClient.Builder(url).withTheseParamNamesInTheUrl(urlParamNames).build();
         LBHttp2SolrClient testClient =
             new LBHttp2SolrClient.Builder(http2SolrClient, url).build()) {
 
       assertArrayEquals(
-          "Wrong queryParams found in lb client.",
-          queryParams.toArray(),
+          "Wrong urlParamNames found in lb client.",
+          urlParamNames.toArray(),
           testClient.getUrlParamNames().toArray());
       assertArrayEquals(
-          "Wrong queryParams found in base client.",
-          queryParams.toArray(),
+          "Wrong urlParamNames found in base client.",
+          urlParamNames.toArray(),
           http2SolrClient.getUrlParamNames().toArray());
 
       testClient.addQueryParams("param2");
-      queryParams.add("param2");
+      urlParamNames.add("param2");
       assertArrayEquals(
-          "Wrong queryParams found in lb client.",
-          queryParams.toArray(),
-          testClient.getQueryParams().toArray());
+          "Wrong urlParamNames found in lb client.",
+          urlParamNames.toArray(),
+          testClient.getUrlParamNames().toArray());
       assertArrayEquals(
-          "Wrong queryParams found in base client.",
-          queryParams.toArray(),
+          "Wrong urlParamNames found in base client.",
+          urlParamNames.toArray(),
           http2SolrClient.getUrlParamNames().toArray());
     }
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientTest.java
@@ -39,12 +39,12 @@ public class LBHttp2SolrClientTest extends SolrTestCase {
   public void testLBHttp2SolrClientSetQueryParams() throws IOException {
     String url = "http://127.0.0.1:8080";
     Set<String> queryParams = new HashSet<>(2);
-    queryParams.add("param1=this");
+    queryParams.add("param1");
 
     try (Http2SolrClient http2Client = new Http2SolrClient.Builder(url).build();
         LBHttp2SolrClient testClient =
             new LBHttp2SolrClient.Builder(http2Client, url)
-                .withQueryParams(new HashSet<>(queryParams))
+                .withQueryParams(queryParams)
                 .build()) {
 
       assertArrayEquals(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-10452


# Description

setQueryParams should be deprecated in favor of SolrClientBuilder methods.

# Solution

I moved the the setQueryParams over for the Http2SolrClient, it already had been done for HttpSolrClient.   I noticed we have a `addQueryParams` method, which I marked deprecated and we shouldn't use, as that goes against the idea of a Solr Client being immutable.   

One area I tried to fix and gave up on was the `DelegationTokenHttpSolrClient`, I couldn't quite figure out what to do there, would love a suggestion or a fix ;-)

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
