### PR TITLE
SOLR-16487: Improve Pull Replica Interval

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -165,6 +165,8 @@ Optimizations
 
 * SOLR-16615: Jersey 'ApplicationHandlers' are now shared by compatible cores where possible (Jason Gerlowski, Houston Putman)
 
+* SOLR-16487: Replication pooling is optimized based on hard and soft commit settings for a given collection
+
 Bug Fixes
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -165,7 +165,7 @@ Optimizations
 
 * SOLR-16615: Jersey 'ApplicationHandlers' are now shared by compatible cores where possible (Jason Gerlowski, Houston Putman)
 
-* SOLR-16487: Replication pooling is optimized based on hard and soft commit settings for a given collection
+* SOLR-16487: Replication pooling is optimized based on hard and soft commit settings for a given collection (Justin Sweeney)
 
 Bug Fixes
 ---------------------

--- a/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
@@ -80,7 +80,8 @@ public class ReplicateFromLeader {
       if (System.getProperty("jetty.testMode") != null) {
         pollIntervalStr = "00:00:01";
       }
-      if (uinfo.autoCommmitMaxTime != -1) {
+
+      if (uinfo.openSearcher && uinfo.autoCommmitMaxTime != -1) {
         pollIntervalStr = toPollIntervalStr(uinfo.autoCommmitMaxTime / 2);
       } else if (uinfo.autoSoftCommmitMaxTime != -1) {
         pollIntervalStr = toPollIntervalStr(uinfo.autoSoftCommmitMaxTime / 2);

--- a/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
@@ -155,6 +155,13 @@ public class ReplicateFromLeader {
     }
   }
 
+  /**
+   * Determine the poll interval for replicas based on the auto soft/hard commit schedule
+   *
+   * @param uinfo the update handler info containing soft/hard commit configuration
+   * @return a poll interval string representing a cadence of polling frequency in the form of
+   *     hh:mm:ss
+   */
   public static String determinePollInterval(SolrConfig.UpdateHandlerInfo uinfo) {
     int hardCommitMaxTime = uinfo.autoCommmitMaxTime;
     int softCommitMaxTime = uinfo.autoSoftCommmitMaxTime;
@@ -162,20 +169,17 @@ public class ReplicateFromLeader {
     String pollIntervalStr = null;
     if (hardCommitMaxTime != -1) {
       // configured hardCommit places a ceiling on the interval at which new segments will be
-      // available
-      // to replicate
+      // available to replicate
       if (softCommitMaxTime != -1
           && (!hardCommitNewSearcher || softCommitMaxTime <= hardCommitMaxTime)) {
         // softCommit is configured.
-        // Usually if softCommit is configured, `hardCommitNewSearcher==false`, in which case you
-        // want
-        // to calculate poll interval wrt the max of hardCommitTime (when segments are available to
-        // replicate) and softCommitTime (when changes are visible).
+        // Usually if softCommit is configured, `hardCommitNewSearcher==false`,
+        // in which case you want to calculate poll interval wrt the max of hardCommitTime
+        // (when segments are available to replicate) and softCommitTime (when changes are visible).
         // But in the unusual case that hardCommit _does_ open a new searcher and
-        // `hardCommitMaxTime < softCommitMaxTime`, then fallback to `else` clause, setting poll
-        // interval
-        // wrt `hardCommitMaxTime` alone.
-        pollIntervalStr = toPollIntervalStr((Math.max(hardCommitMaxTime, softCommitMaxTime)) / 2);
+        // `hardCommitMaxTime < softCommitMaxTime`, then fallback to `else` clause,
+        // setting poll interval wrt `hardCommitMaxTime` alone.
+        pollIntervalStr = toPollIntervalStr(Math.max(hardCommitMaxTime, softCommitMaxTime) / 2);
       } else {
         pollIntervalStr = toPollIntervalStr(hardCommitMaxTime / 2);
       }

--- a/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
@@ -81,10 +81,9 @@ public class ReplicateFromLeader {
         pollIntervalStr = "00:00:01";
       }
 
-      if (uinfo.openSearcher && uinfo.autoCommmitMaxTime != -1) {
-        pollIntervalStr = toPollIntervalStr(uinfo.autoCommmitMaxTime / 2);
-      } else if (uinfo.autoSoftCommmitMaxTime != -1) {
-        pollIntervalStr = toPollIntervalStr(uinfo.autoSoftCommmitMaxTime / 2);
+      String calculatedPollIntervalString = determinePollInterval(uinfo);
+      if (calculatedPollIntervalString != null) {
+        pollIntervalStr = calculatedPollIntervalString;
       }
       log.info("Will start replication from leader with poll interval: {}", pollIntervalStr);
 
@@ -154,6 +153,38 @@ public class ReplicateFromLeader {
       log.warn("Cannot get commit command version from index commit point ", e);
       return null;
     }
+  }
+
+  public static String determinePollInterval(SolrConfig.UpdateHandlerInfo uinfo) {
+    int hardCommitMaxTime = uinfo.autoCommmitMaxTime;
+    int softCommitMaxTime = uinfo.autoSoftCommmitMaxTime;
+    boolean hardCommitNewSearcher = uinfo.openSearcher;
+    String pollIntervalStr = null;
+    if (hardCommitMaxTime != -1) {
+      // configured hardCommit places a ceiling on the interval at which new segments will be
+      // available
+      // to replicate
+      if (softCommitMaxTime != -1
+          && (!hardCommitNewSearcher || softCommitMaxTime <= hardCommitMaxTime)) {
+        // softCommit is configured.
+        // Usually if softCommit is configured, `hardCommitNewSearcher==false`, in which case you
+        // want
+        // to calculate poll interval wrt the max of hardCommitTime (when segments are available to
+        // replicate) and softCommitTime (when changes are visible).
+        // But in the unusual case that hardCommit _does_ open a new searcher and
+        // `hardCommitMaxTime < softCommitMaxTime`, then fallback to `else` clause, setting poll
+        // interval
+        // wrt `hardCommitMaxTime` alone.
+        pollIntervalStr = toPollIntervalStr((Math.max(hardCommitMaxTime, softCommitMaxTime)) / 2);
+      } else {
+        pollIntervalStr = toPollIntervalStr(hardCommitMaxTime / 2);
+      }
+    } else if (softCommitMaxTime != -1) {
+      // visibility of changes places a ceiling on polling frequency
+      pollIntervalStr = toPollIntervalStr(softCommitMaxTime / 2);
+    }
+
+    return pollIntervalStr;
   }
 
   private static String toPollIntervalStr(int ms) {

--- a/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ReplicateFromLeader.java
@@ -172,13 +172,15 @@ public class ReplicateFromLeader {
       // available to replicate
       if (softCommitMaxTime != -1
           && (!hardCommitNewSearcher || softCommitMaxTime <= hardCommitMaxTime)) {
-        // softCommit is configured.
-        // Usually if softCommit is configured, `hardCommitNewSearcher==false`,
-        // in which case you want to calculate poll interval wrt the max of hardCommitTime
-        // (when segments are available to replicate) and softCommitTime (when changes are visible).
-        // But in the unusual case that hardCommit _does_ open a new searcher and
-        // `hardCommitMaxTime < softCommitMaxTime`, then fallback to `else` clause,
-        // setting poll interval wrt `hardCommitMaxTime` alone.
+        /*
+         * softCommit is configured.
+         * Usually if softCommit is configured, `hardCommitNewSearcher==false`,
+         * in which case you want to calculate poll interval wrt the max of hardCommitTime
+         * (when segments are available to replicate) and softCommitTime (when changes are visible).
+         * But in the unusual case that hardCommit _does_ open a new searcher and
+         * `hardCommitMaxTime < softCommitMaxTime`, then fallback to `else` clause,
+         * setting poll interval wrt `hardCommitMaxTime` alone.
+         */
         pollIntervalStr = toPollIntervalStr(Math.max(hardCommitMaxTime, softCommitMaxTime) / 2);
       } else {
         pollIntervalStr = toPollIntervalStr(hardCommitMaxTime / 2);

--- a/solr/core/src/test/org/apache/solr/cloud/ReplicateFromLeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplicateFromLeaderTest.java
@@ -17,10 +17,12 @@
 
 package org.apache.solr.cloud;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.solr.core.SolrConfig;
 import org.junit.Test;
 
-public class ReplicateFromLeaderTest extends SolrCloudTestCase {
+public class ReplicateFromLeaderTest {
 
   @Test
   public void determinePollIntervalString() {

--- a/solr/core/src/test/org/apache/solr/cloud/ReplicateFromLeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplicateFromLeaderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.cloud;
+
+import org.apache.solr.core.SolrConfig;
+import org.junit.Test;
+
+public class ReplicateFromLeaderTest extends SolrCloudTestCase {
+
+  @Test
+  public void determinePollIntervalString() {
+    SolrConfig.UpdateHandlerInfo updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, 15000, -1, true, -1, 60000, false);
+    String pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:7", pollInterval);
+
+    updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, 60000, -1, true, -1, 15000, false);
+    pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:30", pollInterval);
+
+    updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, 15000, -1, false, -1, 60000, false);
+    pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:30", pollInterval);
+
+    updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, 60000, -1, false, -1, 15000, false);
+    pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:30", pollInterval);
+
+    updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, -1, -1, false, -1, 60000, false);
+    pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:30", pollInterval);
+
+    updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, 15000, -1, false, -1, -1, false);
+    pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:7", pollInterval);
+
+    updateHandlerInfo =
+        new SolrConfig.UpdateHandlerInfo(
+            "solr.DirectUpdateHandler2", -1, 60000, -1, true, -1, -1, false);
+    pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
+    assertEquals("0:0:30", pollInterval);
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16487

# Description

The polling for replication is fairly simply, but can lead to polling too often. As an example if you had the following config for commits:
```
<autoCommit>
    <maxTime>15000</maxTime>
    <openSearcher>false</openSearcher>
</autoCommit>

<autoSoftCommit>
    <maxTime>60000</maxTime>
</autoSoftCommit>
```
The current logic would setup polling to be half of the autoCommit time, so poll every 7.5 seconds. However since a new searcher isn't opened, there will only be changes reflected every 60 seconds on the leader. We can make this logic a bit smarter knowing that the replication handler won't reflect changes until a new searcher is opened.

# Solution

Modified the code setting the polling interval for replication to only use the autoCommit time if openSearcher is true, otherwise it will use the soft commit time.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
