### PR TITLE
SOLR-16650, SOLR-16532: OTEL tracer additional tags

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -311,10 +311,7 @@ public abstract class ServletUtils {
             .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER)
             .withTag(Tags.HTTP_METHOD, request.getMethod())
             .withTag(Tags.HTTP_URL, request.getRequestURL().toString())
-            .withTag("net.host.name", request.getServerName())
-            .withTag("net.host.port", request.getServerPort())
-            .withTag("net.peer.name", request.getRemoteHost())
-            .withTag("net.peer.port", request.getRemotePort());
+            .withTag(Tags.PEER_HOSTNAME, request.getServerName());
     if (request.getQueryString() != null) {
       spanBuilder.withTag("http.params", request.getQueryString());
     }

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -314,7 +314,9 @@ public abstract class ServletUtils {
     if (request.getQueryString() != null) {
       spanBuilder.withTag("http.params", request.getQueryString());
     }
-    spanBuilder.withTag(Tags.DB_TYPE, "solr");
+    spanBuilder.withTag(Tags.DB_TYPE, "solr")
+        .withTag("net.host.name", request.getServerName())
+        .withTag("net.host.port", request.getServerPort());
     return spanBuilder.start();
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -310,8 +310,7 @@ public abstract class ServletUtils {
             .asChildOf(tracer.extract(Format.Builtin.HTTP_HEADERS, new HttpServletCarrier(request)))
             .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER)
             .withTag(Tags.HTTP_METHOD, request.getMethod())
-            .withTag(Tags.HTTP_URL, request.getRequestURL().toString())
-            .withTag(Tags.PEER_HOSTNAME, request.getServerName());
+            .withTag(Tags.HTTP_URL, request.getRequestURL().toString());
     if (request.getQueryString() != null) {
       spanBuilder.withTag("http.params", request.getQueryString());
     }

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -310,13 +310,15 @@ public abstract class ServletUtils {
             .asChildOf(tracer.extract(Format.Builtin.HTTP_HEADERS, new HttpServletCarrier(request)))
             .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER)
             .withTag(Tags.HTTP_METHOD, request.getMethod())
-            .withTag(Tags.HTTP_URL, request.getRequestURL().toString());
+            .withTag(Tags.HTTP_URL, request.getRequestURL().toString())
+            .withTag("net.host.name", request.getServerName())
+            .withTag("net.host.port", request.getServerPort())
+            .withTag("net.peer.name", request.getRemoteHost())
+            .withTag("net.peer.port", request.getRemotePort());
     if (request.getQueryString() != null) {
       spanBuilder.withTag("http.params", request.getQueryString());
     }
-    spanBuilder.withTag(Tags.DB_TYPE, "solr")
-        .withTag("net.host.name", request.getServerName())
-        .withTag("net.host.port", request.getServerPort());
+    spanBuilder.withTag(Tags.DB_TYPE, "solr");
     return spanBuilder.start();
   }
 

--- a/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtelTracerConfigurator.java
+++ b/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtelTracerConfigurator.java
@@ -20,15 +20,16 @@ import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentracing.Tracer;
+import org.apache.solr.core.TracerConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.apache.solr.core.TracerConfigurator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * OpenTracing TracerConfigurator implementation which exports spans to OpenTelemetry in OTLP
@@ -46,6 +47,12 @@ public class OtelTracerConfigurator extends TracerConfigurator {
     setDefaultIfNotConfigured("OTEL_TRACES_EXPORTER", "otlp");
     setDefaultIfNotConfigured("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
     setDefaultIfNotConfigured("OTEL_TRACES_SAMPLER", "parentbased_always_on");
+
+    // User-configurable trace attributes. Comma separated list of key=value. We always append current host name
+    String resourceAttributes = getEnvOrSysprop("OTEL_RESOURCE_ATTRIBUTES");
+    resourceAttributes = resourceAttributes == null ? "" : resourceAttributes + ",";
+    resourceAttributes += "host.name=" + System.getProperty("host");
+    System.setProperty(envNameToSyspropName("OTEL_RESOURCE_ATTRIBUTES"), resourceAttributes);
 
     final String currentConfig = getCurrentOtelConfigAsString();
     log.info("OpenTelemetry tracer enabled with configuration: {}", currentConfig);

--- a/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtelTracerConfigurator.java
+++ b/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtelTracerConfigurator.java
@@ -78,6 +78,7 @@ public class OtelTracerConfigurator extends TracerConfigurator {
     if (commaSepAttrs != null) {
       attrs.putAll(
           Arrays.stream(commaSepAttrs.split(","))
+              .filter(e -> e.contains("="))
               .map(e -> e.strip().split("="))
               .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1])));
     }

