### PR TITLE
buildAndPushRelease should optionally pause before assembleRelease

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -91,7 +91,7 @@ def getGitRev():
   return os.popen('git rev-parse HEAD').read().strip()
 
 
-def prepare(root, version, mf_username, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
+def prepare(root, version, pause_before_sign, mf_username, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
   print()
   print('Prepare release...')
   if os.path.exists(LOG):
@@ -116,6 +116,9 @@ def prepare(root, version, mf_username, gpg_key_id, gpg_password, gpg_home=None,
     run('./gradlew --no-daemon -Dtests.badapples=false clean check')
   else:
     print('  skipping precommit check due to dev-mode')
+
+  if pause_before_sign:
+    str(input("Tests complete! Please press ENTER to proceed to assembleRelease: "))
 
   print('  prepare-release')
   cmd = './gradlew --no-daemon assembleRelease' \
@@ -256,6 +259,8 @@ def parse_config():
                       help='Push the release to the local path')
   parser.add_argument('--mf-username', metavar='ID',
                       help='Use the specified username in the Implementation-Version for jar MANIFEST.MF files (e.g., Apache ID).')
+  parser.add_argument('--pause-before-sign', default=False, action='store_true',
+                      help='Pause for user confirmation before the assembleRelease step (to prevent timeout on gpg pinentry')
   parser.add_argument('--sign', metavar='FINGERPRINT',
                       help='Sign the release with the given gpg key. This must be the full GPG fingerprint, not just the last 8 characters.')
   parser.add_argument('--sign-method-gradle', dest='sign_method_gradle', default=False, action='store_true',
@@ -398,7 +403,7 @@ def main():
     c.key_password = None
 
   if c.prepare:
-    prepare(c.root, c.version, c.mf_username, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
+    prepare(c.root, c.version, c.pause_before_sign, c.mf_username, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
   else:
     os.chdir(c.root)
 

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -91,7 +91,7 @@ def getGitRev():
   return os.popen('git rev-parse HEAD').read().strip()
 
 
-def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
+def prepare(root, version, mf_username, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
   print()
   print('Prepare release...')
   if os.path.exists(LOG):
@@ -120,6 +120,8 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
   print('  prepare-release')
   cmd = './gradlew --no-daemon assembleRelease' \
         ' -Dversion.release=%s' % version
+  if mf_username is not None:
+    cmd += ' -Dmanifest.username=%s' % mf_username
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'
   if gpg_key_id is None:
@@ -252,6 +254,8 @@ def parse_config():
                       help='Uses local KEYS file to validate presence of RM\'s gpg key')
   parser.add_argument('--push-local', metavar='PATH',
                       help='Push the release to the local path')
+  parser.add_argument('--mf-username', metavar='ID',
+                      help='Use the specified username in the Implementation-Version for jar MANIFEST.MF files (e.g., Apache ID).')
   parser.add_argument('--sign', metavar='FINGERPRINT',
                       help='Sign the release with the given gpg key. This must be the full GPG fingerprint, not just the last 8 characters.')
   parser.add_argument('--sign-method-gradle', dest='sign_method_gradle', default=False, action='store_true',
@@ -394,7 +398,7 @@ def main():
     c.key_password = None
 
   if c.prepare:
-    prepare(c.root, c.version, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
+    prepare(c.root, c.version, c.mf_username, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
   else:
     os.chdir(c.root)
 

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -749,7 +749,7 @@ groups:
         cmd: git pull --ff-only
         tee: true
       - !Command
-        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }}  --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }} --gpg-pass-noprompt
+        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }} --manifest-username {{ gpg.apache_id }} --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }} --gpg-pass-noprompt
         comment: "Using gpg command for signing."
         logfile: build_rc.log
         tee: true

--- a/gradle/java/jar-manifest.gradle
+++ b/gradle/java/jar-manifest.gradle
@@ -44,7 +44,9 @@ subprojects {
                     if (snapshotBuild) {
                       return "${project.version} ${gitRev} [snapshot build, details omitted]"
                     } else {
-                      return "${project.version} ${gitRev} - ${System.properties['user.name']} - ${buildDate} ${buildTime}"
+                      def sysProps = System.properties
+                      def manifestUsername = sysProps.getOrDefault('manifest.username', sysProps['user.name'])
+                      return "${project.version} ${gitRev} - ${manifestUsername} - ${buildDate} ${buildTime}"
                     }
                 }
 


### PR DESCRIPTION
apache/solr#1125 works around gpg pinentry via a `setup_gpg` step that caches the user pin in `gpg-agent`.

For configurations that require explicit user PIN entry via non-tty-based pinentry program, as discussed in [help/publishing.txt](https://github.com/apache/solr/blob/releases/solr/9.1.0/help/publishing.txt#L125-L128) -- i.e., where gpg-agent is not configured to cache user PIN -- the approach followed in apache/solr#1125 will not work.

In such cases, we should provide the option to pause for user confirmation before proceeding to the `assembleRelease`/signing phase. Without such a pause, it's likely that an RM will step away while tests are running, and once tests complete but before the RM returns, the pinentry prompt will timeout, causing the entire invocation of `buildAndPushRelease.py` to fail unnecessarily (ask me how I know 😁).

This PR, if merged, should ideally be merged after https://github.com/apache/solr/pull/1290