### PR TITLE
releaseWizard: allow explicitly setting MANIFEST.MF userid (e.g., to apache id)

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -91,7 +91,7 @@ def getGitRev():
   return os.popen('git rev-parse HEAD').read().strip()
 
 
-def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
+def prepare(root, version, mf_username, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
   print()
   print('Prepare release...')
   if os.path.exists(LOG):
@@ -120,6 +120,8 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
   print('  prepare-release')
   cmd = './gradlew --no-daemon assembleRelease' \
         ' -Dversion.release=%s' % version
+  if mf_username is not None:
+    cmd += ' -Dmanifest.username=%s' % mf_username
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'
   if gpg_key_id is None:
@@ -252,6 +254,8 @@ def parse_config():
                       help='Uses local KEYS file to validate presence of RM\'s gpg key')
   parser.add_argument('--push-local', metavar='PATH',
                       help='Push the release to the local path')
+  parser.add_argument('--mf-username', metavar='ID',
+                      help='Use the specified username in the Implementation-Version for jar MANIFEST.MF files (e.g., Apache ID).')
   parser.add_argument('--sign', metavar='FINGERPRINT',
                       help='Sign the release with the given gpg key. This must be the full GPG fingerprint, not just the last 8 characters.')
   parser.add_argument('--sign-method-gradle', dest='sign_method_gradle', default=False, action='store_true',
@@ -394,7 +398,7 @@ def main():
     c.key_password = None
 
   if c.prepare:
-    prepare(c.root, c.version, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
+    prepare(c.root, c.version, c.mf_username, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
   else:
     os.chdir(c.root)
 

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -734,7 +734,7 @@ groups:
         cmd: git pull --ff-only
         tee: true
       - !Command
-        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }}  --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }}{% if gpg.use_gradle %}  --sign-method-gradle{% endif %}{% if not gpg.prompt_pass %}  --gpg-pass-noprompt{% endif %}
+        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }} --manifest-username {{ gpg.apache_id }} --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }}{% if gpg.use_gradle %}  --sign-method-gradle{% endif %}{% if not gpg.prompt_pass %}  --gpg-pass-noprompt{% endif %}
         comment: "Using {% if gpg.use_gradle %}gradle{% else %}gpg command{% endif %} for signing.{% if gpg.prompt_pass %} Remember to type your GPG pass-phrase at the prompt!{% endif %}"
         logfile: build_rc.log
         tee: true

--- a/gradle/java/jar-manifest.gradle
+++ b/gradle/java/jar-manifest.gradle
@@ -44,7 +44,9 @@ subprojects {
                     if (snapshotBuild) {
                       return "${project.version} ${gitRev} [snapshot build, details omitted]"
                     } else {
-                      return "${project.version} ${gitRev} - ${System.properties['user.name']} - ${buildDate} ${buildTime}"
+                      def sysProps = System.properties
+                      def manifestUsername = sysProps.getOrDefault('manifest.username', sysProps['user.name'])
+                      return "${project.version} ${gitRev} - ${manifestUsername} - ${buildDate} ${buildTime}"
                     }
                 }
 


### PR DESCRIPTION
I'm opening this PR against `branch_9_1` just to have it live somewhere while resolving conflicts in forward-porting to `branch_9x` and `main`, which look very different because #1125 appears to have been merged differently on [branch_9_1](https://github.com/apache/solr/commit/ef9acb33058b9575fd384f3563133ffdf5c930dd) vs [branch_9x](https://github.com/apache/solr/commit/8a21fa702d57a89431cb484527773ac7fddb4b41) and [main](https://github.com/apache/solr/commit/360923eaf6c1aaefb08f4f6d3a398aeaaf6bfd70) (the latter two are similar).

This PR may not need to be merged to branch_9_1 ever (assuming branch9_1 is basically be end-of-life after 9.1.1 bugifx release); but in case an RC2 is needed, this will be here. The conflicts should be pretty straightforward to resolve.

The _purpose_ of this PR (burying the lead) is to pass the RM's apache id into the `assembleRelease` task, for a more consistent `Implementation-Version` property in MANIFEST.MF in built jars.