### PR TITLE
SOLR-16731: Use the right cluster property for determining if TLS is enabled

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -92,6 +92,8 @@ Bug Fixes
 
 * SOLR-16649: Http2SolrClient.processErrorsAndResponse uses wrong instance of ResponseParser (Andrzej Białecki)
 
+* SOLR-16731: Use the right cluster property for displaying if TLS is enabled (Tomás Fernández Löbbe)
+
 Dependency Upgrades
 ---------------------
 * PR#1494: Upgrade forbiddenapis to 3.5 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -350,9 +350,7 @@ public class SystemInfoHandler extends RequestHandlerBase {
 
     if (cc != null && cc.getZkController() != null) {
       String urlScheme =
-          cc.getZkController()
-              .zkStateReader
-              .getClusterProperty(ZkStateReader.BASE_URL_PROP, "http");
+          cc.getZkController().zkStateReader.getClusterProperty(ZkStateReader.URL_SCHEME, "http");
       info.add("tls", ZkStateReader.HTTPS.equals(urlScheme));
     }
 


### PR DESCRIPTION
Note that this only changes what's displayed by `SystemInfoHandler`