### PR TITLE
SOLR-16608: Fixing replacement of line ending in test to be OS agnostic

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/ZkCLITest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkCLITest.java
@@ -445,7 +445,7 @@ public class ZkCLITest extends SolrTestCaseJ4 {
     ZkCLI.main(args);
     assertArrayEquals(
         data,
-        StringUtils.removeEnd(systemOut.toString(StandardCharsets.UTF_8), "\n")
+        StringUtils.removeEnd(systemOut.toString(StandardCharsets.UTF_8), System.lineSeparator())
             .getBytes(StandardCharsets.UTF_8));
   }
 
@@ -464,7 +464,7 @@ public class ZkCLITest extends SolrTestCaseJ4 {
     ZkCLI.main(args);
     assertArrayEquals(
         data,
-        StringUtils.removeEnd(systemOut.toString(StandardCharsets.UTF_8), "\n")
+        StringUtils.removeEnd(systemOut.toString(StandardCharsets.UTF_8), System.lineSeparator())
             .getBytes(StandardCharsets.UTF_8));
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16608

# Description

Fixing a test failure on Windows for a recent test addition.

# Solution

Using System.lineSeparator() to work on any OS

# Tests

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
