### PR TITLE
SOLR-16680: Add JMH benchmark for Solr startup

### DIFF
--- a/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
@@ -69,7 +69,7 @@ public class SolrStartup {
     public void bootstrapJettyServer() throws Exception {
       tmpSolrHome = Files.createTempDirectory("solrstartup-perthreadstate-jsr").toAbsolutePath();
 
-      final Path configsetsDir = Path.of(tmpSolrHome.toString(), "configsets");
+      final Path configsetsDir = tmpSolrHome.resolve("configsets");
       final Path defaultConfigsetDir = Path.of(configsetsDir.toString(), "defaultConfigSet");
       Files.createDirectories(defaultConfigsetDir);
       PathUtils.copyDirectory(

--- a/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
@@ -70,7 +70,7 @@ public class SolrStartup {
       tmpSolrHome = Files.createTempDirectory("solrstartup-perthreadstate-jsr").toAbsolutePath();
 
       final Path configsetsDir = tmpSolrHome.resolve("configsets");
-      final Path defaultConfigsetDir = Path.of(configsetsDir.toString(), "defaultConfigSet");
+      final Path defaultConfigsetDir = configsetsDir.resolve("defaultConfigSet");
       Files.createDirectories(defaultConfigsetDir);
       PathUtils.copyDirectory(
           Path.of("src/resources/configs/minimal/conf"),

--- a/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.bench.lifecycle;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.util.IOUtils;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.request.CoreAdminRequest;
+import org.apache.solr.client.solrj.response.CoreAdminResponse;
+import org.apache.solr.embedded.JettyConfig;
+import org.apache.solr.embedded.JettySolrRunner;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+
+/**
+ * A simple JMH benchmark that attempts to measure approximate Solr startup behavior by measuring
+ * {@link JettySolrRunner#start()}
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(time = 60, iterations = 10)
+@Threads(3)
+@Fork(value = 1)
+public class SolrStartup {
+
+  @Benchmark
+  public void startSolr(PerThreadState threadState) throws Exception {
+    threadState.solrRunner.start(
+        false); // 'false' tells Jetty to not go out of its way to reuse any previous ports
+  }
+
+  @State(Scope.Thread)
+  public static class PerThreadState {
+
+    private static final int NUM_CORES = 10;
+
+    public File tmpSolrHome;
+    public JettySolrRunner solrRunner;
+
+    @Setup(Level.Trial)
+    public void bootstrapJettyServer() throws Exception {
+      tmpSolrHome =
+          Files.createTempDirectory("solrstartup-perthreadstate-jsr").toFile().getAbsoluteFile();
+      final File configsetsDir = new File(tmpSolrHome, "configsets");
+      Files.createDirectory(configsetsDir.toPath());
+      FileUtils.copyDirectory(
+          new File("src/resources/configs/minimal/conf"),
+          new File(configsetsDir, "/defaultConfigSet/conf"));
+      FileUtils.copyFile(new File("src/resources/solr.xml"), new File(tmpSolrHome, "solr.xml"));
+
+      solrRunner = new JettySolrRunner(tmpSolrHome.getAbsolutePath(), buildJettyConfig("/solr"));
+      solrRunner.start(false);
+      try (SolrClient client = solrRunner.newClient()) {
+        for (int i = 0; i < NUM_CORES; i++) {
+          createCore(client, "core-prefix-" + i);
+        }
+      }
+      solrRunner.stop();
+    }
+
+    private void createCore(SolrClient client, String coreName) throws Exception {
+      CoreAdminRequest.Create create = new CoreAdminRequest.Create();
+      create.setCoreName(coreName);
+      create.setConfigSet("defaultConfigSet");
+
+      final CoreAdminResponse response = create.process(client);
+      if (response.getStatus() != 0) {
+        throw new RuntimeException("Some error creating core: " + response.jsonStr());
+      }
+    }
+
+    @TearDown(Level.Invocation)
+    public void stopJettyServerIfNecessary() throws Exception {
+      if (solrRunner.isRunning()) {
+        solrRunner.stop();
+      }
+    }
+
+    @TearDown(Level.Trial)
+    public void destroyJettyServer() throws Exception {
+      if (solrRunner.isRunning()) {
+        solrRunner.stop();
+      }
+
+      IOUtils.rm(Path.of(tmpSolrHome.toURI()));
+    }
+
+    private static JettyConfig buildJettyConfig(String context) {
+      return JettyConfig.builder().setContext(context).stopAtShutdown(true).build();
+    }
+  }
+}

--- a/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
@@ -73,8 +73,7 @@ public class SolrStartup {
       final Path defaultConfigsetDir = configsetsDir.resolve("defaultConfigSet");
       Files.createDirectories(defaultConfigsetDir);
       PathUtils.copyDirectory(
-          Path.of("src/resources/configs/minimal/conf"),
-          defaultConfigsetDir.resolve("conf"));
+          Path.of("src/resources/configs/minimal/conf"), defaultConfigsetDir.resolve("conf"));
       PathUtils.copyFileToDirectory(Path.of("src/resources/solr.xml"), tmpSolrHome);
 
       solrRunner = new JettySolrRunner(tmpSolrHome.toString(), buildJettyConfig("/solr"));

--- a/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/SolrStartup.java
@@ -74,7 +74,7 @@ public class SolrStartup {
       Files.createDirectories(defaultConfigsetDir);
       PathUtils.copyDirectory(
           Path.of("src/resources/configs/minimal/conf"),
-          Path.of(defaultConfigsetDir.toString(), "/conf"));
+          defaultConfigsetDir.resolve("conf"));
       PathUtils.copyFileToDirectory(Path.of("src/resources/solr.xml"), tmpSolrHome);
 
       solrRunner = new JettySolrRunner(tmpSolrHome.toString(), buildJettyConfig("/solr"));

--- a/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/package-info.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/lifecycle/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Benchmarks for various resource lifecycle events (e.g. Solr startup, collection creation) */
+package org.apache.solr.bench.lifecycle;

--- a/solr/benchmark/src/resources/configs/minimal/conf/schema.xml
+++ b/solr/benchmark/src/resources/configs/minimal/conf/schema.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<schema name="minimal" version="1.1">
+  <fieldType name="string" class="solr.StrField"/>
+  <dynamicField name="*" type="string" indexed="true" stored="true"/>
+</schema>

--- a/solr/benchmark/src/resources/configs/minimal/conf/solrconfig.xml
+++ b/solr/benchmark/src/resources/configs/minimal/conf/solrconfig.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- Minimal solrconfig.xml with /select, /admin and /update only -->
+
+<config>
+
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <directoryFactory name="DirectoryFactory"
+                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <commitWithin>
+      <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
+    </commitWithin>
+
+  </updateHandler>
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="indent">true</str>
+      <str name="df">text</str>
+    </lst>
+
+  </requestHandler>
+</config>
+

--- a/solr/benchmark/src/resources/solr.xml
+++ b/solr/benchmark/src/resources/solr.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+ All (relative) paths are relative to the installation path
+-->
+<solr>
+
+  <metrics enabled="${metricsEnabled:true}"/>
+
+  <str name="shareSchema">${shareSchema:false}</str>
+  <str name="configSetBaseDir">${configSetBaseDir:configsets}</str>
+  <str name="coreRootDirectory">${coreRootDirectory:.}</str>
+  <str name="allowPaths">${solr.allowPaths:}</str>
+  <str name="allowUrls">${solr.tests.allowUrls:}</str>
+
+  <shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory">
+    <str name="urlScheme">${urlScheme:}</str>
+    <int name="socketTimeout">${socketTimeout:15000}</int>
+    <int name="connTimeout">${connTimeout:15000}</int>
+  </shardHandlerFactory>
+
+  <solrcloud>
+    <str name="host">127.0.0.1</str>
+    <int name="hostPort">${hostPort:8983}</int>
+    <str name="hostContext">${hostContext:solr}</str>
+    <int name="zkClientTimeout">${solr.zkclienttimeout:60000}</int> <!-- This should be high by default - dc's are expensive -->
+    <bool name="genericCoreNodeNames">${genericCoreNodeNames:true}</bool>
+    <int name="leaderVoteWait">${leaderVoteWait:15000}</int>   <!-- We are running tests - the default should be low, not like production -->
+    <int name="leaderConflictResolveWait">${leaderConflictResolveWait:45000}</int> 
+    <int name="distribUpdateConnTimeout">${distribUpdateConnTimeout:5000}</int>
+    <int name="distribUpdateSoTimeout">${distribUpdateSoTimeout:30000}</int> <!-- We are running tests - the default should be low, not like production -->
+  </solrcloud>
+  
+</solr>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16680

# Description

Solr has a benchmarking module built around an integration with JMH.  But it doesn't have a ton of benchmarks to run quite yet.

# Solution

This PR adds a JMH benchmark that attempts to measure Solr Startup, by using the JettySolrRunner test-framework class.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
