### PR TITLE
SOLR-16755: bin/solr's '-noprompt' option no longer works for examples

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -134,6 +134,8 @@ Bug Fixes
 * SOLR-16747: The Solr source release can now be built/checked using gradle.
   The solr-ref-guide tasks will not be included by default if the root directory is not a github repository. (Houston Putman)
 
+* SOLR-16755: bin/solr's '-noprompt' option no longer works for examples (hossman, janhoy)
+
 Dependency Upgrades
 ---------------------
 * PR#1494: Upgrade forbiddenapis to 3.5 (Uwe Schindler)

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -134,7 +134,7 @@ Bug Fixes
 * SOLR-16747: The Solr source release can now be built/checked using gradle.
   The solr-ref-guide tasks will not be included by default if the root directory is not a github repository. (Houston Putman)
 
-* SOLR-16755: bin/solr's '-noprompt' option no longer works for examples (hossman, janhoy)
+* SOLR-16755: bin/solr's '-noprompt' option no longer works for examples (hossman, janhoy, Houston Putman)
 
 Dependency Upgrades
 ---------------------

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1835,7 +1835,6 @@ fi
 # otherwise let this script proceed to process the user request
 #
 if [ -n "${EXAMPLE:-}" ] && [ "$SCRIPT_CMD" == "start" ]; then
-  # shellcheck disable=SC2086
   run_tool run_example -e "$EXAMPLE" -d "$SOLR_SERVER_DIR" -urlScheme "$SOLR_URL_SCHEME" "${PASS_TO_RUN_EXAMPLE[@]}"
   exit $?
 fi

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1835,7 +1835,8 @@ fi
 # otherwise let this script proceed to process the user request
 #
 if [ -n "${EXAMPLE:-}" ] && [ "$SCRIPT_CMD" == "start" ]; then
-  run_tool run_example -e "$EXAMPLE" -d "$SOLR_SERVER_DIR" -urlScheme "$SOLR_URL_SCHEME" "$PASS_TO_RUN_EXAMPLE"
+  # shellcheck disable=SC2086
+  run_tool run_example -e "$EXAMPLE" -d "$SOLR_SERVER_DIR" -urlScheme "$SOLR_URL_SCHEME" $PASS_TO_RUN_EXAMPLE
   exit $?
 fi
 

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1645,14 +1645,14 @@ fi
 FG="false"
 FORCE=false
 SOLR_OPTS=(${SOLR_OPTS:-})
-PASS_TO_RUN_EXAMPLE=
+PASS_TO_RUN_EXAMPLE=()
 
 if [ $# -gt 0 ]; then
   while true; do
     case "${1:-}" in
         -c|-cloud)
             SOLR_MODE="solrcloud"
-            PASS_TO_RUN_EXAMPLE+=" -c"
+            PASS_TO_RUN_EXAMPLE+=("-c")
             shift
         ;;
         -d|-dir)
@@ -1706,7 +1706,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             SOLR_HOST="$2"
-            PASS_TO_RUN_EXAMPLE+=" -h $SOLR_HOST"
+            PASS_TO_RUN_EXAMPLE+=("-h" "$SOLR_HOST")
             shift 2
         ;;
         -m|-memory)
@@ -1715,7 +1715,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             SOLR_HEAP="$2"
-            PASS_TO_RUN_EXAMPLE+=" -m $SOLR_HEAP"
+            PASS_TO_RUN_EXAMPLE+=("-m" "$SOLR_HEAP")
             shift 2
         ;;
         -p|-port)
@@ -1724,7 +1724,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             SOLR_PORT="$2"
-            PASS_TO_RUN_EXAMPLE+=" -p $SOLR_PORT"
+            PASS_TO_RUN_EXAMPLE+=("-p" "$SOLR_PORT")
             shift 2
         ;;
         -z|-zkhost|-zkHost)
@@ -1734,17 +1734,17 @@ if [ $# -gt 0 ]; then
             fi
             ZK_HOST="$2"
             SOLR_MODE="solrcloud"
-            PASS_TO_RUN_EXAMPLE+=" -z $ZK_HOST"
+            PASS_TO_RUN_EXAMPLE+=("-z" "$ZK_HOST")
             shift 2
         ;;
         -a|-addlopts)
             ADDITIONAL_CMD_OPTS="$2"
