### PR TITLE
SAI-4401: Experimental DocCollection Refactoring

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/overseer/ClusterStateMutator.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/ClusterStateMutator.java
@@ -127,7 +127,7 @@ public class ClusterStateMutator {
     assert !collectionProps.containsKey(CollectionAdminParams.COLL_CONF);
     DocCollection newCollection =
         new DocCollection(
-            cName, slices, collectionProps, router, -1, stateManager.getPrsSupplier(cName));
+            cName, slices, collectionProps, router, -1, stateManager.getPrsSupplier(cName).get());
 
     return new ZkWriteCommand(cName, newCollection);
   }

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/CollectionMutator.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/CollectionMutator.java
@@ -177,7 +177,7 @@ public class CollectionMutator {
             props,
             coll.getRouter(),
             coll.getZNodeVersion(),
-            stateManager.getPrsSupplier(coll.getName()));
+            coll.getPerReplicaStates());
     if (replicaOps == null) {
       return new ZkWriteCommand(coll.getName(), collection);
     } else {

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
@@ -313,7 +313,7 @@ public class ZkStateWriter {
                       c.getProperties(),
                       c.getRouter(),
                       0,
-                      null);
+                      c.getPerReplicaStates());
               clusterState = clusterState.copyWith(name, newCollection);
             }
           }

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
@@ -301,7 +301,7 @@ public class ZkStateWriter {
                       c.getProperties(),
                       c.getRouter(),
                       stat.getVersion(),
-                      new PerReplicaStatesFetcher.LazyPrsSupplier(reader.getZkClient(), path));
+                      c.getPerReplicaStates());
               clusterState = clusterState.copyWith(name, newCollection);
             } else {
               log.debug("going to create_collection {}", path);
@@ -313,7 +313,7 @@ public class ZkStateWriter {
                       c.getProperties(),
                       c.getRouter(),
                       0,
-                      new PerReplicaStatesFetcher.LazyPrsSupplier(reader.getZkClient(), path));
+                      null);
               clusterState = clusterState.copyWith(name, newCollection);
             }
           }

--- a/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
@@ -189,10 +189,10 @@ public class ClusterStatus {
       }
       String configName = clusterStateCollection.getConfigName();
       collectionStatus.put("configName", configName);
-      if (message.getBool("prs", false) && clusterStateCollection.isPerReplicaState()) {
-        PerReplicaStates prs = clusterStateCollection.getPerReplicaStates();
-        collectionStatus.put("PRS", prs);
-      }
+//      if (message.getBool("prs", false) && clusterStateCollection.isPerReplicaState()) {
+//        PerReplicaStates prs = clusterStateCollection.getPerReplicaStates();
+//        collectionStatus.put("PRS", prs);
+//      } //TODO
       collectionProps.add(name, collectionStatus);
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerCollectionConfigSetProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerCollectionConfigSetProcessorTest.java
@@ -691,7 +691,7 @@ public class OverseerCollectionConfigSetProcessorTest extends SolrTestCaseJ4 {
                       props.getProperties(),
                       DocRouter.DEFAULT,
                       0,
-                      distribStateManagerMock.getPrsSupplier(collName))));
+                      distribStateManagerMock.getPrsSupplier(collName).get())));
       }
       if (CollectionParams.CollectionAction.ADDREPLICA.isEqual(props.getStr("operation"))) {
         replicas.add(props);

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleCollectionCreateDeleteTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleCollectionCreateDeleteTest.java
@@ -123,7 +123,7 @@ public class SimpleCollectionCreateDeleteTest extends AbstractFullDistribZkTestB
 
     DocCollection c =
         ClusterState.createFromCollectionMap(
-                0, (Map<String, Object>) Utils.fromJSON(node.data), Collections.emptySet(), null)
+                0, (Map<String, Object>) Utils.fromJSON(node.data), Collections.emptySet())
             .getCollection(collectionName);
 
     Set<String> knownKeys =

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -143,9 +143,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
                 new HashMap<>(),
                 Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
                 DocRouter.DEFAULT,
