### PR TITLE
SOLR-16612: fix-hadoop-openj9

### DIFF
--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosTestServices.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosTestServices.java
@@ -190,6 +190,9 @@ public class KerberosTestServices {
 
   public static final String krb5LoginModuleName =
       System.getProperty("java.vendor").contains("IBM")
+              // added the following check for Solr since newer OpenJ9 builds don't have IBM
+              // specific classes.
+              && System.getProperty("java.specification.vendor").contains("IBM")
           ? "com.ibm.security.auth.module.Krb5LoginModule"
           : "com.sun.security.auth.module.Krb5LoginModule";
 

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosTestServices.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/KerberosTestServices.java
@@ -30,6 +30,7 @@ import javax.security.auth.login.Configuration;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder;
+import org.apache.solr.client.solrj.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -189,10 +190,7 @@ public class KerberosTestServices {
   }
 
   public static final String krb5LoginModuleName =
-      System.getProperty("java.vendor").contains("IBM")
-              // added the following check for Solr since newer OpenJ9 builds don't have IBM
-              // specific classes.
-              && System.getProperty("java.specification.vendor").contains("IBM")
+      Constants.IS_IBM_JAVA
           ? "com.ibm.security.auth.module.Krb5LoginModule"
           : "com.sun.security.auth.module.Krb5LoginModule";
 

--- a/solr/modules/hdfs/src/test/org/apache/hadoop/util/PlatformName.java
+++ b/solr/modules/hdfs/src/test/org/apache/hadoop/util/PlatformName.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.util;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.solr.client.solrj.util.Constants;
 
 /**
  * A helper class for getting build-info of the java-vm.
@@ -45,9 +46,7 @@ public class PlatformName {
    * A public static variable to indicate the current java vendor is
    * IBM java or not.
    */
-  public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM")
-      // added the following check for Solr since newer OpenJ9 builds don't have IBM specific classes.
-      && System.getProperty("java.specification.vendor").contains("IBM");
+  public static final boolean IBM_JAVA = Constants.IS_IBM_JAVA;
 
   public static void main(String[] args) {
     System.out.println(PLATFORM_NAME);

--- a/solr/modules/hdfs/src/test/org/apache/hadoop/util/PlatformName.java
+++ b/solr/modules/hdfs/src/test/org/apache/hadoop/util/PlatformName.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * A helper class for getting build-info of the java-vm.
+ *
+ */
+@InterfaceAudience.LimitedPrivate({"HBase"})
+@InterfaceStability.Unstable
+public class PlatformName {
+  /**
+   * The complete platform 'name' to identify the platform as
+   * per the java-vm.
+   */
+  public static final String PLATFORM_NAME =
+      (System.getProperty("os.name").startsWith("Windows")
+          ? System.getenv("os") : System.getProperty("os.name"))
+          + "-" + System.getProperty("os.arch")
+          + "-" + System.getProperty("sun.arch.data.model");
+
+  /**
+   * The java vendor name used in this platform.
+   */
+  public static final String JAVA_VENDOR_NAME = System.getProperty("java.vendor");
+
+  /**
+   * A public static variable to indicate the current java vendor is
+   * IBM java or not.
+   */
+  public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM")
+      // added the following check for Solr since newer OpenJ9 builds don't have IBM specific classes.
+      && System.getProperty("java.specification.vendor").contains("IBM");
+
+  public static void main(String[] args) {
+    System.out.println(PLATFORM_NAME);
+  }
+}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/Constants.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/Constants.java
@@ -17,8 +17,14 @@
 
 package org.apache.solr.client.solrj.util;
 
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 // Clone of org.apache.lucene.util.Constants, so SolrJ can use it
 public class Constants {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   public static final String JVM_SPEC_VERSION = System.getProperty("java.specification.version");
 
   public static final boolean JRE_IS_MINIMUM_JAVA9 = true;
@@ -30,9 +36,14 @@ public class Constants {
 
   private static boolean isIBMJava() {
     try {
-      Class.forName("com.ibm.security.auth.module.Krb5LoginModule", false, null);
+      Class.forName(
+          "com.ibm.security.auth.module.Krb5LoginModule", false, Constants.class.getClassLoader());
       return true;
-    } catch (ClassNotFoundException e) {
+    } catch (SecurityException se) {
+      log.warn(
+          "Unable to determine if IBM Java due to SecurityException. Assuming not IBM Java.", se);
+      return false;
+    } catch (ClassNotFoundException ignore) {
       return false;
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/Constants.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/Constants.java
@@ -25,4 +25,15 @@ public class Constants {
   public static final boolean JRE_IS_MINIMUM_JAVA11 = true;
   // Future, enable if needed...
   // public static final boolean JRE_IS_MINIMUM_JAVA17 = Runtime.version().feature() >= 17;
+
+  public static final boolean IS_IBM_JAVA = isIBMJava();
+
+  private static boolean isIBMJava() {
+    try {
+      Class.forName("com.ibm.security.auth.module.Krb5LoginModule", false, null);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16612

I'm looking into the Hadoop integration test failures on openj9 that are related to https://lists.apache.org/thread/b3053cvc2jqw768jrrw8npxkow4k70r6

I know Hadoop had some IBM java checks that look to be not necessary anymore after SOME change in IBM. I made an initial check change here, but not sure its correct.

@uschindler is there a good way to determine old IBM java vs new IBM Java based on openjdk?