### PR TITLE
SOLR-16604: Use the Builders directly in unit tests

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestTolerantSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestTolerantSearch.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrException;
@@ -63,8 +64,8 @@ public class TestTolerantSearch extends SolrJettyTestBase {
     File solrHome = createSolrHome();
     createAndStartJetty(solrHome.getAbsolutePath());
     String url = jetty.getBaseUrl().toString();
-    collection1 = getHttpSolrClient(url + "/collection1");
-    collection2 = getHttpSolrClient(url + "/collection2");
+    collection1 = new Http2SolrClient.Builder(url + "/collection1").build();
+    collection2 = new Http2SolrClient.Builder(url + "/collection2").build();
 
     String urlCollection1 = jetty.getBaseUrl().toString() + "/" + "collection1";
     String urlCollection2 = jetty.getBaseUrl().toString() + "/" + "collection2";
@@ -72,7 +73,7 @@ public class TestTolerantSearch extends SolrJettyTestBase {
     shard2 = urlCollection2.replaceAll("https?://", "");
 
     // create second core
-    try (SolrClient nodeClient = getHttpSolrClient(url)) {
+    try (SolrClient nodeClient = new Http2SolrClient.Builder(url).build()) {
       CoreAdminRequest.Create req = new CoreAdminRequest.Create();
       req.setCoreName("collection2");
       req.setConfigSet("collection1");

--- a/solr/core/src/test/org/apache/solr/cloud/AliasIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/AliasIntegrationTest.java
@@ -43,6 +43,7 @@ import org.apache.solr.client.solrj.cloud.SolrCloudManager;
 import org.apache.solr.client.solrj.impl.CloudLegacySolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.ClusterStateProvider;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -970,11 +971,13 @@ public class AliasIntegrationTest extends SolrCloudTestCase {
       JettySolrRunner jetty = cluster.getRandomJetty(random());
       if (random().nextBoolean()) {
         try (SolrClient client =
-            getHttpSolrClient(jetty.getBaseUrl().toString() + "/" + collectionList)) {
+            new Http2SolrClient.Builder(jetty.getBaseUrl().toString() + "/" + collectionList)
+                .build()) {
           responseConsumer.accept(client.query(null, solrQuery));
         }
       } else {
-        try (SolrClient client = getHttpSolrClient(jetty.getBaseUrl().toString())) {
+        try (SolrClient client =
+            new Http2SolrClient.Builder(jetty.getBaseUrl().toString()).build()) {
           responseConsumer.accept(client.query(collectionList, solrQuery));
         }
       }

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTest.java
@@ -41,6 +41,7 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.request.CoreStatus;
@@ -401,7 +402,8 @@ public class CollectionsAPISolrJTest extends SolrCloudTestCase {
     String corename = (String) response._get(asList("success", nodeName, "core"), null);
 
     try (SolrClient coreClient =
-        getHttpSolrClient(cluster.getZkStateReader().getBaseUrlForNodeName(nodeName))) {
+        new Http2SolrClient.Builder(cluster.getZkStateReader().getBaseUrlForNodeName(nodeName))
+            .build()) {
       CoreAdminResponse status = CoreAdminRequest.getStatus(corename, coreClient);
       assertEquals(
           collectionName, status._get(asList("status", corename, "cloud", "collection"), null));

--- a/solr/core/src/test/org/apache/solr/cloud/ConcurrentCreateRoutedAliasTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ConcurrentCreateRoutedAliasTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.common.util.IOUtils;
@@ -95,7 +96,7 @@ public class ConcurrentCreateRoutedAliasTest extends SolrTestCaseJ4 {
     for (; num < threads.length + numStart; num++) {
       final String aliasName = "testAlias" + num;
       final String baseUrl = solrCluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-      final SolrClient solrClient = getHttpSolrClient(baseUrl);
+      final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
 
       int i = num - numStart;
       threads[i] =
@@ -119,7 +120,7 @@ public class ConcurrentCreateRoutedAliasTest extends SolrTestCaseJ4 {
     for (; num < threads.length + numStart; num++) {
       final String aliasName = "testAliasCplx" + num;
       final String baseUrl = solrCluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-      final SolrClient solrClient = getHttpSolrClient(baseUrl);
+      final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
 
       int i = num - numStart;
       threads[i] =

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteInactiveReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteInactiveReplicaTest.java
@@ -20,6 +20,7 @@ import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.common.cloud.DocCollection;
@@ -102,7 +103,8 @@ public class DeleteInactiveReplicaTest extends SolrCloudTestCase {
                 && !FileUtils.fileExists(replicaCd.getDataDir()));
 
     // Check that we can't create a core with no coreNodeName
-    try (SolrClient queryClient = getHttpSolrClient(jetty.getBaseUrl().toString())) {
+    try (SolrClient queryClient =
+        new Http2SolrClient.Builder(jetty.getBaseUrl().toString()).build()) {
       Exception e =
           expectThrows(
               Exception.class,

--- a/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
@@ -31,6 +31,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -315,7 +316,7 @@ public class DistribDocExpirationUpdateProcessorTest extends SolrCloudTestCase {
     for (Replica replica : collectionState.getReplicas()) {
 
       String coreName = replica.getCoreName();
-      try (SolrClient client = getHttpSolrClient(replica.getCoreUrl())) {
+      try (SolrClient client = new Http2SolrClient.Builder(replica.getCoreUrl()).build()) {
 
         ModifiableSolrParams params = new ModifiableSolrParams();
         params.set("command", "indexversion");

--- a/solr/core/src/test/org/apache/solr/cloud/HttpPartitionOnCommitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/HttpPartitionOnCommitTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.http.NoHttpResponseException;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkStateReader;
@@ -190,7 +191,7 @@ public class HttpPartitionOnCommitTest extends BasicDistributedZkTest {
     String replicaCoreUrl = replica.getCoreUrl();
     log.info("Sending commit request to: {}", replicaCoreUrl);
     final RTimer timer = new RTimer();
-    try (SolrClient client = getHttpSolrClient(replicaCoreUrl)) {
+    try (SolrClient client = new Http2SolrClient.Builder(replicaCoreUrl).build()) {
       try {
         client.commit();
 

--- a/solr/core/src/test/org/apache/solr/cloud/HttpPartitionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/HttpPartitionTest.java
@@ -36,6 +36,7 @@ import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -543,7 +544,7 @@ public class HttpPartitionTest extends AbstractFullDistribZkTestBase {
   protected SolrClient getHttpSolrClient(Replica replica, String collection) {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + collection;
-    return getHttpSolrClient(url);
+    return new Http2SolrClient.Builder(url).build();
   }
 
   // Send doc directly to a server (without going through proxy)

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderVoteWaitTimeoutTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderVoteWaitTimeoutTest.java
@@ -33,6 +33,7 @@ import org.apache.solr.JSONTestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
@@ -343,6 +344,6 @@ public class LeaderVoteWaitTimeoutTest extends SolrCloudTestCase {
   protected SolrClient getSolrClient(Replica replica, String coll) {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + coll;
-    return getHttpSolrClient(url);
+    return new Http2SolrClient.Builder(url).build();
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/MigrateRouteKeyTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MigrateRouteKeyTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
@@ -134,7 +135,7 @@ public class MigrateRouteKeyTest extends SolrCloudTestCase {
 
     DocCollection state = getCollectionState(targetCollection);
     Replica replica = state.getReplicas().get(0);
-    try (SolrClient collectionClient = getHttpSolrClient(replica.getCoreUrl())) {
+    try (SolrClient collectionClient = new Http2SolrClient.Builder(replica.getCoreUrl()).build()) {
 
       SolrQuery solrQuery = new SolrQuery("*:*");
       assertEquals(

--- a/solr/core/src/test/org/apache/solr/cloud/NestedShardedAtomicUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/NestedShardedAtomicUpdateTest.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -65,7 +66,7 @@ public class NestedShardedAtomicUpdateTest extends SolrCloudTestCase {
     clients = new ArrayList<>();
     ClusterState clusterState = cloudClient.getClusterState();
     for (Replica replica : clusterState.getCollection(DEFAULT_COLLECTION).getReplicas()) {
-      clients.add(getHttpSolrClient(replica.getCoreUrl()));
+      clients.add(new Http2SolrClient.Builder(replica.getCoreUrl()).build());
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/ReplaceNodeTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplaceNodeTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
@@ -120,7 +121,8 @@ public class ReplaceNodeTest extends SolrCloudTestCase {
         .processAndWait("000", cloudClient, 15);
     ZkStateReader zkStateReader = ZkStateReader.from(cloudClient);
     try (SolrClient coreClient =
-        getHttpSolrClient(zkStateReader.getBaseUrlForNodeName(nodeToBeDecommissioned))) {
+        new Http2SolrClient.Builder(zkStateReader.getBaseUrlForNodeName(nodeToBeDecommissioned))
+            .build()) {
       CoreAdminResponse status = CoreAdminRequest.getStatus(null, coreClient);
       assertEquals(0, status.getCoreStatus().size());
     }
@@ -142,7 +144,7 @@ public class ReplaceNodeTest extends SolrCloudTestCase {
     replaceNodeRequest.processAndWait("001", cloudClient, 10);
 
     try (SolrClient coreClient =
-        getHttpSolrClient(zkStateReader.getBaseUrlForNodeName(emptyNode))) {
+        new Http2SolrClient.Builder(zkStateReader.getBaseUrlForNodeName(emptyNode)).build()) {
       CoreAdminResponse status = CoreAdminRequest.getStatus(null, coreClient);
       assertEquals(
           "Expecting no cores but found some: " + status.getCoreStatus(),

--- a/solr/core/src/test/org/apache/solr/cloud/ReplicationFactorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplicationFactorTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
@@ -269,7 +270,7 @@ public class ReplicationFactorTest extends AbstractFullDistribZkTestBase {
       Replica replica, UpdateRequest up, int expectedRf, String collection) throws Exception {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + collection;
-    try (SolrClient solrServer = getHttpSolrClient(url)) {
+    try (SolrClient solrServer = new Http2SolrClient.Builder(url).build()) {
       NamedList<?> resp = solrServer.request(up);
       NamedList<?> hdr = (NamedList<?>) resp.get("responseHeader");
       Integer batchRf = (Integer) hdr.get(UpdateRequest.REPFACT);

--- a/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
@@ -35,6 +35,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.UpdateResponse;
@@ -196,7 +197,7 @@ public class SplitShardTest extends SolrCloudTestCase {
       long lastReplicaCount = -1;
       for (Replica replica : slice.getReplicas()) {
         SolrClient replicaClient =
-            getHttpSolrClient(replica.getBaseUrl() + "/" + replica.getCoreName());
+            new Http2SolrClient.Builder(replica.getBaseUrl() + "/" + replica.getCoreName()).build();
         long numFound;
         try {
           numFound =

--- a/solr/core/src/test/org/apache/solr/cloud/TestBaseStatsCacheCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestBaseStatsCacheCloud.java
@@ -23,6 +23,7 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -134,7 +135,8 @@ public abstract class TestBaseStatsCacheCloud extends SolrCloudTestCase {
     // check cache metrics
     StatsCache.StatsCacheMetrics statsCacheMetrics = new StatsCache.StatsCacheMetrics();
     for (JettySolrRunner jettySolrRunner : cluster.getJettySolrRunners()) {
-      try (SolrClient client = getHttpSolrClient(jettySolrRunner.getBaseUrl().toString())) {
+      try (SolrClient client =
+          new Http2SolrClient.Builder(jettySolrRunner.getBaseUrl().toString()).build()) {
         NamedList<Object> metricsRsp =
             client.request(
                 new GenericSolrRequest(

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudConsistency.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudConsistency.java
@@ -31,6 +31,7 @@ import org.apache.solr.JSONTestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
@@ -351,6 +352,6 @@ public class TestCloudConsistency extends SolrCloudTestCase {
   protected SolrClient getHttpSolrClient(Replica replica, String coll) {
     ZkCoreNodeProps zkProps = new ZkCoreNodeProps(replica);
     String url = zkProps.getBaseUrl() + "/" + coll;
-    return getHttpSolrClient(url);
+    return new Http2SolrClient.Builder(url).build();
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudDeleteByQuery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudDeleteByQuery.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrDocument;
@@ -157,18 +158,23 @@ public class TestCloudDeleteByQuery extends SolrCloudTestCase {
       assertNotNull("could not find URL for " + shardName + " replica", passiveUrl);
 
       if (shardName.equals("shard1")) {
-        S_ONE_LEADER_CLIENT = getHttpSolrClient(leaderUrl + "/" + COLLECTION_NAME + "/");
-        S_ONE_NON_LEADER_CLIENT = getHttpSolrClient(passiveUrl + "/" + COLLECTION_NAME + "/");
+        S_ONE_LEADER_CLIENT =
+            new Http2SolrClient.Builder(leaderUrl + "/" + COLLECTION_NAME + "/").build();
+        S_ONE_NON_LEADER_CLIENT =
+            new Http2SolrClient.Builder(passiveUrl + "/" + COLLECTION_NAME + "/").build();
       } else if (shardName.equals("shard2")) {
-        S_TWO_LEADER_CLIENT = getHttpSolrClient(leaderUrl + "/" + COLLECTION_NAME + "/");
-        S_TWO_NON_LEADER_CLIENT = getHttpSolrClient(passiveUrl + "/" + COLLECTION_NAME + "/");
+        S_TWO_LEADER_CLIENT =
+            new Http2SolrClient.Builder(leaderUrl + "/" + COLLECTION_NAME + "/").build();
+        S_TWO_NON_LEADER_CLIENT =
+            new Http2SolrClient.Builder(passiveUrl + "/" + COLLECTION_NAME + "/").build();
       } else {
         fail("unexpected shard: " + shardName);
       }
     }
     assertEquals("Should be exactly one server left (not hosting either shard)", 1, urlMap.size());
     NO_COLLECTION_CLIENT =
-        getHttpSolrClient(urlMap.values().iterator().next() + "/" + COLLECTION_NAME + "/");
+        new Http2SolrClient.Builder(urlMap.values().iterator().next() + "/" + COLLECTION_NAME + "/")
+            .build();
 
     assertNotNull(S_ONE_LEADER_CLIENT);
     assertNotNull(S_TWO_LEADER_CLIENT);

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPhrasesIdentificationComponent.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPhrasesIdentificationComponent.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -79,7 +80,8 @@ public class TestCloudPhrasesIdentificationComponent extends SolrCloudTestCase {
     waitForRecoveriesToFinish(COLLECTION_CLIENT);
 
     for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
-      CLIENTS.add(getHttpSolrClient(jetty.getBaseUrl() + "/" + COLLECTION_NAME + "/"));
+      CLIENTS.add(
+          new Http2SolrClient.Builder(jetty.getBaseUrl() + "/" + COLLECTION_NAME + "/").build());
     }
 
     // index some docs...

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPseudoReturnFields.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPseudoReturnFields.java
@@ -30,6 +30,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest.Field;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -87,7 +88,8 @@ public class TestCloudPseudoReturnFields extends SolrCloudTestCase {
     waitForRecoveriesToFinish(COLLECTION_CLIENT);
 
     for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
-      CLIENTS.add(getHttpSolrClient(jetty.getBaseUrl() + "/" + COLLECTION_NAME + "/"));
+      CLIENTS.add(
+          new Http2SolrClient.Builder(jetty.getBaseUrl() + "/" + COLLECTION_NAME + "/").build());
     }
 
     assertEquals(

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery2.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery2.java
@@ -19,6 +19,7 @@ package org.apache.solr.cloud;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.cloud.Replica;
@@ -49,7 +50,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
   public void test() throws Exception {
     JettySolrRunner node1 = cluster.getJettySolrRunner(0);
     JettySolrRunner node2 = cluster.getJettySolrRunner(1);
-    try (SolrClient client1 = getHttpSolrClient(node1.getBaseUrl().toString())) {
+    try (SolrClient client1 = new Http2SolrClient.Builder(node1.getBaseUrl().toString()).build()) {
 
       node2.stop();
       waitForState("", COLLECTION, (liveNodes, collectionState) -> liveNodes.size() == 1);
@@ -63,7 +64,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
       node2.start();
       waitForState("", COLLECTION, clusterShape(1, 2));
 
-      try (SolrClient client = getHttpSolrClient(node2.getBaseUrl().toString())) {
+      try (SolrClient client = new Http2SolrClient.Builder(node2.getBaseUrl().toString()).build()) {
         long numFound =
             client
                 .query(COLLECTION, new SolrQuery("q", "*:*", "distrib", "false"))
@@ -80,7 +81,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
 
       new UpdateRequest().add("id", "1", "num", "10").commit(client1, COLLECTION);
 
-      try (SolrClient client = getHttpSolrClient(node2.getBaseUrl().toString())) {
+      try (SolrClient client = new Http2SolrClient.Builder(node2.getBaseUrl().toString()).build()) {
         Object v =
             client
                 .query(COLLECTION, new SolrQuery("q", "id:1", "distrib", "false"))
@@ -112,7 +113,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
 
       node2.start();
       waitForState("", COLLECTION, clusterShape(1, 2));
-      try (SolrClient client = getHttpSolrClient(node2.getBaseUrl().toString())) {
+      try (SolrClient client = new Http2SolrClient.Builder(node2.getBaseUrl().toString()).build()) {
         v =
             client
                 .query(COLLECTION, new SolrQuery("q", "id:1", "distrib", "false"))
@@ -137,7 +138,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
       node2.start();
       waitForState("", COLLECTION, clusterShape(1, 2));
 
-      try (SolrClient client = getHttpSolrClient(node2.getBaseUrl().toString())) {
+      try (SolrClient client = new Http2SolrClient.Builder(node2.getBaseUrl().toString()).build()) {
         v =
             client
                 .query(COLLECTION, new SolrQuery("q", "id:1", "distrib", "false"))
@@ -166,7 +167,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
 
     node1.start();
     waitForState("", COLLECTION, clusterShape(1, 2));
-    try (SolrClient client = getHttpSolrClient(node1.getBaseUrl().toString())) {
+    try (SolrClient client = new Http2SolrClient.Builder(node1.getBaseUrl().toString()).build()) {
       Object v =
           client
               .query(COLLECTION, new SolrQuery("q", "id:1", "distrib", "false"))
@@ -175,7 +176,7 @@ public class TestCloudRecovery2 extends SolrCloudTestCase {
               .get("num");
       assertEquals("30", v.toString());
     }
-    try (SolrClient client = getHttpSolrClient(node2.getBaseUrl().toString())) {
+    try (SolrClient client = new Http2SolrClient.Builder(node2.getBaseUrl().toString()).build()) {
       Object v =
           client
               .query(COLLECTION, new SolrQuery("q", "id:1", "distrib", "false"))

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPI.java
@@ -71,6 +71,7 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.CloudLegacySolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest.Create;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest.Delete;
@@ -146,7 +147,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
   @Test
   public void testCreateErrors() throws Exception {
     final String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-    try (final SolrClient solrClient = getHttpSolrClient(baseUrl)) {
+    try (final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build()) {
       getConfigSetService().uploadConfig("configSet", configset("configset-2"));
 
       // no action
@@ -309,7 +310,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
       String username)
       throws Exception {
     final String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-    try (final SolrClient solrClient = getHttpSolrClient(baseUrl)) {
+    try (final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build()) {
       setupBaseConfigSet(baseConfigSetName, oldProps);
 
       try (SolrZkClient zkClient =
@@ -417,7 +418,8 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
   @Test
   public void testUploadErrors() throws Exception {
     final SolrClient solrClient =
-        getHttpSolrClient(cluster.getJettySolrRunners().get(0).getBaseUrl().toString());
+        new Http2SolrClient.Builder(cluster.getJettySolrRunners().get(0).getBaseUrl().toString())
+            .build();
 
     ByteBuffer emptyData = ByteBuffer.allocate(0);
 
@@ -1870,7 +1872,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
   @Test
   public void testDeleteErrors() throws Exception {
     final String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-    final SolrClient solrClient = getHttpSolrClient(baseUrl);
+    final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
     final Path configDir = getFile("solr").toPath().resolve("configsets/configset-2/conf");
     final Path tmpConfigDir = createTempDir();
     tmpConfigDir.toFile().deleteOnExit();
@@ -1906,7 +1908,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
   @Test
   public void testDelete() throws Exception {
     final String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-    final SolrClient solrClient = getHttpSolrClient(baseUrl);
+    final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
     final String configSet = "testDelete";
     getConfigSetService().uploadConfig(configSet, configset("configset-2"));
     assertDelete(solrClient, configSet, true);
@@ -1938,7 +1940,7 @@ public class TestConfigSetsAPI extends SolrCloudTestCase {
   @Test
   public void testList() throws Exception {
     final String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-    final SolrClient solrClient = getHttpSolrClient(baseUrl);
+    final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
 
     SolrZkClient zkClient =
         new SolrZkClient.Builder()

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIExclusivity.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIExclusivity.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest.Create;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest.Delete;
@@ -126,7 +127,7 @@ public class TestConfigSetsAPIExclusivity extends SolrTestCaseJ4 {
     @Override
     public void run() {
       final String baseUrl = solrCluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-      final SolrClient solrClient = getHttpSolrClient(baseUrl);
+      final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
       ConfigSetAdminRequest<?, ?> request = createRequest();
 
       for (int i = 0; i < trials; ++i) {

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIZkFailure.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIZkFailure.java
@@ -37,6 +37,7 @@ import org.apache.jute.Record;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient.RemoteSolrException;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest.Create;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -108,7 +109,7 @@ public class TestConfigSetsAPIZkFailure extends SolrTestCaseJ4 {
   @Test
   public void testCreateZkFailure() throws Exception {
     final String baseUrl = solrCluster.getJettySolrRunners().get(0).getBaseUrl().toString();
-    final SolrClient solrClient = getHttpSolrClient(baseUrl);
+    final SolrClient solrClient = new Http2SolrClient.Builder(baseUrl).build();
     final ConfigSetService configSetService =
         solrCluster.getOpenOverseer().getCoreContainer().getConfigSetService();
 


### PR DESCRIPTION


https://issues.apache.org/jira/browse/SOLR-16604

# Description

Swap to using Builder directly. 

# Solution

Using the non deprecated version of the Builders where possible, so as not to just add more use of the deprecate SolrClients.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
