### PR TITLE
SOLR-16730: Exclude username, roles and permissions for inter-node requests to SystemInfoHandler

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -96,6 +96,9 @@ Bug Fixes
 
 * SOLR-16734: SOLR_DATA_HOME is only honored in verbode mode (Kevin Risden)
 
+* SOLR-16730: Fix NPE in SystemInfoHandler for inter-node requests that would cause the Nodes page not to load.
+  SystemInfoHandler no longer populates the username, roles and permissions in inter-node requests. (Tomás Fernández Löbbe)
+
 Dependency Upgrades
 ---------------------
 * PR#1494: Upgrade forbiddenapis to 3.5 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
@@ -179,7 +179,9 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
     }
 
     final Principal principal =
-        "$".equals(headerData.userName) ? SU : new BasicUserPrincipal(headerData.userName);
+        "$".equals(headerData.userName)
+            ? CLUSTER_MEMBER_NODE
+            : new BasicUserPrincipal(headerData.userName);
 
     numAuthenticated.inc();
     filterChain.doFilter(wrapWithPrincipal(request, principal), response);
@@ -402,7 +404,7 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
   }
 
   public boolean needsAuthorization(HttpServletRequest req) {
-    return req.getUserPrincipal() != SU;
+    return req.getUserPrincipal() != CLUSTER_MEMBER_NODE;
   }
 
   private class HttpHeaderClientInterceptor implements HttpRequestInterceptor {
@@ -515,5 +517,5 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
   public static final String HEADER_V2 = "SolrAuthV2";
   public static final String NODE_IS_USER = "$";
   // special principal to denote the cluster member
-  private static final Principal SU = new BasicUserPrincipal("$");
+  public static final Principal CLUSTER_MEMBER_NODE = new BasicUserPrincipal("$");
 }


### PR DESCRIPTION
This PR addresses `SOLR-16730` by completely skipping including the username, roles and permissions when the request is an inter-node request to `SystemInfoHandler`. 
Having this part alone:
```
if (roles == null) {
     info.add("permissions", Set.of());
}
```
should be enough to handle the NPE described in the Jira issue, but I think it may be better to just skip this section for internal requests, since the data displayed is unrelated to the user that issues the request.