### PR TITLE
SOLR-15928 Dim add collection buttons in Admin UI when no permission

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -285,6 +285,8 @@ Other Changes
 * SOLR-16573: Introduce EmbeddedSolrServerTestRule, a JUnit 4 TestRule for Solr testing
   (Joshua Ouma, David Smiley)
 
+* SOLR-15928: Dim 'Add Collection' and 'Create Alias' buttons when user lacks proper permissions (janhoy)
+
 ==================  9.1.1 ==================
 
 Bug Fixes

--- a/solr/webapp/web/css/angular/collections.css
+++ b/solr/webapp/web/css/angular/collections.css
@@ -148,6 +148,12 @@ limitations under the License.
   background-image: url( ../../img/ico/cross.png );
 }
 
+button.disabled
+{
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 #content #collections #navigation #add span
 {
   background-image: url( ../../img/ico/plus-button.png );

--- a/solr/webapp/web/js/angular/app.js
+++ b/solr/webapp/web/js/angular/app.js
@@ -497,6 +497,9 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
   }
 
   $scope.permissions = permissions;
+  $scope.isPermitted = function (permissions) {
+    return hasAllRequiredPermissions(permissions, $scope.usersPermissions);
+  }
 
   $scope.refresh();
   $scope.resetMenu = function(page, pageType) {
@@ -589,9 +592,6 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
     $scope.page = page;
     $scope.currentUser = sessionStorage.getItem("auth.username");
     $scope.http401 = sessionStorage.getItem("http401");
-    $scope.isPermitted = function (permissions) {
-      return hasAllRequiredPermissions(permissions, $scope.usersPermissions);
-    }
   };
 
   $scope.isMultiDestAlias = function(selectedColl) {

--- a/solr/webapp/web/js/angular/app.js
+++ b/solr/webapp/web/js/angular/app.js
@@ -497,9 +497,6 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
   }
 
   $scope.permissions = permissions;
-  $scope.isPermitted = function (permissions) {
-    return hasAllRequiredPermissions(permissions, $scope.usersPermissions);
-  }
 
   $scope.refresh();
   $scope.resetMenu = function(page, pageType) {
@@ -532,6 +529,8 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
         permissions.READ_PERM,
         permissions.UPDATE_PERM
       ]);
+
+      $scope.canEditColl = $scope.isPermitted(permissions.COLL_EDIT_PERM);
 
       var currentCollectionName = $route.current.params.core;
       delete $scope.currentCollection;
@@ -590,6 +589,9 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
     $scope.page = page;
     $scope.currentUser = sessionStorage.getItem("auth.username");
     $scope.http401 = sessionStorage.getItem("http401");
+    $scope.isPermitted = function (permissions) {
+      return hasAllRequiredPermissions(permissions, $scope.usersPermissions);
+    }
   };
 
   $scope.isMultiDestAlias = function(selectedColl) {

--- a/solr/webapp/web/js/angular/app.js
+++ b/solr/webapp/web/js/angular/app.js
@@ -533,8 +533,6 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
         permissions.UPDATE_PERM
       ]);
 
-      $scope.canEditColl = $scope.isPermitted(permissions.COLL_EDIT_PERM);
-
       var currentCollectionName = $route.current.params.core;
       delete $scope.currentCollection;
       if ($scope.isCloudEnabled) {

--- a/solr/webapp/web/partials/collections.html
+++ b/solr/webapp/web/partials/collections.html
@@ -84,7 +84,7 @@ limitations under the License.
         </p>
 
         <p class="clearfix buttons">
-          <button type="submit" ng-class="{submit,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="addCollection()">
+          <button type="submit" ng-class="{submit,disabled:!isPermitted(permissions.COLL_EDIT_PERM)}" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="addCollection()">
             <span>Add Collection</span>
           </button>
           <button type="reset" class="reset" ng-click="cancelAddCollection()"><span>Cancel</span></button>
@@ -112,7 +112,7 @@ limitations under the License.
         </p>
 
         <p class="clearfix buttons">
-          <button ng-class="{submit,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="createAlias()"><span>Create Alias</span></button>
+          <button ng-class="{submit,disabled:!isPermitted(permissions.COLL_EDIT_PERM)}" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="createAlias()"><span>Create Alias</span></button>
           <button type="reset" class="reset" ng-click="cancelCreateAlias()"><span>Cancel</span></button>
         </p>
       </form>
@@ -124,10 +124,11 @@ limitations under the License.
 
     <div id="actions" class="actions clearfix" ng-show="collection">
 
-      <button id="delete-collection" ng-class="{warn,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="showDeleteCollection()" ng-show="collection && collection.type === 'collection'"><span>Delete collection</span></button>
-      <button id="delete-alias" ng-class="{action,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="toggleDeleteAlias()" ng-show="collection && collection.type === 'alias'"><span>Delete alias</span></button>
-      <button id="reload" class="requires-core" ng-click="reloadCollection()" ng-show="collection && collection.type === 'collection'"
-         ng-class="{success: reloadSuccess, warn: reloadFailure}"><span>Reload</span></button>
+      <button id="delete-collection" ng-class="{warn,disabled:!isPermitted(permissions.COLL_EDIT_PERM)}" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="showDeleteCollection()" ng-show="collection && collection.type === 'collection'"><span>Delete collection</span></button>
+      <button id="delete-alias" ng-class="{action,disabled:!isPermitted(permissions.COLL_EDIT_PERM)}" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="toggleDeleteAlias()" ng-show="collection && collection.type === 'alias'"><span>Delete alias</span></button>
+      <button id="reload" ng-click="reloadCollection()" ng-show="collection && collection.type === 'collection'"
+              ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)"
+              ng-class="{success: reloadSuccess, warn: reloadFailure, disabled:!isPermitted(permissions.COLL_EDIT_PERM)}"><span>Reload</span></button>
 
       <div class="action delete" ng-show="showDelete">
 
