### PR TITLE
SOLR-16648: NullPointerException when excluding facets in More Like This Handler

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -169,6 +169,8 @@ Bug Fixes
 
 * SOLR-16647: Fix circuit breaker examples in solrconfig.xml (Colvin Cowie via Kevin Risden)
 
+* SOLR-16648: NullPointerException when excluding facets in More Like This Handler (Mikhail Khludnev)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -218,6 +218,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
         } else {
           final ResponseBuilder responseBuilder =
               new ResponseBuilder(req, rsp, Collections.emptyList());
+          responseBuilder.setQuery(mlt.getRealMLTQuery());
           SimpleFacets f = new SimpleFacets(req, mltDocs.docSet, params, responseBuilder);
           FacetComponent.FacetContext.initContext(responseBuilder);
           rsp.add("facet_counts", FacetComponent.getFacetCounts(f));

--- a/solr/core/src/test/org/apache/solr/handler/MoreLikeThisHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/MoreLikeThisHandlerTest.java
@@ -246,6 +246,14 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='facet_counts']/lst[@name='facet_fields']/lst[@name='name']/int[@name='George'][.='1']");
     }
+    params.set("facet.field", "{!ex=tg}name");
+    params.set("fq", "{!tag=tg}name:George");
+    try (SolrQueryRequest mltreq = new LocalSolrQueryRequest(core, params)) {
+      assertQ(
+          mltreq,
+          "//result/doc[1]/str[@name='id'][.='45']",
+          "//lst[@name='facet_counts']/lst[@name='facet_fields']/lst[@name='name']/int[@name='George'][.='1']");
+    }
   }
 
   @Test


### PR DESCRIPTION
Co-authored-by: Renato Haeberli <>

Cherry-pick #1305 