-            PASS_TO_RUN_EXAMPLE+=" -a \"$ADDITIONAL_CMD_OPTS\""
+            PASS_TO_RUN_EXAMPLE+=("-a" "$ADDITIONAL_CMD_OPTS")
             shift 2
         ;;
         -j|-jettyconfig)
             ADDITIONAL_JETTY_CONFIG="$2"
-            PASS_TO_RUN_EXAMPLE+=" -j \"$ADDITIONAL_JETTY_CONFIG\""
+            PASS_TO_RUN_EXAMPLE+=("-j" "$ADDITIONAL_JETTY_CONFIG")
             shift 2
         ;;
         -k|-key)
@@ -1756,22 +1756,22 @@ if [ $# -gt 0 ]; then
             exit 0
         ;;
         -noprompt)
-            PASS_TO_RUN_EXAMPLE+=" -noprompt"
+            PASS_TO_RUN_EXAMPLE+=("-noprompt")
             shift
         ;;
         -V|-verbose)
             verbose=true
-            PASS_TO_RUN_EXAMPLE+=" --verbose"
+            PASS_TO_RUN_EXAMPLE+=("--verbose")
             shift
         ;;
         -v)
             SOLR_LOG_LEVEL=DEBUG
-            PASS_TO_RUN_EXAMPLE+=" -Dsolr.log.level=$SOLR_LOG_LEVEL"
+            PASS_TO_RUN_EXAMPLE+=("-Dsolr.log.level=$SOLR_LOG_LEVEL")
             shift
         ;;
         -q)
             SOLR_LOG_LEVEL=WARN
-            PASS_TO_RUN_EXAMPLE+=" -Dsolr.log.level=$SOLR_LOG_LEVEL"
+            PASS_TO_RUN_EXAMPLE+=("-Dsolr.log.level=$SOLR_LOG_LEVEL")
             shift
         ;;
         -all)
@@ -1780,7 +1780,7 @@ if [ $# -gt 0 ]; then
         ;;
         -force)
             FORCE=true
-            PASS_TO_RUN_EXAMPLE+=" -force"
+            PASS_TO_RUN_EXAMPLE+=("-force")
             shift
         ;;
         --)
@@ -1793,7 +1793,7 @@ if [ $# -gt 0 ]; then
             elif [ "${1:0:2}" == "-D" ]; then
               # pass thru any opts that begin with -D (java system props)
               SOLR_OPTS+=("$1")
-              PASS_TO_RUN_EXAMPLE+=" $1"
+              PASS_TO_RUN_EXAMPLE+=("$1")
               shift
             else
               print_usage "$SCRIPT_CMD" "$1 is not supported by this script"
@@ -1836,7 +1836,7 @@ fi
 #
 if [ -n "${EXAMPLE:-}" ] && [ "$SCRIPT_CMD" == "start" ]; then
   # shellcheck disable=SC2086
-  run_tool run_example -e "$EXAMPLE" -d "$SOLR_SERVER_DIR" -urlScheme "$SOLR_URL_SCHEME" $PASS_TO_RUN_EXAMPLE
+  run_tool run_example -e "$EXAMPLE" -d "$SOLR_SERVER_DIR" -urlScheme "$SOLR_URL_SCHEME" "${PASS_TO_RUN_EXAMPLE[@]}"
   exit $?
 fi
 

--- a/solr/packaging/test/test_example_noprompt.bats
+++ b/solr/packaging/test/test_example_noprompt.bats
@@ -29,8 +29,6 @@ teardown() {
 }
 
 @test "SOLR16755 test works with noprompt" {
-  echo starting solr
   solr start -e cloud -noprompt
-  echo waiting for solr to start
   solr assert --started http://localhost:8983/solr --timeout 10000
 }

--- a/solr/packaging/test/test_example_noprompt.bats
+++ b/solr/packaging/test/test_example_noprompt.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load bats_helper
+
+setup() {
+  common_clean_setup
+}
+
+teardown() {
+  # save a snapshot of SOLR_HOME for failed tests
+  save_home_on_failure
+
+  solr stop -all >/dev/null 2>&1
+}
+
+@test "SOLR16755 test works with noprompt" {
+  echo starting solr
+  solr start -e cloud -noprompt
+  echo waiting for solr to start
+  solr assert --started http://localhost:8983/solr --timeout 10000
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16755

The new test fails with `# ERROR: No line found` without this patch.