### PR TITLE
SOLR-16752 Reduce attack surface and size for Docker image

### DIFF
--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -70,7 +70,7 @@ RUN set -ex; \
 
 RUN set -ex; \
     apt-get update; \
-    apt-get -y install acl lsof procps wget netcat gosu tini jattach; \
+    apt-get -y --no-install-recommends install acl lsof procps wget netcat gosu tini jattach; \
     rm -rf /var/lib/apt/lists/*;
 
 VOLUME /var/solr


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16752


# Description

The Dockerfiles should contain the `--no-install-recommends` option wherever there is an `apt-get install` command. This should help improve the security of the container and reduce the risk of potential attacks.

In detail, the `--no-install-recommends` option helps remove unnecessary apt packages that are not needed for the container's functionality. This change can not only trim your image size but also reduce the attack surface.

I hope you find this information useful. Please let me know if you have any concerns.

Thank you.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
