### PR TITLE
SOLR-16708: Update major-changes-in-solr-9.adoc

### DIFF
--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -67,8 +67,6 @@ Due to changes in Lucene 9, that isn't possible any more.
 == Solr 9.2
 === Upgrade to Jetty 10.x
 * Solr upgraded to Jetty 10.x from 9.x due to Jetty 9.x is now end of life. Jetty 10.x has a Java 11 minimum and matches Solr 9 minimum Java version. Jetty logging has been replaced with slf4j again matching Solr. See https://webtide.com/jetty-10-and-11-have-arrived/ for additional Jetty 10.x highlights.
-* Loading solr.xml from Zookeeper is deprecated. See xref:configuration-guide:configuring-solr-xml.adoc[Configuring solr.xml].
-* The xref:query-guide:analytics.adoc[Analytics Component] has been deprecated. Consider using xref:query-guide:json-facet-api.adoc[JSON Facet API] as a substitute. Please notify the project if there's functionality you need that isn't currently covered by JSON facets.
 
 === Jetty Configuration
 * Solr no longer duplicates certain Jetty "server" library dependencies between `server/lib` and `WEB-INF/lib` (jetty-util, jetty-io, etc.).
@@ -82,8 +80,6 @@ This is what has been documented in xref:deployment-guide:enabling-ssl.adoc#star
 
 === Tracing
 * A new `opentelemetry` module is added, with support for OTEL tracing in `OTLP` format using gRPC.
-  At the same time, the `jaegertracer-configurator` module is deprecated for removal in Solr 10.
-  Users should start migrating to the new module to prepare for a smooth transition.
 
 === Docker
 * The OS version of the official Docker image and provided Dockerfile has been upgraded to Ubuntu 22 (jammy) from Ubuntu 20 (focal).
@@ -95,7 +91,11 @@ of Solr. Streaming expressions sent to the /stream handler will still operate ex
 External clients using streaming expression classes will need to update their depenencies to reference
 the `solrj-streaming` artifacts under the `org.apache.solr` groupId.
 
-
+=== Deprecations
+* Loading solr.xml from Zookeeper is deprecated. See xref:configuration-guide:configuring-solr-xml.adoc[Configuring solr.xml].
+* The xref:query-guide:analytics.adoc[Analytics Component] has been deprecated. Consider using xref:query-guide:json-facet-api.adoc[JSON Facet API] as a substitute. Please notify the project if there's functionality you need that isn't currently covered by JSON facets.
+* The `jaegertracer-configurator` module is deprecated for removal in Solr 10. Users should start migrating to the new `opentelemetry` module.
+  
 == Solr 9.1.1
 * Solr no longer accepts all file types for configSets. Please see xref:configuration-guide:config-sets.adoc#forbidden-file-types[ConfigSet Forbidden File Types] for more information.
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -110,6 +110,13 @@ If you use SolrJ's Maven POM to depend on SolrJ, then this should happen automat
 Instead of depending on ZooKeeper, consider migrating to use of specifying a list of Solr URLs in the client's builder.
 Not only does this reduce dependencies, but it improves security by being able to limit ZooKeeper access.
 
+=== Zookeeper
+Zookeeper Credentials support now follows a new paradigm.
+Old classes, such as `VMParamsAllAndReadonlyDigestZkACLProvider` and `VMParamsSingleSetCredentialsDigestZkCredentialsProvider`, are deprecated but still supported until at least `10.0`.
+Users are encouraged to upgrade to the non-deprecated classes before the next major version release.
+Please refer to xref:deployment-guide:zookeeper-access-control.adoc#solr-to-zookeeper-acls-workflow[] for more information.
+
+
 == Solr 9.0
 === Querying and Indexing
 * xref:query-guide:dense-vector-search.adoc[Dense Vector "Neural" Search] through `DenseVectorField` fieldType and K-Nearest-Neighbor (KNN) Query Parser.

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/solr-upgrade-notes.adoc
@@ -22,8 +22,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-The following notes describe changes to Solr in recent releases that you should be aware of before upgrading.
-
+This section provides changes to Solr in recent releases that you should be aware of before upgrading.
 These notes highlight the important changes that may impact the largest number of implementations.
 It is not a comprehensive list of all changes to Solr in any release.
 
