### PR TITLE
Correcting default minimalFreeDiskGB

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/replica-placement-plugins.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/replica-placement-plugins.adoc
@@ -146,7 +146,7 @@ This plugin supports the following configuration parameters:
 +
 [%autowidth,frame=none]
 |===
-|Optional |Default: `10` Gigabytes
+|Optional |Default: `20` Gigabytes
 |===
 +
 If a node has strictly less GB of free disk than this value, the node is excluded from assignment decisions.


### PR DESCRIPTION
Minor change: according to the code (and I remember testing it, too), the default is 20GB, not 10: https://github.com/apache/solr/blob/c99af207c761ec34812ef1cc3054eb2804b7448b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/AffinityPlacementConfig.java#L28