@@ -397,12 +398,12 @@ limitations under the License.
   </div>
 
   <div id="navigation" class="requires-core clearfix">
-    <button id="add" ng-class="{action,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="showAddCollection()"><span>Add Collection</span></button>
+    <button id="add" ng-class="{action,disabled:!isPermitted(permissions.COLL_EDIT_PERM)}" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="showAddCollection()"><span>Add Collection</span></button>
     <ul>
       <li ng-repeat="c in collections" ng-class="{current: collection.name == c.name && collection.type === 'collection'}"><a href="#~collections/{{c.name}}">{{c.name}}</a></li>
     </ul>
     <hr/>
-    <button id="create-alias" ng-class="{action,disabled:!canEditColl}" ng-click="toggleCreateAlias()" ng-disabled="collections.length == 0"><span>Create Alias</span></button>
+    <button id="create-alias" ng-class="{action,disabled:!isPermitted(permissions.COLL_EDIT_PERM)}" ng-click="toggleCreateAlias()" ng-disabled="collections.length == 0 || !isPermitted(permissions.COLL_EDIT_PERM)"><span>Create Alias</span></button>
     <ul>
       <li ng-repeat="c in aliases" ng-class="{current: collection.name == c.name && collection.type === 'alias'}"><a href="#~collections/alias_{{c.name}}">{{c.name}}</a></li>
     </ul>

--- a/solr/webapp/web/partials/collections.html
+++ b/solr/webapp/web/partials/collections.html
@@ -84,7 +84,9 @@ limitations under the License.
         </p>
 
         <p class="clearfix buttons">
-          <button type="submit" class="submit" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="addCollection()"><span>Add Collection</span></button>
+          <button type="submit" ng-class="{submit,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="addCollection()">
+            <span>Add Collection</span>
+          </button>
           <button type="reset" class="reset" ng-click="cancelAddCollection()"><span>Cancel</span></button>
         </p>
 
@@ -110,7 +112,7 @@ limitations under the License.
         </p>
 
         <p class="clearfix buttons">
-          <button class="submit" ng-click="createAlias()"><span>Create Alias</span></button>
+          <button ng-class="{submit,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="createAlias()"><span>Create Alias</span></button>
           <button type="reset" class="reset" ng-click="cancelCreateAlias()"><span>Cancel</span></button>
         </p>
       </form>
@@ -122,8 +124,8 @@ limitations under the License.
 
     <div id="actions" class="actions clearfix" ng-show="collection">
 
-      <button id="delete-collection" class="warn requires-core" ng-click="showDeleteCollection()" ng-show="collection && collection.type === 'collection'"><span>Delete collection</span></button>
-      <button id="delete-alias" class="action requires-core" ng-click="toggleDeleteAlias()" ng-show="collection && collection.type === 'alias'"><span>Delete alias</span></button>
+      <button id="delete-collection" ng-class="{warn,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="showDeleteCollection()" ng-show="collection && collection.type === 'collection'"><span>Delete collection</span></button>
+      <button id="delete-alias" ng-class="{action,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="toggleDeleteAlias()" ng-show="collection && collection.type === 'alias'"><span>Delete alias</span></button>
       <button id="reload" class="requires-core" ng-click="reloadCollection()" ng-show="collection && collection.type === 'collection'"
          ng-class="{success: reloadSuccess, warn: reloadFailure}"><span>Reload</span></button>
 
@@ -395,12 +397,12 @@ limitations under the License.
   </div>
 
   <div id="navigation" class="requires-core clearfix">
-    <button id="add" class="action" ng-disabled="!isPermitted(permissions.COLL_EDIT_PERM)" ng-click="showAddCollection()"><span>Add Collection</span></button>
+    <button id="add" ng-class="{action,disabled:!canEditColl}" ng-disabled="!canEditColl" ng-click="showAddCollection()"><span>Add Collection</span></button>
     <ul>
       <li ng-repeat="c in collections" ng-class="{current: collection.name == c.name && collection.type === 'collection'}"><a href="#~collections/{{c.name}}">{{c.name}}</a></li>
     </ul>
     <hr/>
-    <button id="create-alias" class="action requires-core" ng-click="toggleCreateAlias()" ng-disabled="collections.length == 0"><span>Create Alias</span></button>
+    <button id="create-alias" ng-class="{action,disabled:!canEditColl}" ng-click="toggleCreateAlias()" ng-disabled="collections.length == 0"><span>Create Alias</span></button>
     <ul>
       <li ng-repeat="c in aliases" ng-class="{current: collection.name == c.name && collection.type === 'alias'}"><a href="#~collections/alias_{{c.name}}">{{c.name}}</a></li>
     </ul>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15928

This is the first of several permission related edits to Admin UI. The "Add Collection" button was already disabled when user lacked `collection-admin-edit`, but it was not dimmed/greyed so hard to understand why you could not click.

<img width="476" alt="Skjermbilde 2023-02-18 kl  00 05 23" src="https://user-images.githubusercontent.com/409128/219814059-785e46e3-8584-4b25-ad7a-74a90ffa0dc2.png">
