### PR TITLE
SOLR-16643: Add reRankOperator=multiply/replace options to ReRank query parser

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -55,6 +55,8 @@ New Features
 
 * SOLR-16646: New function query operator isnan to verify if value is NaN (Gabriel Magno via Kevin Risden)
 
+* SOLR-16643: Add reRankOperator=multiply/replace options to rerank query parser (Andy Webb, Christine Poerschke, Mikhail Khludnev)
+
 Improvements
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/search/ReRankOperator.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankOperator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.util.Locale;
+import org.apache.solr.common.SolrException;
+
+public enum ReRankOperator {
+  ADD,
+  MULTIPLY,
+  REPLACE;
+
+  public static ReRankOperator get(String p) {
+    if (p != null) {
+      try {
+        return ReRankOperator.valueOf(p.toUpperCase(Locale.ROOT));
+      } catch (Exception ex) {
+        throw new SolrException(
+            SolrException.ErrorCode.BAD_REQUEST, "Invalid reRankOperator: " + p);
+      }
+    }
+    return null;
+  }
+
+  public String toLower() {
+    return toString().toLowerCase(Locale.ROOT);
+  }
+}

--- a/solr/solr-ref-guide/modules/query-guide/pages/query-re-ranking.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/query-re-ranking.adoc
@@ -67,9 +67,18 @@ This number will be treated as a minimum, and may be increased internally automa
 |Optional |Default: `2.0`
 |===
 +
-A multiplicative factor that will be applied to the score from the reRankQuery for each of the top matching documents, before that score is added to the original score.
+A multiplicative factor that will be applied to the score from the reRankQuery for each of the top matching documents, before that score is combined with the original score.
 
-In the example below, the top 1000 documents matching the query "greetings" will be re-ranked using the query "(hi hello hey hiya)".
+`reRankOperator`::
++
+[%autowidth,frame=none]
+|===
+|Optional |Default: `add`
+|===
++
+By default the score from the reRankQuery multiplied by the `reRankWeight` is added to the original score.
+
+In the example below using the default `add` behaviour, the top 1000 documents matching the query "greetings" will be re-ranked using the query "(hi hello hey hiya)".
 The resulting scores for each of those 1000 documents will be 3 times their score from the "(hi hello hey hiya)", plus the score from the original "greetings" query:
 
 [source,text]
@@ -78,6 +87,25 @@ q=greetings&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=3}&rqq=(hi
 ----
 
 If a document matches the original query, but does not match the re-ranking query, the document's original score will remain.
+
+Setting `reRankOperator` to `multiply` will multiply the three numbers instead. This means that other multiplying operations such as xref:edismax-query-parser.adoc#extended-dismax-parameters[eDisMax `boost` functions] can be converted to Re-Rank operations.
+
+In the example below, the scores for the top 1000 documents matching the query "phone" will be multiplied by a function of the `price` field.
+
+[source,text]
+----
+q=phone&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=1 reRankOperator=multiply}&rqq={!func v=div(1,sum(1,price))}
+----
+
+Setting `reRankOperator` to `replace` will replace the score, so the final scores can be independent of documents' original scores.
+
+In the example below, the scores for the top 1000 documents matching the query "phone" will be replaced with a function of the `price` field.
+
+[source,text]
+----
+q=phone&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=1 reRankOperator=replace}&rqq={!func v=div(1,sum(1,price))}
+----
+
 
 === LTR Query Parser
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16643

This PR supersedes https://github.com/apache/solr/pull/1324 - please see that PR for earlier comments.

# Description

Add `reRankOperator=multiply` and `replace` options to ReRank query parser

# Solution

The new options can be used to replace or multiply (rather than add to) documents' original scores with the output of the ReRankQuery.

# Tests

We've added tests that validates that scores have changed as expected.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
