### PR TITLE
SOLR-15493: Throw an error message if the feature store doesn't exist

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -98,6 +98,8 @@ Improvements
 
 * SOLR-16711: Extract SolrCLI tool implementations into their own classes and reorganize CLI related classes into new org.apache.solr.cli package. (Eric Pugh)
 
+* SOLR-15493: Throw an error message if the feature store doesn't exist.  (Ilaria Petreti via Alessandro Benedetti)
+
 Optimizations
 ---------------------
 

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedFeatureStore.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedFeatureStore.java
@@ -82,6 +82,10 @@ public class ManagedFeatureStore extends ManagedResource
     super(resourceId, loader, storageIO);
   }
 
+  public Map<String, FeatureStore> getStores() {
+    return stores;
+  }
+
   public synchronized FeatureStore getFeatureStore(String name) {
     if (name == null) {
       name = FeatureStore.DEFAULT_FEATURE_STORE_NAME;
@@ -160,11 +164,12 @@ public class ManagedFeatureStore extends ManagedResource
     if (childId == null) {
       response.add(FEATURE_STORE_JSON_FIELD, stores.keySet());
     } else {
-      final FeatureStore store = getFeatureStore(childId);
-      if (store == null) {
+      // check for non-existent feature store name
+      if (!stores.containsKey(childId)) {
         throw new SolrException(
-            SolrException.ErrorCode.BAD_REQUEST, "missing feature store [" + childId + "]");
+            SolrException.ErrorCode.BAD_REQUEST, "Missing feature store: " + childId);
       }
+      final FeatureStore store = getFeatureStore(childId);
       response.add(FEATURES_JSON_FIELD, featuresAsManagedResources(store));
     }
   }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestManagedFeatureStore.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestManagedFeatureStore.java
@@ -30,17 +30,17 @@ import org.junit.Test;
 
 public class TestManagedFeatureStore extends SolrTestCaseJ4 {
 
-  private ManagedFeatureStore fstore = null;
+  private ManagedFeatureStore featureStore = null;
 
   @Before
   public void setup() throws Exception {
     initCore("solrconfig-ltr.xml", "schema.xml");
-    fstore = ManagedFeatureStore.getManagedFeatureStore(h.getCore());
+    featureStore = ManagedFeatureStore.getManagedFeatureStore(h.getCore());
   }
 
   @After
   public void cleanup() throws Exception {
-    fstore = null;
+    featureStore = null;
     deleteCore();
   }
 
@@ -59,8 +59,8 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
   public void testDefaultFeatureStoreName() {
     assertEquals("_DEFAULT_", FeatureStore.DEFAULT_FEATURE_STORE_NAME);
     final FeatureStore expectedFeatureStore =
-        fstore.getFeatureStore(FeatureStore.DEFAULT_FEATURE_STORE_NAME);
-    final FeatureStore actualFeatureStore = fstore.getFeatureStore(null);
+        featureStore.getFeatureStore(FeatureStore.DEFAULT_FEATURE_STORE_NAME);
+    final FeatureStore actualFeatureStore = featureStore.getFeatureStore(null);
     assertEquals(
         "getFeatureStore(null) should return the default feature store",
         expectedFeatureStore,
@@ -69,12 +69,12 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
 
   @Test
   public void testFeatureStoreAdd() throws FeatureException {
-    final FeatureStore fs = fstore.getFeatureStore("fstore-testFeature");
+    final FeatureStore fs = featureStore.getFeatureStore("featureStore-testFeature");
     for (int i = 0; i < 5; i++) {
       final String name = "c" + i;
 
-      fstore.addFeature(
-          createMap(name, OriginalScoreFeature.class.getName(), null), "fstore-testFeature");
+      featureStore.addFeature(
+          createMap(name, OriginalScoreFeature.class.getName(), null), "featureStore-testFeature");
 
       final Feature f = fs.get(name);
       assertNotNull(f);
@@ -84,14 +84,14 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
 
   @Test
   public void testFeatureStoreGet() throws FeatureException {
-    final FeatureStore fs = fstore.getFeatureStore("fstore-testFeature2");
+    final FeatureStore fs = featureStore.getFeatureStore("featureStore-testFeature2");
     for (int i = 0; i < 5; i++) {
       Map<String, Object> params = new HashMap<String, Object>();
       params.put("value", i);
       final String name = "c" + i;
 
-      fstore.addFeature(
-          createMap(name, ValueFeature.class.getName(), params), "fstore-testFeature2");
+      featureStore.addFeature(
+          createMap(name, ValueFeature.class.getName(), params), "featureStore-testFeature2");
     }
 
     for (int i = 0; i < 5; i++) {
@@ -105,21 +105,22 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
 
   @Test
   public void testMissingFeatureReturnsNull() {
-    final FeatureStore fs = fstore.getFeatureStore("fstore-testFeature3");
+    final FeatureStore fs = featureStore.getFeatureStore("featureStore-testFeature3");
     for (int i = 0; i < 5; i++) {
       Map<String, Object> params = new HashMap<String, Object>();
       params.put("value", i);
       final String name = "testc" + (float) i;
-      fstore.addFeature(
-          createMap(name, ValueFeature.class.getName(), params), "fstore-testFeature3");
+      featureStore.addFeature(
+          createMap(name, ValueFeature.class.getName(), params), "featureStore-testFeature3");
     }
     assertNull(fs.get("missing_feature_name"));
   }
 
   @Test
   public void getInstanceTest() throws FeatureException {
-    fstore.addFeature(createMap("test", OriginalScoreFeature.class.getName(), null), "testFstore");
-    final Feature feature = fstore.getFeatureStore("testFstore").get("test");
+    featureStore.addFeature(
+        createMap("test", OriginalScoreFeature.class.getName(), null), "testFeatureStore");
+    final Feature feature = featureStore.getFeatureStore("testFeatureStore").get("test");
     assertNotNull(feature);
     assertEquals("test", feature.getName());
     assertEquals(OriginalScoreFeature.class.getName(), feature.getClass().getName());
@@ -134,7 +135,8 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
         expectThrows(
             Exception.class,
             () -> {
-              fstore.addFeature(createMap("test", nonExistingClassName, null), "testFstore2");
+              featureStore.addFeature(
+                  createMap("test", nonExistingClassName, null), "testFeatureStore2");
             });
     Throwable rootError = getRootCause(ex);
     assertEquals(expectedException.toString(), rootError.toString());

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManagerPersistence.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManagerPersistence.java
@@ -107,18 +107,33 @@ public class TestModelManagerPersistence extends TestRerankBase {
 
     assertJDelete(ManagedFeatureStore.REST_END_POINT + "/test2", "/responseHeader/status==0");
     assertJDelete(ManagedModelStore.REST_END_POINT + "/test-model2", "/responseHeader/status==0");
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/test2", "/features/==[]");
+    // check for exception
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/test2",
+        "/error/msg=='Missing feature store: test2'");
+    // check that the deleted feature store is not inappropriately added again to the feature store
+    // list
+    assertJQ(ManagedFeatureStore.REST_END_POINT, "/featureStores==['test', 'test1']");
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/[0]/name=='test-model'");
     restTestHarness.reload();
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/test2", "/features/==[]");
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/test2",
+        "/error/msg=='Missing feature store: test2'");
+    assertJQ(ManagedFeatureStore.REST_END_POINT, "/featureStores==['test', 'test1']");
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/[0]/name=='test-model'");
 
     assertJDelete(ManagedModelStore.REST_END_POINT + "/test-model", "/responseHeader/status==0");
     assertJDelete(ManagedFeatureStore.REST_END_POINT + "/test1", "/responseHeader/status==0");
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/test1", "/features/==[]");
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/test1",
+        "/error/msg=='Missing feature store: test1'");
+    assertJQ(ManagedFeatureStore.REST_END_POINT, "/featureStores==['test']");
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
     restTestHarness.reload();
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/test1", "/features/==[]");
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/test1",
+        "/error/msg=='Missing feature store: test1'");
+    assertJQ(ManagedFeatureStore.REST_END_POINT, "/featureStores==['test']");
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
   }
 
@@ -128,7 +143,7 @@ public class TestModelManagerPersistence extends TestRerankBase {
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
     assertJQ(
         ManagedFeatureStore.REST_END_POINT + "/" + FeatureStore.DEFAULT_FEATURE_STORE_NAME,
-        "/features/==[]");
+        "/error/msg=='Missing feature store: " + FeatureStore.DEFAULT_FEATURE_STORE_NAME + "'");
 
     // load models and features from files
     loadFeatures("features-linear.json");
@@ -172,14 +187,14 @@ public class TestModelManagerPersistence extends TestRerankBase {
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
     assertJQ(
         ManagedFeatureStore.REST_END_POINT + "/" + FeatureStore.DEFAULT_FEATURE_STORE_NAME,
-        "/features/==[]");
+        "/error/msg=='Missing feature store: " + FeatureStore.DEFAULT_FEATURE_STORE_NAME + "'");
 
     // check persistence after reload
     restTestHarness.reload();
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
     assertJQ(
         ManagedFeatureStore.REST_END_POINT + "/" + FeatureStore.DEFAULT_FEATURE_STORE_NAME,
-        "/features/==[]");
+        "/error/msg=='Missing feature store: " + FeatureStore.DEFAULT_FEATURE_STORE_NAME + "'");
 
     // check persistence after restart
     jetty.stop();
@@ -187,7 +202,7 @@ public class TestModelManagerPersistence extends TestRerankBase {
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
     assertJQ(
         ManagedFeatureStore.REST_END_POINT + "/" + FeatureStore.DEFAULT_FEATURE_STORE_NAME,
-        "/features/==[]");
+        "/error/msg=='Missing feature store: " + FeatureStore.DEFAULT_FEATURE_STORE_NAME + "'");
   }
 
   private static void doWrapperModelPersistenceChecks(
@@ -214,7 +229,9 @@ public class TestModelManagerPersistence extends TestRerankBase {
 
     // check whether models and features are empty
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/" + FS_NAME, "/features/==[]");
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/" + FS_NAME,
+        "/error/msg=='Missing feature store: " + FS_NAME + "'");
 
     // setup features
     loadFeature(
@@ -260,7 +277,9 @@ public class TestModelManagerPersistence extends TestRerankBase {
     restTestHarness.delete(ManagedModelStore.REST_END_POINT + "/" + modelName);
     restTestHarness.delete(ManagedFeatureStore.REST_END_POINT + "/" + FS_NAME);
     assertJQ(ManagedModelStore.REST_END_POINT, "/models/==[]");
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/" + FS_NAME, "/features/==[]");
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/" + FS_NAME,
+        "/error/msg=='Missing feature store: " + FS_NAME + "'");
 
     // NOTE: we don't test the persistence of the deletion here because it's tested in
     // testFilePersistence
@@ -330,6 +349,8 @@ public class TestModelManagerPersistence extends TestRerankBase {
 
     assertJDelete(
         ManagedFeatureStore.REST_END_POINT + "/" + featureStoreName, "/responseHeader/status==0");
-    assertJQ(ManagedFeatureStore.REST_END_POINT + "/" + featureStoreName, "/features/==[]");
+    assertJQ(
+        ManagedFeatureStore.REST_END_POINT + "/" + featureStoreName,
+        "/error/msg=='Missing feature store: " + featureStoreName + "'");
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15493
https://issues.apache.org/jira/browse/SOLR-15494
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

When a wrong/non-existent feature store name is passed to the query for feature extraction, an empty list is returned;
it also happens when inspecting the contents of a non-existent feature store. It would be helpful if a message was returned indicating that the feature store I am calling is not present.
Also, this non-existent (and empty) feature store is inappropriately added to the feature store list and only disappears after the collection is reloaded.
This contribution wants to add the ability to throw an exception when a non-existent feature store name is passed and thus wants to prevent it from being inappropriately added to the feature store list.

# Solution

A check for a non-existent feature store was added in the doGet method of the _ManagedFeatureStore.java_ class, throwing a Solr exception.

Also, a getter method of the "stores" variable was added in the _ManagedFeatureStore.java_ class and used to throw the exception during the feature extraction (logging phase) if the passed feature store is missing from the store list.
In this phase, there is the need to differentiate between the two cases where no feature store name is passed (i.e., it is null):
If a reranking query (qr) is not passed, it means the model name is not passed either, so the only feature store that could be used is the default feature store (which should not be empty, otherwise an error is thrown).
On the other hand, if a reranking query is passed, it means that a model name has been specified, so a temporarily empty feature store is created to later add features in the implTransform() method, using the methods of the FeatureLogger class.

# Tests

To verify that an Exception is thrown when a non-existent feature store is passed to the query (with fl parameter) 3 tests have been added in _solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureLogging.java_:

- _featureExtraction_NonExistentFeatureStore_shouldThrowException_
- _featureExtraction_NonExistentFeatureStoreReRanking_shouldThrowException_
- _featureExtraction_NoFeatureAndModelStore_shouldThrowException_

To verify that an Exception is thrown when trying to get a missing feature store and that this feature store is not inappropriately added to the feature store list, some tests in solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManagerPersistence.java have been modified.
# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
