### PR TITLE
SOLR-16683 Fix frequent failures of OtelTracerConfiguratorTest

### DIFF
--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/OtelTracerConfiguratorTest.java
@@ -27,7 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-@ThreadLeakLingering(linger = 10)
+@ThreadLeakLingering(linger = 10000)
 public class OtelTracerConfiguratorTest extends SolrTestCaseJ4 {
   private OtelTracerConfigurator instance;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16683

The `@ThreadLeakLingering`  should be in millis, not seconds, so 10 means 10ms, but we should wait for 10s.