### PR TITLE
SOLR-16621 Use $scope.isPermitted("my-permissiong") in security dash

### DIFF
--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -320,10 +320,10 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
         $scope.roleNames = [];
       }
 
-      $scope.permissions = data.authorization["permissions"];
+      $scope.permissionsConfig = data.authorization["permissions"];
       $scope.permissionsTable = [];
-      for (p in $scope.permissions) {
-        $scope.permissionsTable.push(permRow($scope.permissions[p], parseInt(p)+1));
+      for (p in $scope.permissionsConfig) {
+        $scope.permissionsTable.push(permRow($scope.permissionsConfig[p], parseInt(p)+1));
       }
       $scope.filteredPerms = $scope.permissionsTable;
 
@@ -575,7 +575,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
 
     $scope.params = [{"name":"", "value":""}];
 
-    var permissionNames = $scope.permissions.map(p => p.name);
+    var permissionNames = $scope.permissionsConfig.map(p => p.name);
     $scope.filteredPredefinedPermissions = $scope.predefinedPermissions.filter(p => !permissionNames.includes(p));
 
     $scope.togglePermDialog();
@@ -642,7 +642,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
         $scope.validationError = "Either select a predefined permission or provide a name for a custom permission";
         return;
       }
-      var permissionNames = $scope.permissions.map(p => p.name);
+      var permissionNames = $scope.permissionsConfig.map(p => p.name);
       if (permissionNames.includes(name)) {
         $scope.validationError = "Permission '"+name+"' already exists!";
         return;
@@ -726,7 +726,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
       var indexOrBefore = isAdd ? "before" : "index";
       var indexInt = parseInt($scope.upsertPerm.index);
       if (indexInt < 1) indexInt = 1;
-      if (indexInt >= $scope.permissions.length) indexInt = null;
+      if (indexInt >= $scope.permissionsConfig.length) indexInt = null;
       if (indexInt != null) {
         setPermJson[indexOrBefore] = indexInt;
       }
@@ -795,7 +795,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     } else if ($scope.userFilter === "role") {
       $scope.userFilterOptions = $scope.roleNames;
     } else if ($scope.userFilter === "perm") {
-      $scope.userFilterOptions = $scope.permissions.map(p => p.name).sort();
+      $scope.userFilterOptions = $scope.permissionsConfig.map(p => p.name).sort();
     } else {
       $scope.userFilter = "";
     }
@@ -1005,7 +1005,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     } else if ($scope.roleFilter === "user") {
       $scope.roleFilterOptions = Array.from(new Set($scope.roles.flatMap(r => r.users))).sort();
     } else if ($scope.roleFilter === "perm") {
-      $scope.roleFilterOptions = $scope.permissions.map(p => p.name).sort();
+      $scope.roleFilterOptions = $scope.permissionsConfig.map(p => p.name).sort();
     } else {
       $scope.roleFilter = "";
     }
@@ -1053,7 +1053,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     $scope.roleDialogAction = "Add Role";
     $scope.upsertRole = {};
     $scope.userNames = $scope.users.map(u => u.username);
-    $scope.grantPermissionNames = Array.from(new Set($scope.predefinedPermissions.concat($scope.permissions.map(p => p.name)))).sort();
+    $scope.grantPermissionNames = Array.from(new Set($scope.predefinedPermissions.concat($scope.permissionsConfig.map(p => p.name)))).sort();
     $scope.toggleRoleDialog();
   };
 
@@ -1203,7 +1203,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     var perms = $scope.permissionsTable.filter(p => p.roles.includes(roleName)).map(p => p.name);
     $scope.upsertRole = { name: roleName, selectedUsers: role.users, grantedPerms: perms };
     $scope.userNames = $scope.users.map(u => u.username);
-    $scope.grantPermissionNames = Array.from(new Set($scope.predefinedPermissions.concat($scope.permissions.map(p => p.name)))).sort();
+    $scope.grantPermissionNames = Array.from(new Set($scope.predefinedPermissions.concat($scope.permissionsConfig.map(p => p.name)))).sort();
     $scope.toggleRoleDialog();
   };
 

--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -255,7 +255,6 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
       $scope.tls = data.security ? data.security["tls"] : false;
       $scope.authenticationPlugin = data.security ? data.security["authenticationPlugin"] : null;
       $scope.authorizationPlugin = data.security ? data.security["authorizationPlugin"] : null;
