### PR TITLE
SOLR-16747: Fix source-release gradle build

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -123,6 +123,9 @@ Bug Fixes
 
 * SOLR-16741: CLUSTERSTATUS API returns wrong value for state ,leader for PRS collections (noble)
 
+* SOLR-16747: The Solr source release can now be built/checked using gradle.
+  The solr-ref-guide tasks will not be included by default if the root directory is not a github repository. (Houston Putman)
+
 Dependency Upgrades
 ---------------------
 * PR#1494: Upgrade forbiddenapis to 3.5 (Uwe Schindler)

--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -40,7 +40,8 @@ def escapeYamlSingleQuotesString(props) {
 
 // Attach building the ref guide to standard convention tasks. This
 // can be optionally turned off (see SOLR-15670).
-if (propertyOrEnvOrDefault('refguide.include', 'SOLR_REF_GUIDE_INCLUDE', "true").toBoolean()) {
+var defaultRefGuideInclude = file('${rootDir}/.git').exists()
+if (propertyOrEnvOrDefault('refguide.include', 'SOLR_REF_GUIDE_INCLUDE', "${defaultRefGuideInclude}").toBoolean()) {
     check.dependsOn 'checkSiteLinks'
     assemble.dependsOn 'buildLocalSite'
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16747

Basically if the root directory is not a git repository, then don't include ref-guide tasks in the build by default.

The ref guide tasks require that the root directory is a git repository, otherwise they will not work. So we can only remove them. No way to "fix" these tasks.