### PR TITLE
SOLR-16393: Migrate alias-deletion to JAX-RS

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -42,6 +42,12 @@ Bug Fixes
 * SOLR-16686: Using bin/solr to copy a file from ZK to local fails if the local filename does not have a path.
   (Shawn Heisey)
 
+Improvements
+---------------------
+
+* SOLR-16393: The path of the v2 "delete alias" API has been tweaked slightly to be more intuitive, and is now available at
+  `DELETE /api/aliases/aliasName`. (Jason Gerlowski)
+
 ==================  9.2.0 ==================
 
 New Features

--- a/solr/core/src/java/org/apache/solr/handler/CollectionsAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/CollectionsAPI.java
@@ -39,7 +39,6 @@ import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.BackupCollectionPayload;
 import org.apache.solr.client.solrj.request.beans.CreateAliasPayload;
 import org.apache.solr.client.solrj.request.beans.CreatePayload;
-import org.apache.solr.client.solrj.request.beans.DeleteAliasPayload;
 import org.apache.solr.client.solrj.request.beans.RestoreCollectionPayload;
 import org.apache.solr.client.solrj.request.beans.SetAliasPropertyPayload;
 import org.apache.solr.client.solrj.request.beans.V2ApiConstants;
@@ -55,7 +54,6 @@ public class CollectionsAPI {
   public static final String V2_RESTORE_CMD = "restore-collection";
   public static final String V2_CREATE_ALIAS_CMD = "create-alias";
   public static final String V2_SET_ALIAS_PROP_CMD = "set-alias-property";
-  public static final String V2_DELETE_ALIAS_CMD = "delete-alias";
 
   private final CollectionsHandler collectionsHandler;
 
@@ -137,16 +135,6 @@ public class CollectionsAPI {
       final Map<String, Object> propertiesMap =
           (Map<String, Object>) v1Params.remove(V2ApiConstants.PROPERTIES_KEY);
       flattenMapWithPrefix(propertiesMap, v1Params, PROPERTY_PREFIX);
-
-      collectionsHandler.handleRequestBody(
-          wrapParams(obj.getRequest(), v1Params), obj.getResponse());
-    }
-
-    @Command(name = V2_DELETE_ALIAS_CMD)
-    public void deleteAlias(PayloadObj<DeleteAliasPayload> obj) throws Exception {
-      final DeleteAliasPayload v2Body = obj.get();
-      final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
-      v1Params.put(ACTION, CollectionAction.DELETEALIAS.toLower());
 
       collectionsHandler.handleRequestBody(
           wrapParams(obj.getRequest(), v1Params), obj.getResponse());

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -210,6 +210,7 @@ import org.apache.solr.handler.admin.api.AdminAPIBase;
 import org.apache.solr.handler.admin.api.BalanceShardUniqueAPI;
 import org.apache.solr.handler.admin.api.CollectionStatusAPI;
 import org.apache.solr.handler.admin.api.CreateShardAPI;
+import org.apache.solr.handler.admin.api.DeleteAliasAPI;
 import org.apache.solr.handler.admin.api.DeleteCollectionAPI;
 import org.apache.solr.handler.admin.api.DeleteNodeAPI;
 import org.apache.solr.handler.admin.api.DeleteReplicaAPI;
@@ -858,7 +859,12 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
           return result;
         }),
 
