### PR TITLE
SOLR-16704: Add simple search benchmark to benchmark module

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -48,6 +48,11 @@ Improvements
 Bug Fixes
 ---------------------
 
+Other Changes
+---------------------
+
+* SOLR-16704: Add simple search benchmark to benchmark module (Tomás Fernández Löbbe)
+
 ==================  9.2.0 ==================
 
 New Features

--- a/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
@@ -113,6 +113,8 @@ public class MiniClusterState {
     private SplittableRandom random;
     private String workDir;
 
+    private boolean useHttp1 = false;
+
     /**
      * Tear down.
      *
@@ -273,7 +275,7 @@ public class MiniClusterState {
         nodes.add(runner.getBaseUrl().toString());
       }
 
-      client = new Http2SolrClient.Builder().build();
+      client = new Http2SolrClient.Builder().useHttp1_1(useHttp1).build();
 
       log("done starting mini cluster");
       log("");
@@ -316,6 +318,15 @@ public class MiniClusterState {
           throw e;
         }
       }
+    }
+
+    /** Setting useHttp1 to true will make the {@link #client} use http1 */
+    public void setUseHttp1(boolean useHttp1) {
+      if (client != null) {
+        throw new IllegalStateException(
+            "You can only change this setting before starting the Mini Cluster");
+      }
+      this.useHttp1 = useHttp1;
     }
 
     /**

--- a/solr/benchmark/src/java/org/apache/solr/bench/search/SimpleSearch.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/search/SimpleSearch.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.bench.search;
+
+import java.io.IOException;
+import org.apache.solr.bench.MiniClusterState;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(value = 1)
+@Warmup(time = 5, iterations = 9)
+@Measurement(time = 5, iterations = 9)
+@Threads(value = 16)
+public class SimpleSearch {
+
+  static final String COLLECTION = "c1";
+
+  @State(Scope.Benchmark)
+  public static class BenchState {
+
+    QueryRequest q = new QueryRequest(new SolrQuery("q", "id:0")); // no match is OK
+
+    @Setup(Level.Trial)
+    public void setupTrial(MiniClusterState.MiniClusterBenchState miniClusterState)
+        throws Exception {
+      miniClusterState.setUseHttp1(true);
+      miniClusterState.startMiniCluster(1);
+      miniClusterState.createCollection(COLLECTION, 1, 1);
+
+      //      Docs docs = Docs.docs().field("id", integers().incrementing());
+
+      //      miniClusterState.index(COLLECTION, docs, 30 * 1000);
+      String base = miniClusterState.nodes.get(0);
+      q.setBasePath(base);
+    }
+
+    @Setup(Level.Iteration)
+    public void setupIteration(MiniClusterState.MiniClusterBenchState miniClusterState)
+        throws SolrServerException, IOException {
+      // Reload the collection/core to drop existing caches
+      CollectionAdminRequest.Reload reload = CollectionAdminRequest.reloadCollection(COLLECTION);
+      reload.setBasePath(miniClusterState.nodes.get(0));
+      miniClusterState.client.request(reload);
+    }
+  }
+
+  @Benchmark
+  public Object query(
+      BenchState benchState, MiniClusterState.MiniClusterBenchState miniClusterState)
+      throws SolrServerException, IOException {
+    return miniClusterState.client.request(benchState.q, COLLECTION);
+  }
+}


### PR DESCRIPTION
The test is very simple, and it's goal (so far at least) is to test the client library more than the server