### PR TITLE
SOLR-16658 List of permissions returned to Admin UI is not complete

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -204,6 +204,8 @@ Bug Fixes
 
 * SOLR-16639: Fix jq parse error of solr-exporter metrics node_thread_pool_completed_total (Naoto Minami)
 
+* SOLR-16658: List of permissions returned to Admin UI is not complete (janhoy)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -34,6 +34,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.lucene.util.Version;
 import org.apache.solr.api.AnnotatedApi;
 import org.apache.solr.api.Api;
@@ -339,7 +341,10 @@ public class SystemInfoHandler extends RequestHandlerBase {
         RuleBasedAuthorizationPluginBase rbap = (RuleBasedAuthorizationPluginBase) auth;
         Set<String> roles = rbap.getUserRoles(req.getUserPrincipal());
         info.add("roles", roles);
-        info.add("permissions", rbap.getPermissionNamesForRoles(roles));
+        info.add(
+            "permissions",
+            rbap.getPermissionNamesForRoles(
+                Stream.concat(roles.stream(), Stream.of("*", null)).collect(Collectors.toSet())));
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/security/RuleBasedAuthorizationPluginBase.java
+++ b/solr/core/src/java/org/apache/solr/security/RuleBasedAuthorizationPluginBase.java
@@ -25,6 +25,8 @@ import java.lang.invoke.MethodHandles;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -119,7 +121,7 @@ public abstract class RuleBasedAuthorizationPluginBase
   }
 
   /** Retrieves permission names for a given set of roles */
-  public Set<String> getPermissionNamesForRoles(Set<String> roles) {
+  public Set<String> getPermissionNamesForRoles(Collection<String> roles) {
     if (roles == null) {
       return Set.of();
     }
@@ -340,11 +342,11 @@ public abstract class RuleBasedAuthorizationPluginBase
         perms.add(permission);
       }
     }
-    if (permission.role != null) {
-      for (String r : permission.role) {
-        Set<Permission> rm = roleToPermissionsMap.computeIfAbsent(r, k -> new HashSet<>());
-        rm.add(permission);
-      }
+    Collection<String> roles =
+        permission.role != null ? permission.role : Collections.singletonList(null);
+    for (String r : roles) {
+      Set<Permission> rm = roleToPermissionsMap.computeIfAbsent(r, k -> new HashSet<>());
+      rm.add(permission);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/security/RuleBasedAuthorizationPluginBase.java
+++ b/solr/core/src/java/org/apache/solr/security/RuleBasedAuthorizationPluginBase.java
@@ -120,7 +120,21 @@ public abstract class RuleBasedAuthorizationPluginBase
     return flag.rsp;
   }
 
-  /** Retrieves permission names for a given set of roles */
+  /**
+   * Retrieves permission names for a given set of roles.
+   *
+   * <p>There are two special role names that can be used in the roles list:
+   *
+   * <ul>
+   *   <li><code>null</code> meaning permission granted for all requests, even without a role
+   *   <li><code>"*"</code> meaning any role will grant the permission
+   * </ul>
+   *
+   * In order to obtain all permissions a user has based on the user's roles, you also need to
+   * include these two special roles to get the full list.
+   *
+   * @param roles a collection of role names.
+   */
   public Set<String> getPermissionNamesForRoles(Collection<String> roles) {
     if (roles == null) {
       return Set.of();

--- a/solr/core/src/test/org/apache/solr/security/BaseTestRuleBasedAuthorizationPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/BaseTestRuleBasedAuthorizationPlugin.java
@@ -31,6 +31,7 @@ import java.io.StringReader;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -719,6 +720,11 @@ public class BaseTestRuleBasedAuthorizationPlugin extends SolrTestCaseJ4 {
           Set.of("schema-edit", "collection-admin-edit", "mycoll_update", "read"),
           plugin.getPermissionNamesForRoles(Set.of("admin", "dev")));
       assertEquals(emptySet(), plugin.getPermissionNamesForRoles(null));
+      assertEquals(
+          Set.of("collection-admin-read"),
+          plugin.getPermissionNamesForRoles(Collections.singletonList(null)));
+      assertEquals(
+          Set.of("freeforall"), plugin.getPermissionNamesForRoles(Collections.singletonList("*")));
     } catch (IOException e) {
       ; // swallow error, otherwise you have to add a _lot_ of exceptions to methods.
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16658

It's a trappy design to allow "null" keys in maps like this. And to define a "null" role in a permission in Admin UI security editor you need to actively de-select all roles, which took me a while to figure. Not trying to fix this here, but at least trying to resolve correct set of permissions for a given user, taking into account that permissions may have `*` or `null` roles.

I discovered this bug when working with a quite open-ended security.json for JWT, where some endpoints don't require authentication and all others do require auth, but we don't care what role the user has, e.g.

```json
"permissions":[
  {
    "name": "info",
    "role": null,
    "collection": null,
    "path": "/admin/info/system"
  },
  {
    "name": "health",
    "role": null
  },
  {
    "name": "all",
    "role": "*"
  }
]
```

With a config like the one above, a user logging in to Admin UI would not be able to create a collection or view schema editor or security editor, even if they basically has all the permissions in the world. After this PR, any user with role `foo` would get a minimum of `["info", "health", "all"]` in return. Of course in this example, with the presence of the `all` permission, any authenticated user could return just `["all"]` since the other permissions are implied, but that is an optimization that is unrelated.