@@ -35,18 +34,29 @@ that may affect your existing implementation.
 
 Detailed steps for upgrading a Solr cluster are in the section xref:deployment-guide:upgrading-a-solr-cluster.adoc[].
 
-// DO NOT ADD MINOR VERSION INFO HERE; see child pages
+== How to use the Major Changes pages
 
-Zookeeper Credentials support now follows a new paradigm.
-Old classes, such as `VMParamsAllAndReadonlyDigestZkACLProvider` and `VMParamsSingleSetCredentialsDigestZkCredentialsProvider`, are deprecated but still supported until at least `10.0`.
-Users are encouraged to upgrade to the non-deprecated classes before the next major version release.
-Please refer to xref:deployment-guide:zookeeper-access-control.adoc#solr-to-zookeeper-acls-workflow[] for more information.
+The Major Changes pages are grouped in two ways:
+- For Solr versions `9.y+`:
+  The `Major Changes in Solr _x_` (e.g. xref:major-changes-in-solr-9.adoc[]) pages include all changes included in any `x.y` release.
+  Therefore xref:major-changes-in-solr-9.adoc[] includes all changes in any Solr `9.x` release.
+- For Solr versions `6.y`-`8.y`:
+  The `Major Changes in Solr _x_` (e.g. xref:major-changes-in-solr-8.adoc[]) pages include all changes from Solr `_(x-1)_.0` to Solr `_x_.0`.
+  Therefore xref:major-changes-in-solr-8.adoc[] includes all changes from Solr `7.0` to Solr `8.0`, starting wil Solr `7.1`.
 
-== Upgrading to 9.0 from 8.x Releases
+In these pages, the first section describes planning for an upgrade from to that major version from the previous major version,
+including system requirements, rolling upgrade concerns and re-indexing recommendations.
+All other sections are version-specific and include relevant changes in each minor version.
 
-The upgrade from 8.x to Solr 9.0 introduces several *major* changes that you should be aware of before upgrading.
-These changes are described in the section xref:major-changes-in-solr-9.adoc[].
-It's strongly recommended that you thoroughly review that section before starting your upgrade.
+It is imperative to carefully review each section for the versions preceding and including the version you are upgrading to.
+(i.e. If you are upgrading from Solr 8.9 to 9.2, you will need to read the upgrade notes for 8.10, 8.11, 9.0, 9.1 and 9.2)
+
+
+== Upgrading to 9.x from 8.x Releases
+
+The upgrade from 8.x to Solr 9.x introduces several *major* changes that you should be aware of before upgrading.
+These changes are described in the xref:major-changes-in-solr-9.adoc[] page.
+It's strongly recommended that you thoroughly review that page before starting your upgrade.
 
 [NOTE]
 If you run in SolrCloud mode and use SolrJ's `CloudSolrClient`, you must first upgrade SolrJ to a version 8.10 or higher before upgrading the cluster to 9.0.
@@ -62,3 +72,4 @@ The upgrade from 7.x to 8.0 introduced several *major* changes that you should b
 Please do a thorough review of the section xref:major-changes-in-solr-8.adoc[] before starting your upgrade.
 
 A summary of the significant changes between Solr 6.x and Solr 7.0 is in the section xref:major-changes-in-solr-7.adoc[].
+

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/solr-upgrade-notes.adoc
@@ -44,7 +44,7 @@ The Major Changes pages are grouped in two ways:
   The `Major Changes in Solr _x_` (e.g. xref:major-changes-in-solr-8.adoc[]) pages include all changes from Solr `_(x-1)_.0` to Solr `_x_.0`.
   Therefore xref:major-changes-in-solr-8.adoc[] includes all changes from Solr `7.0` to Solr `8.0`, starting wil Solr `7.1`.
 
-In these pages, the first section describes planning for an upgrade from to that major version from the previous major version,
+In these pages, the first section describes planning for an upgrade to that major version from the previous major version,
 including system requirements, rolling upgrade concerns and re-indexing recommendations.
 All other sections are version-specific and include relevant changes in each minor version.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16708

Re-arranging some upgrade notes

While reviewing the 9.2 release, I started reading release notes and found that two of my own deprecations notes were listed under a Jetty heading. Thus I added a new `Deprecations` heading and moved things around.