-                0,
-                new PerReplicaStatesFetcher.LazyPrsSupplier(
-                    fixture.zkClient, DocCollection.getCollectionPath("c1"))));
+                0));
 
     writer.enqueueUpdate(reader.getClusterState(), Collections.singletonList(c1), null);
     writer.writePendingUpdates();
@@ -170,9 +168,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
     ZkWriteCommand wc = new ZkWriteCommand("c1", state);
     writer.enqueueUpdate(reader.getClusterState(), Collections.singletonList(wc), null);
     writer.writePendingUpdates();
@@ -189,9 +185,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             props,
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
     wc = new ZkWriteCommand("c1", state);
     writer.enqueueUpdate(reader.getClusterState(), Collections.singletonList(wc), null);
     writer.writePendingUpdates();
@@ -230,9 +224,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
     ZkWriteCommand wc = new ZkWriteCommand("c1", state);
     writer.enqueueUpdate(reader.getClusterState(), Collections.singletonList(wc), null);
     writer.writePendingUpdates();
@@ -268,9 +260,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
                 DocCollection.CollectionStateProps.PER_REPLICA_STATE,
                 "true"),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
     ZkWriteCommand wc = new ZkWriteCommand("c1", state);
     writer.enqueueUpdate(clusterState, Collections.singletonList(wc), null);
     clusterState = writer.writePendingUpdates();
@@ -388,9 +378,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
     ZkWriteCommand wc = new ZkWriteCommand("c1", state);
     writer.enqueueUpdate(reader.getClusterState(), Collections.singletonList(wc), null);
     writer.writePendingUpdates();
@@ -410,9 +398,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            ref.get().getZNodeVersion(),
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            ref.get().getZNodeVersion());
     wc = new ZkWriteCommand("c1", state);
     writer.enqueueUpdate(reader.getClusterState(), Collections.singletonList(wc), null);
     writer.writePendingUpdates();
@@ -433,9 +419,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c2")));
+            0);
     ZkWriteCommand wc2 = new ZkWriteCommand("c2", state);
 
     writer.enqueueUpdate(reader.getClusterState(), Arrays.asList(wc1, wc2), null);
@@ -549,9 +533,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
     ZkWriteCommand wc1 = new ZkWriteCommand("c1", state1);
     DocCollection state2 =
         new DocCollection(
@@ -559,9 +541,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
             new HashMap<>(),
             Map.of(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
             DocRouter.DEFAULT,
-            0,
-            new PerReplicaStatesFetcher.LazyPrsSupplier(
-                fixture.zkClient, DocCollection.getCollectionPath("c1")));
+            0);
 
     // do not listen to c2
     fixture.zkClient.makePath(ZkStateReader.COLLECTIONS_ZKNODE + "/c2", true);
@@ -614,9 +594,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
                             ZkStateReader.CONFIGNAME_PROP,
                             ConfigSetsHandler.DEFAULT_CONFIGSET_NAME),
                         DocRouter.DEFAULT,
-                        currentVersion,
-                        new PerReplicaStatesFetcher.LazyPrsSupplier(
-                            fixture.zkClient, DocCollection.getCollectionPath("c1")));
+                        currentVersion);
                 ZkWriteCommand wc = new ZkWriteCommand("c1", state);
                 writer.enqueueUpdate(clusterState, Collections.singletonList(wc), null);
                 clusterState = writer.writePendingUpdates();

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -290,22 +290,22 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
         "Timeout on waiting for c1 updated to have PRS state r1",
         () -> {
           DocCollection c = reader.getCollection("c1");
-          return c.getPerReplicaStates() != null
-              && c.getPerReplicaStates().get("r1") != null
-              && c.getPerReplicaStates().get("r1").state == Replica.State.DOWN;
+          return c.getReplica("r1") != null
+              && c.getReplica("r1").getState() == Replica.State.DOWN;
         });
 
     ref = reader.getClusterState().getCollectionRef("c1");
     assertEquals(0, ref.get().getZNodeVersion()); // no change in Znode version
     assertEquals(3, ref.get().getChildNodesVersion()); // but child version should be 1 now
 
