### PR TITLE
SOLR-16713: Replace Guava usages with pure Java (part 2)

### DIFF
--- a/gradle/validation/forbidden-apis/com.google.guava.guava.all.txt
+++ b/gradle/validation/forbidden-apis/com.google.guava.guava.all.txt
@@ -38,6 +38,9 @@ com.google.common.collect.ObjectArrays
 @defaultMessage Use Java collections
 com.google.common.collect.**
 
+@defaultMessage Use Java methods
+com.google.common.io.**
+
 @defaultMessage Use org.apache.solr.common.util.StrUtils
 com.google.common.base.Strings
 

--- a/gradle/validation/forbidden-apis/com.google.guava.guava.all.txt
+++ b/gradle/validation/forbidden-apis/com.google.guava.guava.all.txt
@@ -18,6 +18,7 @@ com.google.common.collect.Ordering
 @defaultMessage Use methods in java.util.Map
 com.google.common.collect.Maps
 com.google.common.collect.ImmutableMap
+com.google.common.collect.ImmutableMap.**
 
 @defaultMessage Use methods in java.util.List
 com.google.common.collect.Lists
@@ -34,6 +35,9 @@ com.google.common.collect.Iterables
 com.google.common.collect.Iterators
 com.google.common.collect.ObjectArrays
 
+@defaultMessage use Java collections
+com.google.common.collect.**
+
 @defaultMessage Use org.apache.solr.common.util.StrUtils
 com.google.common.base.Strings
 
@@ -46,5 +50,11 @@ com.google.common.base.MoreObjects#toStringHelper(**)
 @defaultMessage Use Objects.requireNonNullElse instead
 com.google.common.base.MoreObjects#firstNonNull(**)
 
-@defaultMessage use Objects methods
+@defaultMessage Use Objects methods instead
 com.google.common.base.MoreObjects
+
+@defaultMessage Use SolrException.getRootCause instead
+com.google.common.base.Throwables#getRootCause(**)
+
+@defaultMessage Don't use Throwables
+com.google.common.base.Throwables

--- a/gradle/validation/forbidden-apis/com.google.guava.guava.all.txt
+++ b/gradle/validation/forbidden-apis/com.google.guava.guava.all.txt
@@ -35,7 +35,7 @@ com.google.common.collect.Iterables
 com.google.common.collect.Iterators
 com.google.common.collect.ObjectArrays
 
-@defaultMessage use Java collections
+@defaultMessage Use Java collections
 com.google.common.collect.**
 
 @defaultMessage Use org.apache.solr.common.util.StrUtils

--- a/gradle/validation/forbidden-apis/commons-io.commons-io.all.txt
+++ b/gradle/validation/forbidden-apis/commons-io.commons-io.all.txt
@@ -31,6 +31,9 @@ org.apache.commons.io.IOUtils#closeQuietly(**)
 @defaultMessage Use new String(inputstream.readAllBytes(), StandardCharsets.UTF_8)
 org.apache.commons.io.IOUtils#toString(java.io.InputStream, java.lang.String)
 
+@defaultMessage Use StrUtis.stringFromReader(reader)
+org.apache.commons.io.IOUtils#toString(java.io.Reader)
+
 @defaultMessage Use readAllBytes() method on InputStream
 org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)
 org.apache.commons.io.IOUtils#toByteArray(java.net.URL)

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CollApiCmds.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CollApiCmds.java
@@ -67,7 +67,6 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.SP
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonParams.NAME;
 
