### PR TITLE
SOLR-16669: Fix default checkPeerName in Http2SolrClient

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -223,6 +223,8 @@ Bug Fixes
 
 * SOLR-16668: Use default to Java SSL for Http2SolrClient when none is provided (Houston Putman)
 
+* SOLR-16669: Http2SolrClient now defaults checkPeerName to True, as the documentation specified (Houston Putman)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to 3.4 (Uwe Schindler)

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -76,6 +76,10 @@ This is an improvement to the binary release artifact, but Jetty does not allow 
 The `server/contexts/solr-jetty-context.xml` now explicitly removes these restrictions, allowing Solr to share these "server" jars which now live in `server/lib/ext`.
 * The "Transient Cores" feature is now deprecated.
 
+=== SSL Configuration
+* When using Solr (or SolrJ) with an SSL-enabled Solr cluster using HTTP2, the default `-Dsolr.ssl.checkPeerName` value is now *true*.
+This is what has been documented in xref:deployment-guide:enabling-ssl.adoc#start-solrcloud[Enabling SSL], and matches the functionality of the original `HttpSolrClient`.
+
 === Tracing
 * A new `opentelemetry` module is added, with support for OTEL tracing in `OTLP` format using gRPC.
   At the same time, the `jaegertracer-configurator` module is deprecated for removal in Solr 10.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -1248,10 +1248,7 @@ public class Http2SolrClient extends SolrClient {
   /* package-private for testing */
   static SslContextFactory.Client getDefaultSslContextFactory() {
     String checkPeerNameStr = System.getProperty(HttpClientUtil.SYS_PROP_CHECK_PEER_NAME);
-    boolean sslCheckPeerName = true;
-    if (checkPeerNameStr == null || "false".equalsIgnoreCase(checkPeerNameStr)) {
-      sslCheckPeerName = false;
-    }
+    boolean sslCheckPeerName = !"false".equalsIgnoreCase(checkPeerNameStr);
 
     SslContextFactory.Client sslContextFactory = new SslContextFactory.Client(!sslCheckPeerName);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16669

The primary issue is the `checkPeerNameStr == null` check. If the sysProp is not provided we want to default to `true`, not `false`.

Not back-compat, but actually follows the code and ref-guide documentation.