### PR TITLE
Make it easy to build a non-snapshot version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,11 @@ version = {
   //  -Dversion.suffix=jenkins123
   
   String versionSuffix = propertyOrDefault('version.suffix', 'SNAPSHOT')
-  return propertyOrDefault('version.release', "${baseVersion}-${versionSuffix}")
+  String v = propertyOrDefault('version.release', "${baseVersion}-${versionSuffix}")
+  if (v.endsWith("-")) {
+    v = v.substring(0, v.length() - 1)
+  }
+  return v
 }()
 description = 'Grandparent project for Apache Solr'
 


### PR DESCRIPTION
Maintaining the Jenkins Smoketest jobs at https://builds.apache.org/job/Solr/ are a pain currently.

Anytime a version changes on the branch, the job requires the version to be manually changed twice in the job (and one location is pretty hard to find).

This makes it possible to just use to build a release without `-SNAPSHOT` at the end, which the smoketester requires.

```
gradle assembleRelease -Pversion.suffix=""
```