--- a/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtelTracerConfigurator.java
+++ b/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtelTracerConfigurator.java
@@ -20,16 +20,15 @@ import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentracing.Tracer;
-import org.apache.solr.core.TracerConfigurator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.apache.solr.core.TracerConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * OpenTracing TracerConfigurator implementation which exports spans to OpenTelemetry in OTLP
@@ -48,7 +47,8 @@ public class OtelTracerConfigurator extends TracerConfigurator {
     setDefaultIfNotConfigured("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
     setDefaultIfNotConfigured("OTEL_TRACES_SAMPLER", "parentbased_always_on");
 
-    // User-configurable trace attributes. Comma separated list of key=value. We always append current host name
+    // User-configurable trace attributes. Comma separated list of key=value. We always append
+    // current host name
     String resourceAttributes = getEnvOrSysprop("OTEL_RESOURCE_ATTRIBUTES");
     resourceAttributes = resourceAttributes == null ? "" : resourceAttributes + ",";
     resourceAttributes += "host.name=" + System.getProperty("host");

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
@@ -94,7 +94,7 @@ public class OtelTracerConfiguratorTest extends SolrTestCaseJ4 {
 
   @Test
   public void testInjected() throws Exception {
-    System.setProperty("otel.resource.attributes", "foo=bar");
+    System.setProperty("otel.resource.attributes", "foo=bar,ILLEGAL-LACKS-VALUE,");
     System.setProperty("host", "my.solr.host");
     // Make sure the batch exporter times out before our thread lingering time of 10s
     instance.setDefaultIfNotConfigured("OTEL_BSP_SCHEDULE_DELAY", "1000");

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
@@ -18,6 +18,7 @@ package org.apache.solr.opentelemetry;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import io.opentracing.util.GlobalTracer;
+import java.util.List;
 import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
@@ -108,7 +109,8 @@ public class OtelTracerConfiguratorTest extends SolrTestCaseJ4 {
           "Tracer shim not registered with GlobalTracer",
           GlobalTracer.get().toString().contains("ClosableTracerShim"));
       assertEquals(
-          "foo=bar,host.name=my.solr.host", System.getProperty("otel.resource.attributes"));
+          List.of("host.name=my.solr.host", "foo=bar"),
+          List.of(System.getProperty("otel.resource.attributes").split(",")));
     } finally {
       cluster.shutdown();
       System.clearProperty("otel.resource.attributes");

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
@@ -93,6 +93,8 @@ public class OtelTracerConfiguratorTest extends SolrTestCaseJ4 {
 
   @Test
   public void testInjected() throws Exception {
+    System.setProperty("otel.resource.attributes", "foo=bar");
+    System.setProperty("host", "my.solr.host");
     // Make sure the batch exporter times out before our thread lingering time of 10s
     instance.setDefaultIfNotConfigured("OTEL_BSP_SCHEDULE_DELAY", "1000");
     instance.setDefaultIfNotConfigured("OTEL_BSP_EXPORT_TIMEOUT", "2000");
@@ -105,8 +107,11 @@ public class OtelTracerConfiguratorTest extends SolrTestCaseJ4 {
       assertTrue(
           "Tracer shim not registered with GlobalTracer",
           GlobalTracer.get().toString().contains("ClosableTracerShim"));
+      assertEquals("foo=bar,host.name=my.solr.host", System.getProperty("otel.resource.attributes"));
     } finally {
       cluster.shutdown();
+      System.clearProperty("otel.resource.attributes");
+      System.clearProperty("host");
     }
   }
 }

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
@@ -107,7 +107,8 @@ public class OtelTracerConfiguratorTest extends SolrTestCaseJ4 {
       assertTrue(
           "Tracer shim not registered with GlobalTracer",
           GlobalTracer.get().toString().contains("ClosableTracerShim"));
-      assertEquals("foo=bar,host.name=my.solr.host", System.getProperty("otel.resource.attributes"));
+      assertEquals(
+          "foo=bar,host.name=my.solr.host", System.getProperty("otel.resource.attributes"));
     } finally {
       cluster.shutdown();
       System.clearProperty("otel.resource.attributes");

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/distributed-tracing.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/distributed-tracing.adoc
@@ -88,6 +88,13 @@ An equivalent configuration using system properties would be:
 SOLR_OPTS=-Dotel.exporter.otlp.endpoint=my-remote-collector:4317 -Dotel.traces.sampler=parentbased_traceidratio -Dotel.traces.sampler.arg=0.1
 ----
 
+To add custom tags to the trace, use `OTEL_RESOURCE_ATTRIBUTES`:
+
+[source,bash]
+----
+OTEL_RESOURCE_ATTRIBUTES="application=OnlineBanking,exampleKey=exampleValue"
+----
+
 Consult the https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/[OTEL documentation] for details on all the configuration options.
 This version of Solr uses https://github.com/open-telemetry/opentelemetry-java/tree/v{dep-version-opentelemetry}[OpenTelemetry SDK v{dep-version-opentelemetry}].
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16650
https://issues.apache.org/jira/browse/SOLR-16532

Testing solr 9.2.0-SNAPSHOT at a client and missing hostname/port from traces. So this PR will add those by default, following the [otel semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/), both local logical host name as seen on the request, and peer host/port. Not yet tested in the wild.