### PR TITLE
SOLR-16594: improve eDismax strategy for generating a term-centric query

### DIFF
--- a/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
+++ b/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
@@ -606,7 +606,7 @@ public class QueryBuilder2 {
     for (TermAndBoost t : terms) {
       builder.addTerm(t.term, t.boost);
     }
-    return builder.build();
+    return new SynonymQueryWithOffset(builder.build());
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
+++ b/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
@@ -614,7 +614,7 @@ public class QueryBuilder2 {
     for (TermAndBoost t : terms) {
       builder.addTerm(t.term, t.boost);
     }
-    return new SynonymQueryWithOffset(builder.build());
+    return new SynonymQueryWithOffset(builder.build(), terms[0].startOffset);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
+++ b/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
@@ -1,0 +1,659 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.parser;
+
+import static org.apache.lucene.search.BoostAttribute.DEFAULT_BOOST;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CachingTokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostAttribute;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.MultiPhraseQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SynonymQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.AttributeSource;
+import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
+
+/**
+ * Creates queries from the {@link Analyzer} chain.
+ *
+ * <p>Example usage:
+ *
+ * <pre class="prettyprint">
+ *   QueryBuilder builder = new QueryBuilder(analyzer);
+ *   Query a = builder.createBooleanQuery("body", "just a test");
+ *   Query b = builder.createPhraseQuery("body", "another test");
+ *   Query c = builder.createMinShouldMatchQuery("body", "another test", 0.5f);
+ * </pre>
+ *
+ * <p>This can also be used as a subclass for query parsers to make it easier to interact with the
+ * analysis chain. Factory methods such as {@code newTermQuery} are provided so that the generated
+ * queries can be customized.
+ *
+ * <p>adapted from https://github.com/apache/lucene/blob/branch_9_4/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java</p>
+ */
+public class QueryBuilder2 {
+  protected Analyzer analyzer;
+  protected boolean enablePositionIncrements = true;
+  protected boolean enableGraphQueries = true;
+  protected boolean autoGenerateMultiTermSynonymsPhraseQuery = false;
+
+  /** Wraps a term and boost */
+  public static class TermAndBoost {
+    /** the term */
+    public final Term term;
+    /** the boost */
+    public final float boost;
+
+    /** Creates a new TermAndBoost */
+    public TermAndBoost(Term term, float boost) {
+      this.term = term;
+      this.boost = boost;
+    }
+  }
+
+  /** Creates a new QueryBuilder using the given analyzer. */
+  public QueryBuilder2(Analyzer analyzer) {
+    this.analyzer = analyzer;
+  }
+
+  /**
+   * Creates a boolean query from the query text.
+   *
+   * <p>This is equivalent to {@code createBooleanQuery(field, queryText, Occur.SHOULD)}
+   *
+   * @param field field name
+   * @param queryText text to be passed to the analyzer
+   * @return {@code TermQuery} or {@code BooleanQuery}, based on the analysis of {@code queryText}
+   */
+  public Query createBooleanQuery(String field, String queryText) {
+    return createBooleanQuery(field, queryText, BooleanClause.Occur.SHOULD);
+  }
+
+  /**
+   * Creates a boolean query from the query text.
+   *
+   * @param field field name
+   * @param queryText text to be passed to the analyzer
+   * @param operator operator used for clauses between analyzer tokens.
+   * @return {@code TermQuery} or {@code BooleanQuery}, based on the analysis of {@code queryText}
+   */
+  public Query createBooleanQuery(String field, String queryText, BooleanClause.Occur operator) {
+    if (operator != BooleanClause.Occur.SHOULD && operator != BooleanClause.Occur.MUST) {
+      throw new IllegalArgumentException("invalid operator: only SHOULD or MUST are allowed");
+    }
+    return createFieldQuery(analyzer, operator, field, queryText, false, 0);
+  }
+
+  /**
+   * Creates a phrase query from the query text.
+   *
+   * <p>This is equivalent to {@code createPhraseQuery(field, queryText, 0)}
+   *
+   * @param field field name
+   * @param queryText text to be passed to the analyzer
+   * @return {@code TermQuery}, {@code BooleanQuery}, {@code PhraseQuery}, or {@code
+   *     MultiPhraseQuery}, based on the analysis of {@code queryText}
+   */
+  public Query createPhraseQuery(String field, String queryText) {
+    return createPhraseQuery(field, queryText, 0);
+  }
+
+  /**
+   * Creates a phrase query from the query text.
+   *
+   * @param field field name
+   * @param queryText text to be passed to the analyzer
+   * @param phraseSlop number of other words permitted between words in query phrase
+   * @return {@code TermQuery}, {@code BooleanQuery}, {@code PhraseQuery}, or {@code
+   *     MultiPhraseQuery}, based on the analysis of {@code queryText}
+   */
+  public Query createPhraseQuery(String field, String queryText, int phraseSlop) {
+    return createFieldQuery(analyzer, BooleanClause.Occur.MUST, field, queryText, true, phraseSlop);
+  }
+
+  /**
+   * Creates a minimum-should-match query from the query text.
+   *
+   * @param field field name
+   * @param queryText text to be passed to the analyzer
+   * @param fraction of query terms {@code [0..1]} that should match
+   * @return {@code TermQuery} or {@code BooleanQuery}, based on the analysis of {@code queryText}
+   */
+  public Query createMinShouldMatchQuery(String field, String queryText, float fraction) {
+    if (Float.isNaN(fraction) || fraction < 0 || fraction > 1) {
+      throw new IllegalArgumentException("fraction should be >= 0 and <= 1");
+    }
+
+    // TODO: weird that BQ equals/rewrite/scorer doesn't handle this?
+    if (fraction == 1) {
+      return createBooleanQuery(field, queryText, BooleanClause.Occur.MUST);
+    }
+
+    Query query =
+      createFieldQuery(analyzer, BooleanClause.Occur.SHOULD, field, queryText, false, 0);
+    if (query instanceof BooleanQuery) {
+      query = addMinShouldMatchToBoolean((BooleanQuery) query, fraction);
+    }
+    return query;
+  }
+
+  /** Rebuilds a boolean query and sets a new minimum number should match value. */
+  private BooleanQuery addMinShouldMatchToBoolean(BooleanQuery query, float fraction) {
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    builder.setMinimumNumberShouldMatch((int) (fraction * query.clauses().size()));
+    for (BooleanClause clause : query) {
+      builder.add(clause);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Returns the analyzer.
+   *
+   * @see #setAnalyzer(Analyzer)
+   */
+  public Analyzer getAnalyzer() {
+    return analyzer;
+  }
+
+  /** Sets the analyzer used to tokenize text. */
+  public void setAnalyzer(Analyzer analyzer) {
+    this.analyzer = analyzer;
+  }
+
+  /**
+   * Returns true if position increments are enabled.
+   *
+   * @see #setEnablePositionIncrements(boolean)
+   */
+  public boolean getEnablePositionIncrements() {
+    return enablePositionIncrements;
+  }
+
+  /**
+   * Set to <code>true</code> to enable position increments in result query.
+   *
+   * <p>When set, result phrase and multi-phrase queries will be aware of position increments.
+   * Useful when e.g. a StopFilter increases the position increment of the token that follows an
+   * omitted token.
+   *
+   * <p>Default: true.
+   */
+  public void setEnablePositionIncrements(boolean enable) {
+    this.enablePositionIncrements = enable;
+  }
+
+  /**
+   * Returns true if phrase query should be automatically generated for multi terms synonyms.
+   *
+   * @see #setAutoGenerateMultiTermSynonymsPhraseQuery(boolean)
+   */
+  public boolean getAutoGenerateMultiTermSynonymsPhraseQuery() {
+    return autoGenerateMultiTermSynonymsPhraseQuery;
+  }
+
+  /**
+   * Set to <code>true</code> if phrase queries should be automatically generated for multi terms
+   * synonyms. Default: false.
+   */
+  public void setAutoGenerateMultiTermSynonymsPhraseQuery(boolean enable) {
+    this.autoGenerateMultiTermSynonymsPhraseQuery = enable;
+  }
+
+  /**
+   * Creates a query from the analysis chain.
+   *
+   * <p>Expert: this is more useful for subclasses such as queryparsers. If using this class
+   * directly, just use {@link #createBooleanQuery(String, String)} and {@link
+   * #createPhraseQuery(String, String)}. This is a complex method and it is usually not necessary
+   * to override it in a subclass; instead, override methods like {@link #newBooleanQuery}, etc., if
+   * possible.
+   *
+   * @param analyzer analyzer used for this query
+   * @param operator default boolean operator used for this query
+   * @param field field to create queries against
+   * @param queryText text to be passed to the analysis chain
+   * @param quoted true if phrases should be generated when terms occur at more than one position
+   * @param phraseSlop slop factor for phrase/multiphrase queries
+   */
+  protected Query createFieldQuery(
+    Analyzer analyzer,
+    BooleanClause.Occur operator,
+    String field,
+    String queryText,
+    boolean quoted,
+    int phraseSlop) {
+    assert operator == BooleanClause.Occur.SHOULD || operator == BooleanClause.Occur.MUST;
+
+    // Use the analyzer to get all the tokens, and then build an appropriate
+    // query based on the analysis chain.
+    try (TokenStream source = analyzer.tokenStream(field, queryText)) {
+      return createFieldQuery(source, operator, field, quoted, phraseSlop);
+    } catch (IOException e) {
+      throw new RuntimeException("Error analyzing query text", e);
+    }
+  }
+
+  /**
+   * Enable or disable graph TokenStream processing (enabled by default).
+   *
+   * @lucene.experimental
+   */
+  public void setEnableGraphQueries(boolean v) {
+    enableGraphQueries = v;
+  }
+
+  /**
+   * Returns true if graph TokenStream processing is enabled (default).
+   *
+   * @lucene.experimental
+   */
+  public boolean getEnableGraphQueries() {
+    return enableGraphQueries;
+  }
+
+  /**
+   * Creates a query from a token stream.
+   *
+   * @param source the token stream to create the query from
+   * @param operator default boolean operator used for this query
+   * @param field field to create queries against
+   * @param quoted true if phrases should be generated when terms occur at more than one position
+   * @param phraseSlop slop factor for phrase/multiphrase queries
+   */
+  protected Query createFieldQuery(
+    TokenStream source,
+    BooleanClause.Occur operator,
+    String field,
+    boolean quoted,
+    int phraseSlop) {
+    assert operator == BooleanClause.Occur.SHOULD || operator == BooleanClause.Occur.MUST;
+
+    // Build an appropriate query based on the analysis chain.
+    try (CachingTokenFilter stream = new CachingTokenFilter(source)) {
+
+      TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+      PositionIncrementAttribute posIncAtt = stream.addAttribute(PositionIncrementAttribute.class);
+      PositionLengthAttribute posLenAtt = stream.addAttribute(PositionLengthAttribute.class);
+
+      if (termAtt == null) {
+        return null;
+      }
+
+      // phase 1: read through the stream and assess the situation:
+      // counting the number of tokens/positions and marking if we have any synonyms.
+
+      int numTokens = 0;
+      int positionCount = 0;
+      boolean hasSynonyms = false;
+      boolean isGraph = false;
+
+      stream.reset();
+      while (stream.incrementToken()) {
+        numTokens++;
+        int positionIncrement = posIncAtt.getPositionIncrement();
+        if (positionIncrement != 0) {
+          positionCount += positionIncrement;
+        } else {
+          hasSynonyms = true;
+        }
+
+        int positionLength = posLenAtt.getPositionLength();
+        if (enableGraphQueries && positionLength > 1) {
+          isGraph = true;
+        }
+      }
+
+      // phase 2: based on token count, presence of synonyms, and options
+      // formulate a single term, boolean, or phrase.
+
+      if (numTokens == 0) {
+        return null;
+      } else if (numTokens == 1) {
+        // single term
+        return analyzeTerm(field, stream);
+      } else if (isGraph) {
+        // graph
+        if (quoted) {
+          return analyzeGraphPhrase(stream, field, phraseSlop);
+        } else {
+          return analyzeGraphBoolean(field, stream, operator);
+        }
+      } else if (quoted && positionCount > 1) {
+        // phrase
+        if (hasSynonyms) {
+          // complex phrase with synonyms
+          return analyzeMultiPhrase(field, stream, phraseSlop);
+        } else {
+          // simple phrase
+          return analyzePhrase(field, stream, phraseSlop);
+        }
+      } else {
+        // boolean
+        if (positionCount == 1) {
+          // only one position, with synonyms
+          return analyzeBoolean(field, stream);
+        } else {
+          // complex case: multiple positions
+          return analyzeMultiBoolean(field, stream, operator);
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Error analyzing query text", e);
+    }
+  }
+
+  /** Creates simple term query from the cached tokenstream contents */
+  protected Query analyzeTerm(String field, TokenStream stream) throws IOException {
+    TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+    BoostAttribute boostAtt = stream.addAttribute(BoostAttribute.class);
+
+    stream.reset();
+    if (!stream.incrementToken()) {
+      throw new AssertionError();
+    }
+
+    return newTermQuery(new Term(field, termAtt.getBytesRef()), boostAtt.getBoost());
+  }
+
+  /** Creates simple boolean query from the cached tokenstream contents */
+  protected Query analyzeBoolean(String field, TokenStream stream) throws IOException {
+    TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+    BoostAttribute boostAtt = stream.addAttribute(BoostAttribute.class);
+
+    stream.reset();
+    List<TermAndBoost> terms = new ArrayList<>();
+    while (stream.incrementToken()) {
+      terms.add(new TermAndBoost(new Term(field, termAtt.getBytesRef()), boostAtt.getBoost()));
+    }
+
+    return newSynonymQuery(terms.toArray(new TermAndBoost[0]));
+  }
+
+  protected void add(
+    BooleanQuery.Builder q, List<TermAndBoost> current, BooleanClause.Occur operator) {
+    if (current.isEmpty()) {
+      return;
+    }
+    if (current.size() == 1) {
+      q.add(newTermQuery(current.get(0).term, current.get(0).boost), operator);
+    } else {
+      q.add(newSynonymQuery(current.toArray(new TermAndBoost[0])), operator);
+    }
+  }
+
+  /** Creates complex boolean query from the cached tokenstream contents */
+  protected Query analyzeMultiBoolean(
+    String field, TokenStream stream, BooleanClause.Occur operator) throws IOException {
+    BooleanQuery.Builder q = newBooleanQuery();
+    List<TermAndBoost> currentQuery = new ArrayList<>();
+
+    TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+    PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
+    BoostAttribute boostAtt = stream.addAttribute(BoostAttribute.class);
+
+    stream.reset();
+    while (stream.incrementToken()) {
+      if (posIncrAtt.getPositionIncrement() != 0) {
+        add(q, currentQuery, operator);
+        currentQuery.clear();
+      }
+      currentQuery.add(
+        new TermAndBoost(new Term(field, termAtt.getBytesRef()), boostAtt.getBoost()));
+    }
+    add(q, currentQuery, operator);
+
+    return q.build();
+  }
+
+  /** Creates simple phrase query from the cached tokenstream contents */
+  protected Query analyzePhrase(String field, TokenStream stream, int slop) throws IOException {
+    PhraseQuery.Builder builder = new PhraseQuery.Builder();
+    builder.setSlop(slop);
+
+    TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+    BoostAttribute boostAtt = stream.addAttribute(BoostAttribute.class);
+    PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
+    int position = -1;
+    float phraseBoost = DEFAULT_BOOST;
+    stream.reset();
+    while (stream.incrementToken()) {
+      if (enablePositionIncrements) {
+        position += posIncrAtt.getPositionIncrement();
+      } else {
+        position += 1;
+      }
+      builder.add(new Term(field, termAtt.getBytesRef()), position);
+      phraseBoost *= boostAtt.getBoost();
+    }
+    PhraseQuery query = builder.build();
+    if (phraseBoost == DEFAULT_BOOST) {
+      return query;
+    }
+    return new BoostQuery(query, phraseBoost);
+  }
+
+  /** Creates complex phrase query from the cached tokenstream contents */
+  protected Query analyzeMultiPhrase(String field, TokenStream stream, int slop)
+    throws IOException {
+    MultiPhraseQuery.Builder mpqb = newMultiPhraseQueryBuilder();
+    mpqb.setSlop(slop);
+
+    TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+
+    PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
+    int position = -1;
+
+    List<Term> multiTerms = new ArrayList<>();
+    stream.reset();
+    while (stream.incrementToken()) {
+      int positionIncrement = posIncrAtt.getPositionIncrement();
+
+      if (positionIncrement > 0 && multiTerms.size() > 0) {
+        if (enablePositionIncrements) {
+          mpqb.add(multiTerms.toArray(new Term[0]), position);
+        } else {
+          mpqb.add(multiTerms.toArray(new Term[0]));
+        }
+        multiTerms.clear();
+      }
+      position += positionIncrement;
+      multiTerms.add(new Term(field, termAtt.getBytesRef()));
+    }
+
+    if (enablePositionIncrements) {
+      mpqb.add(multiTerms.toArray(new Term[0]), position);
+    } else {
+      mpqb.add(multiTerms.toArray(new Term[0]));
+    }
+    return mpqb.build();
+  }
+
+  /**
+   * Creates a boolean query from a graph token stream. The articulation points of the graph are
+   * visited in order and the queries created at each point are merged in the returned boolean
+   * query.
+   */
+  protected Query analyzeGraphBoolean(
+    String field, TokenStream source, BooleanClause.Occur operator) throws IOException {
+    source.reset();
+    GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(source);
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    int[] articulationPoints = graph.articulationPoints();
+    int lastState = 0;
+    for (int i = 0; i <= articulationPoints.length; i++) {
+      int start = lastState;
+      int end = -1;
+      if (i < articulationPoints.length) {
+        end = articulationPoints[i];
+      }
+      lastState = end;
+      final Query positionalQuery;
+      if (graph.hasSidePath(start)) {
+        final Iterator<TokenStream> sidePathsIterator = graph.getFiniteStrings(start, end);
+        Iterator<Query> queries =
+          new Iterator<Query>() {
+            @Override
+            public boolean hasNext() {
+              return sidePathsIterator.hasNext();
+            }
+
+            @Override
+            public Query next() {
+              TokenStream sidePath = sidePathsIterator.next();
+              return createFieldQuery(
+                sidePath,
+                BooleanClause.Occur.MUST,
+                field,
+                getAutoGenerateMultiTermSynonymsPhraseQuery(),
+                0);
+            }
+          };
+        positionalQuery = newGraphSynonymQuery(queries);
+      } else {
+        List<AttributeSource> attributes = graph.getTerms(start);
+        TermAndBoost[] terms =
+          attributes.stream()
+            .map(
+              s -> {
+                TermToBytesRefAttribute t = s.addAttribute(TermToBytesRefAttribute.class);
+                BoostAttribute b = s.addAttribute(BoostAttribute.class);
+                return new TermAndBoost(new Term(field, t.getBytesRef()), b.getBoost());
+              })
+            .toArray(TermAndBoost[]::new);
+        assert terms.length > 0;
+        if (terms.length == 1) {
+          positionalQuery = newTermQuery(terms[0].term, terms[0].boost);
+        } else {
+          positionalQuery = newSynonymQuery(terms);
+        }
+      }
+      if (positionalQuery != null) {
+        builder.add(positionalQuery, operator);
+      }
+    }
+    return builder.build();
+  }
+
+  /** Creates graph phrase query from the tokenstream contents */
+  protected Query analyzeGraphPhrase(TokenStream source, String field, int phraseSlop)
+    throws IOException {
+    source.reset();
+    GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(source);
+
+    // Creates a boolean query from the graph token stream by extracting all the
+    // finite strings from the graph and using them to create phrase queries with
+    // the appropriate slop.
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    Iterator<TokenStream> it = graph.getFiniteStrings();
+    while (it.hasNext()) {
+      Query query = createFieldQuery(it.next(), BooleanClause.Occur.MUST, field, true, phraseSlop);
+      if (query != null) {
+        builder.add(query, BooleanClause.Occur.SHOULD);
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Builds a new BooleanQuery instance.
+   *
+   * <p>This is intended for subclasses that wish to customize the generated queries.
+   *
+   * @return new BooleanQuery instance
+   */
+  protected BooleanQuery.Builder newBooleanQuery() {
+    return new BooleanQuery.Builder();
+  }
+
+  /**
+   * Builds a new SynonymQuery instance.
+   *
+   * <p>This is intended for subclasses that wish to customize the generated queries.
+   *
+   * @return new Query instance
+   */
+  protected Query newSynonymQuery(TermAndBoost[] terms) {
+    SynonymQuery.Builder builder = new SynonymQuery.Builder(terms[0].term.field());
+    for (TermAndBoost t : terms) {
+      builder.addTerm(t.term, t.boost);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Builds a new GraphQuery for multi-terms synonyms.
+   *
+   * <p>This is intended for subclasses that wish to customize the generated queries.
+   *
+   * @return new Query instance
+   */
+  protected Query newGraphSynonymQuery(Iterator<Query> queries) {
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    while (queries.hasNext()) {
+      builder.add(queries.next(), BooleanClause.Occur.SHOULD);
+    }
+    BooleanQuery bq = builder.build();
+    if (bq.clauses().size() == 1) {
+      return bq.clauses().get(0).getQuery();
+    }
+    return bq;
+  }
+
+  /**
+   * Builds a new TermQuery instance.
+   *
+   * <p>This is intended for subclasses that wish to customize the generated queries.
+   *
+   * @param term term
+   * @return new TermQuery instance
+   */
+  protected Query newTermQuery(Term term, float boost) {
+    Query q = new TermQuery(term);
+    if (boost == DEFAULT_BOOST) {
+      return q;
+    }
+    return new BoostQuery(q, boost);
+  }
+
+  /**
+   * Builds a new MultiPhraseQuery instance.
+   *
+   * <p>This is intended for subclasses that wish to customize the generated queries.
+   *
+   * @return new MultiPhraseQuery instance
+   */
+  protected MultiPhraseQuery.Builder newMultiPhraseQueryBuilder() {
+    return new MultiPhraseQuery.Builder();
+  }
+}
+

--- a/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
+++ b/solr/core/src/java/org/apache/solr/parser/QueryBuilder2.java
@@ -37,7 +37,6 @@ import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
 
@@ -638,7 +637,7 @@ public class QueryBuilder2 {
    * @return new TermQuery instance
    */
   protected Query newTermQuery(Term term, float boost) {
-    Query q = new TermQuery(term);
+    Query q = new TermQueryWithOffset(term);
     if (boost == DEFAULT_BOOST) {
       return q;
     }

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryBuilder.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryBuilder.java
@@ -42,7 +42,21 @@ import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
 
 /**
- * Creates queries from the {@link Analyzer} chain.
+ * <p>Adapted from org.apache.lucene.util.QueryBuilder as of lucene version 9.4.
+ * Provisionally included here in the Solr codebase so that behavior can be modified without requiring changes
+ * that span two repositories.
+ *
+ * <p>The key change is that startOffsets are now stored on term queries and synonym queries that are created via
+ * this builder, including when they are nested inside larger queries.
+ * newTermQuery() now returns a TermQueryWithOffset instead of a TermQuery
+ * newSynonymQuery() now returns a SynonymQueryWithOffset instead of a SynonymQuery
+ *
+ * <p>Original source:
+ * https://github.com/apache/lucene/blob/branch_9_4/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java</p>
+ *
+ * <p>Original doc:</p>
+ *
+ * <p>Creates queries from the {@link Analyzer} chain.
  *
  * <p>Example usage:
  *
@@ -57,9 +71,8 @@ import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
  * analysis chain. Factory methods such as {@code newTermQuery} are provided so that the generated
  * queries can be customized.
  *
- * <p>adapted from https://github.com/apache/lucene/blob/branch_9_4/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java</p>
  */
-public class QueryBuilder2 {
+public class SolrQueryBuilder {
   protected Analyzer analyzer;
   protected boolean enablePositionIncrements = true;
   protected boolean enableGraphQueries = true;
@@ -83,7 +96,7 @@ public class QueryBuilder2 {
   }
 
   /** Creates a new QueryBuilder using the given analyzer. */
-  public QueryBuilder2(Analyzer analyzer) {
+  public SolrQueryBuilder(Analyzer analyzer) {
     this.analyzer = analyzer;
   }
 

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryBuilder.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryBuilder.java
@@ -42,19 +42,19 @@ import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
 
 /**
- * <p>Adapted from org.apache.lucene.util.QueryBuilder as of lucene version 9.4.
- * Provisionally included here in the Solr codebase so that behavior can be modified without requiring changes
- * that span two repositories.
+ * Adapted from org.apache.lucene.util.QueryBuilder as of lucene version 9.4. Provisionally included
+ * here in the Solr codebase so that behavior can be modified without requiring changes that span
+ * two repositories.
  *
- * <p>The key change is that startOffsets are now stored on term queries and synonym queries that are created via
- * this builder, including when they are nested inside larger queries.
- * newTermQuery() now returns a TermQueryWithOffset instead of a TermQuery
- * newSynonymQuery() now returns a SynonymQueryWithOffset instead of a SynonymQuery
+ * <p>The key change is that startOffsets are now stored on term queries and synonym queries that
+ * are created via this builder, including when they are nested inside larger queries.
+ * newTermQuery() now returns a TermQueryWithOffset instead of a TermQuery newSynonymQuery() now
+ * returns a SynonymQueryWithOffset instead of a SynonymQuery
  *
  * <p>Original source:
- * https://github.com/apache/lucene/blob/branch_9_4/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java</p>
+ * https://github.com/apache/lucene/blob/branch_9_4/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
  *
- * <p>Original doc:</p>
+ * <p>Original doc:
  *
  * <p>Creates queries from the {@link Analyzer} chain.
  *
@@ -70,7 +70,6 @@ import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
  * <p>This can also be used as a subclass for query parsers to make it easier to interact with the
  * analysis chain. Factory methods such as {@code newTermQuery} are provided so that the generated
  * queries can be customized.
- *
  */
 public class SolrQueryBuilder {
   protected Analyzer analyzer;
@@ -174,7 +173,7 @@ public class SolrQueryBuilder {
     }
 
     Query query =
-      createFieldQuery(analyzer, BooleanClause.Occur.SHOULD, field, queryText, false, 0);
+        createFieldQuery(analyzer, BooleanClause.Occur.SHOULD, field, queryText, false, 0);
     if (query instanceof BooleanQuery) {
       query = addMinShouldMatchToBoolean((BooleanQuery) query, fraction);
     }
@@ -262,12 +261,12 @@ public class SolrQueryBuilder {
    * @param phraseSlop slop factor for phrase/multiphrase queries
    */
   protected Query createFieldQuery(
-    Analyzer analyzer,
-    BooleanClause.Occur operator,
-    String field,
-    String queryText,
-    boolean quoted,
-    int phraseSlop) {
+      Analyzer analyzer,
+      BooleanClause.Occur operator,
+      String field,
+      String queryText,
+      boolean quoted,
+      int phraseSlop) {
     assert operator == BooleanClause.Occur.SHOULD || operator == BooleanClause.Occur.MUST;
 
     // Use the analyzer to get all the tokens, and then build an appropriate
@@ -307,11 +306,11 @@ public class SolrQueryBuilder {
    * @param phraseSlop slop factor for phrase/multiphrase queries
    */
   protected Query createFieldQuery(
-    TokenStream source,
-    BooleanClause.Occur operator,
-    String field,
-    boolean quoted,
-    int phraseSlop) {
+      TokenStream source,
+      BooleanClause.Occur operator,
+      String field,
+      boolean quoted,
+      int phraseSlop) {
     assert operator == BooleanClause.Occur.SHOULD || operator == BooleanClause.Occur.MUST;
 
     // Build an appropriate query based on the analysis chain.
@@ -399,7 +398,8 @@ public class SolrQueryBuilder {
     }
 
     OffsetAttribute offsetAtt = stream.getAttribute(OffsetAttribute.class);
-    return newTermQuery(new Term(field, termAtt.getBytesRef()), boostAtt.getBoost(), offsetAtt.startOffset());
+    return newTermQuery(
+        new Term(field, termAtt.getBytesRef()), boostAtt.getBoost(), offsetAtt.startOffset());
   }
 
   /** Creates simple boolean query from the cached tokenstream contents */
@@ -411,19 +411,25 @@ public class SolrQueryBuilder {
     stream.reset();
     List<TermAndBoost> terms = new ArrayList<>();
     while (stream.incrementToken()) {
-      terms.add(new TermAndBoost(new Term(field, termAtt.getBytesRef()), boostAtt.getBoost(), offsetAtt.startOffset()));
+      terms.add(
+          new TermAndBoost(
+              new Term(field, termAtt.getBytesRef()),
+              boostAtt.getBoost(),
+              offsetAtt.startOffset()));
     }
 
     return newSynonymQuery(terms.toArray(new TermAndBoost[0]));
   }
 
   protected void add(
-    BooleanQuery.Builder q, List<TermAndBoost> current, BooleanClause.Occur operator) {
+      BooleanQuery.Builder q, List<TermAndBoost> current, BooleanClause.Occur operator) {
     if (current.isEmpty()) {
       return;
     }
     if (current.size() == 1) {
-      q.add(newTermQuery(current.get(0).term, current.get(0).boost, current.get(0).startOffset), operator);
+      q.add(
+          newTermQuery(current.get(0).term, current.get(0).boost, current.get(0).startOffset),
+          operator);
     } else {
       q.add(newSynonymQuery(current.toArray(new TermAndBoost[0])), operator);
     }
@@ -431,7 +437,7 @@ public class SolrQueryBuilder {
 
   /** Creates complex boolean query from the cached tokenstream contents */
   protected Query analyzeMultiBoolean(
-    String field, TokenStream stream, BooleanClause.Occur operator) throws IOException {
+      String field, TokenStream stream, BooleanClause.Occur operator) throws IOException {
     BooleanQuery.Builder q = newBooleanQuery();
     List<TermAndBoost> currentQuery = new ArrayList<>();
 
@@ -447,7 +453,10 @@ public class SolrQueryBuilder {
         currentQuery.clear();
       }
       currentQuery.add(
-        new TermAndBoost(new Term(field, termAtt.getBytesRef()), boostAtt.getBoost(), offsetAtt.startOffset()));
+          new TermAndBoost(
+              new Term(field, termAtt.getBytesRef()),
+              boostAtt.getBoost(),
+              offsetAtt.startOffset()));
     }
     add(q, currentQuery, operator);
 
@@ -483,7 +492,7 @@ public class SolrQueryBuilder {
 
   /** Creates complex phrase query from the cached tokenstream contents */
   protected Query analyzeMultiPhrase(String field, TokenStream stream, int slop)
-    throws IOException {
+      throws IOException {
     MultiPhraseQuery.Builder mpqb = newMultiPhraseQueryBuilder();
     mpqb.setSlop(slop);
 
@@ -523,7 +532,7 @@ public class SolrQueryBuilder {
    * query.
    */
   protected Query analyzeGraphBoolean(
-    String field, TokenStream source, BooleanClause.Occur operator) throws IOException {
+      String field, TokenStream source, BooleanClause.Occur operator) throws IOException {
     source.reset();
     GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(source);
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
@@ -540,36 +549,37 @@ public class SolrQueryBuilder {
       if (graph.hasSidePath(start)) {
         final Iterator<TokenStream> sidePathsIterator = graph.getFiniteStrings(start, end);
         Iterator<Query> queries =
-          new Iterator<Query>() {
-            @Override
-            public boolean hasNext() {
-              return sidePathsIterator.hasNext();
-            }
+            new Iterator<Query>() {
+              @Override
+              public boolean hasNext() {
+                return sidePathsIterator.hasNext();
+              }
 
-            @Override
-            public Query next() {
-              TokenStream sidePath = sidePathsIterator.next();
-              return createFieldQuery(
-                sidePath,
-                BooleanClause.Occur.MUST,
-                field,
-                getAutoGenerateMultiTermSynonymsPhraseQuery(),
-                0);
-            }
-          };
+              @Override
+              public Query next() {
+                TokenStream sidePath = sidePathsIterator.next();
+                return createFieldQuery(
+                    sidePath,
+                    BooleanClause.Occur.MUST,
+                    field,
+                    getAutoGenerateMultiTermSynonymsPhraseQuery(),
+                    0);
+              }
+            };
         positionalQuery = newGraphSynonymQuery(queries);
       } else {
         List<AttributeSource> attributes = graph.getTerms(start);
         TermAndBoost[] terms =
-          attributes.stream()
-            .map(
-              s -> {
-                TermToBytesRefAttribute t = s.addAttribute(TermToBytesRefAttribute.class);
-                BoostAttribute b = s.addAttribute(BoostAttribute.class);
-                OffsetAttribute o = s.getAttribute(OffsetAttribute.class);
-                return new TermAndBoost(new Term(field, t.getBytesRef()), b.getBoost(), o.startOffset());
-              })
-            .toArray(TermAndBoost[]::new);
+            attributes.stream()
+                .map(
+                    s -> {
+                      TermToBytesRefAttribute t = s.addAttribute(TermToBytesRefAttribute.class);
+                      BoostAttribute b = s.addAttribute(BoostAttribute.class);
+                      OffsetAttribute o = s.getAttribute(OffsetAttribute.class);
+                      return new TermAndBoost(
+                          new Term(field, t.getBytesRef()), b.getBoost(), o.startOffset());
+                    })
+                .toArray(TermAndBoost[]::new);
         assert terms.length > 0;
         if (terms.length == 1) {
           positionalQuery = newTermQuery(terms[0].term, terms[0].boost, terms[0].startOffset);
@@ -586,7 +596,7 @@ public class SolrQueryBuilder {
 
   /** Creates graph phrase query from the tokenstream contents */
   protected Query analyzeGraphPhrase(TokenStream source, String field, int phraseSlop)
-    throws IOException {
+      throws IOException {
     source.reset();
     GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(source);
 
@@ -676,4 +686,3 @@ public class SolrQueryBuilder {
     return new MultiPhraseQuery.Builder();
   }
 }
-

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -74,7 +74,7 @@ import org.apache.solr.search.SyntaxError;
  * This class is overridden by QueryParser in QueryParser.jj and acts to separate the majority of
  * the Java code from the .jj grammar file.
  */
-public abstract class SolrQueryParserBase extends QueryBuilder {
+public abstract class SolrQueryParserBase extends QueryBuilder2 {
 
   protected static final String REVERSE_WILDCARD_LOWER_BOUND =
       new String(new char[] {ReverseStringFilter.START_OF_HEADING_MARKER + 1});

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -629,14 +629,14 @@ public abstract class SolrQueryParserBase extends QueryBuilder2 {
       case PICK_BEST:
         List<Query> currPosnClauses = new ArrayList<>(terms.length);
         for (TermAndBoost term : terms) {
-          currPosnClauses.add(newTermQuery(term.term, term.boost));
+          currPosnClauses.add(newTermQuery(term.term, term.boost, term.startOffset));
         }
         DisjunctionMaxQuery dm = new DisjunctionMaxQuery(currPosnClauses, 0.0f);
         return dm;
       case AS_DISTINCT_TERMS:
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         for (TermAndBoost term : terms) {
-          builder.add(newTermQuery(term.term, term.boost), BooleanClause.Occur.SHOULD);
+          builder.add(newTermQuery(term.term, term.boost, term.startOffset), BooleanClause.Occur.SHOULD);
         }
         return builder.build();
       case AS_SAME_TERM:

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -53,7 +53,6 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.QueryBuilder;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
@@ -74,7 +73,7 @@ import org.apache.solr.search.SyntaxError;
  * This class is overridden by QueryParser in QueryParser.jj and acts to separate the majority of
  * the Java code from the .jj grammar file.
  */
-public abstract class SolrQueryParserBase extends QueryBuilder2 {
+public abstract class SolrQueryParserBase extends SolrQueryBuilder {
 
   protected static final String REVERSE_WILDCARD_LOWER_BOUND =
       new String(new char[] {ReverseStringFilter.START_OF_HEADING_MARKER + 1});

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -635,7 +635,8 @@ public abstract class SolrQueryParserBase extends SolrQueryBuilder {
       case AS_DISTINCT_TERMS:
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         for (TermAndBoost term : terms) {
-          builder.add(newTermQuery(term.term, term.boost, term.startOffset), BooleanClause.Occur.SHOULD);
+          builder.add(
+              newTermQuery(term.term, term.boost, term.startOffset), BooleanClause.Occur.SHOULD);
         }
         return builder.build();
       case AS_SAME_TERM:

--- a/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
@@ -16,9 +16,15 @@
  */
 package org.apache.solr.parser;
 
-import java.io.IOException;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.SynonymQuery;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
 
 /**
  * Wraps a SynonymQuery and stores an Integer startOffset taken from the

--- a/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
@@ -1,0 +1,52 @@
+package org.apache.solr.parser;
+
+import java.io.IOException;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.*;
+
+/**
+ * A query that treats multiple terms as synonyms.
+ *
+ * <p>For scoring purposes, this query tries to score the terms as if you had indexed them as one
+ * term: it will match any of the terms but only invoke the similarity a single time, scoring the
+ * sum of all term frequencies for the document.
+ */
+public final class SynonymQueryWithOffset extends Query {
+
+  private SynonymQuery query;
+
+  public SynonymQueryWithOffset(SynonymQuery query) {
+    this.query = query;
+  }
+
+  @Override
+  public String toString(String field) {
+    return query.toString();
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    query.visit(visitor);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return query.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return query.hashCode();
+  }
+
+  public Query rewrite(IndexReader reader) throws IOException {
+    return query.rewrite(reader);
+  }
+
+  @Override
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+    return query.createWeight(searcher, scoreMode, boost);
+  }
+
+}
+

--- a/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.parser;
 
 import java.io.IOException;

--- a/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
@@ -15,8 +15,15 @@ public final class SynonymQueryWithOffset extends Query {
 
   private SynonymQuery query;
 
-  public SynonymQueryWithOffset(SynonymQuery query) {
+  private int offset = -1;
+
+  public SynonymQueryWithOffset(SynonymQuery query, int offset) {
     this.query = query;
+    this.offset = offset;
+  }
+
+  public int getStartOffset() {
+    return offset;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.parser;
 
+import java.io.IOException;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -24,11 +25,9 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.Weight;
 
-import java.io.IOException;
-
 /**
- * Wraps a SynonymQuery and stores an Integer startOffset taken from the
- * Token that gave rise to the contained Terms.
+ * Wraps a SynonymQuery and stores an Integer startOffset taken from the Token that gave rise to the
+ * contained Terms.
  */
 public final class SynonymQueryWithOffset extends Query {
 
@@ -60,13 +59,13 @@ public final class SynonymQueryWithOffset extends Query {
   }
 
   /**
-   * Equality is based on the contained SynonymQuery and ignores the startOffset.
-   * A SynonymQueryWithOffset will consider itself equal to the SynonymQuery that it contains.
+   * Equality is based on the contained SynonymQuery and ignores the startOffset. A
+   * SynonymQueryWithOffset will consider itself equal to the SynonymQuery that it contains.
    *
-   * Note that this relationship is not currently symmetric. A SynonymQuery that
-   * will not consider itself equal to any SynonymQueryWithOffset
-   * because SynonymQuery.equals() requires class equality. This could be fixed by updating
-   * SynonymQuery.equals() inside the lucene codebase.
+   * <p>Note that this relationship is not currently symmetric. A SynonymQuery that will not
+   * consider itself equal to any SynonymQueryWithOffset because SynonymQuery.equals() requires
+   * class equality. This could be fixed by updating SynonymQuery.equals() inside the lucene
+   * codebase.
    */
   @Override
   public boolean equals(Object obj) {
@@ -83,9 +82,8 @@ public final class SynonymQueryWithOffset extends Query {
   }
 
   @Override
-  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+      throws IOException {
     return query.createWeight(searcher, scoreMode, boost);
   }
-
 }
-

--- a/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/SynonymQueryWithOffset.java
@@ -5,25 +5,26 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.*;
 
 /**
- * A query that treats multiple terms as synonyms.
- *
- * <p>For scoring purposes, this query tries to score the terms as if you had indexed them as one
- * term: it will match any of the terms but only invoke the similarity a single time, scoring the
- * sum of all term frequencies for the document.
+ * Wraps a SynonymQuery and stores an Integer startOffset taken from the
+ * Token that gave rise to the contained Terms.
  */
 public final class SynonymQueryWithOffset extends Query {
 
   private SynonymQuery query;
 
-  private int offset = -1;
+  private Integer startOffset = null;
 
   public SynonymQueryWithOffset(SynonymQuery query, int offset) {
     this.query = query;
-    this.offset = offset;
+    this.startOffset = offset;
   }
 
-  public int getStartOffset() {
-    return offset;
+  public Integer getStartOffset() {
+    return startOffset;
+  }
+
+  public boolean hasStartOffset() {
+    return startOffset != null;
   }
 
   @Override
@@ -36,6 +37,15 @@ public final class SynonymQueryWithOffset extends Query {
     query.visit(visitor);
   }
 
+  /**
+   * Equality is based on the contained SynonymQuery and ignores the startOffset.
+   * A SynonymQueryWithOffset will consider itself equal to the SynonymQuery that it contains.
+   *
+   * Note that this relationship is not currently symmetric. A SynonymQuery that
+   * will not consider itself equal to any SynonymQueryWithOffset
+   * because SynonymQuery.equals() requires class equality. This could be fixed by updating
+   * SynonymQuery.equals() inside the lucene codebase.
+   */
   @Override
   public boolean equals(Object obj) {
     return query.equals(obj);

--- a/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
@@ -3,19 +3,37 @@ package org.apache.solr.parser;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 
+/**
+ * A TermQuery that also has an Integer startOffset taken from the Token that
+ * gave rise to the contained Term.
+ */
 public class TermQueryWithOffset extends TermQuery {
 
-  private int offset = -1;
+  private Integer startOffset = null;
 
-  public TermQueryWithOffset(Term t, int offset) {
+  public TermQueryWithOffset(Term t, int startOffset) {
     super(t);
-    this.offset = offset;
+    this.startOffset = startOffset;
   }
 
-  public int getOffset() {
-    return offset;
+  public Integer getStartOffset() {
+    return startOffset;
   }
 
+  public boolean hasStartOffset() {
+    return startOffset != null;
+  }
+
+  /**
+   * Equality is based on the contained Term and ignores the startOffset.
+   * A TermQueryWithOffset will consider itself equal to a TermQuery as long as
+   * the contained Terms are themselves equal.
+   *
+   * Note that this relationship is not currently symmetric. A TermQuery that
+   * isn't a TermQueryWithOffset will not consider itself equal to any TermQueryWithOffset
+   * because TermQuery.equals requires class equality. This could be fixed by updating
+   * TermQuery.equals inside the lucene codebase.
+   */
   @Override
   public boolean equals(Object other) {
     if (!(other instanceof TermQuery)) {

--- a/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.parser;
 
 import org.apache.lucene.index.Term;

--- a/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
@@ -1,7 +1,6 @@
 package org.apache.solr.parser;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.index.TermStates;
 import org.apache.lucene.search.TermQuery;
 
 public class TermQueryWithOffset extends TermQuery {

--- a/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
@@ -20,8 +20,8 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 
 /**
- * A TermQuery that also has an Integer startOffset taken from the Token that
- * gave rise to the contained Term.
+ * A TermQuery that also has an Integer startOffset taken from the Token that gave rise to the
+ * contained Term.
  */
 public class TermQueryWithOffset extends TermQuery {
 
@@ -41,14 +41,13 @@ public class TermQueryWithOffset extends TermQuery {
   }
 
   /**
-   * Equality is based on the contained Term and ignores the startOffset.
-   * A TermQueryWithOffset will consider itself equal to a TermQuery as long as
-   * the contained Terms are themselves equal.
+   * Equality is based on the contained Term and ignores the startOffset. A TermQueryWithOffset will
+   * consider itself equal to a TermQuery as long as the contained Terms are themselves equal.
    *
-   * Note that this relationship is not currently symmetric. A TermQuery that
-   * isn't a TermQueryWithOffset will not consider itself equal to any TermQueryWithOffset
-   * because TermQuery.equals requires class equality. This could be fixed by updating
-   * TermQuery.equals inside the lucene codebase.
+   * <p>Note that this relationship is not currently symmetric. A TermQuery that isn't a
+   * TermQueryWithOffset will not consider itself equal to any TermQueryWithOffset because
+   * TermQuery.equals requires class equality. This could be fixed by updating TermQuery.equals
+   * inside the lucene codebase.
    */
   @Override
   public boolean equals(Object other) {

--- a/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
@@ -5,12 +5,16 @@ import org.apache.lucene.index.TermStates;
 import org.apache.lucene.search.TermQuery;
 
 public class TermQueryWithOffset extends TermQuery {
-  public TermQueryWithOffset(Term t) {
+
+  private int offset = -1;
+
+  public TermQueryWithOffset(Term t, int offset) {
     super(t);
+    this.offset = offset;
   }
 
-  public TermQueryWithOffset(Term t, TermStates states) {
-    super(t, states);
+  public int getOffset() {
+    return offset;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
+++ b/solr/core/src/java/org/apache/solr/parser/TermQueryWithOffset.java
@@ -1,0 +1,23 @@
+package org.apache.solr.parser;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermStates;
+import org.apache.lucene.search.TermQuery;
+
+public class TermQueryWithOffset extends TermQuery {
+  public TermQueryWithOffset(Term t) {
+    super(t);
+  }
+
+  public TermQueryWithOffset(Term t, TermStates states) {
+    super(t, states);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof TermQuery)) {
+      return false;
+    }
+    return getTerm().equals(((TermQuery) other).getTerm());
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenFilterFactory;
@@ -1264,31 +1263,31 @@ public class ExtendedDismaxQParser extends QParser {
     }
 
     /**
-     * Determines whether a list of field-centric queries can be rewritten as term-centric ones
-     * by regrouping clauses according to startOffset. Requires taht each query is a
-     * BooleanQuery (or BoostQuery containing a BooleanQuery) with clauses of type
-     * SynonymQueryWithOffset or TermQueryWithOffset and that each clause has a non-null offset.
+     * Determines whether a list of field-centric queries can be rewritten as term-centric ones by
+     * regrouping clauses according to startOffset. Requires taht each query is a BooleanQuery (or
+     * BoostQuery containing a BooleanQuery) with clauses of type SynonymQueryWithOffset or
+     * TermQueryWithOffset and that each clause has a non-null offset.
      */
     private boolean canRewriteUsingStartOffset(List<Query> lst) {
       for (Query q : lst) {
 
         Query unwrappedQuery = q;
         if (q instanceof BoostQuery) {
-          unwrappedQuery = ((BoostQuery)q).getQuery();
+          unwrappedQuery = ((BoostQuery) q).getQuery();
         }
 
         if (!(unwrappedQuery instanceof BooleanQuery)) {
           return false;
         }
-        BooleanQuery bq = (BooleanQuery)unwrappedQuery;
+        BooleanQuery bq = (BooleanQuery) unwrappedQuery;
 
         for (BooleanClause clause : bq.clauses()) {
           Query innerQuery = clause.getQuery();
 
           if (!(((innerQuery instanceof TermQueryWithOffset)
-                  && ((TermQueryWithOffset)innerQuery).hasStartOffset()) ||
-               ((innerQuery instanceof SynonymQueryWithOffset)
-                  && ((SynonymQueryWithOffset)innerQuery).hasStartOffset()))) {
+                  && ((TermQueryWithOffset) innerQuery).hasStartOffset())
+              || ((innerQuery instanceof SynonymQueryWithOffset)
+                  && ((SynonymQueryWithOffset) innerQuery).hasStartOffset()))) {
             return false;
           }
         }
@@ -1297,12 +1296,12 @@ public class ExtendedDismaxQParser extends QParser {
     }
 
     /**
-     * Rewrites a list of field-centric queries as term-centric queries by creating
-     * a term-centric query for each unique startOffset found in the clauses inside the field-centric queries.
+     * Rewrites a list of field-centric queries as term-centric queries by creating a term-centric
+     * query for each unique startOffset found in the clauses inside the field-centric queries.
      *
-     * Assumes the list contains only instance BooleanQuery or BoostQuery containing BooleanQuery,
-     * and that each BooleanQuery has clauses of type TermQueryWithOffset or SynonymQueryWithOffset,
-     * as confirmed via canRewriteUsingStartOffset()
+     * <p>Assumes the list contains only instance BooleanQuery or BoostQuery containing
+     * BooleanQuery, and that each BooleanQuery has clauses of type TermQueryWithOffset or
+     * SynonymQueryWithOffset, as confirmed via canRewriteUsingStartOffset()
      */
     private BooleanQuery.Builder rewriteUsingStartOffset(List<Query> lst, float tie) {
 
@@ -1313,8 +1312,8 @@ public class ExtendedDismaxQParser extends QParser {
         Float boost = null;
         BooleanQuery bq = null;
         if (q instanceof BoostQuery) {
-          boost = ((BoostQuery)q).getBoost();
-          bq = (BooleanQuery) ((BoostQuery)q).getQuery();
+          boost = ((BoostQuery) q).getBoost();
+          bq = (BooleanQuery) ((BoostQuery) q).getQuery();
         } else {
           bq = (BooleanQuery) q;
         }
@@ -1351,18 +1350,16 @@ public class ExtendedDismaxQParser extends QParser {
       Collection<Integer> keys = offsets.keySet();
       for (Integer key : keys) {
         List<Query> queries = offsets.get(key);
-        q.add(
-          newBooleanClause(
-            new DisjunctionMaxQuery(queries, tie), BooleanClause.Occur.SHOULD));
+        q.add(newBooleanClause(new DisjunctionMaxQuery(queries, tie), BooleanClause.Occur.SHOULD));
       }
       return q;
     }
 
     /**
-     * Rewrites a list of field-centric queries as term-centric queries by creating
-     * a term-centric query for each clause position in the field-centric queries.
+     * Rewrites a list of field-centric queries as term-centric queries by creating a term-centric
+     * query for each clause position in the field-centric queries.
      *
-     * Assumes the list contains only instance BooleanQuery or BoostQuery containing BooleanQuery
+     * <p>Assumes the list contains only instance BooleanQuery or BoostQuery containing BooleanQuery
      * and that all queries have the same structure as confirmed by allSameQueryStructure()
      */
     private BooleanQuery.Builder rewriteUsingClausePosition(List<Query> lst, float tie) {
@@ -1370,9 +1367,9 @@ public class ExtendedDismaxQParser extends QParser {
       BooleanQuery.Builder q = new BooleanQuery.Builder();
       List<Query> subs = new ArrayList<>(lst.size());
       BooleanQuery firstBooleanQuery =
-        firstQuery instanceof BoostQuery
-          ? (BooleanQuery) ((BoostQuery) firstQuery).getQuery()
-          : (BooleanQuery) firstQuery;
+          firstQuery instanceof BoostQuery
+              ? (BooleanQuery) ((BoostQuery) firstQuery).getQuery()
+              : (BooleanQuery) firstQuery;
       for (int c = 0; c < firstBooleanQuery.clauses().size(); ++c) {
         subs.clear();
         // Make a dismax query for each clause position in the boolean per-field queries.
@@ -1381,15 +1378,12 @@ public class ExtendedDismaxQParser extends QParser {
             BoostQuery boostQuery = (BoostQuery) lst.get(n);
             BooleanQuery booleanQuery = (BooleanQuery) boostQuery.getQuery();
             subs.add(
-              new BoostQuery(
-                booleanQuery.clauses().get(c).getQuery(), boostQuery.getBoost()));
+                new BoostQuery(booleanQuery.clauses().get(c).getQuery(), boostQuery.getBoost()));
           } else {
             subs.add(((BooleanQuery) lst.get(n)).clauses().get(c).getQuery());
           }
         }
-        q.add(
-          newBooleanClause(
-            new DisjunctionMaxQuery(subs, tie), BooleanClause.Occur.SHOULD));
+        q.add(newBooleanClause(new DisjunctionMaxQuery(subs, tie), BooleanClause.Occur.SHOULD));
       }
       return q;
     }

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -18,8 +18,18 @@ package org.apache.solr.search;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.Analyzer;

--- a/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
@@ -1297,8 +1297,10 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
             sf.getValueSource().getClass() + " is vs type of: " + param,
             sf.getValueSource() instanceof QueryValueSource);
         QueryValueSource qvs = (QueryValueSource) sf.getValueSource();
-        assertEquals("query of :" + param,
-          new TermQueryWithOffset(new Term("foo_t", "cow"), -1), qvs.getQuery());
+        assertEquals(
+            "query of :" + param,
+            new TermQueryWithOffset(new Term("foo_t", "cow"), -1),
+            qvs.getQuery());
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
@@ -38,7 +38,6 @@ import java.util.TimeZone;
 import org.apache.commons.math3.util.Combinations;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.function.valuesource.QueryValueSource;
-import org.apache.lucene.search.TermQuery;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;

--- a/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
@@ -51,6 +51,7 @@ import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.component.StatsField.HllOptions;
 import org.apache.solr.handler.component.StatsField.Stat;
+import org.apache.solr.parser.TermQueryWithOffset;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -1297,7 +1298,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
             sf.getValueSource().getClass() + " is vs type of: " + param,
             sf.getValueSource() instanceof QueryValueSource);
         QueryValueSource qvs = (QueryValueSource) sf.getValueSource();
-        assertEquals("query of :" + param, new TermQuery(new Term("foo_t", "cow")), qvs.getQuery());
+        assertEquals("query of :" + param, new TermQueryWithOffset(new Term("foo_t", "cow")), qvs.getQuery());
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
@@ -1298,7 +1298,8 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
             sf.getValueSource().getClass() + " is vs type of: " + param,
             sf.getValueSource() instanceof QueryValueSource);
         QueryValueSource qvs = (QueryValueSource) sf.getValueSource();
-        assertEquals("query of :" + param, new TermQueryWithOffset(new Term("foo_t", "cow")), qvs.getQuery());
+        assertEquals("query of :" + param,
+          new TermQueryWithOffset(new Term("foo_t", "cow"), -1), qvs.getQuery());
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -2525,16 +2525,16 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
                 "debugQuery",
                 "true"));
     MatcherAssert.assertThat(
-      parsedquery,
-      anyOf(
-        containsString("((text_sw:oliv | title:olive))"),
-        containsString("((title:olive | text_sw:oliv))")));
+        parsedquery,
+        anyOf(
+            containsString("((text_sw:oliv | title:olive))"),
+            containsString("((title:olive | text_sw:oliv))")));
     MatcherAssert.assertThat(parsedquery, containsString("DisjunctionMaxQuery((title:the))"));
     MatcherAssert.assertThat(
-      parsedquery,
-      anyOf(
-        containsString("((text_sw:other | title:other))"),
-        containsString("((title:other | text_sw:other))")));
+        parsedquery,
+        anyOf(
+            containsString("((text_sw:other | title:other))"),
+            containsString("((title:other | text_sw:other))")));
 
     // When field's analysis produce different query structures, mm processing is always done on the
     // boolean query.
@@ -2584,16 +2584,16 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
                 "debugQuery",
                 "true"));
     MatcherAssert.assertThat(
-      parsedquery,
-      anyOf(
-        containsString("((text_sw:oliv | title:olive))"),
-        containsString("((title:olive | text_sw:oliv))")));
+        parsedquery,
+        anyOf(
+            containsString("((text_sw:oliv | title:olive))"),
+            containsString("((title:olive | text_sw:oliv))")));
     MatcherAssert.assertThat(parsedquery, containsString("DisjunctionMaxQuery((title:the))"));
     MatcherAssert.assertThat(
-      parsedquery,
-      anyOf(
-        containsString("((text_sw:other | title:other))"),
-        containsString("((title:other | text_sw:other))")));
+        parsedquery,
+        anyOf(
+            containsString("((text_sw:other | title:other))"),
+            containsString("((title:other | text_sw:other))")));
     MatcherAssert.assertThat(parsedquery, containsString("))~3"));
 
     // When the *structure* of produced queries is the same in each field,

--- a/solr/core/src/test/org/apache/solr/search/TestMaxScoreQueryParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMaxScoreQueryParser.java
@@ -54,10 +54,10 @@ public class TestMaxScoreQueryParser extends SolrTestCaseJ4 {
   @Test
   public void testFallbackToLucene() {
     q = parse("foo");
-    assertEquals(new TermQueryWithOffset(new Term("text", "foo")), q);
+    assertEquals(new TermQueryWithOffset(new Term("text", "foo"), -1), q);
 
     q = parse("foo^3.0");
-    assertEquals(new BoostQuery(new TermQueryWithOffset(new Term("text", "foo")), 3f), q);
+    assertEquals(new BoostQuery(new TermQueryWithOffset(new Term("text", "foo"), -1), 3f), q);
 
     q = parse("price:[0 TO 10]");
     Class<? extends Query> expected = LegacyNumericRangeQuery.class;

--- a/solr/core/src/test/org/apache/solr/search/TestMaxScoreQueryParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMaxScoreQueryParser.java
@@ -36,6 +36,7 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.legacy.LegacyNumericRangeQuery;
+import org.apache.solr.parser.TermQueryWithOffset;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
@@ -53,10 +54,10 @@ public class TestMaxScoreQueryParser extends SolrTestCaseJ4 {
   @Test
   public void testFallbackToLucene() {
     q = parse("foo");
-    assertEquals(new TermQuery(new Term("text", "foo")), q);
+    assertEquals(new TermQueryWithOffset(new Term("text", "foo")), q);
 
     q = parse("foo^3.0");
-    assertEquals(new BoostQuery(new TermQuery(new Term("text", "foo")), 3f), q);
+    assertEquals(new BoostQuery(new TermQueryWithOffset(new Term("text", "foo")), 3f), q);
 
     q = parse("price:[0 TO 10]");
     Class<? extends Query> expected = LegacyNumericRangeQuery.class;

--- a/solr/test-framework/src/java/org/apache/solr/util/QueryMatchers.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/QueryMatchers.java
@@ -82,7 +82,7 @@ public class QueryMatchers {
 
   public static Matcher<Query> termQuery(String field, String text) {
     // TODO Use a better matcher for more descriptive results?
-    return is(new TermQueryWithOffset(new Term(field, text)));
+    return is(new TermQueryWithOffset(new Term(field, text), -1));
   }
 
   public static Matcher<Query> boosted(String field, String text, float boost) {

--- a/solr/test-framework/src/java/org/apache/solr/util/QueryMatchers.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/QueryMatchers.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.solr.parser.TermQueryWithOffset;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -81,7 +82,7 @@ public class QueryMatchers {
 
   public static Matcher<Query> termQuery(String field, String text) {
     // TODO Use a better matcher for more descriptive results?
-    return is(new TermQuery(new Term(field, text)));
+    return is(new TermQueryWithOffset(new Term(field, text)));
   }
 
   public static Matcher<Query> boosted(String field, String text, float boost) {

--- a/solr/test-framework/src/java/org/apache/solr/util/QueryMatchers.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/QueryMatchers.java
@@ -27,7 +27,6 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.apache.solr.parser.TermQueryWithOffset;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16594

# Description

When a query spans multiple fields, edismax first generates a clause for each field. Then it attempts to rewrite the clauses so there is one for each term. But sometimes it gives up on the rewrite.

This PR introduces a better strategy for rewriting a field-centric query as a term-centric one, so that edismax's behavior will be more consistent. It will "give up" less often. The idea is to propogate the startOffsets from Tokens emitted by the field analyzers so they are stored on the TermQuery and SynonymQuery instances that are created in the parsing process. When rewriting a field-centric query as a term-centric one, edismax is now able to able to do the grouping based on startOffset.

# Solution

TermQueryWithOffset and SynonymQueryWithOffset have been created to store a query with its corresponding startOffset.

QueryBuilder from the lucene repository has been provisionally copied here as SolrQueryBuilder and modified to use the new TermQueryWithOffset and SynonymQueryWithOffset classes.

ExtendedDismaxQParser has been updated to use startOffsets as a basis for regrouping field-centric clauses into term-centric ones. This happens in getAliasedMultiTermQuery(). In the case where startOffets are not available, the logic that had been in place previously is applied.

# Tests

TestExtendedDismaxParser has been updated to reflect the new behavior. 
This is a provisional PR submitted in hopes of gathering feedback.
More tests will be written.

The following two tests are currently failing:
org.apache.solr.search.TestExtendedDismaxParser.testAliasing
org.apache.solr.search.QueryEqualityTest.testBlockJoin

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
