### PR TITLE
SOLR-16701: Race condition on PRS enabled collection deletion

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -207,6 +207,8 @@ Bug Fixes
 
 * SOLR-16925: Fix indentation for JacksonJsonWriter (Houston Putman)
 
+* SOLR-16701: Fix race condition on PRS enabled collection deletion (Patson Luk)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -43,16 +43,19 @@ import org.apache.solr.common.cloud.DocRouter;
 import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.cloud.PerReplicaStatesOps;
 import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.CommonTestInjection;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.common.util.ZLibCompressor;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 import org.apache.solr.util.LogLevel;
 import org.apache.solr.util.TimeOut;
+import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -662,6 +665,109 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
       stopMutatingThread.set(true);
       CommonTestInjection.reset();
       ExecutorUtil.awaitTermination(executorService);
+    }
+  }
+
+  /**
+   * Ensure that collection state fetching (getCollectionLive etc.) would not throw exception when the state.json is
+   * deleted in between the state.json read and PRS entries read
+   */
+  public void testDeletePrsCollection() throws Exception {
+    ZkStateWriter writer = fixture.writer;
+    ZkStateReader reader = fixture.reader;
+
+    String collectionName = "c1";
+    fixture.zkClient.makePath(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collectionName, true);
+
+    ClusterState clusterState = reader.getClusterState();
+
+    String nodeName = "node1:10000_solr";
+    String sliceName = "shard1";
+    Slice slice = new Slice(sliceName, Map.of(), Map.of(), collectionName);
+
+    // create new collection
+    DocCollection state =
+            new DocCollection(
+                    collectionName,
+                    Map.of(sliceName, slice),
+                    Collections.singletonMap(DocCollection.CollectionStateProps.PER_REPLICA_STATE, true),
+                    DocRouter.DEFAULT,
+                    0,
+                    new PerReplicaStatesFetcher.LazyPrsSupplier(
+                            fixture.zkClient, DocCollection.getCollectionPath(collectionName)));
+    ZkWriteCommand wc = new ZkWriteCommand(collectionName, state);
+    writer.enqueueUpdate(clusterState, Collections.singletonList(wc), null);
+    clusterState = writer.writePendingUpdates();
+
+    TimeOut timeOut = new TimeOut(5000, TimeUnit.MILLISECONDS, TimeSource.NANO_TIME);
+    timeOut.waitFor(
+            "Timeout on waiting for c1 to show up in cluster state",
+            () -> reader.getClusterState().getCollectionOrNull(collectionName) != null);
+
+    String collectionPath = ZkStateReader.getCollectionPath(collectionName);
+
+    //now create the replica, take note that this has to be done after DocCollection creation with empty slice,
+    //otherwise the DocCollection ctor would fetch the PRS entries and throw exceptions
+    String replicaBaseUrl = Utils.getBaseUrlForNodeName(nodeName, "http");
+
+    String replicaName = "replica1";
+    Replica replica =
+            new Replica(
+                    replicaName,
+                    Map.of(
+                            ZkStateReader.CORE_NAME_PROP, "core1",
+                            ZkStateReader.STATE_PROP, Replica.State.ACTIVE.toString(),
+                            ZkStateReader.NODE_NAME_PROP, nodeName,
+                            ZkStateReader.BASE_URL_PROP, replicaBaseUrl,
+                            ZkStateReader.REPLICA_TYPE, Replica.Type.NRT.name()),
+                    collectionName,
+                    sliceName);
+
+    wc = new ZkWriteCommand(collectionName, SliceMutator.updateReplica(state, slice, replica.getName(), replica));
+    writer.enqueueUpdate(clusterState, Collections.singletonList(wc), null);
+    clusterState = writer.writePendingUpdates();
+
+    timeOut.waitFor(
+            "Timeout on waiting for replica to show up in cluster state",
+            () -> reader.getCollectionLive(collectionName).getSlice(sliceName).getReplica(replicaName) != null);
+
+
+    try {
+      //set breakpoint such that after state.json fetch and before PRS entry fetch, we can delete the state.json and
+      // PRS entries to trigger the race condition
+      CommonTestInjection.setBreakpoint(PerReplicaStatesFetcher.class.getName() + "/beforePrsFetch", (args) -> {
+        try {
+          //this is invoked after ZkStateReader.fetchCollectionState has fetched the state.json but before PRS entries.
+          //call delete state.json on ZK directly, very tricky to control execution order with writer.enqueueUpdate
+          reader.getZkClient().clean(collectionPath);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        } catch (KeeperException e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      //set breakpoint to verify the expected PrsZkNodeNotFoundException is indeed thrown within the execution flow,
+      //such exception is caught within the logic and not thrown to the caller
+      AtomicBoolean prsZkNodeNotFoundExceptionThrown = new AtomicBoolean(false);
+      CommonTestInjection.setBreakpoint(ZkStateReader.class.getName()+"/exercised", (args) -> {
+        if (args[0] instanceof PerReplicaStatesFetcher.PrsZkNodeNotFoundException) {
+          prsZkNodeNotFoundExceptionThrown.set(true);
+        }
+      });
+
+
+      timeOut.waitFor("Timeout waiting for collection state to become null", () -> {
+        //this should not throw exception even if the PRS entry read is delayed artificially (by previous command)
+        //and deleted after the following getCollectionLive call
+        return reader.getCollectionLive(collectionName) == null;
+      });
+
+      assertTrue(prsZkNodeNotFoundExceptionThrown.get());
+    } finally {
+      //clear breakpoints
+      CommonTestInjection.setBreakpoint(ZkStateReader.class.getName()+"/beforePrsFetch", null);
+      CommonTestInjection.setBreakpoint(ZkStateReader.class.getName()+"/exercised", null);
     }
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -707,8 +707,8 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     String collectionPath = ZkStateReader.getCollectionPath(collectionName);
 
     // now create the replica, take note that this has to be done after DocCollection creation with
-    // empty slice,
-    // otherwise the DocCollection ctor would fetch the PRS entries and throw exceptions
+    // empty slice, otherwise the DocCollection ctor would fetch the PRS entries and throw
+    // exceptions
     String replicaBaseUrl = Utils.getBaseUrlForNodeName(nodeName, "http");
 
     String replicaName = "replica1";
@@ -743,8 +743,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
 
     try {
       // set breakpoint such that after state.json fetch and before PRS entry fetch, we can delete
-      // the state.json and
-      // PRS entries to trigger the race condition
+      // the state.json and PRS entries to trigger the race condition
       CommonTestInjection.setBreakpoint(
           PerReplicaStatesOps.class.getName() + "/beforePrsFetch",
           (args) -> {
@@ -762,8 +761,8 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
           });
 
       // set breakpoint to verify the expected PrsZkNodeNotFoundException is indeed thrown within
-      // the execution flow,
-      // such exception is caught within the logic and not thrown to the caller
+      // the execution flow, such exception is caught within the logic and not thrown to the
+      // caller
       AtomicBoolean prsZkNodeNotFoundExceptionThrown = new AtomicBoolean(false);
       CommonTestInjection.setBreakpoint(
           ZkStateReader.class.getName() + "/exercised",
@@ -777,8 +776,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
           "Timeout waiting for collection state to become null",
           () -> {
             // this should not throw exception even if the PRS entry read is delayed artificially
-            // (by previous command)
-            // and deleted after the following getCollectionLive call
+            // (by previous command) and deleted after the following getCollectionLive call
             return reader.getCollectionLive(collectionName) == null;
           });
 

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -687,13 +687,13 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
 
     // create new collection
     DocCollection state =
-        new DocCollection(
+        DocCollection.create(
             collectionName,
             Map.of(sliceName, slice),
             Collections.singletonMap(DocCollection.CollectionStateProps.PER_REPLICA_STATE, true),
             DocRouter.DEFAULT,
             0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
+            PerReplicaStatesOps.getZkClientPrsSupplier(
                 fixture.zkClient, DocCollection.getCollectionPath(collectionName)));
     ZkWriteCommand wc = new ZkWriteCommand(collectionName, state);
     writer.enqueueUpdate(clusterState, Collections.singletonList(wc), null);
@@ -746,7 +746,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
       // the state.json and
       // PRS entries to trigger the race condition
       CommonTestInjection.setBreakpoint(
-          PerReplicaStatesFetcher.class.getName() + "/beforePrsFetch",
+          PerReplicaStatesOps.class.getName() + "/beforePrsFetch",
           (args) -> {
             try {
               // this is invoked after ZkStateReader.fetchCollectionState has fetched the state.json
@@ -768,7 +768,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
       CommonTestInjection.setBreakpoint(
           ZkStateReader.class.getName() + "/exercised",
           (args) -> {
-            if (args[0] instanceof PerReplicaStatesFetcher.PrsZkNodeNotFoundException) {
+            if (args[0] instanceof PerReplicaStatesOps.PrsZkNodeNotFoundException) {
               prsZkNodeNotFoundExceptionThrown.set(true);
             }
           });

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1628,7 +1628,8 @@ public class ZkStateReader implements SolrCloseable {
         }
         return null;
       } catch (PerReplicaStatesOps.PrsZkNodeNotFoundException e) {
-        assert CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
+        assert CommonTestInjection.injectBreakpoint(
+            ZkStateReader.class.getName() + "/exercised", e);
         // could be a race condition that state.json and PRS entries are deleted between the
         // state.json fetch and PRS entry fetch
         Stat exists = zkClient.exists(collectionPath, watcher, true);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1629,15 +1629,19 @@ public class ZkStateReader implements SolrCloseable {
         return null;
       } catch (PerReplicaStatesFetcher.PrsZkNodeNotFoundException e) {
         CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
-        //could be a race condition that state.json and PRS entries are deleted between the state.json fetch and PRS entry fetch
+        // could be a race condition that state.json and PRS entries are deleted between the
+        // state.json fetch and PRS entry fetch
         Stat exists = zkClient.exists(collectionPath, watcher, true);
         if (exists == null) {
           if (log.isInfoEnabled()) {
-            log.info("PRS entry for collection " + coll + " not found in ZK. It was probably deleted between state.json read and PRS entry read.");
+            log.info(
+                "PRS entry for collection "
+                    + coll
+                    + " not found in ZK. It was probably deleted between state.json read and PRS entry read.");
           }
           return null;
         } else {
-          throw e; //unexpected, PRS node not found but the collection state.json still exists
+          throw e; // unexpected, PRS node not found but the collection state.json still exists
         }
       }
     }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1616,7 +1616,8 @@ public class ZkStateReader implements SolrCloseable {
 
         ClusterState.CollectionRef collectionRef = state.getCollectionStates().get(coll);
         return collectionRef == null ? null : collectionRef.get();
-      } catch (KeeperException.NoNodeException e) {
+      } catch (KeeperException.NoNodeException | PerReplicaStatesFetcher.PrsZkNodeNotFoundException e) {
+        assert CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
         if (watcher != null) {
           // Leave an exists watch in place in case a state.json is created later.
           Stat exists = zkClient.exists(collectionPath, watcher, true);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1616,8 +1616,10 @@ public class ZkStateReader implements SolrCloseable {
 
         ClusterState.CollectionRef collectionRef = state.getCollectionStates().get(coll);
         return collectionRef == null ? null : collectionRef.get();
-      } catch (KeeperException.NoNodeException | PerReplicaStatesFetcher.PrsZkNodeNotFoundException e) {
-        assert CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
+      } catch (KeeperException.NoNodeException
+          | PerReplicaStatesFetcher.PrsZkNodeNotFoundException e) {
+        assert CommonTestInjection.injectBreakpoint(
+            ZkStateReader.class.getName() + "/exercised", e);
         if (watcher != null) {
           // Leave an exists watch in place in case a state.json is created later.
           Stat exists = zkClient.exists(collectionPath, watcher, true);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1627,7 +1627,7 @@ public class ZkStateReader implements SolrCloseable {
           }
         }
         return null;
-      } catch (PerReplicaStatesFetcher.PrsZkNodeNotFoundException e) {
+      } catch (PerReplicaStatesOps.PrsZkNodeNotFoundException e) {
         CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
         // could be a race condition that state.json and PRS entries are deleted between the
         // state.json fetch and PRS entry fetch

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1628,7 +1628,7 @@ public class ZkStateReader implements SolrCloseable {
         }
         return null;
       } catch (PerReplicaStatesOps.PrsZkNodeNotFoundException e) {
-        CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
+        assert CommonTestInjection.injectBreakpoint(ZkStateReader.class.getName() + "/exercised", e);
         // could be a race condition that state.json and PRS entries are deleted between the
         // state.json fetch and PRS entry fetch
         Stat exists = zkClient.exists(collectionPath, watcher, true);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1633,12 +1633,10 @@ public class ZkStateReader implements SolrCloseable {
         // state.json fetch and PRS entry fetch
         Stat exists = zkClient.exists(collectionPath, watcher, true);
         if (exists == null) {
-          if (log.isInfoEnabled()) {
-            log.info(
-                "PRS entry for collection "
-                    + coll
-                    + " not found in ZK. It was probably deleted between state.json read and PRS entry read.");
-          }
+          log.info(
+              "PRS entry for collection {} not found in ZK. It was probably deleted between state.json read and PRS entry read.",
+              coll);
+
           return null;
         } else {
           throw e; // unexpected, PRS node not found but the collection state.json still exists

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1632,7 +1632,9 @@ public class ZkStateReader implements SolrCloseable {
         //could be a race condition that state.json and PRS entries are deleted between the state.json fetch and PRS entry fetch
         Stat exists = zkClient.exists(collectionPath, watcher, true);
         if (exists == null) {
-          log.info("PRS entry for collection " + coll + " not found in ZK. It was probably deleted between state.json read and PRS entry read.");
+          if (log.isInfoEnabled()) {
+            log.info("PRS entry for collection " + coll + " not found in ZK. It was probably deleted between state.json read and PRS entry read.");
+          }
           return null;
         } else {
           throw e; //unexpected, PRS node not found but the collection state.json still exists

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -21,7 +21,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +34,7 @@ public class CommonTestInjection {
 
   private static volatile Map<String, String> additionalSystemProps = null;
   private static volatile Integer delay = null;
-  private final static ConcurrentMap<String, Breakpoint> breakpoints = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Breakpoint> breakpoints = new ConcurrentHashMap<>();
 
   public static void reset() {
     additionalSystemProps = null;
@@ -81,15 +80,17 @@ public class CommonTestInjection {
   /**
    * This should ONLY be set from unit test cases.
    *
-   * If defined, code execution would break at certain code execution point at the invocation of injectBreakpoint
-   * with matching key until the provided method in the {@link Breakpoint} implementation is executed.
+   * <p>If defined, code execution would break at certain code execution point at the invocation of
+   * injectBreakpoint with matching key until the provided method in the {@link Breakpoint}
+   * implementation is executed.
    *
-   * Setting the breakpoint to null would remove the breakpoint
+   * <p>Setting the breakpoint to null would remove the breakpoint
    *
    * @see CommonTestInjection#injectBreakpoint(String)
-   * @param key could simply be the fully qualified class name or more granular like class name + other id
-   *    (such as method name). This should batch the key used in {@link Breakpoint#injectBreakpoint(String)}
-   * @param breakpoint  The Breakpoint implementation, null to remove the breakpoint
+   * @param key could simply be the fully qualified class name or more granular like class name +
+   *     other id (such as method name). This should batch the key used in {@link
+   *     Breakpoint#injectBreakpoint(String)}
+   * @param breakpoint The Breakpoint implementation, null to remove the breakpoint
    */
   public static void setBreakpoint(String key, Breakpoint breakpoint) {
     if (breakpoint != null) {
@@ -100,25 +101,27 @@ public class CommonTestInjection {
   }
 
   /**
-   * Injects a breakpoint that pauses the existing code execution, executes the code defined in the breakpoint
-   * implementation and then resumes afterwards. The breakpoint implementation is looked up by the corresponding key
-   * used in {@link CommonTestInjection#setBreakpoint(String, Breakpoint)}
+   * Injects a breakpoint that pauses the existing code execution, executes the code defined in the
+   * breakpoint implementation and then resumes afterwards. The breakpoint implementation is looked
+   * up by the corresponding key used in {@link CommonTestInjection#setBreakpoint(String,
+   * Breakpoint)}
    *
-   * An example usages :
+   * <p>An example usages :
+   *
    * <ol>
-   *   <li>Inject a precise wait until a race condition is fulfilled before proceeding with original code execution</li>
-   *   <li>Inject a flag to catch exception statement which handles the exception without re-throwing. This could verify
-   *   caught exception does get triggered</li>
+   *   <li>Inject a precise wait until a race condition is fulfilled before proceeding with original
+   *       code execution
+   *   <li>Inject a flag to catch exception statement which handles the exception without
+   *       re-throwing. This could verify caught exception does get triggered
    * </ol>
    *
-   *
-   *
-   * This should always be a part of an assert statement (ie assert injectBreakpoint(key)) such that it will be skipped
-   * for normal code execution
+   * This should always be a part of an assert statement (ie assert injectBreakpoint(key)) such that
+   * it will be skipped for normal code execution
    *
    * @see CommonTestInjection#setBreakpoint(String, Breakpoint)
-   * @param key could simply be the fully qualified class name or more granular like class name + other id
-   *    (such as method name). This should only be set by corresponding unit test cases with CommonTestInjection#setBreakpoint
+   * @param key could simply be the fully qualified class name or more granular like class name +
+   *     other id (such as method name). This should only be set by corresponding unit test cases
+   *     with CommonTestInjection#setBreakpoint
    */
   public static boolean injectBreakpoint(String key) {
     Breakpoint breakpoint = breakpoints.get(key);
@@ -130,8 +133,8 @@ public class CommonTestInjection {
 
   public interface Breakpoint {
     /**
-     * Code execution should break at where the breakpoint was injected, then it would execute this method and
-     * resumes the execution afterwards.
+     * Code execution should break at where the breakpoint was injected, then it would execute this
+     * method and resumes the execution afterwards.
      */
     void executeAndResume();
   }

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -78,7 +78,7 @@ public class CommonTestInjection {
   }
 
   /**
-   * This should ONLY be set from unit test cases.
+   * This is usually set by the test cases.
    *
    * <p>If defined, code execution would break at certain code execution point at the invocation of
    * injectBreakpoint with matching key until the provided method in the {@link Breakpoint}
@@ -89,7 +89,7 @@ public class CommonTestInjection {
    * @see CommonTestInjection#injectBreakpoint(String)
    * @param key could simply be the fully qualified class name or more granular like class name +
    *     other id (such as method name). This should batch the key used in {@link
-   *     Breakpoint#injectBreakpoint(String)}
+   *     CommonTestInjection#injectBreakpoint(String)}
    * @param breakpoint The Breakpoint implementation, null to remove the breakpoint
    */
   public static void setBreakpoint(String key, Breakpoint breakpoint) {
@@ -115,8 +115,8 @@ public class CommonTestInjection {
    *       re-throwing. This could verify caught exception does get triggered
    * </ol>
    *
-   * This should always be a part of an assert statement (ie assert injectBreakpoint(key)) such that
-   * it will be skipped for normal code execution
+   * <p>This should always be a part of an assert statement (ie assert injectBreakpoint(key)) such
+   * that it will be skipped for normal code execution
    *
    * @see CommonTestInjection#setBreakpoint(String, Breakpoint)
    * @param key could simply be the fully qualified class name or more granular like class name +

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -123,7 +123,7 @@ public class CommonTestInjection {
    *     with CommonTestInjection#setBreakpoint
    * @param args optional arguments list to be passed to the Breakpoint
    */
-  public static boolean injectBreakpoint(String key, Object...args) {
+  public static boolean injectBreakpoint(String key, Object... args) {
     Breakpoint breakpoint = breakpoints.get(key);
     if (breakpoint != null) {
       breakpoint.executeAndResume(args);
@@ -136,6 +136,6 @@ public class CommonTestInjection {
      * Code execution should break at where the breakpoint was injected, then it would execute this
      * method and resumes the execution afterwards.
      */
-    void executeAndResume(Object...args);
+    void executeAndResume(Object... args);
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -86,10 +86,9 @@ public class CommonTestInjection {
    *
    * <p>Setting the breakpoint to null would remove the breakpoint
    *
-   * @see CommonTestInjection#injectBreakpoint(String)
+   * @see CommonTestInjection#injectBreakpoint(String, Object...)
    * @param key could simply be the fully qualified class name or more granular like class name +
-   *     other id (such as method name). This should batch the key used in {@link
-   *     CommonTestInjection#injectBreakpoint(String)}
+   *     other id (such as method name). This should batch the key used in injectBreakpoint
    * @param breakpoint The Breakpoint implementation, null to remove the breakpoint
    */
   public static void setBreakpoint(String key, Breakpoint breakpoint) {
@@ -122,11 +121,12 @@ public class CommonTestInjection {
    * @param key could simply be the fully qualified class name or more granular like class name +
    *     other id (such as method name). This should only be set by corresponding unit test cases
    *     with CommonTestInjection#setBreakpoint
+   * @param args optional arguments list to be passed to the Breakpoint
    */
-  public static boolean injectBreakpoint(String key) {
+  public static boolean injectBreakpoint(String key, Object...args) {
     Breakpoint breakpoint = breakpoints.get(key);
     if (breakpoint != null) {
-      breakpoint.executeAndResume();
+      breakpoint.executeAndResume(args);
     }
     return true;
   }
@@ -136,6 +136,6 @@ public class CommonTestInjection {
      * Code execution should break at where the breakpoint was injected, then it would execute this
      * method and resumes the execution afterwards.
      */
-    void executeAndResume();
+    void executeAndResume(Object...args);
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -19,6 +19,9 @@ package org.apache.solr.common.util;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +35,7 @@ public class CommonTestInjection {
 
   private static volatile Map<String, String> additionalSystemProps = null;
   private static volatile Integer delay = null;
+  private final static ConcurrentMap<String, Breakpoint> breakpoints = new ConcurrentHashMap<>();
 
   public static void reset() {
     additionalSystemProps = null;
@@ -72,5 +76,63 @@ public class CommonTestInjection {
       }
     }
     return true;
+  }
+
+  /**
+   * This should ONLY be set from unit test cases.
+   *
+   * If defined, code execution would break at certain code execution point at the invocation of injectBreakpoint
+   * with matching key until the provided method in the {@link Breakpoint} implementation is executed.
+   *
+   * Setting the breakpoint to null would remove the breakpoint
+   *
+   * @see CommonTestInjection#injectBreakpoint(String)
+   * @param key could simply be the fully qualified class name or more granular like class name + other id
+   *    (such as method name). This should batch the key used in {@link Breakpoint#injectBreakpoint(String)}
+   * @param breakpoint  The Breakpoint implementation, null to remove the breakpoint
+   */
+  public static void setBreakpoint(String key, Breakpoint breakpoint) {
+    if (breakpoint != null) {
+      breakpoints.put(key, breakpoint);
+    } else {
+      breakpoints.remove(key);
+    }
+  }
+
+  /**
+   * Injects a breakpoint that pauses the existing code execution, executes the code defined in the breakpoint
+   * implementation and then resumes afterwards. The breakpoint implementation is looked up by the corresponding key
+   * used in {@link CommonTestInjection#setBreakpoint(String, Breakpoint)}
+   *
+   * An example usages :
+   * <ol>
+   *   <li>Inject a precise wait until a race condition is fulfilled before proceeding with original code execution</li>
+   *   <li>Inject a flag to catch exception statement which handles the exception without re-throwing. This could verify
+   *   caught exception does get triggered</li>
+   * </ol>
+   *
+   *
+   *
+   * This should always be a part of an assert statement (ie assert injectBreakpoint(key)) such that it will be skipped
+   * for normal code execution
+   *
+   * @see CommonTestInjection#setBreakpoint(String, Breakpoint)
+   * @param key could simply be the fully qualified class name or more granular like class name + other id
+   *    (such as method name). This should only be set by corresponding unit test cases with CommonTestInjection#setBreakpoint
+   */
+  public static boolean injectBreakpoint(String key) {
+    Breakpoint breakpoint = breakpoints.get(key);
+    if (breakpoint != null) {
+      breakpoint.executeAndResume();
+    }
+    return true;
+  }
+
+  public interface Breakpoint {
+    /**
+     * Code execution should break at where the breakpoint was injected, then it would execute this method and
+     * resumes the execution afterwards.
+     */
+    void executeAndResume();
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -112,7 +112,7 @@ public class CommonTestInjection {
       breakpoint.executeAndResume(args);
       log.info("Breakpoint with key {} was executed and normal code execution resumes", key);
     } else {
-      log.info(
+      log.debug(
           "Breakpoint with key {} is triggered but there's no implementation set. Skipping...",
           key);
     }
@@ -156,7 +156,7 @@ public class CommonTestInjection {
     public void setImplementation(String key, Breakpoint implementation) {
       if (breakpoints.containsKey(key)) {
         throw new IllegalArgumentException(
-            "Cannot refine Breakpoint implementation with key " + key);
+            "Cannot redefine Breakpoint implementation with key " + key);
       }
       breakpoints.put(key, implementation);
       keys.add(key);

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -126,7 +126,9 @@ public class CommonTestInjection {
   public static boolean injectBreakpoint(String key, Object... args) {
     Breakpoint breakpoint = breakpoints.get(key);
     if (breakpoint != null) {
+      log.info("Breakpoint with key {} is triggered", key);
       breakpoint.executeAndResume(args);
+      log.info("Breakpoint with key {} was executed and normal code execution resumes", key);
     }
     return true;
   }

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -17,8 +17,12 @@
 
 package org.apache.solr.common.util;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
@@ -78,31 +82,9 @@ public class CommonTestInjection {
   }
 
   /**
-   * This is usually set by the test cases.
-   *
-   * <p>If defined, code execution would break at certain code execution point at the invocation of
-   * injectBreakpoint with matching key until the provided method in the {@link Breakpoint}
-   * implementation is executed.
-   *
-   * <p>Setting the breakpoint to null would remove the breakpoint
-   *
-   * @see CommonTestInjection#injectBreakpoint(String, Object...)
-   * @param key could simply be the fully qualified class name or more granular like class name +
-   *     other id (such as method name). This should batch the key used in injectBreakpoint
-   * @param breakpoint The Breakpoint implementation, null to remove the breakpoint
-   */
-  public static void setBreakpoint(String key, Breakpoint breakpoint) {
-    if (breakpoint != null) {
-      breakpoints.put(key, breakpoint);
-    } else {
-      breakpoints.remove(key);
-    }
-  }
-
-  /**
    * Injects a breakpoint that pauses the existing code execution, executes the code defined in the
-   * breakpoint implementation and then resumes afterwards. The breakpoint implementation is looked
-   * up by the corresponding key used in {@link CommonTestInjection#setBreakpoint(String,
+   * breakpoint implementation and then resumes afterward. The breakpoint implementation is looked
+   * up by the corresponding key used in {@link BreakpointSetter#setImplementation(String,
    * Breakpoint)}
    *
    * <p>An example usages :
@@ -117,7 +99,7 @@ public class CommonTestInjection {
    * <p>This should always be a part of an assert statement (ie assert injectBreakpoint(key)) such
    * that it will be skipped for normal code execution
    *
-   * @see CommonTestInjection#setBreakpoint(String, Breakpoint)
+   * @see BreakpointSetter#setImplementation(String, Breakpoint)
    * @param key could simply be the fully qualified class name or more granular like class name +
    *     other id (such as method name). This should only be set by corresponding unit test cases
    *     with CommonTestInjection#setBreakpoint
@@ -129,6 +111,10 @@ public class CommonTestInjection {
       log.info("Breakpoint with key {} is triggered", key);
       breakpoint.executeAndResume(args);
       log.info("Breakpoint with key {} was executed and normal code execution resumes", key);
+    } else {
+      log.info(
+          "Breakpoint with key {} is triggered but there's no implementation set. Skipping...",
+          key);
     }
     return true;
   }
@@ -136,8 +122,50 @@ public class CommonTestInjection {
   public interface Breakpoint {
     /**
      * Code execution should break at where the breakpoint was injected, then it would execute this
-     * method and resumes the execution afterwards.
+     * method and resumes the execution afterward.
      */
     void executeAndResume(Object... args);
+  }
+
+  /**
+   * Breakpoints should be set via this {@link BreakpointSetter} within the test case and close
+   * should be invoked as cleanup. Since this is closeable, it should usually be used in the
+   * try-with-resource syntax, such as:
+   *
+   * <pre>{@code
+   * try (BreakpointSetter breakpointSetter = new BreakpointSetter() {
+   *     //... test code here that calls breakpointSetter.setImplementation(...)
+   * }
+   * }</pre>
+   */
+  public static class BreakpointSetter implements Closeable {
+    private Set<String> keys = new HashSet<>();
+    /**
+     * This is usually set by the test cases.
+     *
+     * <p>If a breakpoint implementation is set by this method, then code execution would break at
+     * the code execution point marked by CommonTestInjection#injectBreakpoint with matching key,
+     * executes the provided implementation in the {@link Breakpoint}, then resumes the normal code
+     * execution.
+     *
+     * @see CommonTestInjection#injectBreakpoint(String, Object...)
+     * @param key could simply be the fully qualified class name or more granular like class name +
+     *     other id (such as method name). This should batch the key used in injectBreakpoint
+     * @param implementation The Breakpoint implementation
+     */
+    public void setImplementation(String key, Breakpoint implementation) {
+      if (breakpoints.containsKey(key)) {
+        throw new IllegalArgumentException(
+            "Cannot refine Breakpoint implementation with key " + key);
+      }
+      breakpoints.put(key, implementation);
+      keys.add(key);
+    }
+
+    public void close() throws IOException {
+      for (String key : keys) {
+        breakpoints.remove(key);
+      }
+    }
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommonTestInjection.java
@@ -162,6 +162,7 @@ public class CommonTestInjection {
       keys.add(key);
     }
 
+    @Override
     public void close() throws IOException {
       for (String key : keys) {
         breakpoints.remove(key);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16701

# Description

This fixes a race condition on PRS enabled collection deletion, which triggers the exception:
```
org.apache.solr.common.SolrException: Error fetching per-replica states
    at __randomizedtesting.SeedInfo.seed([C2BFFBF8FE49C1E1:F1C8D9E308D2745]:0)
    at app//org.apache.solr.common.cloud.PerReplicaStatesFetcher.fetch(PerReplicaStatesFetcher.java:49)
    at app//org.apache.solr.common.cloud.PerReplicaStatesFetcher$LazyPrsSupplier.lambda$new$0(PerReplicaStatesFetcher.java:62)
    at app//org.apache.solr.common.cloud.DocCollection$PrsSupplier.get(DocCollection.java:515)
    at app//org.apache.solr.common.cloud.Replica.isLeader(Replica.java:314)
    at app//org.apache.solr.common.cloud.Slice.findLeader(Slice.java:242)
    at app//org.apache.solr.common.cloud.Slice.setPrsSupplier(Slice.java:56)
    at app//org.apache.solr.common.cloud.DocCollection.<init>(DocCollection.java:123)
    at app//org.apache.solr.common.cloud.ClusterState.collectionFromObjects(ClusterState.java:305)
    at app//org.apache.solr.common.cloud.ClusterState.createFromCollectionMap(ClusterState.java:254)
    at app//org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider.createFromJsonSupportingLegacyConfigName(ZkClientClusterStateProvider.java:117)
    at app//org.apache.solr.common.cloud.ZkStateReader.fetchCollectionState(ZkStateReader.java:1695)
```

This could be triggered by:
1. `fetchCollectionState` is called, and the state.json is fetched
2. But before the `fetchCollectionState` fetches the PRS entries, the collection state.json/PRS are deleted by someone else
3. `fetchCollectionState` would throw below exception when it reaches the PRS fetching logic as the Zk node state.json is no longer around


# Solution

Create a specific exception `PrsZkNodeNotFoundException` (that extends `SolrException`) when the PRS entries cannot be fetched. Then in `ZkStateReader#fetchCollectionState`, we have added a new catch clause for this exception, we will use the similar check as the handling for `NoNodeException`, but in this case if exists is null, then it's the expected race condition (prs entries deleted after state.json is fetched), and  `fetchCollectionState` should just return null (collection gone), otherwise it will rethrow the `PrsZkNodeNotFoundException` case (unexpected, PRS entries gone but state.json is still around)


# Tests

Added `ZkStateReaderTest#testDeletePrsCollection` which reproduce such race condition, and verify that:
1. The `ZkStateReader#fetchCollectionState` should not throw exception, instead, it should eventually return `null` which indicates the collection is deleted
2. The `PrsZkNodeNotFoundException` was indeed triggered


Please take note that the test case was built on the `Breakpoint` introduced by another PR https://github.com/apache/solr/pull/1457

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
