### PR TITLE
Tolerate comments in versions.props

### DIFF
--- a/gradle/validation/versions-props-sorted.gradle
+++ b/gradle/validation/versions-props-sorted.gradle
@@ -23,6 +23,7 @@ configure(rootProject) {
   task versionsPropsAreSorted() {
     doFirst {
       def versionsProps = file('versions.props')
+      // remove # commented lines and blank lines
       def lines = versionsProps.readLines("UTF-8").stream().filter(l -> !l.matches(/^(#.*|\s*)$/)).collect(Collectors.toList())
       def sorted = lines.toSorted()
 

--- a/gradle/validation/versions-props-sorted.gradle
+++ b/gradle/validation/versions-props-sorted.gradle
@@ -21,7 +21,7 @@ configure(rootProject) {
   task versionsPropsAreSorted() {
     doFirst {
       def versionsProps = file('versions.props')
-      def lines = versionsProps.readLines("UTF-8")
+      def lines = versionsProps.readLines("UTF-8").stream().filter(l -> !l.startsWith("#")).collect(java.util.stream.Collectors.toList())
       def sorted = lines.toSorted()
 
       if (!Objects.equals(lines, sorted)) {

--- a/gradle/validation/versions-props-sorted.gradle
+++ b/gradle/validation/versions-props-sorted.gradle
@@ -17,17 +17,17 @@
 
 // This ensures 'versions.props' file is sorted lexicographically.
 
+import java.util.stream.Collectors
+
 configure(rootProject) {
   task versionsPropsAreSorted() {
     doFirst {
       def versionsProps = file('versions.props')
-      def lines = versionsProps.readLines("UTF-8").stream().filter(l -> !l.startsWith("#")).collect(java.util.stream.Collectors.toList())
+      def lines = versionsProps.readLines("UTF-8").stream().filter(l -> !l.matches(/^(#.*|\s*)$/)).collect(Collectors.toList())
       def sorted = lines.toSorted()
 
       if (!Objects.equals(lines, sorted)) {
-        def sortedFile = file("${buildDir}/versions.props")
-        sortedFile.write(sorted.join("\n"), "UTF-8")
-        throw new GradleException("${versionsProps} file is not sorted lexicographically. I wrote a sorted file to ${sortedFile} - please review and commit.")
+        throw new GradleException("${versionsProps} file is not sorted lexicographically.")
       }
     }
   }

--- a/versions.props
+++ b/versions.props
@@ -1,3 +1,5 @@
+# The lines in this file needs to be lexicographically sorted.
+# Please only add first-party dependencies. Overrides of transitive versions should be called out in a comment.
 biz.aQute.bnd:biz.aQute.bnd.annotation=6.4.0
 com.adobe.testing:s3mock-junit4=2.11.0
 com.carrotsearch.randomizedtesting:*=2.8.1

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,5 @@
 # The lines in this file needs to be lexicographically sorted.
-# Please only add first-party dependencies. Overrides of transitive versions should be called out in a comment.
+# Please only add direct dependencies. Overrides of transitive versions should be called out in a comment.
 biz.aQute.bnd:biz.aQute.bnd.annotation=6.4.0
 com.adobe.testing:s3mock-junit4=2.11.0
 com.carrotsearch.randomizedtesting:*=2.8.1


### PR DESCRIPTION
This will not fail the build even if `versions.props` contains lines starting with `#`.