### PR TITLE
SOLR-16706: Reduce the ZLibCompressor compression buffer size.

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkCLI.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkCLI.java
@@ -407,7 +407,7 @@ public class ZkCLI implements CLIO {
           byte[] data = arglist.get(1).getBytes(StandardCharsets.UTF_8);
           if (shouldCompressData(data, path, minStateByteLenForCompression)) {
             // state.json should be compressed before being put to ZK
-            data = compressor.compressBytes(data);
+            data = compressor.compressBytes(data, data.length / 10);
           }
           if (zkClient.exists(path, true)) {
             zkClient.setData(path, data, true);
@@ -429,7 +429,7 @@ public class ZkCLI implements CLIO {
           byte[] data = IOUtils.toByteArray(is);
           if (shouldCompressData(data, path, minStateByteLenForCompression)) {
             // state.json should be compressed before being put to ZK
-            data = compressor.compressBytes(data);
+            data = compressor.compressBytes(data, data.length / 10);
           }
           try {
             if (zkClient.exists(path, true)) {

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
@@ -286,7 +286,8 @@ public class ZkStateWriter {
           } else {
             byte[] data = Utils.toJSON(singletonMap(c.getName(), c));
             if (minStateByteLenForCompression > -1 && data.length > minStateByteLenForCompression) {
-              data = compressor.compressBytes(data);
+              // When compressing state.json, we expect at least a 10:1 compression ratio.
+              data = compressor.compressBytes(data, data.length / 10);
             }
             if (reader.getZkClient().exists(path, true)) {
               if (log.isDebugEnabled()) {

--- a/solr/core/src/test/org/apache/solr/cloud/ZkCLITest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkCLITest.java
@@ -184,7 +184,11 @@ public class ZkCLITest extends SolrTestCaseJ4 {
 
     String data = "my data";
     ZLibCompressor zLibCompressor = new ZLibCompressor();
-    byte[] expected = zLibCompressor.compressBytes(data.getBytes(StandardCharsets.UTF_8));
+    byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+    byte[] expected =
+        random().nextBoolean()
+            ? zLibCompressor.compressBytes(dataBytes)
+            : zLibCompressor.compressBytes(dataBytes, dataBytes.length / 10);
     String[] args =
         new String[] {"-zkhost", zkServer.getZkAddress(), "-cmd", "put", "/state.json", data};
     ZkCLI.main(args);
@@ -192,7 +196,11 @@ public class ZkCLITest extends SolrTestCaseJ4 {
 
     // test re-put to existing
     data = "my data deux";
-    expected = zLibCompressor.compressBytes(data.getBytes(StandardCharsets.UTF_8));
+    dataBytes = data.getBytes(StandardCharsets.UTF_8);
+    expected =
+        random().nextBoolean()
+            ? zLibCompressor.compressBytes(dataBytes)
+            : zLibCompressor.compressBytes(dataBytes, dataBytes.length / 10);
     args = new String[] {"-zkhost", zkServer.getZkAddress(), "-cmd", "put", "/state.json", data};
     ZkCLI.main(args);
     assertArrayEquals(zkClient.getZooKeeper().getData("/state.json", null, null), expected);
@@ -458,7 +466,11 @@ public class ZkCLITest extends SolrTestCaseJ4 {
     byte[] data = "getNode-data".getBytes(StandardCharsets.UTF_8);
     ZLibCompressor zLibCompressor = new ZLibCompressor();
     ByteArrayOutputStream systemOut = new ByteArrayOutputStream();
-    this.zkClient.create(getNode, zLibCompressor.compressBytes(data), CreateMode.PERSISTENT, true);
+    byte[] compressedData =
+        random().nextBoolean()
+            ? zLibCompressor.compressBytes(data)
+            : zLibCompressor.compressBytes(data, data.length / 10);
+    this.zkClient.create(getNode, compressedData, CreateMode.PERSISTENT, true);
     String[] args = new String[] {"-zkhost", zkServer.getZkAddress(), "-cmd", "get", getNode};
     ZkCLI.setStdout(new PrintStream(systemOut, true, StandardCharsets.UTF_8));
     ZkCLI.main(args);
@@ -495,7 +507,11 @@ public class ZkCLITest extends SolrTestCaseJ4 {
     String getNode = "/getFileNode";
     byte[] data = "getFileNode-data".getBytes(StandardCharsets.UTF_8);
     ZLibCompressor zLibCompressor = new ZLibCompressor();
-    this.zkClient.create(getNode, zLibCompressor.compressBytes(data), CreateMode.PERSISTENT, true);
+    byte[] compressedData =
+        random().nextBoolean()
+            ? zLibCompressor.compressBytes(data)
+            : zLibCompressor.compressBytes(data, data.length / 10);
+    this.zkClient.create(getNode, compressedData, CreateMode.PERSISTENT, true);
 
     File file =
         new File(tmpDir, "solrtest-getfile-" + this.getClass().getName() + "-" + System.nanoTime());

--- a/solr/solrj/src/java/org/apache/solr/common/util/Compressor.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Compressor.java
@@ -45,4 +45,15 @@ public interface Compressor {
    * @return compressed bytes
    */
   byte[] compressBytes(byte[] data);
+
+  /**
+   * Compresses bytes into compressed bytes using the compression implementation
+   *
+   * @param data the input uncompressed data to be compressed
+   * @param initialBufferCapacity the initial capacity of the buffer storing the compressed data. It
+   *     depends on the data type and the caller may know the expected average compression factor.
+   *     If this initial capacity is smaller than 16, the buffer capacity will be 16 anyway.
+   * @return compressed bytes
+   */
+  byte[] compressBytes(byte[] data, int initialBufferCapacity);
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/ZLibCompressor.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ZLibCompressor.java
@@ -73,11 +73,18 @@ public class ZLibCompressor implements Compressor {
 
   @Override
   public byte[] compressBytes(byte[] data) {
+    // By default, the compression ratio is assumed to be 5:1 to set the initial capacity of the
+    // compression buffer.
+    return compressBytes(data, data.length / 5);
+  }
+
+  @Override
+  public byte[] compressBytes(byte[] data, int initialBufferCapacity) {
     Deflater compressor = new Deflater(Deflater.BEST_SPEED);
     try {
       compressor.setInput(data);
       compressor.finish();
-      byte[] buf = new byte[data.length + 8];
+      byte[] buf = new byte[Math.max(initialBufferCapacity, 16)];
       int compressedSize = 0;
       while (!compressor.finished()) {
         if (compressedSize >= buf.length) {

--- a/solr/solrj/src/test/org/apache/solr/common/util/ZLibCompressorTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/ZLibCompressorTest.java
@@ -65,12 +65,15 @@ public class ZLibCompressorTest extends SolrTestCase {
           120, 1, 11, -50, -49, 77, 85, 40, 73, 45, 46, 81, 72, 73, 44, 73, -28, 2, 0, 43, -36, 5,
           57
         };
+    byte[] data = "Some test data\n".getBytes(StandardCharsets.UTF_8);
     byte[] compressedBytes =
-        stateCompression.compressBytes("Some test data\n".getBytes(StandardCharsets.UTF_8));
+        random().nextBoolean()
+            ? stateCompression.compressBytes(data)
+            : stateCompression.compressBytes(data, data.length / 10);
     int decompressedSize = ByteBuffer.wrap(compressedBytes, compressedBytes.length - 8, 4).getInt();
     int xoredSize = ByteBuffer.wrap(compressedBytes, compressedBytes.length - 4, 4).getInt();
     assertEquals(xoredSize, decompressedSize ^ 2018370979);
-    assertEquals("Some test data\n".getBytes(StandardCharsets.UTF_8).length, decompressedSize);
+    assertEquals(data.length, decompressedSize);
     assertArrayEquals(
         testBytes, ArrayUtil.copyOfSubArray(compressedBytes, 0, compressedBytes.length - 8));
   }


### PR DESCRIPTION
Currently ZLibCompressor.compress() works with a compression buffer initialized with a capacity equal to the source data (to compress) length.
Since we expect a good compression ratio, specially for state.json, we propose a small adjustment to have the initial capacity of the buffer configurable. That way, when the caller knows it is compressing a state.json data, it can set the initial buffer capacity to sourceData.length / 10.

This PR adds ZLibCompressor.compressBytes(byte[] data, int initialBufferCapacity)