-import com.google.common.collect.ImmutableMap;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.HashMap;
@@ -141,44 +140,42 @@ public class CollApiCmds {
 
     private CommandMap(OverseerNodePrioritizer overseerPrioritizer, CollectionCommandContext ccc) {
       commandMap =
-          new ImmutableMap.Builder<
-                  CollectionParams.CollectionAction, CollApiCmds.CollectionApiCommand>()
-              .put(REPLACENODE, new ReplaceNodeCmd(ccc))
-              .put(DELETENODE, new DeleteNodeCmd(ccc))
-              .put(BACKUP, new BackupCmd(ccc))
-              .put(RESTORE, new RestoreCmd(ccc))
-              .put(INSTALLSHARDDATA, new InstallShardDataCmd(ccc))
-              .put(DELETEBACKUP, new DeleteBackupCmd(ccc))
-              .put(CREATESNAPSHOT, new CreateSnapshotCmd(ccc))
-              .put(DELETESNAPSHOT, new DeleteSnapshotCmd(ccc))
-              .put(SPLITSHARD, new SplitShardCmd(ccc))
-              .put(ADDROLE, new OverseerRoleCmd(ccc, ADDROLE, overseerPrioritizer))
-              .put(REMOVEROLE, new OverseerRoleCmd(ccc, REMOVEROLE, overseerPrioritizer))
-              .put(MOCK_COLL_TASK, new CollApiCmds.MockOperationCmd())
-              .put(MOCK_SHARD_TASK, new CollApiCmds.MockOperationCmd())
-              .put(MOCK_REPLICA_TASK, new CollApiCmds.MockOperationCmd())
-              .put(CREATESHARD, new CreateShardCmd(ccc))
-              .put(MIGRATE, new MigrateCmd(ccc))
-              .put(CREATE, new CreateCollectionCmd(ccc))
-              .put(MODIFYCOLLECTION, new CollApiCmds.ModifyCollectionCmd(ccc))
-              .put(ADDREPLICAPROP, new CollApiCmds.AddReplicaPropCmd(ccc))
-              .put(DELETEREPLICAPROP, new CollApiCmds.DeleteReplicaPropCmd(ccc))
-              .put(BALANCESHARDUNIQUE, new CollApiCmds.BalanceShardsUniqueCmd(ccc))
-              .put(REBALANCELEADERS, new CollApiCmds.RebalanceLeadersCmd(ccc))
-              .put(RELOAD, new CollApiCmds.ReloadCollectionCmd(ccc))
-              .put(DELETE, new DeleteCollectionCmd(ccc))
-              .put(CREATEALIAS, new CreateAliasCmd(ccc))
-              .put(DELETEALIAS, new DeleteAliasCmd(ccc))
-              .put(ALIASPROP, new SetAliasPropCmd(ccc))
-              .put(MAINTAINROUTEDALIAS, new MaintainRoutedAliasCmd(ccc))
-              .put(OVERSEERSTATUS, new OverseerStatusCmd(ccc))
-              .put(DELETESHARD, new DeleteShardCmd(ccc))
-              .put(DELETEREPLICA, new DeleteReplicaCmd(ccc))
-              .put(ADDREPLICA, new AddReplicaCmd(ccc))
-              .put(MOVEREPLICA, new MoveReplicaCmd(ccc))
-              .put(REINDEXCOLLECTION, new ReindexCollectionCmd(ccc))
-              .put(RENAME, new RenameCmd(ccc))
-              .build();
+          Map.ofEntries(
+              Map.entry(REPLACENODE, new ReplaceNodeCmd(ccc)),
+              Map.entry(DELETENODE, new DeleteNodeCmd(ccc)),
+              Map.entry(BACKUP, new BackupCmd(ccc)),
+              Map.entry(RESTORE, new RestoreCmd(ccc)),
+              Map.entry(INSTALLSHARDDATA, new InstallShardDataCmd(ccc)),
+              Map.entry(DELETEBACKUP, new DeleteBackupCmd(ccc)),
+              Map.entry(CREATESNAPSHOT, new CreateSnapshotCmd(ccc)),
+              Map.entry(DELETESNAPSHOT, new DeleteSnapshotCmd(ccc)),
+              Map.entry(SPLITSHARD, new SplitShardCmd(ccc)),
+              Map.entry(ADDROLE, new OverseerRoleCmd(ccc, ADDROLE, overseerPrioritizer)),
+              Map.entry(REMOVEROLE, new OverseerRoleCmd(ccc, REMOVEROLE, overseerPrioritizer)),
+              Map.entry(MOCK_COLL_TASK, new CollApiCmds.MockOperationCmd()),
+              Map.entry(MOCK_SHARD_TASK, new CollApiCmds.MockOperationCmd()),
+              Map.entry(MOCK_REPLICA_TASK, new CollApiCmds.MockOperationCmd()),
+              Map.entry(CREATESHARD, new CreateShardCmd(ccc)),
+              Map.entry(MIGRATE, new MigrateCmd(ccc)),
+              Map.entry(CREATE, new CreateCollectionCmd(ccc)),
+              Map.entry(MODIFYCOLLECTION, new CollApiCmds.ModifyCollectionCmd(ccc)),
+              Map.entry(ADDREPLICAPROP, new CollApiCmds.AddReplicaPropCmd(ccc)),
+              Map.entry(DELETEREPLICAPROP, new CollApiCmds.DeleteReplicaPropCmd(ccc)),
+              Map.entry(BALANCESHARDUNIQUE, new CollApiCmds.BalanceShardsUniqueCmd(ccc)),
+              Map.entry(REBALANCELEADERS, new CollApiCmds.RebalanceLeadersCmd(ccc)),
+              Map.entry(RELOAD, new CollApiCmds.ReloadCollectionCmd(ccc)),
+              Map.entry(DELETE, new DeleteCollectionCmd(ccc)),
+              Map.entry(CREATEALIAS, new CreateAliasCmd(ccc)),
+              Map.entry(DELETEALIAS, new DeleteAliasCmd(ccc)),
+              Map.entry(ALIASPROP, new SetAliasPropCmd(ccc)),
+              Map.entry(MAINTAINROUTEDALIAS, new MaintainRoutedAliasCmd(ccc)),
+              Map.entry(OVERSEERSTATUS, new OverseerStatusCmd(ccc)),
+              Map.entry(DELETESHARD, new DeleteShardCmd(ccc)),
+              Map.entry(DELETEREPLICA, new DeleteReplicaCmd(ccc)),
+              Map.entry(ADDREPLICA, new AddReplicaCmd(ccc)),
+              Map.entry(MOVEREPLICA, new MoveReplicaCmd(ccc)),
+              Map.entry(REINDEXCOLLECTION, new ReindexCollectionCmd(ccc)),
+              Map.entry(RENAME, new RenameCmd(ccc)));
     }
 
     CollApiCmds.CollectionApiCommand getActionCommand(CollectionParams.CollectionAction action) {

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -20,7 +20,6 @@ import static org.apache.solr.common.params.CommonParams.PATH;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.MapMaker;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -55,6 +54,7 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.UUID;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -272,7 +272,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   }
 
   private final Map<IndexReader.CacheKey, IndexFingerprint> perSegmentFingerprintCache =
-      new MapMaker().weakKeys().makeMap();
+      new WeakHashMap<>();
 
   public long getStartNanoTime() {
     return startNanoTime;

--- a/solr/core/src/java/org/apache/solr/handler/DumpRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/DumpRequestHandler.java
@@ -18,9 +18,7 @@ package org.apache.solr.handler;
 
 import static org.apache.solr.common.params.CommonParams.NAME;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -93,10 +91,7 @@ public class DumpRequestHandler extends RequestHandlerBase implements SolrCoreAw
         stream.add("sourceInfo", content.getSourceInfo());
         stream.add("size", content.getSize());
         stream.add("contentType", content.getContentType());
-        try (Reader reader = content.getReader();
-            BufferedReader bufferedReader = new BufferedReader(reader)) {
-          stream.add("stream", StrUtils.stringFromReader(bufferedReader));
-        }
+        stream.add("stream", StrUtils.stringFromReader(content.getReader()));
         streams.add(stream);
       }
       rsp.add("streams", streams);

--- a/solr/core/src/java/org/apache/solr/handler/DumpRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/DumpRequestHandler.java
@@ -18,6 +18,7 @@ package org.apache.solr.handler;
 
 import static org.apache.solr.common.params.CommonParams.NAME;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.invoke.MethodHandles;
@@ -25,10 +26,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.PluginInfo;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
@@ -92,8 +93,9 @@ public class DumpRequestHandler extends RequestHandlerBase implements SolrCoreAw
         stream.add("sourceInfo", content.getSourceInfo());
         stream.add("size", content.getSize());
         stream.add("contentType", content.getContentType());
-        try (Reader reader = content.getReader()) {
-          stream.add("stream", IOUtils.toString(reader));
+        try (Reader reader = content.getReader();
+            BufferedReader bufferedReader = new BufferedReader(reader)) {
+          stream.add("stream", StrUtils.stringFromReader(bufferedReader));
         }
         streams.add(stream);
       }

--- a/solr/core/src/java/org/apache/solr/handler/FieldAnalysisRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/FieldAnalysisRequestHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.handler;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
@@ -153,8 +152,8 @@ public class FieldAnalysisRequestHandler extends AnalysisRequestHandlerBase {
     if (streams != null) {
       // NOTE: Only the first content stream is currently processed
       for (ContentStream stream : streams) {
-        try (BufferedReader reader = new BufferedReader(stream.getReader())) {
-          value = StrUtils.stringFromReader(reader);
+        try {
+          value = StrUtils.stringFromReader(stream.getReader());
         } catch (IOException e) {
           // do nothing, leave value set to the request parameter
         }

--- a/solr/core/src/java/org/apache/solr/handler/FieldAnalysisRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/FieldAnalysisRequestHandler.java
@@ -16,11 +16,10 @@
  */
 package org.apache.solr.handler;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.util.Arrays;
 import java.util.Set;
-import org.apache.commons.io.IOUtils;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.client.solrj.request.FieldAnalysisRequest;
 import org.apache.solr.common.SolrException;
@@ -30,6 +29,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.IndexSchema;
@@ -153,8 +153,8 @@ public class FieldAnalysisRequestHandler extends AnalysisRequestHandlerBase {
     if (streams != null) {
       // NOTE: Only the first content stream is currently processed
       for (ContentStream stream : streams) {
-        try (Reader reader = stream.getReader()) {
-          value = IOUtils.toString(reader);
+        try (BufferedReader reader = new BufferedReader(stream.getReader())) {
+          value = StrUtils.stringFromReader(reader);
         } catch (IOException e) {
           // do nothing, leave value set to the request parameter
         }

--- a/solr/core/src/java/org/apache/solr/handler/admin/SolrInfoMBeanHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SolrInfoMBeanHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.handler.admin;
 
-import java.io.BufferedReader;
 import java.io.StringReader;
 import java.text.NumberFormat;
 import java.util.HashSet;
@@ -64,10 +63,7 @@ public class SolrInfoMBeanHandler extends RequestHandlerBase {
       } catch (Exception ex) {
         throw new SolrException(ErrorCode.BAD_REQUEST, "missing content-stream for diff");
       }
-      final String content;
-      try (BufferedReader reader = new BufferedReader(body.getReader())) {
-        content = StrUtils.stringFromReader(reader);
-      }
+      final String content = StrUtils.stringFromReader(body.getReader());
 
       NamedList<NamedList<NamedList<Object>>> ref = fromXML(content);
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/SolrInfoMBeanHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SolrInfoMBeanHandler.java
@@ -16,19 +16,20 @@
  */
 package org.apache.solr.handler.admin;
 
+import java.io.BufferedReader;
 import java.io.StringReader;
 import java.text.NumberFormat;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.impl.XMLResponseParser;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.request.SolrQueryRequest;
@@ -63,7 +64,10 @@ public class SolrInfoMBeanHandler extends RequestHandlerBase {
       } catch (Exception ex) {
         throw new SolrException(ErrorCode.BAD_REQUEST, "missing content-stream for diff");
       }
-      String content = IOUtils.toString(body.getReader());
+      final String content;
+      try (BufferedReader reader = new BufferedReader(body.getReader())) {
+        content = StrUtils.stringFromReader(reader);
+      }
 
       NamedList<NamedList<NamedList<Object>>> ref = fromXML(content);
 

--- a/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
@@ -23,7 +23,6 @@ import static org.apache.solr.common.params.CommonParams.PATH;
 import static org.apache.solr.common.params.CommonParams.VERSION_FIELD;
 import static org.apache.solr.common.params.ShardParams._ROUTE_;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -158,11 +157,9 @@ public class JsonLoader extends ContentStreamLoader {
 
     private Reader getReader(ContentStream stream) throws IOException {
       if (log.isTraceEnabled()) {
-        try (BufferedReader reader = new BufferedReader(stream.getReader())) {
-          String body = StrUtils.stringFromReader(reader);
-          log.trace("body: {}", body);
-          return new StringReader(body);
-        }
+        String body = StrUtils.stringFromReader(stream.getReader());
+        log.trace("body: {}", body);
+        return new StringReader(body);
       }
       return stream.getReader();
     }

--- a/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
@@ -23,6 +23,7 @@ import static org.apache.solr.common.params.CommonParams.PATH;
 import static org.apache.solr.common.params.CommonParams.VERSION_FIELD;
 import static org.apache.solr.common.params.ShardParams._ROUTE_;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -37,7 +38,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
@@ -46,6 +46,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.UpdateParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.JsonRecordReader;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.handler.RequestHandlerUtils;
 import org.apache.solr.handler.UpdateRequestHandler;
 import org.apache.solr.request.SolrQueryRequest;
@@ -157,8 +158,8 @@ public class JsonLoader extends ContentStreamLoader {
 
     private Reader getReader(ContentStream stream) throws IOException {
       if (log.isTraceEnabled()) {
-        try (Reader reader = stream.getReader()) {
-          String body = IOUtils.toString(reader);
+        try (BufferedReader reader = new BufferedReader(stream.getReader())) {
+          String body = StrUtils.stringFromReader(reader);
           log.trace("body: {}", body);
           return new StringReader(body);
         }

--- a/solr/core/src/java/org/apache/solr/handler/tagger/TaggerRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/tagger/TaggerRequestHandler.java
@@ -22,7 +22,7 @@
 
 package org.apache.solr.handler.tagger;
 
-import com.google.common.io.CharStreams;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -57,6 +57,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -263,7 +264,9 @@ public class TaggerRequestHandler extends RequestHandlerBase {
     @Override
     public String call() throws IOException {
       if (inputString == null) {
-        inputString = CharStreams.toString(inputReader);
+        try (BufferedReader reader = new BufferedReader(inputReader)) {
+          inputString = StrUtils.stringFromReader(reader);
+        }
       }
       return inputString;
     }

--- a/solr/core/src/java/org/apache/solr/handler/tagger/TaggerRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/tagger/TaggerRequestHandler.java
@@ -22,7 +22,6 @@
 
 package org.apache.solr.handler.tagger;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -264,9 +263,7 @@ public class TaggerRequestHandler extends RequestHandlerBase {
     @Override
     public String call() throws IOException {
       if (inputString == null) {
-        try (BufferedReader reader = new BufferedReader(inputReader)) {
-          inputString = StrUtils.stringFromReader(reader);
-        }
+        inputString = StrUtils.stringFromReader(inputReader);
       }
       return inputString;
     }

--- a/solr/core/src/java/org/apache/solr/logging/jul/JulWatcher.java
+++ b/solr/core/src/java/org/apache/solr/logging/jul/JulWatcher.java
@@ -16,7 +16,8 @@
  */
 package org.apache.solr.logging.jul;
 
-import com.google.common.base.Throwables;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -157,7 +158,9 @@ public class JulWatcher extends LogWatcher<LogRecord> {
     doc.setField("message", event.getMessage().toString());
     Throwable t = event.getThrown();
     if (t != null) {
-      doc.setField("trace", Throwables.getStackTraceAsString(t));
+      StringWriter trace = new StringWriter();
+      t.printStackTrace(new PrintWriter(trace));
+      doc.setField("trace", trace.toString());
     }
     return doc;
   }

--- a/solr/core/src/java/org/apache/solr/logging/log4j2/Log4j2Watcher.java
+++ b/solr/core/src/java/org/apache/solr/logging/log4j2/Log4j2Watcher.java
@@ -16,7 +16,8 @@
  */
 package org.apache.solr.logging.log4j2;
 
-import com.google.common.base.Throwables;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -272,7 +273,11 @@ public class Log4j2Watcher extends LogWatcher<LogEvent> {
     Message message = event.getMessage();
     doc.setField("message", message.getFormattedMessage());
     Throwable t = message.getThrowable();
-    if (t != null) doc.setField("trace", Throwables.getStackTraceAsString(t));
+    if (t != null) {
+      StringWriter trace = new StringWriter();
+      t.printStackTrace(new PrintWriter(trace));
+      doc.setField("trace", trace.toString());
+    }
 
     Map<String, String> contextMap = event.getContextMap();
     if (contextMap != null) {

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -19,7 +19,6 @@ package org.apache.solr.request.json;
 import static org.apache.solr.common.params.CommonParams.JSON;
 import static org.apache.solr.common.params.CommonParams.SORT;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -88,8 +87,8 @@ public class RequestUtil {
               "Bad contentType for search handler :" + contentType + " request=" + req);
         }
 
-        try (BufferedReader reader = new BufferedReader(cs.getReader())) {
-          String jsonString = StrUtils.stringFromReader(reader);
+        try {
+          String jsonString = StrUtils.stringFromReader(cs.getReader());
           MultiMapSolrParams.addParam(JSON, jsonString, map);
         } catch (IOException e) {
           throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -19,11 +19,11 @@ package org.apache.solr.request.json;
 import static org.apache.solr.common.params.CommonParams.JSON;
 import static org.apache.solr.common.params.CommonParams.SORT;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
@@ -88,11 +88,9 @@ public class RequestUtil {
               "Bad contentType for search handler :" + contentType + " request=" + req);
         }
 
-        try {
-          String jsonString = IOUtils.toString(cs.getReader());
-          if (jsonString != null) {
-            MultiMapSolrParams.addParam(JSON, jsonString, map);
-          }
+        try (BufferedReader reader = new BufferedReader(cs.getReader())) {
+          String jsonString = StrUtils.stringFromReader(reader);
+          MultiMapSolrParams.addParam(JSON, jsonString, map);
         } catch (IOException e) {
           throw new SolrException(
               SolrException.ErrorCode.BAD_REQUEST,

--- a/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
@@ -21,12 +21,9 @@ import static org.apache.solr.response.transform.ChildDocTransformerFactory.NUM_
 import static org.apache.solr.response.transform.ChildDocTransformerFactory.PATH_SEP_CHAR;
 import static org.apache.solr.schema.IndexSchema.NEST_PATH_FIELD_NAME;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +61,7 @@ class ChildDocTransformer extends DocTransformer {
   private final int limit;
   private final boolean isNestedSchema;
   private final SolrReturnFields childReturnFields;
-  private String[] extraRequestedFields;
+  private final String[] extraRequestedFields;
 
   ChildDocTransformer(
       String name,
@@ -172,8 +169,8 @@ class ChildDocTransformer extends DocTransformer {
               segRootId, DocValues.getSorted(leafReaderContext.reader(), NEST_PATH_FIELD_NAME));
 
       // the key in the Map is the document's ancestors key (one above the parent), while the key in
-      // the intermediate MultiMap is the direct child document's key(of the parent document)
-      final Map<String, Multimap<String, SolrDocument>> pendingParentPathsToChildren =
+      // the intermediate Map is the direct child document's key(of the parent document)
+      final Map<String, Map<String, List<SolrDocument>>> pendingParentPathsToChildren =
           new HashMap<>();
 
       final int firstChildId = segBaseId + segPrevRootId + 1;
@@ -230,12 +227,13 @@ class ChildDocTransformer extends DocTransformer {
           // put into pending:
           // trim path if the doc was inside array, see trimPathIfArrayDoc()
           // e.g. toppings#1/ingredients#1 -> outer map key toppings#1
-          // -> inner MultiMap key ingredients
+          // -> inner Map key ingredients
           // or lonely#/lonelyGrandChild# -> outer map key lonely#
-          // -> inner MultiMap key lonelyGrandChild#
+          // -> inner Map key lonelyGrandChild#
           pendingParentPathsToChildren
-              .computeIfAbsent(parentDocPath, x -> ArrayListMultimap.create())
-              .put(trimLastPoundIfArray(lastPath), doc); // multimap add (won't replace)
+              .computeIfAbsent(parentDocPath, x -> new HashMap<>())
+              .computeIfAbsent(trimLastPoundIfArray(lastPath), k -> new ArrayList<>())
+              .add(doc);
         }
       }
 
@@ -258,14 +256,14 @@ class ChildDocTransformer extends DocTransformer {
   }
 
   private static void addChildrenToParent(
-      SolrDocument parent, Multimap<String, SolrDocument> children) {
-    for (String childLabel : children.keySet()) {
-      addChildrenToParent(parent, children.get(childLabel), childLabel);
+      SolrDocument parent, Map<String, List<SolrDocument>> children) {
+    for (Map.Entry<String, List<SolrDocument>> entry : children.entrySet()) {
+      addChildrenToParent(parent, entry.getValue(), entry.getKey());
     }
   }
 
   private static void addChildrenToParent(
-      SolrDocument parent, Collection<SolrDocument> children, String cDocsPath) {
+      SolrDocument parent, List<SolrDocument> children, String cDocsPath) {
     // if no paths; we do not need to add the child document's relation to its parent document.
     if (cDocsPath.equals(ANON_CHILD_KEY)) {
       parent.addChildDocuments(children);
@@ -282,7 +280,7 @@ class ChildDocTransformer extends DocTransformer {
       return;
     }
     // is single value
-    parent.setField(trimmedPath, ((List) children).get(0));
+    parent.setField(trimmedPath, children.get(0));
   }
 
   private static String getLastPath(String path) {

--- a/solr/core/src/java/org/apache/solr/schema/AbstractSpatialPrefixTreeFieldType.java
+++ b/solr/core/src/java/org/apache/solr/schema/AbstractSpatialPrefixTreeFieldType.java
@@ -16,12 +16,12 @@
  */
 package org.apache.solr.schema;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import org.apache.commons.io.IOUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
@@ -29,6 +29,7 @@ import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTreeFactory;
 import org.apache.lucene.spatial.query.SpatialArgsParser;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.util.MapListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -180,8 +181,8 @@ public abstract class AbstractSpatialPrefixTreeFieldType<T extends PrefixTreeStr
         PrefixTreeStrategy.ShapeTokenStream ts = s.tokenStream();
         return new TokenStreamComponents(
             r -> {
-              try {
-                ts.setShape(parseShape(IOUtils.toString(r)));
+              try (BufferedReader reader = new BufferedReader(r)) {
+                ts.setShape(parseShape(StrUtils.stringFromReader(reader)));
               } catch (IOException e) {
                 throw new RuntimeException(e);
               }

--- a/solr/core/src/java/org/apache/solr/schema/AbstractSpatialPrefixTreeFieldType.java
+++ b/solr/core/src/java/org/apache/solr/schema/AbstractSpatialPrefixTreeFieldType.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.schema;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
@@ -181,8 +180,8 @@ public abstract class AbstractSpatialPrefixTreeFieldType<T extends PrefixTreeStr
         PrefixTreeStrategy.ShapeTokenStream ts = s.tokenStream();
         return new TokenStreamComponents(
             r -> {
-              try (BufferedReader reader = new BufferedReader(r)) {
-                ts.setShape(parseShape(StrUtils.stringFromReader(reader)));
+              try {
+                ts.setShape(parseShape(StrUtils.stringFromReader(r)));
               } catch (IOException e) {
                 throw new RuntimeException(e);
               }

--- a/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
@@ -18,7 +18,6 @@ package org.apache.solr.servlet;
 
 import static org.apache.solr.common.params.CommonParams.PATH;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -632,11 +631,8 @@ public class SolrRequestParsers {
       for (Part part : req.getParts()) {
         if (part.getSubmittedFileName() == null) { // thus a form field and not file upload
           // If it's a form field, put it in our parameter map
-          try (BufferedReader reader =
-              new BufferedReader(new PartContentStream(part).getReader())) {
-            String partAsString = StrUtils.stringFromReader(reader);
-            MultiMapSolrParams.addParam(part.getName().trim(), partAsString, params.getMap());
-          }
+          String partAsString = StrUtils.stringFromReader(new PartContentStream(part).getReader());
+          MultiMapSolrParams.addParam(part.getName().trim(), partAsString, params.getMap());
         } else { // file upload
           streams.add(new PartContentStream(part));
         }

--- a/solr/core/src/java/org/apache/solr/util/MapListener.java
+++ b/solr/core/src/java/org/apache/solr/util/MapListener.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.util;
 
-import com.google.common.collect.ForwardingMap;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import org.apache.solr.common.util.CollectionUtil;
@@ -25,8 +25,7 @@ import org.apache.solr.common.util.CollectionUtil;
  * Wraps another map, keeping track of each key that was seen via {@link #get(Object)} or {@link
  * #remove(Object)}.
  */
-@SuppressWarnings("unchecked")
-public class MapListener<K, V> extends ForwardingMap<K, V> {
+public class MapListener<K, V> implements Map<K, V> {
   private final Map<K, V> target;
   private final Set<K> seenKeys;
 
@@ -40,19 +39,66 @@ public class MapListener<K, V> extends ForwardingMap<K, V> {
   }
 
   @Override
+  public int size() {
+    return target.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return target.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return target.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return target.containsValue(value);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   public V get(Object key) {
     seenKeys.add((K) key);
-    return super.get(key);
+    return target.get(key);
   }
 
   @Override
+  public V put(K key, V value) {
+    return target.put(key, value);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   public V remove(Object key) {
     seenKeys.add((K) key);
-    return super.remove(key);
+    return target.remove(key);
   }
 
   @Override
-  protected Map<K, V> delegate() {
-    return target;
+  public void putAll(Map<? extends K, ? extends V> m) {
+    target.putAll(m);
+  }
+
+  @Override
+  public void clear() {
+    target.clear();
+  }
+
+  @Override
+  public Set<K> keySet() {
+    return target.keySet();
+  }
+
+  @Override
+  public Collection<V> values() {
+    return target.values();
+  }
+
+  @Override
+  public Set<Entry<K, V>> entrySet() {
+    return target.entrySet();
   }
 }

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-import com.google.common.base.Throwables;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -832,7 +831,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
             () -> {
               cc.create("bogus", Map.of("configSet", "bogus_path"));
             });
-    Throwable rootCause = Throwables.getRootCause(thrown);
+    Throwable rootCause = SolrException.getRootCause(thrown);
     assertTrue(
         "init exception doesn't mention bogus dir: " + rootCause.getMessage(),
         0 < rootCause.getMessage().indexOf("bogus_path"));
@@ -862,7 +861,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
               SolrCore c = cc.getCore("bogus");
             });
     assertEquals(500, thrown.code());
-    String cause = Throwables.getRootCause(thrown).getMessage();
+    String cause = SolrException.getRootCause(thrown).getMessage();
     assertTrue(
         "getCore() ex cause doesn't mention init fail: " + cause, 0 < cause.indexOf("bogus_path"));
 

--- a/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -93,9 +92,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
         parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams)) {
       assertNotNull(req);
       assertEquals(1, streams.size());
-      try (BufferedReader reader = new BufferedReader(streams.get(0).getReader())) {
-        assertEquals(body1, StrUtils.stringFromReader(reader));
-      }
+      assertEquals(body1, StrUtils.stringFromReader(streams.get(0).getReader()));
     }
 
     // Now add three and make sure they come out ok
@@ -111,9 +108,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
       input.add(body2);
       input.add(body3);
       for (ContentStream cs : streams) {
-        try (BufferedReader reader = new BufferedReader(cs.getReader())) {
-          output.add(StrUtils.stringFromReader(reader));
-        }
+        output.add(StrUtils.stringFromReader(cs.getReader()));
       }
       // sort them so the output is consistent
       Collections.sort(input);
@@ -541,9 +536,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
       for (ContentStream cs : req.getContentStreams()) {
         num++;
         assertTrue(cs.getContentType().startsWith(expectedContentType));
-        try (BufferedReader reader = new BufferedReader(cs.getReader())) {
-          assertEquals(body, StrUtils.stringFromReader(reader));
-        }
+        assertEquals(body, StrUtils.stringFromReader(cs.getReader()));
       }
       assertEquals(1, num);
     }

--- a/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,13 +39,13 @@ import java.util.Vector;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.servlet.SolrRequestParsers.FormDataRequestParser;
@@ -88,39 +89,49 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
 
     // Make sure it got a single stream in and out ok
     List<ContentStream> streams = new ArrayList<>();
-    SolrQueryRequest req = parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams);
-    assertEquals(1, streams.size());
-    assertEquals(body1, IOUtils.toString(streams.get(0).getReader()));
-    req.close();
+    try (SolrQueryRequest req =
+        parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams)) {
+      assertNotNull(req);
+      assertEquals(1, streams.size());
+      try (BufferedReader reader = new BufferedReader(streams.get(0).getReader())) {
+        assertEquals(body1, StrUtils.stringFromReader(reader));
+      }
+    }
 
     // Now add three and make sure they come out ok
     streams = new ArrayList<>();
     args.put(CommonParams.STREAM_BODY, new String[] {body1, body2, body3});
-    req = parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams);
-    assertEquals(3, streams.size());
-    ArrayList<String> input = new ArrayList<>();
-    ArrayList<String> output = new ArrayList<>();
-    input.add(body1);
-    input.add(body2);
-    input.add(body3);
-    output.add(IOUtils.toString(streams.get(0).getReader()));
-    output.add(IOUtils.toString(streams.get(1).getReader()));
-    output.add(IOUtils.toString(streams.get(2).getReader()));
-    // sort them so the output is consistent
-    Collections.sort(input);
-    Collections.sort(output);
-    assertEquals(input.toString(), output.toString());
-    req.close();
+    try (SolrQueryRequest req =
+        parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams)) {
+      assertNotNull(req);
+      assertEquals(3, streams.size());
+      ArrayList<String> input = new ArrayList<>();
+      ArrayList<String> output = new ArrayList<>();
+      input.add(body1);
+      input.add(body2);
+      input.add(body3);
+      for (ContentStream cs : streams) {
+        try (BufferedReader reader = new BufferedReader(cs.getReader())) {
+          output.add(StrUtils.stringFromReader(reader));
+        }
+      }
+      // sort them so the output is consistent
+      Collections.sort(input);
+      Collections.sort(output);
+      assertEquals(input.toString(), output.toString());
+    }
 
     // set the contentType and make sure that it gets set
     String ctype = "text/xxx";
     streams = new ArrayList<>();
     args.put(CommonParams.STREAM_CONTENTTYPE, new String[] {ctype});
-    req = parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams);
-    for (ContentStream s : streams) {
-      assertEquals(ctype, s.getContentType());
+    try (SolrQueryRequest req =
+        parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams)) {
+      assertNotNull(req);
+      for (ContentStream s : streams) {
+        assertEquals(ctype, s.getContentType());
+      }
     }
-    req.close();
   }
 
   @Test
@@ -143,6 +154,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
     List<ContentStream> streams = new ArrayList<>();
     try (SolrQueryRequest req =
         parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams)) {
+      assertNotNull(req);
       assertEquals(1, streams.size());
       try (InputStream in = streams.get(0).getStream()) {
         assertArrayEquals(bytes, in.readAllBytes());
@@ -166,6 +178,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
     List<ContentStream> streams = new ArrayList<>();
     try (SolrQueryRequest req =
         parser.buildRequestFrom(core, new MultiMapSolrParams(args), streams)) {
+      assertNotNull(req);
       assertEquals(1, streams.size());
       try (InputStream in = streams.get(0).getStream()) {
         assertArrayEquals(bytes, in.readAllBytes());
@@ -528,8 +541,9 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
       for (ContentStream cs : req.getContentStreams()) {
         num++;
         assertTrue(cs.getContentType().startsWith(expectedContentType));
-        String returnedBody = IOUtils.toString(cs.getReader());
-        assertEquals(body, returnedBody);
+        try (BufferedReader reader = new BufferedReader(cs.getReader())) {
+          assertEquals(body, StrUtils.stringFromReader(reader));
+        }
       }
       assertEquals(1, num);
     }

--- a/solr/modules/langid/src/java/org/apache/solr/update/processor/SolrInputDocumentReader.java
+++ b/solr/modules/langid/src/java/org/apache/solr/update/processor/SolrInputDocumentReader.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.update.processor;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.invoke.MethodHandles;
@@ -219,8 +218,8 @@ public class SolrInputDocumentReader extends Reader {
    * @return string of concatenated fields
    */
   public static String asString(Reader reader) {
-    try (BufferedReader bufferedReader = new BufferedReader(reader)) {
-      return StrUtils.stringFromReader(bufferedReader);
+    try {
+      return StrUtils.stringFromReader(reader);
     } catch (IOException e) {
       throw new SolrException(
           SolrException.ErrorCode.SERVER_ERROR, "Failed reading doc content from reader", e);

--- a/solr/modules/langid/src/java/org/apache/solr/update/processor/SolrInputDocumentReader.java
+++ b/solr/modules/langid/src/java/org/apache/solr/update/processor/SolrInputDocumentReader.java
@@ -16,17 +16,16 @@
  */
 package org.apache.solr.update.processor;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
+import org.apache.solr.common.util.StrUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,8 +219,8 @@ public class SolrInputDocumentReader extends Reader {
    * @return string of concatenated fields
    */
   public static String asString(Reader reader) {
-    try {
-      return IOUtils.toString(reader);
+    try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+      return StrUtils.stringFromReader(bufferedReader);
     } catch (IOException e) {
       throw new SolrException(
           SolrException.ErrorCode.SERVER_ERROR, "Failed reading doc content from reader", e);
@@ -229,12 +228,9 @@ public class SolrInputDocumentReader extends Reader {
   }
 
   protected static String[] getStringFields(SolrInputDocument doc) {
-    Iterable<SolrInputField> iterable = () -> doc.iterator();
-    List<String> strFields =
-        StreamSupport.stream(iterable.spliterator(), false)
-            .filter(f -> f.getFirstValue() instanceof String)
-            .map(SolrInputField::getName)
-            .collect(Collectors.toList());
-    return strFields.toArray(new String[0]);
+    return StreamSupport.stream(doc.spliterator(), false)
+        .filter(f -> f.getFirstValue() instanceof String)
+        .map(SolrInputField::getName)
+        .toArray(String[]::new);
   }
 }

--- a/solr/solrj-zookeeper/build.gradle
+++ b/solr/solrj-zookeeper/build.gradle
@@ -49,7 +49,6 @@ dependencies {
 
     testImplementation 'junit:junit'
     testImplementation 'commons-io:commons-io'
-    testImplementation 'com.google.guava:guava'
 
     permitTestUsedUndeclared project(':solr:solrj-zookeeper') // duh!
 }

--- a/solr/solrj-zookeeper/src/test/org/apache/solr/common/cloud/TestZkConfigSetService.java
+++ b/solr/solrj-zookeeper/src/test/org/apache/solr/common/cloud/TestZkConfigSetService.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.common.cloud;
 
-import com.google.common.base.Throwables;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -220,10 +219,10 @@ public class TestZkConfigSetService extends SolrTestCaseJ4 {
         buildZkClient(zkServer.getZkAddress("/acl"), aclProvider, readonly)) {
       ConfigSetService configSetService = new ZkConfigSetService(client);
       assertEquals(1, configSetService.listConfigs().size());
-      configSetService.uploadConfig("acltest2", configPath);
-      fail("Should have thrown an ACL exception");
-    } catch (IOException e) {
-      assertEquals(KeeperException.NoAuthException.class, Throwables.getRootCause(e).getClass());
+      IOException ioException =
+          assertThrows(
+              IOException.class, () -> configSetService.uploadConfig("acltest2", configPath));
+      assertEquals(KeeperException.NoAuthException.class, ioException.getCause().getClass());
     }
 
     // Client with no auth whatsoever can't even get the list of configs
@@ -232,11 +231,9 @@ public class TestZkConfigSetService extends SolrTestCaseJ4 {
             .withUrl(zkServer.getZkAddress("/acl"))
             .withTimeout(10000, TimeUnit.MILLISECONDS)
             .build()) {
-      ConfigSetService configSetService = new ZkConfigSetService(client);
-      configSetService.listConfigs();
-      fail("Should have thrown an ACL exception");
-    } catch (IOException e) {
-      assertEquals(KeeperException.NoAuthException.class, Throwables.getRootCause(e).getClass());
+      IOException ioException =
+          assertThrows(IOException.class, () -> new ZkConfigSetService(client).listConfigs());
+      assertEquals(KeeperException.NoAuthException.class, ioException.getCause().getClass());
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.common.util;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.nio.CharBuffer;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -362,5 +364,15 @@ public class StrUtils {
 
   public static boolean isNullOrEmpty(String string) {
     return string == null || string.isEmpty();
+  }
+
+  public static String stringFromReader(Reader reader) throws IOException {
+    char[] arr = new char[8 * 1024];
+    StringBuilder buffer = new StringBuilder();
+    int numCharsRead;
+    while ((numCharsRead = reader.read(arr, 0, arr.length)) != -1) {
+      buffer.append(arr, 0, numCharsRead);
+    }
+    return buffer.toString();
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.common.util;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.CharBuffer;
@@ -366,13 +367,15 @@ public class StrUtils {
     return string == null || string.isEmpty();
   }
 
-  public static String stringFromReader(Reader reader) throws IOException {
-    char[] arr = new char[8 * 1024];
-    StringBuilder buffer = new StringBuilder();
-    int numCharsRead;
-    while ((numCharsRead = reader.read(arr, 0, arr.length)) != -1) {
-      buffer.append(arr, 0, numCharsRead);
+  public static String stringFromReader(Reader inReader) throws IOException {
+    try (Reader reader = new BufferedReader(inReader)) {
+      char[] arr = new char[8 * 1024];
+      StringBuilder buffer = new StringBuilder();
+      int numCharsRead;
+      while ((numCharsRead = reader.read(arr, 0, arr.length)) != -1) {
+        buffer.append(arr, 0, numCharsRead);
+      }
+      return buffer.toString();
     }
-    return buffer.toString();
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
@@ -16,9 +16,9 @@
  */
 package org.apache.solr.common.util;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -368,14 +368,10 @@ public class StrUtils {
   }
 
   public static String stringFromReader(Reader inReader) throws IOException {
-    try (Reader reader = new BufferedReader(inReader)) {
-      char[] arr = new char[8 * 1024];
-      StringBuilder buffer = new StringBuilder();
-      int numCharsRead;
-      while ((numCharsRead = reader.read(arr, 0, arr.length)) != -1) {
-        buffer.append(arr, 0, numCharsRead);
-      }
-      return buffer.toString();
+    try (Reader reader = inReader) {
+      StringWriter stringWriter = new StringWriter();
+      reader.transferTo(stringWriter);
+      return stringWriter.toString();
     }
   }
 }

--- a/solr/solrj/src/test/org/apache/solr/common/util/ContentStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/ContentStreamTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.common.util;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -41,9 +40,7 @@ public class ContentStreamTest extends SolrTestCaseJ4 {
     ContentStreamBase stream = new ContentStreamBase.StringStream(input);
     assertEquals(input.length(), stream.getSize().longValue());
     assertEquals(input, new String(stream.getStream().readAllBytes(), StandardCharsets.UTF_8));
-    try (BufferedReader reader = new BufferedReader(stream.getReader())) {
-      assertEquals(input, StrUtils.stringFromReader(reader));
-    }
+    assertEquals(input, StrUtils.stringFromReader(stream.getReader()));
   }
 
   public void testFileStream() throws IOException {

--- a/solr/solrj/src/test/org/apache/solr/common/util/ContentStreamTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/ContentStreamTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.common.util;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -40,7 +41,9 @@ public class ContentStreamTest extends SolrTestCaseJ4 {
     ContentStreamBase stream = new ContentStreamBase.StringStream(input);
     assertEquals(input.length(), stream.getSize().longValue());
     assertEquals(input, new String(stream.getStream().readAllBytes(), StandardCharsets.UTF_8));
-    assertEquals(input, IOUtils.toString(stream.getReader()));
+    try (BufferedReader reader = new BufferedReader(stream.getReader())) {
+      assertEquals(input, StrUtils.stringFromReader(reader));
+    }
   }
 
   public void testFileStream() throws IOException {

--- a/solr/test-framework/build.gradle
+++ b/solr/test-framework/build.gradle
@@ -54,7 +54,6 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'io.opentracing:opentracing-noop'
   implementation 'io.opentracing:opentracing-util'
-  implementation 'com.google.guava:guava'
   implementation 'io.dropwizard.metrics:metrics-core'
   implementation 'io.dropwizard.metrics:metrics-jetty10'
   implementation 'commons-cli:commons-cli'

--- a/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import com.google.common.util.concurrent.AtomicLongMap;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.management.JMException;
 import org.apache.solr.SolrTestCaseJ4;
@@ -139,8 +139,8 @@ public class ZkTestServer {
       private final String desc;
 
       private volatile LimitViolationAction action;
-      private AtomicLongMap<String> counters = AtomicLongMap.create();
-      private ConcurrentHashMap<String, Long> maxCounters = new ConcurrentHashMap<>();
+      private final Map<String, AtomicLong> counters = new ConcurrentHashMap<>();
+      private final ConcurrentHashMap<String, Long> maxCounters = new ConcurrentHashMap<>();
 
       WatchLimit(long limit, String desc, LimitViolationAction action) {
         this.limit = limit;
@@ -159,7 +159,7 @@ public class ZkTestServer {
       public void updateForWatch(String key, Watcher watcher) {
         if (watcher != null) {
           log.debug("Watch added: {}: {}", desc, key);
-          long count = counters.incrementAndGet(key);
+          long count = counters.computeIfAbsent(key, k -> new AtomicLong()).incrementAndGet();
           Long lastCount = maxCounters.get(key);
           if (lastCount == null || count > lastCount) {
             maxCounters.put(key, count);
@@ -185,11 +185,11 @@ public class ZkTestServer {
         if (log.isDebugEnabled()) {
           log.debug("Watch fired: {}: {}", desc, event.getPath());
         }
-        counters.decrementAndGet(event.getPath());
+        counters.get(event.getPath()).decrementAndGet();
       }
 
       private String reportLimitViolations() {
-        String[] maxKeys = maxCounters.keySet().toArray(new String[maxCounters.size()]);
+        String[] maxKeys = maxCounters.keySet().toArray(new String[0]);
         Arrays.sort(
             maxKeys,
             new Comparator<>() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16713

Cleans up the following by adding forbiddenapis rules:
* com.google.common.base.Throwables
* com.google.common.collect.ImmutableMap
* com.google.common.collect.**
* com.google.common.io.** (and consequently org.apache.commons.io.IOUtils#toString(java.io.Reader) since its the same usage)