-    DELETEALIAS_OP(DELETEALIAS, (req, rsp, h) -> copy(req.getParams().required(), null, NAME)),
+    DELETEALIAS_OP(DELETEALIAS, (req, rsp, h) -> {
+      final DeleteAliasAPI deleteAliasAPI = new DeleteAliasAPI(h.coreContainer, req, rsp);
+      final SolrJerseyResponse response = deleteAliasAPI.deleteAlias(req.getParams().required().get(NAME), req.getParams().get(ASYNC));
+      V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
+      return null;
+    }),
 
     /**
      * Change properties for an alias (use CREATEALIAS_OP to change the actual value of the alias)
@@ -2068,6 +2074,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
   public Collection<Class<? extends JerseyResource>> getJerseyResources() {
     return List.of(
         AddReplicaPropertyAPI.class,
+        DeleteAliasAPI.class,
         DeleteCollectionAPI.class,
         DeleteReplicaPropertyAPI.class,
         ListCollectionsAPI.class,

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -859,12 +859,16 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
           return result;
         }),
 
-    DELETEALIAS_OP(DELETEALIAS, (req, rsp, h) -> {
-      final DeleteAliasAPI deleteAliasAPI = new DeleteAliasAPI(h.coreContainer, req, rsp);
-      final SolrJerseyResponse response = deleteAliasAPI.deleteAlias(req.getParams().required().get(NAME), req.getParams().get(ASYNC));
-      V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
-      return null;
-    }),
+    DELETEALIAS_OP(
+        DELETEALIAS,
+        (req, rsp, h) -> {
+          final DeleteAliasAPI deleteAliasAPI = new DeleteAliasAPI(h.coreContainer, req, rsp);
+          final SolrJerseyResponse response =
+              deleteAliasAPI.deleteAlias(
+                  req.getParams().required().get(NAME), req.getParams().get(ASYNC));
+          V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
+          return null;
+        }),
 
     /**
      * Change properties for an alias (use CREATEALIAS_OP to change the actual value of the alias)

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteAliasAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteAliasAPI.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.admin.api;
+
+import org.apache.solr.client.solrj.SolrResponse;
+import org.apache.solr.common.cloud.ZkNodeProps;
+import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.handler.admin.CollectionsHandler;
+import org.apache.solr.jersey.AsyncJerseyResponse;
+import org.apache.solr.jersey.PermissionName;
+import org.apache.solr.jersey.SolrJerseyResponse;
+import org.apache.solr.jersey.SubResponseAccumulatingJerseyResponse;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.security.PermissionNameProvider;
+
+import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONTENT_TYPE_V2;
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+import static org.apache.solr.common.params.CommonParams.NAME;
+import static org.apache.solr.handler.admin.CollectionsHandler.DEFAULT_COLLECTION_OP_TIMEOUT;
+import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
+
+@Path("/aliases/{aliasName}")
+public class DeleteAliasAPI extends AdminAPIBase {
+    @Inject
+    public DeleteAliasAPI(CoreContainer coreContainer, SolrQueryRequest solrQueryRequest, SolrQueryResponse solrQueryResponse) {
+        super(coreContainer, solrQueryRequest, solrQueryResponse);
+    }
+
+    @DELETE
+    @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
+    @PermissionName(COLL_EDIT_PERM)
+    public SolrJerseyResponse deleteAlias(@PathParam("aliasName") String aliasName, @QueryParam("async") String asyncId) throws Exception {
+        final AsyncJerseyResponse response = instantiateJerseyResponse(AsyncJerseyResponse.class);
+        final CoreContainer coreContainer = fetchAndValidateZooKeeperAwareCoreContainer();
+
+        final ZkNodeProps remoteMessage = createRemoteMessage(aliasName, asyncId);
+        final SolrResponse remoteResponse =
+                CollectionsHandler.submitCollectionApiCommand(
+                        coreContainer,
+                        coreContainer.getDistributedCollectionCommandRunner(),
+                        remoteMessage,
+                        CollectionParams.CollectionAction.DELETEALIAS,
+                        DEFAULT_COLLECTION_OP_TIMEOUT);
+        if (remoteResponse.getException() != null) {
+            throw remoteResponse.getException();
+        }
+
+        if (asyncId != null) {
+            response.requestId = asyncId;
+        }
+
+        return response;
+    }
+
+    public static ZkNodeProps createRemoteMessage(String aliasName, String asyncId) {
+        final Map<String, Object> remoteMessage = new HashMap<>();
+        remoteMessage.put(QUEUE_OPERATION, CollectionParams.CollectionAction.DELETEALIAS.toLower());
+        remoteMessage.put(NAME, aliasName);
+        if (asyncId != null) remoteMessage.put(ASYNC, asyncId);
+
+        return new ZkNodeProps(remoteMessage);
+    }
+}

--- a/solr/core/src/java/org/apache/solr/jersey/AsyncJerseyResponse.java
+++ b/solr/core/src/java/org/apache/solr/jersey/AsyncJerseyResponse.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.solr.client.solrj.request.beans;
 
-import org.apache.solr.common.annotation.JsonProperty;
-import org.apache.solr.common.util.ReflectMapWriter;
+package org.apache.solr.jersey;
 
-public class DeleteAliasPayload implements ReflectMapWriter {
-  @JsonProperty(required = true)
-  public String name;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-  @JsonProperty public String async;
+public class AsyncJerseyResponse extends SolrJerseyResponse {
+    @JsonProperty("requestid")
+    public String requestId;
 }

--- a/solr/core/src/java/org/apache/solr/jersey/AsyncJerseyResponse.java
+++ b/solr/core/src/java/org/apache/solr/jersey/AsyncJerseyResponse.java
@@ -20,6 +20,6 @@ package org.apache.solr.jersey;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AsyncJerseyResponse extends SolrJerseyResponse {
-    @JsonProperty("requestid")
-    public String requestId;
+  @JsonProperty("requestid")
+  public String requestId;
 }

--- a/solr/core/src/java/org/apache/solr/jersey/SubResponseAccumulatingJerseyResponse.java
+++ b/solr/core/src/java/org/apache/solr/jersey/SubResponseAccumulatingJerseyResponse.java
@@ -27,10 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * during the APIs execution. (e.g. the collection-deletion response itself contains the responses
  * from the 'UNLOAD' call send to each core.) This class encapsulates those responses as possible.
  */
