### PR TITLE
Fix smoke test jar checks & release wizard

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -747,7 +747,7 @@ groups:
         cmd: git pull --ff-only
         tee: true
       - !Command
-        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }} --manifest-username {{ gpg.apache_id }} --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }} --gpg-pass-noprompt
+        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }} --dev-mode --mf-username {{ gpg.apache_id }} --sign {{ gpg.gpg_fingerprint | default("<gpg_fingerprint>", True) }} --gpg-pass-noprompt
         comment: "Using gpg command for signing."
         logfile: build_rc.log
         tee: true

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -204,9 +204,9 @@ def checkAllJARs(topDir, gitRevision, version):
     for file in files:
       if file.lower().endswith('.jar'):
         if ((normRoot.endswith('/modules/extraction/lib') and file.startswith('jakarta.activation-'))
-            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('jakarta.annotation-api-'))
-            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('jakarta.xml.bind-api-'))
-            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('unit-api-'))):
+            or (normRoot.endswith('/modules/extraction/lib') and file.startswith('unit-api-'))
+            or (normRoot.endswith('/server/solr-webapp/webapp/WEB-INF/lib') and file.startswith('jakarta.'))
+            or (normRoot.endswith('/server/lib/ext') and file.startswith('jetty-servlet-api-'))):
           print('      **WARNING**: skipping check of %s/%s: it has javax.* classes' % (root, file))
           continue
         fullPath = '%s/%s' % (root, file)


### PR DESCRIPTION
The Jars were introduced by JAX-RS. All Jakarta jars have javax classes, so I just made all of them accepted.

The release wizard has a small typo in the command line of buildAndPushRelease.