-    prs = ref.get().getPerReplicaStates();
+    prs = PerReplicaStatesFetcher.fetch(
+                    collection.getZNode(), fixture.zkClient, collection.getPerReplicaStates());
     PerReplicaStatesOps.flipState("r1", Replica.State.ACTIVE, prs)
         .persist(collection.getZNode(), fixture.zkClient);
     timeOut.waitFor(
         "Timeout on waiting for c1 updated to have PRS state r1 marked as DOWN",
         () ->
-            reader.getCollection("c1").getPerReplicaStates().get("r1").state
+            reader.getCollection("c1").getReplica("r1").getState()
                 == Replica.State.ACTIVE);
 
     ref = reader.getClusterState().getCollectionRef("c1");
@@ -349,9 +349,8 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
         "Timeout on waiting for c1 updated to have PRS state r1",
         () -> {
           DocCollection c = reader.getCollection("c1");
-          return c.getPerReplicaStates() != null
-              && c.getPerReplicaStates().get("r1") != null
-              && c.getPerReplicaStates().get("r1").state == Replica.State.DOWN;
+          return c.getReplica("r1") != null
+              && c.getReplica("r1").getState() == Replica.State.DOWN;
         });
 
     ref = reader.getClusterState().getCollectionRef("c1");

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateWriterTest.java
@@ -183,9 +183,7 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
                     new HashMap<>(),
                     prsProps,
                     DocRouter.DEFAULT,
-                    0,
-                    new PerReplicaStatesFetcher.LazyPrsSupplier(
-                        zkClient, DocCollection.getCollectionPath("c1"))));
+                    0));
         ZkStateWriter writer =
             new ZkStateWriter(reader, new Stats(), -1, STATE_COMPRESSION_PROVIDER);
 
@@ -248,17 +246,17 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
             new ZkWriteCommand(
                 "c1",
                 new DocCollection(
-                    "c1", new HashMap<>(), new HashMap<>(), DocRouter.DEFAULT, 0, null));
+                    "c1", new HashMap<>(), new HashMap<>(), DocRouter.DEFAULT, 0));
         ZkWriteCommand c2 =
             new ZkWriteCommand(
                 "c2",
                 new DocCollection(
-                    "c2", new HashMap<>(), new HashMap<>(), DocRouter.DEFAULT, 0, null));
+                    "c2", new HashMap<>(), new HashMap<>(), DocRouter.DEFAULT, 0));
         ZkWriteCommand c3 =
             new ZkWriteCommand(
                 "c3",
                 new DocCollection(
-                    "c3", new HashMap<>(), new HashMap<>(), DocRouter.DEFAULT, 0, null));
+                    "c3", new HashMap<>(), new HashMap<>(), DocRouter.DEFAULT, 0));
         Map<String, Object> prsProps = new HashMap<>();
         prsProps.put("perReplicaState", Boolean.TRUE);
         ZkWriteCommand prs1 =
@@ -269,9 +267,7 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
                     new HashMap<>(),
                     prsProps,
                     DocRouter.DEFAULT,
-                    0,
-                    new PerReplicaStatesFetcher.LazyPrsSupplier(
-                        zkClient, DocCollection.getCollectionPath("prs1"))));
+                    0));
         ZkStateWriter writer =
             new ZkStateWriter(reader, new Stats(), -1, STATE_COMPRESSION_PROVIDER);
 

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/ZkClientClusterStateProvider.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/ZkClientClusterStateProvider.java
@@ -117,9 +117,7 @@ public class ZkClientClusterStateProvider implements ClusterStateProvider {
     return ClusterState.createFromCollectionMap(
         version,
         stateMap,
-        liveNodes,
-        new PerReplicaStatesFetcher.LazyPrsSupplier(
-            zkClient, DocCollection.getCollectionPath(coll)));
+        liveNodes);
   }
 
   @Override

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/PerReplicaStatesFetcher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/PerReplicaStatesFetcher.java
@@ -55,9 +55,9 @@ public class PerReplicaStatesFetcher {
     }
   }
 
