### PR TITLE
what happens if we remove SSL annotation?

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZk2Test.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZk2Test.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.junit.Test;
 
 /**
@@ -24,7 +23,6 @@ import org.junit.Test;
  * expected. Implementation moved to AbstractBasicDistributedZk2TestBase as it is used by HDFS
  * contrib module tests.
  */
-@SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class BasicDistributedZk2Test extends AbstractBasicDistributedZk2TestBase {
 
   @Test

--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.junit.Test;
 
 /**
@@ -24,7 +23,6 @@ import org.junit.Test;
  * expected. Implementation moved to AbstractBasicDistributedZkTestBase as it is used by many HDFS
  * contrib tests.
  */
-@SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class BasicDistributedZkTest extends AbstractBasicDistributedZkTestBase {
 
   @Test

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/CollectionReloadTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/CollectionReloadTest.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Verifies cluster state remains consistent after collection reload. */
-@SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class CollectionReloadTest extends SolrCloudTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/CollectionReloadTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/CollectionReloadTest.java
@@ -18,7 +18,6 @@ package org.apache.solr.cloud.api.collections;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
-import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.cloud.Replica;

--- a/solr/test-framework/src/java/org/apache/solr/util/RandomizeSSL.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/RandomizeSSL.java
@@ -154,7 +154,7 @@ public @interface RandomizeSSL {
         //
         // (If it didn't work this way, it would be a pain in the ass to quickly disable SSL for a
         // broad hierarchy of tests)
-        return new SSLRandomizer(0.0D, 0.0D, suppressSSL.toString());
+        return new SSLRandomizer(1.0D, 1.0D, suppressSSL.toString());
       }
 
       final RandomizeSSL randomizeSSL = clazz.getAnnotation(RandomizeSSL.class);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-XXXXX



# Description

I am attempting to remove the SSL annotation and have Crave run the test suite to see what happens.  I don't yet know how to force SSL to be used to trigger the problem (or NOT problem)...  Maybe can change the randomization to not be random at all?

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
