### PR TITLE
update `releaseWizard.py` to support offline gpg key

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -1151,14 +1151,14 @@ def configure_pgp(gpg_todo):
         res = run("gpg --list-secret-keys %s" % gpg_fingerprint)
         print("Found key %s on your private gpg keychain" % gpg_id)
         # Check rsa and key length >= 4096
-        match = re.search(r'^sec +((rsa|dsa)(\d{4})) ', res)
+        match = re.search(r'^sec#? +((rsa|dsa)(\d{4})) ', res)
         type = "(unknown)"
         length = -1
         if match:
             type = match.group(2)
             length = int(match.group(3))
         else:
-            match = re.search(r'^sec +((\d{4})([DR])/.*?) ', res)
+            match = re.search(r'^sec#? +((\d{4})([DR])/.*?) ', res)
             if match:
                 type = 'rsa' if match.group(3) == 'R' else 'dsa'
                 length = int(match.group(2))


### PR DESCRIPTION
The release wizard detection of gpg keys fails in the event that the main key is offline (which causes the script output for `gpg --list-secret-keys` to display slightly differently). This PR introduces a minor tweak to parsing only, to enable gpg key detection to work in such cases.

The relevant section (full flag description from `man gpg` below) is `A # after the initial tags sec or ssb means that the secret key or subkey is currently not usable.`

```
       --list-secret-keys
       -K     List the specified secret keys.  If no keys are specified, then
              all known secret keys are listed.  A # after the initial tags
              sec or ssb means that the secret key or subkey is currently not
              usable.  We also say that this key has been taken offline (for
              example, a primary key can be taken offline by exporting the key
              using the command --export-secret-subkeys).  A > after these
              tags indicate that the key is stored on a smartcard.  See also
              --list-keys.
```