### PR TITLE
SOLR-16104 Fix TestCoreDiscovery.testTooManyTransientCores

### DIFF
--- a/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,8 +46,11 @@ import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestCoreDiscovery extends SolrTestCaseJ4 {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -334,11 +338,19 @@ public class TestCoreDiscovery extends SolrTestCaseJ4 {
       // Just check that the proper number of cores are loaded since making the test depend on order
       // would be fragile
       RetryUtil.retryUntil(
-          "There should only be 3 cores loaded, coreLOS and two coreT? cores",
-          5,
+          "There should only be 3 cores loaded, coreLOS and two coreT# cores",
+          20,
           200,
           TimeUnit.MILLISECONDS,
-          () -> 3 == cc.getLoadedCoreNames().size());
+          () -> {
+            // See SOLR-16104 about this flakiness
+            final var loadedCoreNames = cc.getLoadedCoreNames();
+            if (3 == loadedCoreNames.size()) {
+              return true;
+            }
+            log.warn("Waiting for 3 loaded cores but got: {}", loadedCoreNames);
+            return false;
+          });
 
       SolrCore c1 = cc.getCore("coreT1");
       assertNotNull("Core T1 should NOT BE NULL", c1);


### PR DESCRIPTION
This has been flapping at ~2% for a long time: http://fucit.org/solr-jenkins-reports/failure-report.html
And it's because the CloserThread closes the core in another thread and perhaps takes a while on a busy CI or high parallelism situation.  So I gave it more time and logged info to help debug if it happens.