-public class SubResponseAccumulatingJerseyResponse extends SolrJerseyResponse {
-
-  @JsonProperty("requestid")
-  public String requestId;
+public class SubResponseAccumulatingJerseyResponse extends AsyncJerseyResponse {
 
   // TODO The 'Object' value in this and the failure prop below have a more defined structure.
   //  Specifically, each value is a map whose keys are node names and whose values are full

--- a/solr/core/src/test/org/apache/solr/handler/admin/TestCollectionAPIs.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/TestCollectionAPIs.java
@@ -130,13 +130,6 @@ public class TestCollectionAPIs extends SolrTestCaseJ4 {
         "{operation : createalias, name: aliasName, collections:\"c1,c2\" }");
 
     compareOutput(
-        apiBag,
-        "/collections",
-        POST,
-        "{delete-alias:{ name: aliasName}}",
-        "{operation : deletealias, name: aliasName}");
-
-    compareOutput(
         apiBag, "/collections/collName", POST, "{reload:{}}", "{name:collName, operation :reload}");
 
     compareOutput(

--- a/solr/core/src/test/org/apache/solr/handler/admin/V2CollectionsAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/V2CollectionsAPIMappingTest.java
@@ -176,19 +176,6 @@ public class V2CollectionsAPIMappingTest extends V2ApiMappingTest<CollectionsHan
   }
 
   @Test
-  public void testDeleteAliasAllProperties() throws Exception {
-    final SolrParams v1Params =
-        captureConvertedV1Params(
-            "/collections",
-            "POST",
-            "{'delete-alias': {" + "'name': 'aliasName', " + "'async': 'requestTrackingId'" + "}}");
-
-    assertEquals(CollectionParams.CollectionAction.DELETEALIAS.lowerName, v1Params.get(ACTION));
-    assertEquals("aliasName", v1Params.get(CommonParams.NAME));
-    assertEquals("requestTrackingId", v1Params.get(CommonAdminParams.ASYNC));
-  }
-
-  @Test
   public void testSetAliasAllProperties() throws Exception {
     final SolrParams v1Params =
         captureConvertedV1Params(

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteAliasAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteAliasAPITest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.admin.api;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+import static org.apache.solr.common.params.CoreAdminParams.NAME;
+
+public class DeleteAliasAPITest extends SolrTestCaseJ4 {
+
+    @Test
+    public void testConstructsValidRemoteMessage() {
+        Map<String, Object> props = DeleteAliasAPI.createRemoteMessage("aliasName", null).getProperties();
+        assertEquals(2, props.size());
+        assertEquals("deletealias", props.get(QUEUE_OPERATION));
+        assertEquals("aliasName", props.get(NAME));
+
+        props = DeleteAliasAPI.createRemoteMessage("aliasName", "asyncId").getProperties();
+        assertEquals(3, props.size());
+        assertEquals("deletealias", props.get(QUEUE_OPERATION));
+        assertEquals("aliasName", props.get(NAME));
+        assertEquals("asyncId", props.get(ASYNC));
+    }
+}

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteAliasAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteAliasAPITest.java
@@ -25,9 +25,7 @@ import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link DeleteAliasAPI}.
- */
+/** Unit tests for {@link DeleteAliasAPI}. */
 public class DeleteAliasAPITest extends SolrTestCaseJ4 {
 
   @Test

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteAliasAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteAliasAPITest.java
@@ -17,28 +17,31 @@
 
 package org.apache.solr.handler.admin.api;
 
-import org.apache.solr.SolrTestCaseJ4;
-import org.junit.Test;
-
-import java.util.Map;
-
 import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CoreAdminParams.NAME;
 
+import java.util.Map;
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DeleteAliasAPI}.
+ */
 public class DeleteAliasAPITest extends SolrTestCaseJ4 {
 
-    @Test
-    public void testConstructsValidRemoteMessage() {
-        Map<String, Object> props = DeleteAliasAPI.createRemoteMessage("aliasName", null).getProperties();
-        assertEquals(2, props.size());
-        assertEquals("deletealias", props.get(QUEUE_OPERATION));
-        assertEquals("aliasName", props.get(NAME));
+  @Test
+  public void testConstructsValidRemoteMessage() {
+    Map<String, Object> props =
+        DeleteAliasAPI.createRemoteMessage("aliasName", null).getProperties();
+    assertEquals(2, props.size());
+    assertEquals("deletealias", props.get(QUEUE_OPERATION));
+    assertEquals("aliasName", props.get(NAME));
 
-        props = DeleteAliasAPI.createRemoteMessage("aliasName", "asyncId").getProperties();
-        assertEquals(3, props.size());
-        assertEquals("deletealias", props.get(QUEUE_OPERATION));
-        assertEquals("aliasName", props.get(NAME));
-        assertEquals("asyncId", props.get(ASYNC));
-    }
+    props = DeleteAliasAPI.createRemoteMessage("aliasName", "asyncId").getProperties();
+    assertEquals(3, props.size());
+    assertEquals("deletealias", props.get(QUEUE_OPERATION));
+    assertEquals("aliasName", props.get(NAME));
+    assertEquals("asyncId", props.get(ASYNC));
+  }
 }

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/alias-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/alias-management.adoc
@@ -749,13 +749,7 @@ http://localhost:8983/solr/admin/collections?action=DELETEALIAS&name=testalias
 
 [source,bash]
 ----
-curl -X POST http://localhost:8983/api/collections -H 'Content-Type: application/json' -d '
-{
-  "delete-alias":{
-    "name":"testalias"
-  }
-}
-'
+curl -X DELETE http://localhost:8983/api/aliases/testalias
 ----
 ====
 --
@@ -770,7 +764,7 @@ curl -X POST http://localhost:8983/api/collections -H 'Content-Type: application
 s|Required |Default: none
 |===
 +
-The name of the alias to delete.
+The name of the alias to delete.  Specified in the path of v2 requests, and as an explicit request parameter for v1 requests.
 
 `async`::
 +


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16393


# Description

Solr is in the process of migrating its v2 APIs over to a JAX-RS framework. This gives us a more feature-rich framework for expressing APIs, makes it easier for the APIs themselves to be more REST-ful and standardized, and also makes it easier for Solr to integrate with tooling such as OpenAPI, which can be used to autogenerate client bindings for a variety of different languages.

But many non-JAX-RS APIs remain.

# Solution

This commit migrates the "delete alias" API to the JAX-RS framework.

It also makes a few cosmetic changes to the v2 API to bring it closer into line with the more REST-ful design we're targeting for v2.  Alias deletion now uses the API:

```
DELETE /api/aliases/aliasName
```


# Tests

Existing alias tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
