### PR TITLE
SOLR-16635: Resolve crypto keys file path in MiniSolrCloudCluster

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -128,6 +128,9 @@ Improvements
 * SOLR-6312: SolrJ Cloud clients now correctly support isUpdatesToLeaders() being false.  This behavior can also be
   configured per AbstractUpdateRequest instance.  (hossman)
 
+* SOLR-16635: Resolve crypto keys file path in MiniSolrCloudCluster. This eliminates the need to set the system
+  properties `pkiHandlerPublicKeyPath` and `pkiHandlerPrivateKeyPath` before starting MiniSolrCloudCluster when using
+  the Solr test framework. (Tomás Fernández Löbbe)
 
 Optimizations
 ---------------------

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -305,19 +305,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     System.setProperty("solr.cloud.wait-for-updates-with-stale-state-pause", "500");
     System.setProperty("solr.filterCache.async", String.valueOf(random().nextBoolean()));
 
-    System.setProperty(
-        "pkiHandlerPrivateKeyPath",
-        SolrTestCaseJ4.class
-            .getClassLoader()
-            .getResource("cryptokeys/priv_key512_pkcs8.pem")
-            .toExternalForm());
-    System.setProperty(
-        "pkiHandlerPublicKeyPath",
-        SolrTestCaseJ4.class
-            .getClassLoader()
-            .getResource("cryptokeys/pub_key512.der")
-            .toExternalForm());
-
     System.setProperty(ZK_WHITELIST_PROPERTY, "*");
     startTrackingSearchers();
     ignoreException("ignore_exception");

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandles;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -89,6 +90,10 @@ import org.slf4j.LoggerFactory;
 public class MiniSolrCloudCluster {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final URL PRE_GENERATED_PRIVATE_K_URL =
+      MiniSolrCloudCluster.class.getClassLoader().getResource("cryptokeys/priv_key512_pkcs8.pem");
+  private static final URL PRE_GENERATED_PUBLIC_K_URL =
+      MiniSolrCloudCluster.class.getClassLoader().getResource("cryptokeys/pub_key512.der");
 
   public static final String TEST_URL_ALLOW_LIST = SolrTestCaseJ4.TEST_URL_ALLOW_LIST;
 
@@ -123,8 +128,14 @@ public class MiniSolrCloudCluster {
           + "    <int name=\"distribUpdateSoTimeout\">${distribUpdateSoTimeout:340000}</int>\n"
           + "    <str name=\"zkCredentialsProvider\">${zkCredentialsProvider:org.apache.solr.common.cloud.DefaultZkCredentialsProvider}</str> \n"
           + "    <str name=\"zkACLProvider\">${zkACLProvider:org.apache.solr.common.cloud.DefaultZkACLProvider}</str> \n"
-          + "    <str name=\"pkiHandlerPrivateKeyPath\">${pkiHandlerPrivateKeyPath:cryptokeys/priv_key512_pkcs8.pem}</str> \n"
-          + "    <str name=\"pkiHandlerPublicKeyPath\">${pkiHandlerPublicKeyPath:cryptokeys/pub_key512.der}</str> \n"
+          + "    <str name=\"pkiHandlerPrivateKeyPath\">${pkiHandlerPrivateKeyPath:"
+          + (PRE_GENERATED_PRIVATE_K_URL != null
+              ? PRE_GENERATED_PRIVATE_K_URL.toExternalForm()
+              : "")
+          + "}</str> \n"
+          + "    <str name=\"pkiHandlerPublicKeyPath\">${pkiHandlerPublicKeyPath:"
+          + (PRE_GENERATED_PUBLIC_K_URL != null ? PRE_GENERATED_PUBLIC_K_URL.toExternalForm() : "")
+          + "}</str> \n"
           + "    <str name=\"distributedClusterStateUpdates\">${solr.distributedClusterStateUpdates:false}</str> \n"
           + "    <str name=\"distributedCollectionConfigSetExecution\">${solr.distributedCollectionConfigSetExecution:false}</str> \n"
           + "  </solrcloud>\n"

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -90,9 +90,9 @@ import org.slf4j.LoggerFactory;
 public class MiniSolrCloudCluster {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private static final URL PRE_GENERATED_PRIVATE_K_URL =
+  private static final URL PRE_GENERATED_PRIVATE_KEY_URL =
       MiniSolrCloudCluster.class.getClassLoader().getResource("cryptokeys/priv_key512_pkcs8.pem");
-  private static final URL PRE_GENERATED_PUBLIC_K_URL =
+  private static final URL PRE_GENERATED_PUBLIC_KEY_URL =
       MiniSolrCloudCluster.class.getClassLoader().getResource("cryptokeys/pub_key512.der");
 
   public static final String TEST_URL_ALLOW_LIST = SolrTestCaseJ4.TEST_URL_ALLOW_LIST;
@@ -129,12 +129,12 @@ public class MiniSolrCloudCluster {
           + "    <str name=\"zkCredentialsProvider\">${zkCredentialsProvider:org.apache.solr.common.cloud.DefaultZkCredentialsProvider}</str> \n"
           + "    <str name=\"zkACLProvider\">${zkACLProvider:org.apache.solr.common.cloud.DefaultZkACLProvider}</str> \n"
           + "    <str name=\"pkiHandlerPrivateKeyPath\">${pkiHandlerPrivateKeyPath:"
-          + (PRE_GENERATED_PRIVATE_K_URL != null
-              ? PRE_GENERATED_PRIVATE_K_URL.toExternalForm()
+          + (PRE_GENERATED_PRIVATE_KEY_URL != null
+              ? PRE_GENERATED_PRIVATE_KEY_URL.toExternalForm()
               : "")
           + "}</str> \n"
           + "    <str name=\"pkiHandlerPublicKeyPath\">${pkiHandlerPublicKeyPath:"
-          + (PRE_GENERATED_PUBLIC_K_URL != null ? PRE_GENERATED_PUBLIC_K_URL.toExternalForm() : "")
+          + (PRE_GENERATED_PUBLIC_KEY_URL != null ? PRE_GENERATED_PUBLIC_KEY_URL.toExternalForm() : "")
           + "}</str> \n"
           + "    <str name=\"distributedClusterStateUpdates\">${solr.distributedClusterStateUpdates:false}</str> \n"
           + "    <str name=\"distributedCollectionConfigSetExecution\">${solr.distributedCollectionConfigSetExecution:false}</str> \n"

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -134,7 +134,9 @@ public class MiniSolrCloudCluster {
               : "")
           + "}</str> \n"
           + "    <str name=\"pkiHandlerPublicKeyPath\">${pkiHandlerPublicKeyPath:"
-          + (PRE_GENERATED_PUBLIC_KEY_URL != null ? PRE_GENERATED_PUBLIC_KEY_URL.toExternalForm() : "")
+          + (PRE_GENERATED_PUBLIC_KEY_URL != null
+              ? PRE_GENERATED_PUBLIC_KEY_URL.toExternalForm()
+              : "")
           + "}</str> \n"
           + "    <str name=\"distributedClusterStateUpdates\">${solr.distributedClusterStateUpdates:false}</str> \n"
           + "    <str name=\"distributedCollectionConfigSetExecution\">${solr.distributedCollectionConfigSetExecution:false}</str> \n"


### PR DESCRIPTION
By resolving the full path of the pre-generated crypto keys in `MiniSolrCloudCluster` we make sure it also works for third party projects testing using Solr test framework