-  public static class LazyPrsSupplier extends DocCollection.PrsSupplier {
-    public LazyPrsSupplier(SolrZkClient zkClient, String collectionPath) {
-      super(() -> PerReplicaStatesFetcher.fetch(collectionPath, zkClient, null));
-    }
-  }
+//  public static class LazyPrsSupplier extends DocCollection.PrsSupplier {
+//    public LazyPrsSupplier(SolrZkClient zkClient, String collectionPath) {
+//      super(() -> PerReplicaStatesFetcher.fetch(collectionPath, zkClient, null));
+//    }
+//  }
 }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -333,14 +333,8 @@ public class ZkStateReader implements SolrCloseable {
               log.debug("Removing cached collection state for [{}]", collection);
               watch.currentState = null;
             } else { // both new and old states are non-null
-              int oldCVersion =
-                  oldState.getPerReplicaStates() == null
-                      ? -1
-                      : oldState.getPerReplicaStates().cversion;
-              int newCVersion =
-                  newState.getPerReplicaStates() == null
-                      ? -1
-                      : newState.getPerReplicaStates().cversion;
+              int oldCVersion = oldState.getChildNodesVersion();
+              int newCVersion = newState.getChildNodesVersion();
               if (oldState.getZNodeVersion() < newState.getZNodeVersion()
                   || oldCVersion < newCVersion) {
                 watch.currentState = newState;

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -305,10 +305,8 @@ public class ClusterState implements JSONWriter.Writable {
     }
 
     PerReplicaStates perReplicaStates = isPrsEnabledCollection && prsSupplier != null ? prsSupplier.get() : null;
-    DocCollection docCollection = new DocCollection(name, slices, props, router, version, perReplicaStates != null ? perReplicaStates.cversion : null);
-    if (perReplicaStates != null) {
-      docCollection = docCollection.copyWith(perReplicaStates);
-    }
+    DocCollection docCollection = new DocCollection(name, slices, props, router, version, perReplicaStates);
+
 
     return docCollection;
   }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Slice.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Slice.java
@@ -91,6 +91,15 @@ public class Slice extends ZkNodeProps implements Iterable<Replica> {
     replicasCopy.put(modified.getName(), modified);
     return new Slice(name, replicasCopy, propMap, collection);
   }
+
+  /** Make a copy with a map of modified Replicas */
+  public Slice copyWith(LinkedHashMap<String, Replica> modified) {
+    if (log.isDebugEnabled()) {
+      log.debug("modified replicas : {}", modified);
+    }
+    return new Slice(name, new LinkedHashMap<>(modified), propMap, collection);
+  }
+
   /** The slice's state. */
   public enum State {
 


### PR DESCRIPTION
Experimental changes to see efforts involved to extract the PRS supplier out from `DocCollection` to keep `DocCollection` immutable. Some background in https://fullstory.atlassian.net/browse/SAI-4401

Pros:
1. When `DocCollection` is fully immutable, the existing Solr logic calling it (and making such assumption) could have easier handling (less concern with state changes that induces race conditions etc)
2. Keep `DocCollection` logic simple as a pure container that simply assign the provided values into itself, this avoid unexpected ZK operations/fetches that trigger unexpected exceptions for caller
3. No longer need to worry about copy operations (such as `DocCollection.copyWithSlices`) would re-fetch PRS entries (since DocCollection no longer fetches anything). We might not need to add extra lazy loading to PRS as re-fetch might not be a concern anymore

This is fully just quick exploratory work to see if a modified flow would still work. I have not really done any testings yet. Really simple ZkStateWriter and ZkStateReader tests did pass.

Will run ./gradlew check and i do expect seeing some failures 😓 

Be nice to get some thoughts from everyone though, especially @chatman  and @noblepaul . Many thanks!! 😊  

