### PR TITLE
SOLR-16621: Admin UI fails to grant user permissions with wildcard role

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -167,6 +167,8 @@ Bug Fixes
 
 * SOLR-16613: CryptoKeys should handle RSA padding for OpenJ9 (Kevin Risden)
 
+* SOLR-16621: Admin UI fails to grant user permissions that have wildcard role (janhoy)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -52,8 +52,16 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     return roles.sort((a, b) => (a.name > b.name) ? 1 : -1);
   }
 
+  /**
+   * Check if user's roles are compatible with permission's roles
+   * @param roles list of roles for a permission, where at least one is required
+   * @param rolesForUser list of roles for user
+   * @return true if user has one of the required roles, or permission has a wildcard role
+   */
   function roleMatch(roles, rolesForUser) {
-    for (r in rolesForUser) {
+    if (roles.includes("*"))
+      return true
+    for (let r in rolesForUser) {
       if (roles.includes(rolesForUser[r]))
         return true;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16621

Always grant access to a permission that has has the wildcard `"*"` role, no matter what roles user has.
Note, this is not the same as not requiring authentication for the permission, `"roles": null`. It means that the permission needs an authenticated user, but any role will do.

Also, this is just UI stuff so will not modify actual permissions on the API level, but will align role checking logic so it matches that of the backend.

To test:

1. Start Solr and enable security
    ```bash
    ./gradlew dev
    cd solr/packaging/build/dev/
    bin/solr start -c
    bin/solr auth enable -credentials solr:solr -blockUnknown true
    ```
2. Log in to Admin UI with 'solr' and 'solr': http://localhost:8983/solr/#/~security
3. Edit the permissions 'security-edit' and 'security-read' to have `*` as role
4. The user can still see the Security Dashboard and edit permissions

(To confirm the bug, do the same test on main branch and see that user is blocked from security dashboard once the permissions are changed to `role=*`).