### PR TITLE
SOLR-15959 Deprecate loading of solr.xml from ZK

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -282,6 +282,8 @@ Other Changes
 
 * SOLR-15955: Upgrade to Jetty 10.x (Mark Miller, Kevin Risden)
 
+* SOLR-15959: Deprecate loading of solr.xml from Zookeeper (janhoy)
+
 * SOLR-16573: Introduce EmbeddedSolrServerTestRule, a JUnit 4 TestRule for Solr testing
   (Joshua Ouma, David Smiley)
 

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -219,7 +219,9 @@ public class NodeConfig {
               .build()) {
         if (zkClient.exists("/solr.xml", true)) {
           log.info("solr.xml found in ZooKeeper. Loading...");
-          DeprecationLog.log("solrxml-zookeeper", "Loading solr.xml from zookeeper is deprecated. See reference guide for details.");
+          DeprecationLog.log(
+              "solrxml-zookeeper",
+              "Loading solr.xml from zookeeper is deprecated. See reference guide for details.");
           byte[] data = zkClient.getData("/solr.xml", null, null, true);
           return SolrXmlConfig.fromInputStream(
               solrHome, new ByteArrayInputStream(data), nodeProperties, true);

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.logging.DeprecationLog;
 import org.apache.solr.logging.LogWatcherConfig;
 import org.apache.solr.servlet.SolrDispatchFilter;
 import org.apache.solr.update.UpdateShardHandlerConfig;
@@ -218,6 +219,7 @@ public class NodeConfig {
               .build()) {
         if (zkClient.exists("/solr.xml", true)) {
           log.info("solr.xml found in ZooKeeper. Loading...");
+          DeprecationLog.log("solrxml-zookeeper", "Loading solr.xml from zookeeper is deprecated. See reference guide for details.");
           byte[] data = zkClient.getData("/solr.xml", null, null, true);
           return SolrXmlConfig.fromInputStream(
               solrHome, new ByteArrayInputStream(data), nodeProperties, true);

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
@@ -25,6 +25,9 @@ For details on how to configure `core.properties`, see the section xref:core-dis
 
 You can find `solr.xml` in your `$SOLR_HOME` directory (usually `server/solr` or `/var/solr/data`) or optionally in ZooKeeper when using SolrCloud. If `$SOLR_HOME/solr.xml` is not found, Solr will use the default `solr.xml` file.
 
+WARNING: Loading `solr.xml` from Zookeeper is deprecated, and will not be supported in a future version.
+Being the node config of Solr, this file must be available at early startup and also be allowed to differ between nodes.
+
 The default `solr.xml` file is found in `$SOLR_TIP/server/solr/solr.xml` and looks like this:
 
 [source,xml]

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/upgrading-a-solr-cluster.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/upgrading-a-solr-cluster.adoc
@@ -39,7 +39,7 @@ You'll be doing a rolling restart of your cluster (each node, one-by-one), but w
 * `ZK_HOST`: The ZooKeeper connection string your current SolrCloud nodes use to connect to ZooKeeper; this value will be the same for all nodes in the cluster.
 * `SOLR_HOST`: The hostname each Solr node used to register with ZooKeeper when joining the SolrCloud cluster; this value will be used to set the *host* Java system property when starting the new Solr process.
 * `SOLR_PORT`: The port each Solr node is listening on, such as 8983.
-* `SOLR_HOME`: The absolute path to the Solr home directory for each Solr node; this directory must contain a `solr.xml` file.
+* `SOLR_HOME`: The absolute path to the Solr home directory for each Solr node.
 This value will be passed to the new Solr process using the `solr.solr.home` system property, see: xref:configuration-guide:configuring-solr-xml.adoc[].
 +
 If you are upgrading from an installation of Solr 5.x or later, these values can typically be found in either `/var/solr/solr.in.sh` or `/etc/default/solr.in.sh`.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
@@ -87,6 +87,8 @@ There are certain configuration files containing cluster wide configuration.
 Since some of these are crucial for the cluster to function properly, you may need to upload such files to ZooKeeper before starting your Solr cluster for the first time.
 Examples of such configuration files (not exhaustive) are `security.json` and `clusterprops.json`.
 
+If you for example would like to enable authentication, you can push your `security.json` file to ZooKeeper with the bin/solr utility (Unix example):
+
 [source,bash]
 ----
 bin/solr zk cp file:local/file/path/to/security.json zk:/security.json -z localhost:2181

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
@@ -85,13 +85,11 @@ Please see xref:taking-solr-to-production.adoc#zookeeper-chroot[ZooKeeper chroot
 
 There are certain configuration files containing cluster wide configuration.
 Since some of these are crucial for the cluster to function properly, you may need to upload such files to ZooKeeper before starting your Solr cluster for the first time.
-Examples of such configuration files (not exhaustive) are `solr.xml`, `security.json` and `clusterprops.json`.
-
-If you for example would like to keep your `solr.xml` in ZooKeeper to avoid having to copy it to every node's `solr_home` directory, you can push it to ZooKeeper with the bin/solr utility (Unix example):
+Examples of such configuration files (not exhaustive) are `security.json` and `clusterprops.json`.
 
 [source,bash]
 ----
-bin/solr zk cp file:local/file/path/to/solr.xml zk:/solr.xml -z localhost:2181
+bin/solr zk cp file:local/file/path/to/security.json zk:/security.json -z localhost:2181
 ----
 
 NOTE: If you have defined `ZK_HOST` in `solr.in.sh`/`solr.in.cmd` (see xref:zookeeper-ensemble.adoc#updating-solr-include-files,Updating Solr Include Files>>) you can omit `-z <zk host string>` from the above command.

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-solrcloud.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-solrcloud.adoc
@@ -200,14 +200,12 @@ bin/solr start -cloud -s solr.home/solr -p <port num> -z <zk hosts string>
 ----
 
 Notice that the above requires you to create a Solr home directory.
-You either need to copy `solr.xml` to the `solr_home` directory, or keep in centrally in ZooKeeper `/solr.xml`.
 
 Example (with directory structure) that adds a node to an example started with "bin/solr -e cloud":
 
 [source,bash]
 ----
 mkdir -p example/cloud/node3/solr
-cp server/solr/solr.xml example/cloud/node3/solr
 bin/solr start -cloud -s example/cloud/node3/solr -p 8987 -z localhost:9983
 ----
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -67,6 +67,7 @@ Due to changes in Lucene 9, that isn't possible any more.
 == Solr 9.2
 === Upgrade to Jetty 10.x
 * Solr upgraded to Jetty 10.x from 9.x due to Jetty 9.x is now end of life. Jetty 10.x has a Java 11 minimum and matches Solr 9 minimum Java version. Jetty logging has been replaced with slf4j again matching Solr. See https://webtide.com/jetty-10-and-11-have-arrived/ for additional Jetty 10.x highlights.
+* Loading solr.xml from Zookeeper is deprecated. See xref:configuration-guide:configuring-solr-xml.adoc[Configuring solr.xml].
 
 === Jetty Configuration
 * Solr no longer duplicates certain Jetty "server" library dependencies between `server/lib` and `WEB-INF/lib` (jetty-util, jetty-io, etc.).


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15959

Deprecation warning in log, and WARNING in refguide.

Also fixed some other refguide mentions of the need for copying solr.xml to SOLR_HOME, which is no longer needed.