### PR TITLE
SOLR-16649 Http2SolrClient.processErrorsAndResponse uses wrong instance of ResponseParser

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -89,6 +89,8 @@ Bug Fixes
 
 * SOLR-16723: Http2SolrClient should not use Apache Http client classes (Kevin Risden)
 
+* SOLR-16649: Http2SolrClient.processErrorsAndResponse uses wrong instance of ResponseParser (Andrzej Białecki)
+
 Dependency Upgrades
 ---------------------
 * PR#1494: Upgrade forbiddenapis to 3.5 (Uwe Schindler)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -823,7 +823,7 @@ public class Http2SolrClient extends SolrClient {
           }
       }
 
-      if (wantStream(parser)) {
+      if (wantStream(processor)) {
         // no processor specified, return raw stream
         NamedList<Object> rsp = new NamedList<>();
         rsp.add("stream", is);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -39,10 +39,12 @@ import org.apache.solr.SolrJettyTestBase;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
 import org.apache.solr.client.solrj.request.SolrPing;
 import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.SimpleSolrResponse;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.CommonParams;
@@ -937,7 +939,22 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
   }
 
-  /**
-   * Missed tests : - set cookies via interceptor - invariant params - compression - get raw stream
-   */
+  @Test
+  public void testGetRawStream() throws Exception {
+    DebugServlet.clear();
+    try (Http2SolrClient client =
+        getHttp2SolrClientBuilder(
+                jetty.getBaseUrl().toString() + "/debug/foo",
+                DEFAULT_CONNECTION_TIMEOUT,
+                DEFAULT_CONNECTION_TIMEOUT)
+            .build()) {
+      GenericSolrRequest req =
+          new GenericSolrRequest(SolrRequest.METHOD.GET, "/select", params("q", "*:*"));
+      req.setResponseParser(new InputStreamResponseParser("xml"));
+      SimpleSolrResponse rsp = req.process(client);
+      assertNotNull(rsp.getResponse().get("stream"));
+    }
+  }
+
+  /** Missed tests : - set cookies via interceptor - invariant params - compression */
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16649

Converted patch into PR, added CHANGES