### PR TITLE
SOLR-12963: add support for node-level uninvertible support configuration

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -139,6 +139,7 @@ import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.SolrFieldCacheBean;
 import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.security.AuditLoggerPlugin;
@@ -403,6 +404,7 @@ public class CoreContainer {
     if (null != this.cfg.getBooleanQueryMaxClauseCount()) {
       IndexSearcher.setMaxClauseCount(this.cfg.getBooleanQueryMaxClauseCount());
     }
+    IndexSchema.setUninvertibleSupport(this.cfg.getUninvertibleSupport());
     setWeakStringInterner();
     this.coresLocator = locator;
     this.containerProperties = new Properties(config.getSolrProperties());

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -39,7 +39,9 @@ import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.logging.DeprecationLog;
 import org.apache.solr.logging.LogWatcherConfig;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.servlet.SolrDispatchFilter;
+import org.apache.solr.uninverting.UninvertingReader;
 import org.apache.solr.update.UpdateShardHandlerConfig;
 import org.apache.solr.util.ModuleUtils;
 import org.slf4j.Logger;
@@ -57,6 +59,8 @@ public class NodeConfig {
   private final Path solrDataHome;
 
   private final Integer booleanQueryMaxClauseCount;
+
+  private final UninvertingReader.Support uninvertibleSupport;
 
   private final Path configSetBaseDirectory;
 
@@ -117,6 +121,7 @@ public class NodeConfig {
       Path coreRootDirectory,
       Path solrDataHome,
       Integer booleanQueryMaxClauseCount,
+      UninvertingReader.Support uninvertibleSupport,
       Path configSetBaseDirectory,
       String sharedLibDirectory,
       PluginInfo shardHandlerFactoryConfig,
@@ -151,6 +156,7 @@ public class NodeConfig {
     this.coreRootDirectory = coreRootDirectory;
     this.solrDataHome = solrDataHome;
     this.booleanQueryMaxClauseCount = booleanQueryMaxClauseCount;
+    this.uninvertibleSupport = uninvertibleSupport;
     this.configSetBaseDirectory = configSetBaseDirectory;
     this.sharedLibDirectory = sharedLibDirectory;
     this.shardHandlerFactoryConfig = shardHandlerFactoryConfig;
@@ -275,6 +281,10 @@ public class NodeConfig {
    */
   public Integer getBooleanQueryMaxClauseCount() {
     return booleanQueryMaxClauseCount;
+  }
+
+  public UninvertingReader.Support getUninvertibleSupport() {
+    return uninvertibleSupport;
   }
 
   public PluginInfo getShardHandlerFactoryPluginInfo() {
@@ -540,6 +550,8 @@ public class NodeConfig {
     private Path coreRootDirectory;
     private Path solrDataHome;
     private Integer booleanQueryMaxClauseCount;
+    private UninvertingReader.Support uninvertibleSupport =
+        IndexSchema.IMPLICIT_DEFAULT_UNINVERTIBLE;
     private Path configSetBaseDirectory;
     private String sharedLibDirectory;
     private String modules;
@@ -623,6 +635,11 @@ public class NodeConfig {
 
     public NodeConfigBuilder setBooleanQueryMaxClauseCount(Integer booleanQueryMaxClauseCount) {
       this.booleanQueryMaxClauseCount = booleanQueryMaxClauseCount;
+      return this;
+    }
+
+    public NodeConfigBuilder setUninvertibleSupport(UninvertingReader.Support uninvertibleSupport) {
+      this.uninvertibleSupport = uninvertibleSupport;
       return this;
     }
 
@@ -782,6 +799,7 @@ public class NodeConfig {
           coreRootDirectory,
           solrDataHome,
           booleanQueryMaxClauseCount,
+          uninvertibleSupport,
           configSetBaseDirectory,
           sharedLibDirectory,
           shardHandlerFactoryConfig,

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -49,6 +49,7 @@ import org.apache.solr.common.util.Utils;
 import org.apache.solr.logging.LogWatcherConfig;
 import org.apache.solr.metrics.reporters.SolrJmxReporter;
 import org.apache.solr.servlet.SolrDispatchFilter;
+import org.apache.solr.uninverting.UninvertingReader;
 import org.apache.solr.update.UpdateShardHandlerConfig;
 import org.apache.solr.util.DOMConfigNode;
 import org.apache.solr.util.DataConfigNode;
@@ -352,6 +353,9 @@ public class SolrXmlConfig {
                 break;
               case "maxBooleanClauses":
                 builder.setBooleanQueryMaxClauseCount(it.intVal(-1));
+                break;
+              case "uninvertibleSupport":
+                builder.setUninvertibleSupport(UninvertingReader.Support.valueOf(it.txt()));
                 break;
               case "managementPath":
                 builder.setManagementPath(it.txt());

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
@@ -116,6 +116,18 @@ public class IndexSchema {
   private static final String SOURCE_DYNAMIC_BASE = "sourceDynamicBase";
   private static final String SOURCE_EXPLICIT_FIELDS = "sourceExplicitFields";
 
+  /**
+   * Implicit default for `uninvertible` FieldType property, if not specified by `fieldType` or
+   * `field`. This implicit default may be overridden by a node-level default specified in
+   * `solr.xml`. The implicit defaults is <code>true</code> for historical reasons, but users are
+   * strongly encouraged to set this to <code>false</code> for stability and use <code>
+   * docValues="true"</code> or <code>uninvertible="true"</code> as needed.
+   */
+  public static final UninvertingReader.Support IMPLICIT_DEFAULT_UNINVERTIBLE =
+      UninvertingReader.Support.DEFAULT_TRUE;
+
+  private static UninvertingReader.Support uninvertibleSupport = IMPLICIT_DEFAULT_UNINVERTIBLE;
+
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   protected String resourceName;
   protected String name;
@@ -409,6 +421,14 @@ public class IndexSchema {
   public void refreshAnalyzers() {
     indexAnalyzer = new SolrIndexAnalyzer();
     queryAnalyzer = new SolrQueryAnalyzer();
+  }
+
+  public static UninvertingReader.Support getUninvertibleSupport() {
+    return uninvertibleSupport;
+  }
+
+  public static void setUninvertibleSupport(UninvertingReader.Support support) {
+    uninvertibleSupport = support;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -197,9 +197,17 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   private static DirectoryReader wrapReader(SolrCore core, DirectoryReader reader)
       throws IOException {
     assert reader != null;
-    return ExitableDirectoryReader.wrap(
-        UninvertingReader.wrap(reader, core.getLatestSchema().getUninversionMapper()),
-        SolrQueryTimeoutImpl.getInstance());
+    switch (IndexSchema.getUninvertibleSupport()) {
+      case DEFAULT_FALSE:
+      case DEFAULT_TRUE:
+        reader = UninvertingReader.wrap(reader, core.getLatestSchema().getUninversionMapper());
+        break;
+      case FORBID:
+      case DISABLE:
+        // No need to wrap in UninvertingReader
+        break;
+    }
+    return ExitableDirectoryReader.wrap(reader, SolrQueryTimeoutImpl.getInstance());
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/uninverting/UninvertingReader.java
+++ b/solr/core/src/java/org/apache/solr/uninverting/UninvertingReader.java
@@ -52,6 +52,13 @@ import org.apache.solr.uninverting.FieldCache.CacheEntry;
  */
 public class UninvertingReader extends FilterLeafReader {
 
+  public enum Support {
+    FORBID,
+    DISABLE,
+    DEFAULT_FALSE,
+    DEFAULT_TRUE
+  }
+
   /** Specifies the type of uninversion to apply for the field. */
   public static enum Type {
     /**


### PR DESCRIPTION
See: SOLR-12963

We missed the boat on changing the uninvertible default for solr 9.

To avoid having to wait until Solr 10, this PR (initially a draft/proposal, no tests) makes it possible to configure "uninvertible" behavior and defaults at the node level. Rather than simply changing the default, this supports 4 modes, configured via `solr.xml`:
1. FORBID: any attempt to configure `uninvertible="true"` at the field level will throw an error and node startup.
2. DISABLE: tolerant of configurations with `uninvertible="true"`, but ignores such configurations, logging an info message to that effect (this option is best for testing/convenience)
3. DEFAULT_FALSE: by default, fields are _not_ uninvertible, but this may be overridden at the fieldType or field level.
4. DEFAULT_TRUE: by default, fields _are_ uninvertible, but this may be overridden at the fieldType or field level

The current implicit default is DEFAULT_TRUE. There are a couple of benefits to this approach over simply changing the default:
1. Allows users to easily configure the safety of `uninvertible="false"` at the node level, without needing to wait for the next major version
2. Providing the ability to forbid/disable uninversion at the node level allows SolrIndexSearcher to avoid UninvertibleReader wrapping entirely.
