### PR TITLE
SOLR-16682: transfer mlt query for component right

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -225,6 +225,9 @@ Bug Fixes
 
 * SOLR-16679: Fix solr.jetty.ssl.verifyClientHostName logging (Kevin Risden)
 
+* SOLR-16682: MoreLikeThis Component fails with SyntaxError: Cannot parse if document terms contains symbols from query parser syntax 
+  (Mikhail Khludnev)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -459,8 +459,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     /**
      * Yields terms with boosts from the boosted MLT query.
      *
-     * @param maxTerms how many terms to return, a negative value means all terms are
-     *     returned
+     * @param maxTerms how many terms to return, a negative value means all terms are returned
      */
     public List<InterestingTerm> getInterestingTerms(BooleanQuery boostedMLTQuery, int maxTerms) {
       assert boostedMLTQuery != null : "strictly expecting it's set";

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -418,8 +418,8 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     }
 
     /** Sets {@link #boostedMLTQuery} and returns it */
-    public BooleanQuery getBoostedMLTQuery(int id) throws IOException {
-      rawMLTQuery = mlt.like(id);
+    public BooleanQuery getBoostedMLTQuery(int docNum) throws IOException {
+      rawMLTQuery = mlt.like(docNum);
       boostedMLTQuery = getBoostedQuery(rawMLTQuery);
       return boostedMLTQuery;
     }
@@ -459,7 +459,8 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     /**
      * Yields terms with boosts from the boosted MLT query.
      *
-     * @param maxTerms how many terms to return, negative value let to return all
+     * @param maxTerms how many terms to return, a negative value means all terms are
+     *     returned
      */
     public List<InterestingTerm> getInterestingTerms(BooleanQuery boostedMLTQuery, int maxTerms) {
       assert boostedMLTQuery != null : "strictly expecting it's set";

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -193,8 +193,8 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
       rsp.addResponse(mltDocs.docList);
 
       if (termStyle != TermStyle.NONE) {
-        final List<InterestingTerm> interesting = mlt.getInterestingTerms(mlt.getBoostedMLTQuery(),
-                mlt.mlt.getMaxQueryTerms());
+        final List<InterestingTerm> interesting =
+            mlt.getInterestingTerms(mlt.getBoostedMLTQuery(), mlt.mlt.getMaxQueryTerms());
         if (termStyle == TermStyle.DETAILS) {
           NamedList<Float> it = new NamedList<>();
           for (InterestingTerm t : interesting) {
@@ -391,8 +391,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     }
 
     public DocListAndSet getMoreLikeThis(
-        int id, int start, int rows, List<Query> filters, int flags)
-        throws IOException {
+        int id, int start, int rows, List<Query> filters, int flags) throws IOException {
       Document doc = reader.document(id);
       final Query boostedQuery = getBoostedMLTQuery(id);
 
@@ -418,9 +417,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
       return results;
     }
 
-    /**
-     * Sets {@link #boostedMLTQuery} and returns it
-     */
+    /** Sets {@link #boostedMLTQuery} and returns it */
     public BooleanQuery getBoostedMLTQuery(int id) throws IOException {
       rawMLTQuery = mlt.like(id);
       boostedMLTQuery = getBoostedQuery(rawMLTQuery);
@@ -428,12 +425,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     }
 
     public DocListAndSet getMoreLikeThis(
-        Reader reader,
-        int start,
-        int rows,
-        List<Query> filters,
-        int flags)
-        throws IOException {
+        Reader reader, int start, int rows, List<Query> filters, int flags) throws IOException {
       // SOLR-5351: if only check against a single field, use the reader directly. Otherwise we
       // repeat the stream's content for multiple fields so that query terms can be pulled from any
       // of those fields.
@@ -466,14 +458,15 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     }
     /**
      * Yields terms with boosts from the boosted MLT query.
+     *
      * @param maxTerms how many terms to return, negative value let to return all
      */
     public List<InterestingTerm> getInterestingTerms(BooleanQuery boostedMLTQuery, int maxTerms) {
-      assert boostedMLTQuery!=null : "strictly expecting it's set";
+      assert boostedMLTQuery != null : "strictly expecting it's set";
       Collection<BooleanClause> clauses = boostedMLTQuery.clauses();
-      List<InterestingTerm> output = new ArrayList<>(maxTerms<0 ? clauses.size() : maxTerms);
+      List<InterestingTerm> output = new ArrayList<>(maxTerms < 0 ? clauses.size() : maxTerms);
       for (BooleanClause o : clauses) {
-        if (maxTerms>-1 && output.size()>=maxTerms) {
+        if (maxTerms > -1 && output.size() >= maxTerms) {
           break;
         }
         Query q = o.getQuery();

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -103,7 +103,8 @@ public class MoreLikeThisComponent extends SearchComponent {
           NamedList<NamedList<?>> temp = new NamedList<>();
           for (DocIterator iterator = rb.getResults().docList.iterator(); iterator.hasNext(); ) {
             int id = iterator.nextDoc();
-            final List<MoreLikeThisHandler.InterestingTerm> terms = mlt.getInterestingTerms(mlt.getBoostedMLTQuery(id), -1);
+            final List<MoreLikeThisHandler.InterestingTerm> terms =
+                mlt.getInterestingTerms(mlt.getBoostedMLTQuery(id), -1);
             if (terms.isEmpty()) {
               continue;
             }
@@ -419,8 +420,7 @@ public class MoreLikeThisComponent extends SearchComponent {
       int id = iterator.nextDoc();
       int rows = p.getInt(MoreLikeThisParams.DOC_COUNT, 5);
 
-      DocListAndSet similarDocuments =
-          mltHelper.getMoreLikeThis(id, 0, rows, null, flags);
+      DocListAndSet similarDocuments = mltHelper.getMoreLikeThis(id, 0, rows, null, flags);
       String name = schema.printableUniqueKey(searcher.doc(id));
       mltResponse.add(name, similarDocuments.docList);
 
@@ -442,8 +442,8 @@ public class MoreLikeThisComponent extends SearchComponent {
 
       if (interestingTermsResponse != null) {
         List<MoreLikeThisHandler.InterestingTerm> interestingTerms =
-                mltHelper.getInterestingTerms(mltHelper.getBoostedMLTQuery(),
-                        mltHelper.getMoreLikeThis().getMaxQueryTerms());
+            mltHelper.getInterestingTerms(
+                mltHelper.getBoostedMLTQuery(), mltHelper.getMoreLikeThis().getMaxQueryTerms());
         if (interestingTermsConfig == MoreLikeThisParams.TermStyle.DETAILS) {
           SimpleOrderedMap<Float> interestingTermsWithScore = new SimpleOrderedMap<>();
           for (MoreLikeThisHandler.InterestingTerm interestingTerm : interestingTerms) {

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -21,6 +21,7 @@ import static org.apache.solr.common.params.CommonParams.SORT;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -512,7 +513,7 @@ public class MoreLikeThisComponent extends SearchComponent {
         public void consumeTerms(Query query, Term... terms) {
           if (terms.length != 1 || terms[0] == null) {
             throw new IllegalArgumentException(
-                "Expecting just a TermQuery, got " + query + ", " + terms);
+                "Expecting just a TermQuery, got " + query + ", " + Arrays.toString(terms));
           }
           params.add(ref(occur), termToQuery(terms[0]));
         }
@@ -529,7 +530,7 @@ public class MoreLikeThisComponent extends SearchComponent {
             public void consumeTerms(Query query, Term... terms) {
               if (terms.length != 1 || terms[0] == null) {
                 throw new IllegalArgumentException(
-                    "Expecting just a TermQuery, got " + query + ", " + terms);
+                    "Expecting just a TermQuery, got " + query + ", " + Arrays.toString(terms));
               }
               final Term term = terms[0];
               params.add(

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -100,22 +100,22 @@ public class MoreLikeThisComponent extends SearchComponent {
           }
           MoreLikeThisHandler.MoreLikeThisHelper mlt =
               new MoreLikeThisHandler.MoreLikeThisHelper(params, searcher);
-          NamedList<NamedList<?>> temp = new NamedList<>();
-          for (DocIterator iterator = rb.getResults().docList.iterator(); iterator.hasNext(); ) {
-            int id = iterator.nextDoc();
+          NamedList<NamedList<?>> mltQueryByDocKey = new NamedList<>();
+          for (DocIterator results = rb.getResults().docList.iterator(); results.hasNext(); ) {
+            int docNum = results.nextDoc();
             final List<MoreLikeThisHandler.InterestingTerm> interestingTerms =
-                mlt.getInterestingTerms(mlt.getBoostedMLTQuery(id), -1);
+                mlt.getInterestingTerms(mlt.getBoostedMLTQuery(docNum), -1);
             if (interestingTerms.isEmpty()) {
               continue;
             }
             final String uniqueKey = rb.req.getSchema().getUniqueKeyField().getName();
-            final Document document = rb.req.getSearcher().doc(id);
+            final Document document = rb.req.getSearcher().doc(docNum);
             final String uniqueVal = rb.req.getSchema().printableUniqueKey(document);
             final NamedList<String> mltQ =
                 mltViaQueryParams(rb.req.getSchema(), interestingTerms, uniqueKey, uniqueVal);
-            temp.add(uniqueVal, mltQ);
+            mltQueryByDocKey.add(uniqueVal, mltQ);
           }
-          rb.rsp.add("moreLikeThis", temp);
+          rb.rsp.add("moreLikeThis", mltQueryByDocKey);
         } else {
           NamedList<DocList> sim =
               getMoreLikeThese(rb, rb.req.getSearcher(), rb.getResults().docList, flags);

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -102,14 +102,14 @@ public class MoreLikeThisComponent extends SearchComponent {
               new MoreLikeThisHandler.MoreLikeThisHelper(params, searcher);
           NamedList<NamedList<?>> mltQueryByDocKey = new NamedList<>();
           for (DocIterator results = rb.getResults().docList.iterator(); results.hasNext(); ) {
-            int docNum = results.nextDoc();
+            int docId = results.nextDoc();
             final List<MoreLikeThisHandler.InterestingTerm> interestingTerms =
-                mlt.getInterestingTerms(mlt.getBoostedMLTQuery(docNum), -1);
+                mlt.getInterestingTerms(mlt.getBoostedMLTQuery(docId), -1);
             if (interestingTerms.isEmpty()) {
               continue;
             }
             final String uniqueKey = rb.req.getSchema().getUniqueKeyField().getName();
-            final Document document = rb.req.getSearcher().doc(docNum);
+            final Document document = rb.req.getSearcher().doc(docId);
             final String uniqueVal = rb.req.getSchema().printableUniqueKey(document);
             final NamedList<String> mltQ =
                 mltViaQueryParams(rb.req.getSchema(), interestingTerms, uniqueKey, uniqueVal);

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -103,16 +103,16 @@ public class MoreLikeThisComponent extends SearchComponent {
           NamedList<NamedList<?>> temp = new NamedList<>();
           for (DocIterator iterator = rb.getResults().docList.iterator(); iterator.hasNext(); ) {
             int id = iterator.nextDoc();
-            final List<MoreLikeThisHandler.InterestingTerm> terms =
+            final List<MoreLikeThisHandler.InterestingTerm> interestingTerms =
                 mlt.getInterestingTerms(mlt.getBoostedMLTQuery(id), -1);
-            if (terms.isEmpty()) {
+            if (interestingTerms.isEmpty()) {
               continue;
             }
             final String uniqueKey = rb.req.getSchema().getUniqueKeyField().getName();
             final Document document = rb.req.getSearcher().doc(id);
             final String uniqueVal = rb.req.getSchema().printableUniqueKey(document);
             final NamedList<String> mltQ =
-                putMLTIntoParamList(rb.req.getSchema(), terms, uniqueKey, uniqueVal);
+                mltViaQueryParams(rb.req.getSchema(), interestingTerms, uniqueKey, uniqueVal);
             temp.add(uniqueVal, mltQ);
           }
           rb.rsp.add("moreLikeThis", temp);
@@ -130,7 +130,7 @@ public class MoreLikeThisComponent extends SearchComponent {
     }
   }
 
-  private static NamedList<String> putMLTIntoParamList(
+  private static NamedList<String> mltViaQueryParams(
       IndexSchema schema,
       List<MoreLikeThisHandler.InterestingTerm> terms,
       String uniqueField,

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -513,11 +514,7 @@ public class MoreLikeThisComponent extends SearchComponent {
             throw new IllegalArgumentException(
                 "Expecting just a TermQuery, got " + query + ", " + terms);
           }
-          final Term term = terms[0];
-          final String paramName = "mltq" + cnt;
-          locParams.add(occur.name().toLowerCase(), "$" + paramName);
-          params.add(paramName, termToQuery(term));
-          cnt += 1;
+          params.add(ref(occur), termToQuery(terms[0]));
         }
 
         @Override
@@ -526,9 +523,7 @@ public class MoreLikeThisComponent extends SearchComponent {
             throw new IllegalArgumentException(
                 "Expecting BoostQuery, got " + parent + ", " + occur);
           }
-          final String paramName = "mltq" + cnt;
-          locParams.add(occur.name().toLowerCase(), "$" + paramName);
-          cnt += 1;
+          final String paramName = ref(occur);
           return new QueryVisitor() {
             @Override
             public void consumeTerms(Query query, Term... terms) {
@@ -544,6 +539,13 @@ public class MoreLikeThisComponent extends SearchComponent {
           };
         }
       };
+    }
+
+    private String ref(BooleanClause.Occur occur) {
+      final String paramName = "mltq" + cnt;
+      locParams.add(occur.name().toLowerCase(Locale.getDefault()), "$" + paramName);
+      cnt += 1;
+      return paramName;
     }
 
     private String termToQuery(Term term) { // shouldn't it be {!term} ??{!raw }?

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
@@ -389,7 +389,7 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
       Long actual = ((SolrDocumentList) entry.getValue()).getNumFound();
       assertEquals("MLT mismatch for id=" + key, expected, actual);
     }
-    // test bost mlt.qf
+    // test boost mlt.qf
     query(
         "q",
         "lowerfilt:moon",

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
@@ -91,7 +91,7 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
         id,
         "9",
         "lowerfilt",
-        "The quick red fox jumped over the lazy big and large brown dogs.",
+        "The quick red:fox jumped over the lazy big and large brown dogs.",
         "lowerfilt1",
         "x");
     index(id, "10", "lowerfilt", "blue", "lowerfilt1", "x");
@@ -100,7 +100,7 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
         id,
         "13",
         "lowerfilt",
-        "The quote red fox jumped over the lazy brown dogs.",
+        "The quote RED)FOX jumped over the lazy brown dogs.",
         "lowerfilt1",
         "y");
     index(
@@ -389,5 +389,29 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
       Long actual = ((SolrDocumentList) entry.getValue()).getNumFound();
       assertEquals("MLT mismatch for id=" + key, expected, actual);
     }
+    // test bost mlt.qf
+    query(
+        "q",
+        "lowerfilt:moon",
+        "fl",
+        id,
+        MoreLikeThisParams.MIN_TERM_FREQ,
+        2,
+        MoreLikeThisParams.MIN_DOC_FREQ,
+        1,
+        "sort",
+        "id_i1 desc",
+        "mlt",
+        "true",
+        "mlt.fl",
+        "lowerfilt1,lowerfilt",
+        "mlt.qf",
+        "lowerfilt1^1.2 lowerfilt^3.4",
+        "qt",
+        requestHandlerName,
+        "shards.qt",
+        requestHandlerName,
+        "mlt.count",
+        "20");
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-788
I think this is a somewhat reliable solution for the problem with distributed mlt component. Reminder, now it naively relies on parsing `booleanQuery.toString()` that's unacceptable. 