### PR TITLE
SOLR-14336 Warn users running old version of Solr

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -218,6 +218,8 @@ Other Changes
 
 * SOLR-16534: Jaegertracer-Configurator is now deprecated. From v10.0 we'll only support OpenTelemetry (janhoy)
 
+* SOLR-14336: Warning about potentially old Solr version in Admin UI dashboard (janhoy)
+
 * SOLR-13243: Correct the initial capacity of the ZK operations to run in ShardLeaderElectionContextBase#runLeaderProcess (Haythem Khiri)
 
 * SOLR-16544: Improve documentation on how to contribute to Solr (Justin Sweeney)

--- a/solr/webapp/web/js/angular/controllers/index.js
+++ b/solr/webapp/web/js/angular/controllers/index.js
@@ -20,6 +20,8 @@ solrAdminApp.controller('IndexController', function($scope, System, Cores, Const
   $scope.reload = function() {
     System.get(function(data) {
       $scope.system = data;
+      const releaseDate = parse_release_date($scope.system.lucene['solr-impl-version'])
+      $scope.releaseDaysOld = (new Date() - releaseDate)/60/60/1000/24;
 
       if ("username" in data.security) {
         // Needed for Kerberos, since this is the only place from where
@@ -82,6 +84,11 @@ var parse_memory_value = function( value ) {
   }
 
   return value;
+};
+
+const parse_release_date = function(value) {
+  const match = value.match( /.* (20\d\d-[0-1]\d-[0-3]\d) .*/ );
+  return match === null ? new Date() : new Date(match[1]);
 };
 
 var pretty_print_bytes = function(byte_value) {

--- a/solr/webapp/web/js/angular/controllers/index.js
+++ b/solr/webapp/web/js/angular/controllers/index.js
@@ -21,7 +21,7 @@ solrAdminApp.controller('IndexController', function($scope, System, Cores, Const
     System.get(function(data) {
       $scope.system = data;
       const releaseDate = parse_release_date($scope.system.lucene['solr-impl-version'])
-      $scope.releaseDaysOld = (new Date() - releaseDate)/60/60/1000/24;
+      $scope.releaseDaysOld = (new Date() - releaseDate)/1000/60/60/24;
 
       if ("username" in data.security) {
         // Needed for Kerberos, since this is the only place from where

--- a/solr/webapp/web/partials/index.html
+++ b/solr/webapp/web/partials/index.html
@@ -97,6 +97,9 @@ limitations under the License.
 
           </div>
 
+          <div class="content" ng-show="releaseDaysOld > 365">
+            <p class="warning-msg"><img src="img/ico/exclamation-button.png"/>&nbsp;WARNING: This Solr release is more than a year old. Consider upgrading.</p>
+          </div>
       </div>
 
     </div>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14336

This impl will simply parse release date from solr-impl string, count number of days old, and warn in Admin UI dashboard if older than a year. No warning in logs.