### PR TITLE
Fix broken documentation for gcs-backups

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
@@ -654,9 +654,9 @@ An example configuration using the overall and GCS-client properties can be seen
     <str name="location">/default/gcs/backup/location</str>
 
     <int name="gcsClientMaxRetries">5</int>
-    <int name="gcsClientHttpInitialHttpDelayMillis">1500</int>
+    <int name="gcsClientHttpInitialRetryDelayMillis">1500</int>
     <double name="gcsClientHttpRetryDelayMultiplier">1.5</double>
-    <int name="gcsClientMaxHttpRetryDelayMillis">10000</int>
+    <int name="gcsClientHttpMaxRetryDelayMillis">10000</int>
   </repository>
 </backup>
 ----


### PR DESCRIPTION
# Description

Configuration keys were mixed up making it hard to find them in the documentation and even harder to debug timeouts on backup.

# Solution

Fixed the documentation.

# Tests

n/a

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
