### PR TITLE
SOLR-16595: Standardize Solr Client Builders handling of times

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -140,6 +140,9 @@ Improvements
 
 * SOLR-16590: Standardize Builder method names on SolrClient's to use the with pattern, deprecating the use of set or bare property name.  (Eric Pugh)
 
+* SOLR-16595: Standardize Builder methods handling of times to use require a TimeUnit to be passed in.  Deprecated methods that
+  do not specify a TimeUnit.  (Eric Pugh)
+
 Optimizations
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -283,7 +283,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
     this.defaultClient =
         new Http2SolrClient.Builder()
             .withConnectionTimeout(connectionTimeout)
-            .withIdleTimeout(soTimeout)
+            .withIdleTimeout(soTimeout, TimeUnit.MILLISECONDS)
             .withExecutor(commExecutor)
             .withMaxConnectionsPerHost(maxConnectionsPerHost)
             .build();

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -282,7 +282,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
 
     this.defaultClient =
         new Http2SolrClient.Builder()
-            .withConnectionTimeout(connectionTimeout)
+            .withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
             .withIdleTimeout(soTimeout, TimeUnit.MILLISECONDS)
             .withExecutor(commExecutor)
             .withMaxConnectionsPerHost(maxConnectionsPerHost)

--- a/solr/core/src/java/org/apache/solr/update/StreamingSolrClients.java
+++ b/solr/core/src/java/org/apache/solr/update/StreamingSolrClients.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
@@ -39,7 +40,8 @@ public class StreamingSolrClients {
 
   private final int runnerCount = Integer.getInteger("solr.cloud.replication.runners", 1);
   // should be less than solr.jetty.http.idleTimeout
-  private final int pollQueueTime = Integer.getInteger("solr.cloud.client.pollQueueTime", 10000);
+  private final int pollQueueTimeMillis =
+      Integer.getInteger("solr.cloud.client.pollQueueTime", 10000);
 
   private Http2SolrClient httpClient;
 
@@ -74,7 +76,8 @@ public class StreamingSolrClients {
               .withThreadCount(runnerCount)
               .withExecutorService(updateExecutor)
               .alwaysStreamDeletes()
-              .setPollQueueTime(pollQueueTime) // minimize connections created
+              .setPollQueueTime(
+                  pollQueueTimeMillis, TimeUnit.MILLISECONDS) // minimize connections created
               .build();
 
       solrClients.put(url, client);

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -144,7 +144,7 @@ public class UpdateShardHandler implements SolrInfoBean {
     Http2SolrClient.Builder updateOnlyClientBuilder = new Http2SolrClient.Builder();
     if (cfg != null) {
       updateOnlyClientBuilder
-          .withConnectionTimeout(cfg.getDistributedConnectionTimeout())
+          .withConnectionTimeout(cfg.getDistributedConnectionTimeout(), TimeUnit.MILLISECONDS)
           .withIdleTimeout(cfg.getDistributedSocketTimeout(), TimeUnit.MILLISECONDS)
           .withMaxConnectionsPerHost(cfg.getMaxUpdateConnectionsPerHost());
     }

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -145,7 +145,7 @@ public class UpdateShardHandler implements SolrInfoBean {
     if (cfg != null) {
       updateOnlyClientBuilder
           .withConnectionTimeout(cfg.getDistributedConnectionTimeout())
-          .withIdleTimeout(cfg.getDistributedSocketTimeout())
+          .withIdleTimeout(cfg.getDistributedSocketTimeout(), TimeUnit.MILLISECONDS)
           .withMaxConnectionsPerHost(cfg.getMaxUpdateConnectionsPerHost());
     }
     updateOnlyClientBuilder.withTheseParamNamesInTheUrl(urlParamNames);

--- a/solr/core/src/test/org/apache/solr/update/MockingHttp2SolrClient.java
+++ b/solr/core/src/test/org/apache/solr/update/MockingHttp2SolrClient.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketException;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -55,7 +57,7 @@ public class MockingHttp2SolrClient extends Http2SolrClient {
     public Builder(UpdateShardHandlerConfig config) {
       super();
       this.withConnectionTimeout(config.getDistributedConnectionTimeout());
-      this.withIdleTimeout(config.getDistributedSocketTimeout());
+      this.withIdleTimeout(config.getDistributedSocketTimeout(), TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/solr/core/src/test/org/apache/solr/update/MockingHttp2SolrClient.java
+++ b/solr/core/src/test/org/apache/solr/update/MockingHttp2SolrClient.java
@@ -22,7 +22,6 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -56,7 +55,7 @@ public class MockingHttp2SolrClient extends Http2SolrClient {
 
     public Builder(UpdateShardHandlerConfig config) {
       super();
-      this.withConnectionTimeout(config.getDistributedConnectionTimeout());
+      this.withConnectionTimeout(config.getDistributedConnectionTimeout(), TimeUnit.MILLISECONDS);
       this.withIdleTimeout(config.getDistributedSocketTimeout(), TimeUnit.MILLISECONDS);
     }
 

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrClientFactory.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrClientFactory.java
@@ -38,7 +38,7 @@ public class SolrClientFactory {
     Http2SolrClient http2SolrClient =
         new Http2SolrClient.Builder(solrHost)
             .withIdleTimeout(settings.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
-            .withConnectionTimeout(settings.getHttpConnectionTimeout())
+            .withConnectionTimeout(settings.getHttpConnectionTimeout(), TimeUnit.MILLISECONDS)
             .withResponseParser(new NoOpResponseParser("json"))
             .build();
 
@@ -57,7 +57,8 @@ public class SolrClientFactory {
             .withInternalClientBuilder(
                 new Http2SolrClient.Builder()
                     .withIdleTimeout(settings.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
-                    .withConnectionTimeout(settings.getHttpConnectionTimeout()))
+                    .withConnectionTimeout(
+                        settings.getHttpConnectionTimeout(), TimeUnit.MILLISECONDS))
             .withResponseParser(new NoOpResponseParser("json"))
             .build();
 

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrClientFactory.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrClientFactory.java
@@ -18,6 +18,7 @@
 package org.apache.solr.prometheus.exporter;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
@@ -36,7 +37,7 @@ public class SolrClientFactory {
   public Http2SolrClient createStandaloneSolrClient(String solrHost) {
     Http2SolrClient http2SolrClient =
         new Http2SolrClient.Builder(solrHost)
-            .withIdleTimeout(settings.getHttpReadTimeout())
+            .withIdleTimeout(settings.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
             .withConnectionTimeout(settings.getHttpConnectionTimeout())
             .withResponseParser(new NoOpResponseParser("json"))
             .build();
@@ -55,7 +56,7 @@ public class SolrClientFactory {
                 Optional.ofNullable(parser.getChrootPath()))
             .withInternalClientBuilder(
                 new Http2SolrClient.Builder()
-                    .withIdleTimeout(settings.getHttpReadTimeout())
+                    .withIdleTimeout(settings.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
                     .withConnectionTimeout(settings.getHttpConnectionTimeout()))
             .withResponseParser(new NoOpResponseParser("json"))
             .build();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -315,19 +315,19 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     /**
      * This is the time to wait to refetch the state after getting the same state version from ZK
      *
-     * @deprecated Please use {@link #withRetryExpiryTime(int)} *
+     * @deprecated Please use {@link #withRetryExpiryTime(long, TimeUnit)}
      */
     @Deprecated(since = "9.2")
     public Builder setRetryExpiryTime(int secs) {
-      this.withRetryExpiryTime(secs);
+      this.withRetryExpiryTime(secs, TimeUnit.SECONDS);
       return this;
     }
 
     /**
      * This is the time to wait to refetch the state after getting the same state version from ZK
      */
-    public Builder withRetryExpiryTime(int secs) {
-      this.retryExpiryTime = TimeUnit.NANOSECONDS.convert(secs, TimeUnit.SECONDS);
+    public Builder withRetryExpiryTime(long expiryTime, TimeUnit unit) {
+      this.retryExpiryTime = TimeUnit.NANOSECONDS.convert(expiryTime, unit);
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -154,7 +154,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     private ResponseParser responseParser;
     private long retryExpiryTimeNano =
         TimeUnit.NANOSECONDS.convert(3, TimeUnit.SECONDS); // 3 seconds or 3 million nanos
-    private long timeToLiveSeconds = TimeUnit.SECONDS.convert(60, TimeUnit.SECONDS);
+    private long timeToLiveSeconds = 60;
     private int parallelCacheRefreshesLocks = 3;
 
     /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -65,7 +65,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
       this.clientIsInternal = false;
       this.myClient = builder.httpClient;
     }
-    this.retryExpiryTime = builder.retryExpiryTime;
+    this.retryExpiryTimeNano = builder.retryExpiryTimeNano;
     if (builder.requestWriter != null) {
       this.myClient.requestWriter = builder.requestWriter;
     }
@@ -98,7 +98,8 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
       this.stateProvider = builder.stateProvider;
     }
 
-    this.collectionStateCache.timeToLiveMs = builder.timeToLiveSeconds * 1000L;
+    this.collectionStateCache.timeToLiveMs =
+        TimeUnit.MILLISECONDS.convert(builder.timeToLiveSeconds, TimeUnit.SECONDS);
 
     //  If caches are expired then they are refreshed after acquiring a lock. Set the number of
     // locks.
@@ -151,9 +152,9 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     protected Http2SolrClient.Builder internalClientBuilder;
     private RequestWriter requestWriter;
     private ResponseParser responseParser;
-    private long retryExpiryTime =
+    private long retryExpiryTimeNano =
         TimeUnit.NANOSECONDS.convert(3, TimeUnit.SECONDS); // 3 seconds or 3 million nanos
-    private int timeToLiveSeconds = 60;
+    private long timeToLiveSeconds = TimeUnit.SECONDS.convert(60, TimeUnit.SECONDS);
     private int parallelCacheRefreshesLocks = 3;
 
     /**
@@ -327,7 +328,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
      * This is the time to wait to refetch the state after getting the same state version from ZK
      */
     public Builder withRetryExpiryTime(long expiryTime, TimeUnit unit) {
-      this.retryExpiryTime = TimeUnit.NANOSECONDS.convert(expiryTime, unit);
+      this.retryExpiryTimeNano = TimeUnit.NANOSECONDS.convert(expiryTime, unit);
       return this;
     }
 
@@ -335,10 +336,22 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
      * Sets the cache ttl for DocCollection Objects cached.
      *
      * @param timeToLiveSeconds ttl value in seconds
+     * @deprecated Please use {@link #withCollectionCacheTtl(long, TimeUnit)}
      */
+    @Deprecated(since = "9.2")
     public Builder withCollectionCacheTtl(int timeToLiveSeconds) {
-      assert timeToLiveSeconds > 0;
-      this.timeToLiveSeconds = timeToLiveSeconds;
+      withCollectionCacheTtl(timeToLiveSeconds, TimeUnit.SECONDS);
+      return this;
+    }
+
+    /**
+     * Sets the cache ttl for DocCollection Objects cached.
+     *
+     * @param timeToLive ttl value
+     */
+    public Builder withCollectionCacheTtl(long timeToLive, TimeUnit unit) {
+      assert timeToLive > 0;
+      this.timeToLiveSeconds = TimeUnit.SECONDS.convert(timeToLive, unit);
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
@@ -107,11 +107,11 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     final LBHttpSolrClient.Builder lbBuilder = builder.lbClientBuilder;
 
     if (builder.connectionTimeoutMillis != null) {
-      lbBuilder.withConnectionTimeout(builder.connectionTimeoutMillis);
+      lbBuilder.withConnectionTimeout(builder.connectionTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     if (builder.socketTimeoutMillis != null) {
-      lbBuilder.withSocketTimeout(builder.socketTimeoutMillis);
+      lbBuilder.withSocketTimeout(builder.socketTimeoutMillis, TimeUnit.MILLISECONDS);
     }
   }
 
@@ -176,10 +176,12 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     final LBHttpSolrClient.Builder lbBuilder = new LBHttpSolrClient.Builder();
     lbBuilder.withHttpClient(httpClient);
     if (cloudSolrClientBuilder.connectionTimeoutMillis != null) {
-      lbBuilder.withConnectionTimeout(cloudSolrClientBuilder.connectionTimeoutMillis);
+      lbBuilder.withConnectionTimeout(
+          cloudSolrClientBuilder.connectionTimeoutMillis, TimeUnit.MILLISECONDS);
     }
     if (cloudSolrClientBuilder.socketTimeoutMillis != null) {
-      lbBuilder.withSocketTimeout(cloudSolrClientBuilder.socketTimeoutMillis);
+      lbBuilder.withSocketTimeout(
+          cloudSolrClientBuilder.socketTimeoutMillis, TimeUnit.MILLISECONDS);
     }
     lbBuilder.withRequestWriter(new BinaryRequestWriter());
     lbBuilder.withResponseParser(new BinaryResponseParser());

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
@@ -87,7 +87,8 @@ public class CloudLegacySolrClient extends CloudSolrClient {
       this.stateProvider = builder.stateProvider;
     }
     this.retryExpiryTimeNano = builder.retryExpiryTimeNano;
-    this.collectionStateCache.timeToLiveMs = TimeUnit.MILLISECONDS.convert(builder.timeToLiveSeconds, TimeUnit.SECONDS);
+    this.collectionStateCache.timeToLiveMs =
+        TimeUnit.MILLISECONDS.convert(builder.timeToLiveSeconds, TimeUnit.SECONDS);
     this.clientIsInternal = builder.httpClient == null;
     this.shutdownLBHttpSolrServer = builder.loadBalancedSolrClient == null;
     if (builder.lbClientBuilder != null) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
@@ -86,7 +86,7 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     } else {
       this.stateProvider = builder.stateProvider;
     }
-    this.retryExpiryTime = builder.retryExpiryTime;
+    this.retryExpiryTimeNano = builder.retryExpiryTime;
     this.collectionStateCache.timeToLiveMs = builder.timeToLiveSeconds * 1000L;
     this.clientIsInternal = builder.httpClient == null;
     this.shutdownLBHttpSolrServer = builder.loadBalancedSolrClient == null;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
@@ -86,8 +86,8 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     } else {
       this.stateProvider = builder.stateProvider;
     }
-    this.retryExpiryTimeNano = builder.retryExpiryTime;
-    this.collectionStateCache.timeToLiveMs = builder.timeToLiveSeconds * 1000L;
+    this.retryExpiryTimeNano = builder.retryExpiryTimeNano;
+    this.collectionStateCache.timeToLiveMs = TimeUnit.MILLISECONDS.convert(builder.timeToLiveSeconds, TimeUnit.SECONDS);
     this.clientIsInternal = builder.httpClient == null;
     this.shutdownLBHttpSolrServer = builder.loadBalancedSolrClient == null;
     if (builder.lbClientBuilder != null) {
@@ -199,7 +199,7 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     protected boolean shardLeadersOnly = true;
     protected boolean directUpdatesToLeadersOnly = false;
     protected boolean parallelUpdates = true;
-    protected long retryExpiryTime =
+    protected long retryExpiryTimeNano =
         TimeUnit.NANOSECONDS.convert(3, TimeUnit.SECONDS); // 3 seconds or 3 million nanos
     protected ClusterStateProvider stateProvider;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -239,25 +239,25 @@ public abstract class CloudSolrClient extends SolrClient {
 
   class ExpiringCachedDocCollection {
     final DocCollection cached;
-    final long cachedAt;
+    final long cachedAtNano;
     // This is the time at which the collection is retried and got the same old version
-    volatile long retriedAt = -1;
+    volatile long retriedAtNano = -1;
     // flag that suggests that this is potentially to be rechecked
     volatile boolean maybeStale = false;
 
     ExpiringCachedDocCollection(DocCollection cached) {
       this.cached = cached;
-      this.cachedAt = System.nanoTime();
+      this.cachedAtNano = System.nanoTime();
     }
 
     boolean isExpired(long timeToLiveMs) {
-      return (System.nanoTime() - cachedAt)
+      return (System.nanoTime() - cachedAtNano)
           > TimeUnit.NANOSECONDS.convert(timeToLiveMs, TimeUnit.MILLISECONDS);
     }
 
     boolean shouldRetry() {
       if (maybeStale) { // we are not sure if it is stale so check with retry time
-        if ((retriedAt == -1 || (System.nanoTime() - retriedAt) > retryExpiryTimeNano)) {
+        if ((retriedAtNano == -1 || (System.nanoTime() - retriedAtNano) > retryExpiryTimeNano)) {
           return true; // we retried a while back. and we could not get anything new.
           // it's likely that it is not going to be available now also.
         }
@@ -266,7 +266,7 @@ public abstract class CloudSolrClient extends SolrClient {
     }
 
     void setRetriedAt() {
-      retriedAt = System.nanoTime();
+      retriedAtNano = System.nanoTime();
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -105,7 +105,7 @@ public abstract class CloudSolrClient extends SolrClient {
           new SolrNamedThreadFactory("CloudSolrClient ThreadPool"));
 
   public static final String STATE_VERSION = "_stateVer_";
-  protected long retryExpiryTime =
+  protected long retryExpiryTimeNano =
       TimeUnit.NANOSECONDS.convert(3, TimeUnit.SECONDS); // 3 seconds or 3 million nanos
   private static final Set<String> NON_ROUTABLE_PARAMS =
       Set.of(
@@ -232,7 +232,7 @@ public abstract class CloudSolrClient extends SolrClient {
    */
   @Deprecated
   public void setRetryExpiryTime(int secs) {
-    this.retryExpiryTime = TimeUnit.NANOSECONDS.convert(secs, TimeUnit.SECONDS);
+    this.retryExpiryTimeNano = TimeUnit.NANOSECONDS.convert(secs, TimeUnit.SECONDS);
   }
 
   protected final StateCache collectionStateCache = new StateCache();
@@ -257,7 +257,7 @@ public abstract class CloudSolrClient extends SolrClient {
 
     boolean shouldRetry() {
       if (maybeStale) { // we are not sure if it is stale so check with retry time
-        if ((retriedAt == -1 || (System.nanoTime() - retriedAt) > retryExpiryTime)) {
+        if ((retriedAt == -1 || (System.nanoTime() - retriedAt) > retryExpiryTimeNano)) {
           return true; // we retried a while back. and we could not get anything new.
           // it's likely that it is not going to be available now also.
         }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -105,8 +105,8 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
     this.client =
         new HttpSolrClient.Builder(builder.baseSolrUrl)
             .withHttpClient(builder.httpClient)
-            .withConnectionTimeout(builder.connectionTimeoutMillis)
-            .withSocketTimeout(builder.socketTimeoutMillis)
+            .withConnectionTimeout(builder.connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+            .withSocketTimeout(builder.socketTimeoutMillis, TimeUnit.MILLISECONDS)
             .withFollowRedirects(false)
             .withTheseParamNamesInTheUrl(builder.urlParamNames)
             .build();
@@ -114,8 +114,8 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
     this.threadCount = builder.threadCount;
     this.runners = new ArrayDeque<>();
     this.streamDeletes = builder.streamDeletes;
-    this.connectionTimeout = builder.connectionTimeoutMillis;
-    this.soTimeout = builder.socketTimeoutMillis;
+    this.connectionTimeout = Math.toIntExact(builder.connectionTimeoutMillis);
+    this.soTimeout = Math.toIntExact(builder.socketTimeoutMillis);
     this.stallTime = Integer.getInteger("solr.cloud.client.stallTime", 15000);
     if (stallTime < pollQueueTime * 2) {
       throw new RuntimeException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -158,8 +158,8 @@ public class Http2SolrClient extends SolrClient {
       this.serverBaseUrl = serverBaseUrl;
     }
 
-    if (builder.idleTimeout != null && builder.idleTimeout > 0) {
-      idleTimeout = builder.idleTimeout;
+    if (builder.idleTimeoutMillis != null && builder.idleTimeoutMillis > 0) {
+      idleTimeout = builder.idleTimeoutMillis;
     } else {
       idleTimeout = HttpClientUtil.DEFAULT_SO_TIMEOUT;
     }
@@ -183,10 +183,10 @@ public class Http2SolrClient extends SolrClient {
     if (builder.responseParser != null) {
       parser = builder.responseParser;
     }
-    if (builder.requestTimeout == null) {
+    if (builder.requestTimeoutMillis == null) {
       requestTimeout = -1;
     } else {
-      requestTimeout = builder.requestTimeout;
+      requestTimeout = builder.requestTimeoutMillis;
     }
     httpClient.setFollowRedirects(builder.followRedirects);
     this.urlParamNames = builder.urlParamNames;
@@ -274,7 +274,8 @@ public class Http2SolrClient extends SolrClient {
     this.authenticationStore = new AuthenticationStoreHolder();
     httpClient.setAuthenticationStore(this.authenticationStore);
 
-    if (builder.connectionTimeout != null) httpClient.setConnectTimeout(builder.connectionTimeout);
+    if (builder.connectionTimeoutMillis != null)
+      httpClient.setConnectTimeout(builder.connectionTimeoutMillis);
 
     try {
       httpClient.start();
@@ -983,9 +984,9 @@ public class Http2SolrClient extends SolrClient {
 
     private Http2SolrClient http2SolrClient;
     private SSLConfig sslConfig = defaultSSLConfig;
-    private Long idleTimeout;
-    private Long connectionTimeout;
-    private Long requestTimeout;
+    private Long idleTimeoutMillis;
+    private Long connectionTimeoutMillis;
+    private Long requestTimeoutMillis;
     private Integer maxConnectionsPerHost;
     private String basicAuthUser;
     private String basicAuthPassword;
@@ -1127,7 +1128,7 @@ public class Http2SolrClient extends SolrClient {
     }
 
     public Builder withIdleTimeout(long idleConnectionTimeout, TimeUnit unit) {
-      this.idleTimeout = TimeUnit.MILLISECONDS.convert(idleConnectionTimeout, unit);
+      this.idleTimeoutMillis = TimeUnit.MILLISECONDS.convert(idleConnectionTimeout, unit);
       return this;
     }
 
@@ -1146,7 +1147,7 @@ public class Http2SolrClient extends SolrClient {
     }
 
     public Builder withConnectionTimeout(long connectionTimeout, TimeUnit unit) {
-      this.connectionTimeout = TimeUnit.MILLISECONDS.convert(connectionTimeout, unit);
+      this.connectionTimeoutMillis = TimeUnit.MILLISECONDS.convert(connectionTimeout, unit);
       return this;
     }
 
@@ -1170,7 +1171,7 @@ public class Http2SolrClient extends SolrClient {
      * @return this Builder.
      */
     public Builder withRequestTimeout(long requestTimeout, TimeUnit unit) {
-      this.requestTimeout = TimeUnit.MILLISECONDS.convert(requestTimeout, unit);
+      this.requestTimeoutMillis = TimeUnit.MILLISECONDS.convert(requestTimeout, unit);
       return this;
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -129,7 +129,7 @@ public class Http2SolrClient extends SolrClient {
 
   private HttpClient httpClient;
   private volatile Set<String> urlParamNames = Set.of();
-  private int idleTimeout;
+  private long idleTimeout;
   private int requestTimeout;
 
   protected ResponseParser parser = new BinaryResponseParser();
@@ -158,8 +158,12 @@ public class Http2SolrClient extends SolrClient {
       this.serverBaseUrl = serverBaseUrl;
     }
 
-    if (builder.idleTimeout != null && builder.idleTimeout > 0) idleTimeout = builder.idleTimeout;
-    else idleTimeout = HttpClientUtil.DEFAULT_SO_TIMEOUT;
+    if (builder.idleTimeout != null && builder.idleTimeout > 0) {
+      idleTimeout = builder.idleTimeout;
+    }
+    else {
+      idleTimeout = HttpClientUtil.DEFAULT_SO_TIMEOUT;
+    }
 
     if (builder.http2SolrClient == null) {
       httpClient = createHttpClient(builder);
@@ -980,7 +984,7 @@ public class Http2SolrClient extends SolrClient {
 
     private Http2SolrClient http2SolrClient;
     private SSLConfig sslConfig = defaultSSLConfig;
-    private Integer idleTimeout;
+    private Long idleTimeout;
     private Integer connectionTimeout;
     private Integer requestTimeout;
     private Integer maxConnectionsPerHost;
@@ -1115,16 +1119,16 @@ public class Http2SolrClient extends SolrClient {
     }
 
     /**
-     * @deprecated Please use {@link #withIdleTimeout(int)}
+     * @deprecated Please use {@link #withIdleTimeout(long, TimeUnit)}
      */
     @Deprecated(since = "9.2")
     public Builder idleTimeout(int idleConnectionTimeout) {
-      withIdleTimeout(idleConnectionTimeout);
+      withIdleTimeout(idleConnectionTimeout, TimeUnit.MILLISECONDS);
       return this;
     }
 
-    public Builder withIdleTimeout(int idleConnectionTimeout) {
-      this.idleTimeout = idleConnectionTimeout;
+    public Builder withIdleTimeout(long idleConnectionTimeout, TimeUnit unit) {
+      this.idleTimeout = TimeUnit.MILLISECONDS.convert(idleConnectionTimeout, unit);
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -130,7 +130,7 @@ public class Http2SolrClient extends SolrClient {
   private HttpClient httpClient;
   private volatile Set<String> urlParamNames = Set.of();
   private long idleTimeout;
-  private int requestTimeout;
+  private long requestTimeout;
 
   protected ResponseParser parser = new BinaryResponseParser();
   protected RequestWriter requestWriter = new BinaryRequestWriter();
@@ -160,8 +160,7 @@ public class Http2SolrClient extends SolrClient {
 
     if (builder.idleTimeout != null && builder.idleTimeout > 0) {
       idleTimeout = builder.idleTimeout;
-    }
-    else {
+    } else {
       idleTimeout = HttpClientUtil.DEFAULT_SO_TIMEOUT;
     }
 
@@ -985,8 +984,8 @@ public class Http2SolrClient extends SolrClient {
     private Http2SolrClient http2SolrClient;
     private SSLConfig sslConfig = defaultSSLConfig;
     private Long idleTimeout;
-    private Integer connectionTimeout;
-    private Integer requestTimeout;
+    private Long connectionTimeout;
+    private Long requestTimeout;
     private Integer maxConnectionsPerHost;
     private String basicAuthUser;
     private String basicAuthPassword;
@@ -1138,29 +1137,29 @@ public class Http2SolrClient extends SolrClient {
     }
 
     /**
-     * @deprecated Please use {@link #withConnectionTimeout(int)}
+     * @deprecated Please use {@link #withConnectionTimeout(long, TimeUnit)}
      */
     @Deprecated(since = "9.2")
     public Builder connectionTimeout(int connectionTimeout) {
-      withConnectionTimeout(connectionTimeout);
+      withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
       return this;
     }
 
-    public Builder withConnectionTimeout(int connectionTimeout) {
-      this.connectionTimeout = connectionTimeout;
+    public Builder withConnectionTimeout(long connectionTimeout, TimeUnit unit) {
+      this.connectionTimeout = TimeUnit.MILLISECONDS.convert(connectionTimeout, unit);
       return this;
     }
 
     /**
      * Set a timeout in milliseconds for requests issued by this client.
      *
-     * @deprecated Please use {@link #withRequestTimeout(int)}
+     * @deprecated Please use {@link #withRequestTimeout(long, TimeUnit)}
      * @param requestTimeout The timeout in milliseconds
      * @return this Builder.
      */
     @Deprecated(since = "9.2")
     public Builder requestTimeout(int requestTimeout) {
-      this.requestTimeout = requestTimeout;
+      withRequestTimeout(requestTimeout, TimeUnit.MILLISECONDS);
       return this;
     }
 
@@ -1170,8 +1169,8 @@ public class Http2SolrClient extends SolrClient {
      * @param requestTimeout The timeout in milliseconds
      * @return this Builder.
      */
-    public Builder withRequestTimeout(int requestTimeout) {
-      this.requestTimeout = requestTimeout;
+    public Builder withRequestTimeout(long requestTimeout, TimeUnit unit) {
+      this.requestTimeout = TimeUnit.MILLISECONDS.convert(requestTimeout, unit);
       return this;
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -185,8 +185,8 @@ public class HttpSolrClient extends BaseHttpSolrClient {
 
     this.parser = builder.responseParser;
     this.invariantParams = builder.invariantParams;
-    this.connectionTimeout = builder.connectionTimeoutMillis;
-    this.soTimeout = builder.socketTimeoutMillis;
+    this.connectionTimeout = Math.toIntExact(builder.connectionTimeoutMillis);
+    this.soTimeout = Math.toIntExact(builder.socketTimeoutMillis);
     this.useMultiPartPost = builder.useMultiPartPost;
     this.urlParamNames = builder.urlParamNames;
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.solr.client.solrj.ResponseParser;
@@ -314,10 +315,9 @@ public class LBHttp2SolrClient extends LBSolrClient {
 
   public static class Builder {
 
-    public static final int CHECK_INTERVAL = 60 * 1000; // 1 minute between checks
     private final Http2SolrClient http2SolrClient;
     private final String[] baseSolrUrls;
-    private int aliveCheckInterval = CHECK_INTERVAL;
+    private long aliveCheckInterval = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
 
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
       this.http2SolrClient = http2Client;
@@ -328,14 +328,15 @@ public class LBHttp2SolrClient extends LBSolrClient {
      * LBHttpSolrServer keeps pinging the dead servers at fixed interval to find if it is alive. Use
      * this to set that interval
      *
-     * @param aliveCheckInterval time in milliseconds
+     * @param aliveCheckInterval how often to ping for aliveness
      */
-    public LBHttp2SolrClient.Builder setAliveCheckInterval(int aliveCheckInterval) {
+    public LBHttp2SolrClient.Builder setAliveCheckInterval(int aliveCheckInterval, TimeUnit unit) {
       if (aliveCheckInterval <= 0) {
         throw new IllegalArgumentException(
             "Alive check interval must be " + "positive, specified value = " + aliveCheckInterval);
       }
-      this.aliveCheckInterval = aliveCheckInterval;
+      this.aliveCheckInterval = TimeUnit.MILLISECONDS.convert(aliveCheckInterval, unit);
+      ;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -337,7 +337,6 @@ public class LBHttp2SolrClient extends LBSolrClient {
             "Alive check interval must be " + "positive, specified value = " + aliveCheckInterval);
       }
       this.aliveCheckIntervalMillis = TimeUnit.MILLISECONDS.convert(aliveCheckInterval, unit);
-      ;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -317,7 +317,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
 
     private final Http2SolrClient http2SolrClient;
     private final String[] baseSolrUrls;
-    private long aliveCheckInterval = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
+    private long aliveCheckIntervalMillis =
+        TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS); // 1 minute between checks
 
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
       this.http2SolrClient = http2Client;
@@ -335,7 +336,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
         throw new IllegalArgumentException(
             "Alive check interval must be " + "positive, specified value = " + aliveCheckInterval);
       }
-      this.aliveCheckInterval = TimeUnit.MILLISECONDS.convert(aliveCheckInterval, unit);
+      this.aliveCheckIntervalMillis = TimeUnit.MILLISECONDS.convert(aliveCheckInterval, unit);
       ;
       return this;
     }
@@ -343,7 +344,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
     public LBHttp2SolrClient build() {
       LBHttp2SolrClient solrClient =
           new LBHttp2SolrClient(this.http2SolrClient, Arrays.asList(this.baseSolrUrls));
-      solrClient.aliveCheckInterval = this.aliveCheckInterval;
+      solrClient.aliveCheckIntervalMillis = this.aliveCheckIntervalMillis;
       return solrClient;
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -81,8 +81,8 @@ public class LBHttpSolrClient extends LBSolrClient {
   private final HttpSolrClient.Builder httpSolrClientBuilder;
   private volatile Set<String> urlParamNames = new HashSet<>();
 
-  private Long connectionTimeout;
-  private volatile Long soTimeout;
+  private Long connectionTimeoutMillis;
+  private volatile Long soTimeoutMillis;
 
   /** The provided httpClient should use a multi-threaded connection manager */
   protected LBHttpSolrClient(Builder builder) {
@@ -93,10 +93,10 @@ public class LBHttpSolrClient extends LBSolrClient {
         builder.httpClient == null
             ? constructClient(builder.baseSolrUrls.toArray(new String[builder.baseSolrUrls.size()]))
             : builder.httpClient;
-    this.connectionTimeout = builder.connectionTimeoutMillis;
-    this.soTimeout = builder.socketTimeoutMillis;
+    this.connectionTimeoutMillis = builder.connectionTimeoutMillis;
+    this.soTimeoutMillis = builder.socketTimeoutMillis;
     this.parser = builder.responseParser;
-    this.aliveCheckInterval = builder.aliveCheckInterval;
+    this.aliveCheckIntervalMillis = builder.aliveCheckInterval;
     for (String baseUrl : builder.baseSolrUrls) {
       urlToClient.put(baseUrl, makeSolrClient(baseUrl));
     }
@@ -118,11 +118,12 @@ public class LBHttpSolrClient extends LBSolrClient {
     if (httpSolrClientBuilder != null) {
       synchronized (this) {
         httpSolrClientBuilder.withBaseSolrUrl(server).withHttpClient(httpClient);
-        if (connectionTimeout != null) {
-          httpSolrClientBuilder.withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
+        if (connectionTimeoutMillis != null) {
+          httpSolrClientBuilder.withConnectionTimeout(
+              connectionTimeoutMillis, TimeUnit.MILLISECONDS);
         }
-        if (soTimeout != null) {
-          httpSolrClientBuilder.withSocketTimeout(soTimeout, TimeUnit.MILLISECONDS);
+        if (soTimeoutMillis != null) {
+          httpSolrClientBuilder.withSocketTimeout(soTimeoutMillis, TimeUnit.MILLISECONDS);
         }
         if (requestWriter != null) {
           httpSolrClientBuilder.withRequestWriter(requestWriter);
@@ -135,11 +136,11 @@ public class LBHttpSolrClient extends LBSolrClient {
     } else {
       final HttpSolrClient.Builder clientBuilder =
           new HttpSolrClient.Builder(server).withHttpClient(httpClient).withResponseParser(parser);
-      if (connectionTimeout != null) {
-        clientBuilder.withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
+      if (connectionTimeoutMillis != null) {
+        clientBuilder.withConnectionTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS);
       }
-      if (soTimeout != null) {
-        clientBuilder.withSocketTimeout(soTimeout, TimeUnit.MILLISECONDS);
+      if (soTimeoutMillis != null) {
+        clientBuilder.withSocketTimeout(soTimeoutMillis, TimeUnit.MILLISECONDS);
       }
       if (requestWriter != null) {
         clientBuilder.withRequestWriter(requestWriter);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -80,8 +81,8 @@ public class LBHttpSolrClient extends LBSolrClient {
   private final HttpSolrClient.Builder httpSolrClientBuilder;
   private volatile Set<String> urlParamNames = new HashSet<>();
 
-  private Integer connectionTimeout;
-  private volatile Integer soTimeout;
+  private Long connectionTimeout;
+  private volatile Long soTimeout;
 
   /** The provided httpClient should use a multi-threaded connection manager */
   protected LBHttpSolrClient(Builder builder) {
@@ -118,10 +119,10 @@ public class LBHttpSolrClient extends LBSolrClient {
       synchronized (this) {
         httpSolrClientBuilder.withBaseSolrUrl(server).withHttpClient(httpClient);
         if (connectionTimeout != null) {
-          httpSolrClientBuilder.withConnectionTimeout(connectionTimeout);
+          httpSolrClientBuilder.withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
         }
         if (soTimeout != null) {
-          httpSolrClientBuilder.withSocketTimeout(soTimeout);
+          httpSolrClientBuilder.withSocketTimeout(soTimeout, TimeUnit.MILLISECONDS);
         }
         if (requestWriter != null) {
           httpSolrClientBuilder.withRequestWriter(requestWriter);
@@ -135,10 +136,10 @@ public class LBHttpSolrClient extends LBSolrClient {
       final HttpSolrClient.Builder clientBuilder =
           new HttpSolrClient.Builder(server).withHttpClient(httpClient).withResponseParser(parser);
       if (connectionTimeout != null) {
-        clientBuilder.withConnectionTimeout(connectionTimeout);
+        clientBuilder.withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
       }
       if (soTimeout != null) {
-        clientBuilder.withSocketTimeout(soTimeout);
+        clientBuilder.withSocketTimeout(soTimeout, TimeUnit.MILLISECONDS);
       }
       if (requestWriter != null) {
         clientBuilder.withRequestWriter(requestWriter);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -82,7 +82,7 @@ public class LBHttpSolrClient extends LBSolrClient {
   private volatile Set<String> urlParamNames = new HashSet<>();
 
   private Long connectionTimeoutMillis;
-  private volatile Long soTimeoutMillis;
+  private Long soTimeoutMillis;
 
   /** The provided httpClient should use a multi-threaded connection manager */
   protected LBHttpSolrClient(Builder builder) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -77,7 +77,8 @@ public abstract class LBSolrClient extends SolrClient {
 
   private volatile ScheduledExecutorService aliveCheckExecutor;
 
-  protected long aliveCheckInterval = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
+  protected long aliveCheckIntervalMillis =
+      TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS); // 1 minute between checks
   private final AtomicInteger counter = new AtomicInteger(-1);
 
   private static final SolrQuery solrQuery = new SolrQuery("*:*");
@@ -442,16 +443,18 @@ public abstract class LBSolrClient extends SolrClient {
    * LBHttpSolrServer keeps pinging the dead servers at fixed interval to find if it is alive. Use
    * this to set that interval
    *
-   * @param aliveCheckInterval time in milliseconds
+   * @param aliveCheckIntervalMillis time in milliseconds
    * @deprecated use {@link LBHttpSolrClient.Builder#setAliveCheckInterval(int)} instead
    */
   @Deprecated
-  public void setAliveCheckInterval(int aliveCheckInterval) {
-    if (aliveCheckInterval <= 0) {
+  public void setAliveCheckInterval(int aliveCheckIntervalMillis) {
+    if (aliveCheckIntervalMillis <= 0) {
       throw new IllegalArgumentException(
-          "Alive check interval must be " + "positive, specified value = " + aliveCheckInterval);
+          "Alive check interval must be "
+              + "positive, specified value = "
+              + aliveCheckIntervalMillis);
     }
-    this.aliveCheckInterval = aliveCheckInterval;
+    this.aliveCheckIntervalMillis = aliveCheckIntervalMillis;
   }
 
   private void startAliveCheckExecutor() {
@@ -465,8 +468,8 @@ public abstract class LBSolrClient extends SolrClient {
                   new SolrNamedThreadFactory("aliveCheckExecutor"));
           aliveCheckExecutor.scheduleAtFixedRate(
               getAliveCheckRunner(new WeakReference<>(this)),
-              this.aliveCheckInterval,
-              this.aliveCheckInterval,
+              this.aliveCheckIntervalMillis,
+              this.aliveCheckIntervalMillis,
               TimeUnit.MILLISECONDS);
         }
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -77,7 +77,7 @@ public abstract class LBSolrClient extends SolrClient {
 
   private volatile ScheduledExecutorService aliveCheckExecutor;
 
-  protected int aliveCheckInterval = LBHttpSolrClient.Builder.CHECK_INTERVAL;
+  protected long aliveCheckInterval = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
   private final AtomicInteger counter = new AtomicInteger(-1);
 
   private static final SolrQuery solrQuery = new SolrQuery("*:*");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.solr.client.solrj.impl;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.impl.HttpSolrClient.Builder;
@@ -33,8 +34,8 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
   protected ResponseParser responseParser;
   protected RequestWriter requestWriter;
   protected boolean useMultiPartPost;
-  protected Integer connectionTimeoutMillis = 15000;
-  protected Integer socketTimeoutMillis = 120000;
+  protected Long connectionTimeoutMillis = 15000l;
+  protected Long socketTimeoutMillis = 120000l;
   protected boolean followRedirects = false;
   protected Set<String> urlParamNames;
 
@@ -86,13 +87,41 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    * Solr servers.
    *
    * <p>For valid values see {@link org.apache.http.client.config.RequestConfig#getConnectTimeout()}
+   *
+   * @deprecated Please use {@link #withConnectionTimeout(long, TimeUnit)}
    */
+  @Deprecated(since = "9.2")
   public B withConnectionTimeout(int connectionTimeoutMillis) {
+    withConnectionTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS);
+    return getThis();
+  }
+
+  /**
+   * Tells {@link Builder} that created clients should obey the following timeout when connecting to
+   * Solr servers.
+   *
+   * <p>For valid values see {@link org.apache.http.client.config.RequestConfig#getConnectTimeout()}
+   */
+  public B withConnectionTimeout(long connectionTimeout, TimeUnit unit) {
     if (connectionTimeoutMillis < 0) {
       throw new IllegalArgumentException("connectionTimeoutMillis must be a non-negative integer.");
     }
 
-    this.connectionTimeoutMillis = connectionTimeoutMillis;
+    this.connectionTimeoutMillis = TimeUnit.MILLISECONDS.convert(connectionTimeout, unit);
+    return getThis();
+  }
+
+  /**
+   * Tells {@link Builder} that created clients should set the following read timeout on all
+   * sockets.
+   *
+   * <p>For valid values see {@link org.apache.http.client.config.RequestConfig#getSocketTimeout()}
+   *
+   * <p>* @deprecated Please use {@link #withSocketTimeout(long, TimeUnit)}
+   */
+  @Deprecated(since = "9.2")
+  public B withSocketTimeout(int socketTimeoutMillis) {
+    withSocketTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS);
     return getThis();
   }
 
@@ -102,12 +131,12 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    *
    * <p>For valid values see {@link org.apache.http.client.config.RequestConfig#getSocketTimeout()}
    */
-  public B withSocketTimeout(int socketTimeoutMillis) {
+  public B withSocketTimeout(long socketTimeout, TimeUnit unit) {
     if (socketTimeoutMillis < 0) {
       throw new IllegalArgumentException("socketTimeoutMillis must be a non-negative integer.");
     }
 
-    this.socketTimeoutMillis = socketTimeoutMillis;
+    this.socketTimeoutMillis = TimeUnit.MILLISECONDS.convert(socketTimeout, unit);
     return getThis();
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -34,8 +34,8 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
   protected ResponseParser responseParser;
   protected RequestWriter requestWriter;
   protected boolean useMultiPartPost;
-  protected Long connectionTimeoutMillis = 15000l;
-  protected Long socketTimeoutMillis = 120000l;
+  protected Long connectionTimeoutMillis = TimeUnit.MILLISECONDS.convert(15, TimeUnit.SECONDS);
+  protected Long socketTimeoutMillis = TimeUnit.MILLISECONDS.convert(120, TimeUnit.SECONDS);
   protected boolean followRedirects = false;
   protected Set<String> urlParamNames;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -103,8 +103,8 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    * <p>For valid values see {@link org.apache.http.client.config.RequestConfig#getConnectTimeout()}
    */
   public B withConnectionTimeout(long connectionTimeout, TimeUnit unit) {
-    if (connectionTimeoutMillis < 0) {
-      throw new IllegalArgumentException("connectionTimeoutMillis must be a non-negative integer.");
+    if (connectionTimeout < 0) {
+      throw new IllegalArgumentException("connectionTimeout must be a non-negative integer.");
     }
 
     this.connectionTimeoutMillis = TimeUnit.MILLISECONDS.convert(connectionTimeout, unit);
@@ -121,7 +121,7 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    */
   @Deprecated(since = "9.2")
   public B withSocketTimeout(int socketTimeoutMillis) {
-    withSocketTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS);
+    withSocketTimeout(socketTimeoutMillis, TimeUnit.MILLISECONDS);
     return getThis();
   }
 
@@ -132,8 +132,8 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
    * <p>For valid values see {@link org.apache.http.client.config.RequestConfig#getSocketTimeout()}
    */
   public B withSocketTimeout(long socketTimeout, TimeUnit unit) {
-    if (socketTimeoutMillis < 0) {
-      throw new IllegalArgumentException("socketTimeoutMillis must be a non-negative integer.");
+    if (socketTimeout < 0) {
+      throw new IllegalArgumentException("socketTimeout must be a non-negative integer.");
     }
 
     this.socketTimeoutMillis = TimeUnit.MILLISECONDS.convert(socketTimeout, unit);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleBinaryHttp2Test.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleBinaryHttp2Test.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.client.solrj;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.impl.BinaryRequestWriter;
 import org.apache.solr.client.solrj.impl.BinaryResponseParser;
@@ -38,7 +39,7 @@ public class SolrExampleBinaryHttp2Test extends SolrExampleTests {
   @Override
   public SolrClient createNewSolrClient() {
     return new Http2SolrClient.Builder(getServerUrl())
-        .withConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT)
+        .withConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
         .withRequestWriter(new BinaryRequestWriter())
         // where the magic happens
         .withResponseParser(new BinaryResponseParser())

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttp2SolrClient.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttp2SolrClient.java
@@ -79,7 +79,7 @@ public class TestLBHttp2SolrClient extends SolrTestCaseJ4 {
   public void setUp() throws Exception {
     super.setUp();
     httpClient =
-        new Http2SolrClient.Builder().withConnectionTimeout(1000).withIdleTimeout(2000).build();
+        new Http2SolrClient.Builder().withConnectionTimeout(1000).withIdleTimeout(2000, TimeUnit.MILLISECONDS).build();
 
     for (int i = 0; i < solr.length; i++) {
       solr[i] =

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttp2SolrClient.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttp2SolrClient.java
@@ -79,7 +79,10 @@ public class TestLBHttp2SolrClient extends SolrTestCaseJ4 {
   public void setUp() throws Exception {
     super.setUp();
     httpClient =
-        new Http2SolrClient.Builder().withConnectionTimeout(1000).withIdleTimeout(2000, TimeUnit.MILLISECONDS).build();
+        new Http2SolrClient.Builder()
+            .withConnectionTimeout(1000, TimeUnit.MILLISECONDS)
+            .withIdleTimeout(2000, TimeUnit.MILLISECONDS)
+            .build();
 
     for (int i = 0; i < solr.length; i++) {
       solr[i] =
@@ -124,7 +127,9 @@ public class TestLBHttp2SolrClient extends SolrTestCaseJ4 {
       solrUrls[i] = solr[i].getUrl();
     }
     try (LBHttp2SolrClient client =
-        new LBHttp2SolrClient.Builder(httpClient, solrUrls).setAliveCheckInterval(500).build()) {
+        new LBHttp2SolrClient.Builder(httpClient, solrUrls)
+            .setAliveCheckInterval(500, TimeUnit.MILLISECONDS)
+            .build()) {
       SolrQuery solrQuery = new SolrQuery("*:*");
       Set<String> names = new HashSet<>();
       QueryResponse resp = null;
@@ -171,7 +176,9 @@ public class TestLBHttp2SolrClient extends SolrTestCaseJ4 {
       solrUrls[i] = solr[i].getUrl();
     }
     try (LBHttp2SolrClient client =
-        new LBHttp2SolrClient.Builder(httpClient, solrUrls).setAliveCheckInterval(500).build()) {
+        new LBHttp2SolrClient.Builder(httpClient, solrUrls)
+            .setAliveCheckInterval(500, TimeUnit.MILLISECONDS)
+            .build()) {
       SolrQuery solrQuery = new SolrQuery("*:*");
       QueryResponse resp = null;
       solr[0].jetty.stop();
@@ -205,7 +212,9 @@ public class TestLBHttp2SolrClient extends SolrTestCaseJ4 {
     }
 
     try (LBHttp2SolrClient client =
-        new LBHttp2SolrClient.Builder(httpClient, solrUrls).setAliveCheckInterval(500).build()) {
+        new LBHttp2SolrClient.Builder(httpClient, solrUrls)
+            .setAliveCheckInterval(500, TimeUnit.MILLISECONDS)
+            .build()) {
 
       // Kill a server and test again
       solr[1].jetty.stop();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/embedded/SolrExampleXMLHttp2Test.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/embedded/SolrExampleXMLHttp2Test.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.client.solrj.embedded;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrExampleTests;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
@@ -39,7 +40,7 @@ public class SolrExampleXMLHttp2Test extends SolrExampleTests {
 
     Http2SolrClient client =
         new Http2SolrClient.Builder(getServerUrl())
-            .withConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT)
+            .withConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
             .withRequestWriter(new RequestWriter())
             .withResponseParser(new XMLResponseParser())
             .build();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClientTest.java
@@ -67,7 +67,7 @@ public class ConcurrentUpdateHttp2SolrClientTest extends SolrJettyTestBase {
                     serverUrl, http2Client, successCounter, errorCounter, errors)
                 .withQueueSize(cussQueueSize)
                 .withThreadCount(cussThreadCount)
-                .setPollQueueTime(0)
+                .setPollQueueTime(0, TimeUnit.MILLISECONDS)
                 .build()) {
 
       // ensure it doesn't block where there's nothing to do yet
@@ -172,7 +172,7 @@ public class ConcurrentUpdateHttp2SolrClientTest extends SolrJettyTestBase {
             new ConcurrentUpdateHttp2SolrClient.Builder(jetty.getBaseUrl().toString(), http2Client)
                 .withQueueSize(cussQueueSize)
                 .withThreadCount(cussThreadCount)
-                .setPollQueueTime(0)
+                .setPollQueueTime(0, TimeUnit.MILLISECONDS)
                 .build()) {
 
       // ensure it doesn't block where there's nothing to do yet

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -190,9 +190,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   }
 
   private Http2SolrClient.Builder getHttp2SolrClientBuilder(
-      String url, int connectionTimeOut, int socketTimeout) {
+      String url, int connectionTimeout, int socketTimeout) {
     return new Http2SolrClient.Builder(url)
-        .withConnectionTimeout(connectionTimeOut)
+        .withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
         .withIdleTimeout(socketTimeout, TimeUnit.MILLISECONDS);
   }
 
@@ -230,7 +230,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     try (Http2SolrClient client =
         getHttp2SolrClientBuilder(
                 jetty.getBaseUrl().toString() + "/slow/foo", DEFAULT_CONNECTION_TIMEOUT, 0)
-            .withRequestTimeout(500)
+            .withRequestTimeout(500, TimeUnit.MILLISECONDS)
             .build()) {
       client.query(q, SolrRequest.METHOD.GET);
       fail("No exception thrown.");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -192,7 +193,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       String url, int connectionTimeOut, int socketTimeout) {
     return new Http2SolrClient.Builder(url)
         .withConnectionTimeout(connectionTimeOut)
-        .withIdleTimeout(socketTimeout);
+        .withIdleTimeout(socketTimeout, TimeUnit.MILLISECONDS);
   }
 
   @Test


### PR DESCRIPTION
This change is going to touch a lot of places ;-)

https://issues.apache.org/jira/browse/SOLR-16595

# Description
Introduce the `TimeUnit unit` parameter to our Builder, and then internally convert what is passed in to what we need.

# Solution

Start converting builder methods.

# Tests

Run the existing test suite.