-      $scope.myRoles = data.security ? data.security["roles"] : [];
       $scope.isSecurityAdminEnabled = $scope.authenticationPlugin != null;
       $scope.isCloudMode = data.mode.match( /solrcloud/i ) != null;
       $scope.zkHost = $scope.isCloudMode ? data["zkHost"] : "";
@@ -276,19 +275,6 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     $scope.showUserDialog = false;
     $scope.showPermDialog = false;
     delete $scope.helpId;
-  };
-
-  $scope.getCurrentUserRoles = function() {
-    return $scope.myRoles;
-  };
-
-  $scope.hasPermission = function(permissionName) {
-    var matched = $scope.permissionsTable.filter(p => permissionName === p.name);
-    if (matched.length === 0 && permissionName !== "all") {
-      // this permission is not explicitly defined, but "all" will apply if it is defined
-      matched = $scope.permissionsTable.filter(p => "all" === p.name);
-    }
-    return matched.length > 0 && roleMatch(matched.flatMap(p => p.roles), $scope.getCurrentUserRoles());
   };
 
   $scope.refreshSecurityPanel = function() {
@@ -346,8 +332,8 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
 
       // use the current user's roles (obtained from System.get) to check if they have the security permissions
       // Note: the backend will check too so this is only for display purposes
-      $scope.hasSecurityEditPerm = $scope.hasPermission("security-edit");
-      $scope.hasSecurityReadPerm = $scope.hasSecurityEditPerm || $scope.hasPermission("security-read");
+      $scope.hasSecurityEditPerm = $scope.isPermitted("security-edit");
+      $scope.hasSecurityReadPerm = $scope.hasSecurityEditPerm || $scope.isPermitted("security-read");
 
       // authentication
       if ($scope.authenticationPlugin === "org.apache.solr.security.BasicAuthPlugin" || $scope.authenticationPlugin === "org.apache.solr.security.MultiAuthPlugin") {

--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -332,8 +332,8 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
 
       // use the current user's roles (obtained from System.get) to check if they have the security permissions
       // Note: the backend will check too so this is only for display purposes
-      $scope.hasSecurityEditPerm = $scope.isPermitted("security-edit");
-      $scope.hasSecurityReadPerm = $scope.hasSecurityEditPerm || $scope.isPermitted("security-read");
+      $scope.hasSecurityEditPerm = $scope.isPermitted(permissions.SECURITY_EDIT_PERM);
+      $scope.hasSecurityReadPerm = $scope.hasSecurityEditPerm || $scope.isPermitted(permissions.SECURITY_READ_PERM);
 
       // authentication
       if ($scope.authenticationPlugin === "org.apache.solr.security.BasicAuthPlugin" || $scope.authenticationPlugin === "org.apache.solr.security.MultiAuthPlugin") {

--- a/solr/webapp/web/js/angular/permissions.js
+++ b/solr/webapp/web/js/angular/permissions.js
@@ -38,17 +38,19 @@ const permissions = {
 }
 
 /**
- * Returns true if all required permissions are available. Also returns true if RBAC is not enabled
+ * Returns true if all required permissions are available. Also returns true if RBAC is not enabled,
+ * or user has the 'all' permission.
  * @param requiredPermissions the permission(s) to check for, can be a single or array
  * @param userPermissions the actual permissions of current user
  * @returns {boolean}
  */
-var hasAllRequiredPermissions = function (requiredPermissions, userPermissions) {
+let hasAllRequiredPermissions = function (requiredPermissions, userPermissions) {
   if (!Array.isArray(requiredPermissions)) {
     requiredPermissions = [requiredPermissions];
   }
   if (userPermissions !== undefined) {
-    return requiredPermissions.every(elem => userPermissions.indexOf(elem) > -1);
+    return userPermissions.includes(permissions.ALL_PERM)
+      || requiredPermissions.every(elem => userPermissions.indexOf(elem) > -1);
   } else {
     // RBAC not enabled, always return true
     return true;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16621

Re-using this global function, we can simplify the js code of the dashboard. Note that the backend `/admin/info/system` already returns an array of user's permissions, not roles.

During testing I found that the app.js `isPermitted()` function did not support the `all` permission, so that's why I added that as well.

The `roleMatch()` function that I patched in #1294 is still in use one other place in `security.js`, in the `onPermFilterOptionChanged()` function. Not sure if we can get rid of that too here?