### PR TITLE
SOLR-16714: addDepsToChanges.py handle empty gitlog

### DIFF
--- a/dev-tools/scripts/addDepsToChanges.py
+++ b/dev-tools/scripts/addDepsToChanges.py
@@ -79,6 +79,7 @@ def update_changes(filename, version, changes_lines):
     buffer = []
     found_ver = False
     found_header = False
+    checked_no_changes = False
     appended = False
     with open(filename) as f:
         version_re = re.compile(r' %s ===' % (version))
@@ -103,6 +104,11 @@ def update_changes(filename, version, changes_lines):
                         buffer.append(change_line)
                         buffer.append("\n")
                     continue
+            else:
+                if not checked_no_changes:
+                    checked_no_changes = True
+                    if re.compile(r'^\(No changes\)').search(line):
+                        continue
             buffer.append(line)
     if appended:
         with open(filename, 'w') as f:

--- a/dev-tools/scripts/addDepsToChanges.py
+++ b/dev-tools/scripts/addDepsToChanges.py
@@ -104,11 +104,13 @@ def update_changes(filename, version, changes_lines):
                         buffer.append(change_line)
                         buffer.append("\n")
                     continue
-            else:
-                if not checked_no_changes:
-                    checked_no_changes = True
-                    if re.compile(r'^\(No changes\)').search(line):
-                        continue
+                else:
+                    print("Mismatch in CHANGES.txt, expected '----' line after header, got: %s" % line)
+                    exit(1)
+            if not checked_no_changes:
+                checked_no_changes = True
+                if re.compile(r'^\(No changes\)').search(line):
+                    continue
             buffer.append(line)
     if appended:
         with open(filename, 'w') as f:

--- a/dev-tools/scripts/addDepsToChanges.py
+++ b/dev-tools/scripts/addDepsToChanges.py
@@ -68,7 +68,8 @@ def gitlog_to_changes(line, user="solrbot"):
         pr_num = match.group(2)
         return "* PR#%s: %s (%s)\n" % (pr_num, text, user)
     else:
-        return None
+        print("Skipped un-parsable line: %s" % line)
+        return ""
 
 
 def update_changes(filename, version, changes_lines):
@@ -124,8 +125,11 @@ def main():
         gitlog_lines = run(
             'git log --author=' + newconf.user + ' --oneline --no-merges --pretty=format:"%s" ' + prev_tag + '..').split(
             "\n")
-        changes_lines = list(map(lambda l: gitlog_to_changes(l, newconf.user), gitlog_lines))
-        update_changes('solr/CHANGES.txt', newconf.version, changes_lines)
+        changes_lines = list(map(lambda l: gitlog_to_changes(l, newconf.user), list(filter(None, gitlog_lines))))
+        if changes_lines and len(changes_lines) > 0:
+            update_changes('solr/CHANGES.txt', newconf.version, changes_lines)
+        else:
+            print("No changes found for version %s" % newconf.version.dot)
         print("Done")
     except subprocess.CalledProcessError:
         print("Error running git log - check your --version")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16714

After committing, I did a test on branch_9_2 and discovered a bug when list of solrbot changes was empty. This will detect not changes and exit script.

Also added a check to remove `(No changes)` line if it exists