### PR TITLE
SOLR-16531: Disable unused Jersey features

### DIFF
--- a/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
+++ b/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
@@ -20,6 +20,7 @@ package org.apache.solr.jersey;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
+import java.util.Map;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -79,6 +80,16 @@ public class JerseyApplications {
                   .in(RequestScoped.class);
             }
           });
+
+      setProperties(
+          Map.of(
+              "jersey.config.server.wadl.disableWadl", "true",
+              "jersey.config.beanValidation.disable.server", "true",
+              "jersey.config.server.disableAutoDiscovery", "true",
+              "jersey.config.server.disableJsonProcessing", "true",
+              "jersey.config.server.disableMetainfServicesLookup", "true",
+              "jersey.config.server.disableMoxyJson", "true",
+              "jersey.config.server.resource.validation.disable", "true"));
       // Logging - disabled by default but useful for debugging Jersey execution
       //      setProperties(
       //          Map.of(

--- a/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
+++ b/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
@@ -85,6 +85,9 @@ public class JerseyApplications {
 
       setProperties(
           Map.of(
+              // Explicit Jersey logging is disabled by default but useful for debugging
+              // "jersey.config.server.tracing.type", "ALL",
+              // "jersey.config.server.tracing.threshold", "VERBOSE",
               "jersey.config.server.wadl.disableWadl", "true",
               "jersey.config.beanValidation.disable.server", "true",
               "jersey.config.server.disableAutoDiscovery", "true",
@@ -92,13 +95,6 @@ public class JerseyApplications {
               "jersey.config.server.disableMetainfServicesLookup", "true",
               "jersey.config.server.disableMoxyJson", "true",
               "jersey.config.server.resource.validation.disable", "true"));
-      // Logging - disabled by default but useful for debugging Jersey execution
-      //      setProperties(
-      //          Map.of(
-      //              "jersey.config.server.tracing.type",
-      //              "ALL",
-      //              "jersey.config.server.tracing.threshold",
-      //              "VERBOSE"));
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
+++ b/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
@@ -26,6 +26,7 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.SolrVersion;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ResourceConfig;
 
@@ -54,6 +55,7 @@ public class JerseyApplications {
       register(MessageBodyWriters.JavabinMessageBodyWriter.class);
       register(MessageBodyWriters.XmlMessageBodyWriter.class);
       register(MessageBodyWriters.CsvMessageBodyWriter.class);
+      register(JacksonJsonProvider.class);
       register(SolrJacksonMapper.class);
 
       // Request lifecycle logic


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16531

# Description

Jersey has several optional features that we don't need or use.  Disabling these keeps our use of Jersey as lightweight as possible.

# Solution

These features are disabled by setting particular configuration props in each Jersey 'application' that gets created.

# Tests

Manually tested via log-message inspection.  Manual validation of the improved Jersey app-startup performance.  Existing tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
