### PR TITLE
SOLR-16754: Change the bin/solr -info logic to work like other tools.

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -919,7 +919,7 @@ if [ $# -eq 1 ]; then
         print_usage ""
         exit
     ;;
-    -info|-i|status)
+    status)
         get_info
         exit $?
     ;;

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -744,8 +744,8 @@ function run_tool() {
   return $?
 } # end run_tool function
 
-# get information about any Solr nodes running on this host
-function get_info() {
+# get status about any Solr nodes running on this host
+function get_status() {
   CODE=4
   # first, see if Solr is running
   numSolrs=$(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f | wc -l | tr -d ' ')
@@ -789,7 +789,7 @@ function get_info() {
   fi
 
   return $CODE
-} # end get_info
+} # end get_status
 
 function run_package() {
   runningSolrUrl=""
@@ -920,7 +920,7 @@ if [ $# -eq 1 ]; then
         exit
     ;;
     status)
-        get_info
+        get_status
         exit $?
     ;;
     -version|-v|version)
@@ -948,7 +948,7 @@ fi
 if [ "$SCRIPT_CMD" == "status" ]; then
   # hacky - the script hits this if the user passes additional args with the status command,
   # which is not supported but also not worth complaining about either
-  get_info
+  get_status
   exit
 fi
 

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -919,10 +919,6 @@ if [ $# -eq 1 ]; then
         print_usage ""
         exit
     ;;
-    status)
-        get_status
-        exit $?
-    ;;
     -version|-v|version)
         run_tool version
         exit
@@ -946,8 +942,28 @@ else
 fi
 
 if [ "$SCRIPT_CMD" == "status" ]; then
-  # hacky - the script hits this if the user passes additional args with the status command,
-  # which is not supported but also not worth complaining about either
+  if [ $# -gt 0 ]; then
+    while true; do
+      case "$1" in
+          -help|-h)
+              print_usage "$SCRIPT_CMD"
+              exit 0
+          ;;
+          --)
+              shift
+              break
+          ;;
+          *)
+              if [ "$1" != "" ]; then
+                print_usage "$SCRIPT_CMD" "Unrecognized or misplaced argument: $1!"
+                exit 1
+              else
+                break # out-of-args, stop looping
+              fi
+          ;;
+      esac
+    done
+  fi
   get_status
   exit
 fi

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -228,7 +228,7 @@ IF "%1"=="-usage" goto usage
 IF "%1"=="-h" goto usage
 IF "%1"=="--help" goto usage
 IF "%1"=="/?" goto usage
-IF "%1"=="status" goto get_info
+IF "%1"=="status" goto get_status
 IF "%1"=="version" goto get_version
 IF "%1"=="-v" goto get_version
 IF "%1"=="-version" goto get_version
@@ -1452,7 +1452,7 @@ REM Run the requested example
 REM End of run_example
 goto done
 
-:get_info
+:get_status
 REM Find all Java processes, correlate with those listening on a port
 REM and then try to contact via that port using the status tool
 for /f "usebackq" %%i in (`dir /b "%SOLR_TIP%\bin" ^| findstr /i "^solr-.*\.port$"`) do (

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -228,8 +228,6 @@ IF "%1"=="-usage" goto usage
 IF "%1"=="-h" goto usage
 IF "%1"=="--help" goto usage
 IF "%1"=="/?" goto usage
-IF "%1"=="-i" goto get_info
-IF "%1"=="-info" goto get_info
 IF "%1"=="status" goto get_info
 IF "%1"=="version" goto get_version
 IF "%1"=="-v" goto get_version

--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -51,6 +51,8 @@ public class StatusTool extends ToolBase {
     return "status";
   }
 
+  // These options are not exposed to the end user, and are
+  // used directly by the bin/solr status CLI.
   @Override
   public List<Option> getOptions() {
     return List.of(

--- a/solr/packaging/test/test_status.bats
+++ b/solr/packaging/test/test_status.bats
@@ -28,7 +28,7 @@ teardown() {
   solr stop -all >/dev/null 2>&1
 }
 
-@test "status for non cloud mode" {
+@test "status detects locally running solr" {
   run solr status
   assert_output --partial "No Solr nodes are running."
   run solr start
@@ -38,4 +38,9 @@ teardown() {
   run solr status
   assert_output --partial "No Solr nodes are running."
 
+}
+
+@test "status does not expose cli parameters to end user" {
+  run solr status -solr http://localhost:8983/solr
+  assert_output --partial "ERROR: Unrecognized or misplaced argument: -solr!"
 }

--- a/solr/packaging/test/test_status.bats
+++ b/solr/packaging/test/test_status.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load bats_helper
+
+setup() {
+  common_clean_setup
+}
+
+teardown() {
+  # save a snapshot of SOLR_HOME for failed tests
+  save_home_on_failure
+
+  solr stop -all >/dev/null 2>&1
+}
+
+@test "status for non cloud mode" {
+  run solr status
+  assert_output --partial "No Solr nodes are running."
+  run solr start
+  run solr status
+  assert_output --partial "Found 1 Solr nodes:"
+  run solr stop
+  run solr status
+  assert_output --partial "No Solr nodes are running."
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16754

# Description

The magic `bin/solr -i` or `bin/solr -info` isn't documented anywhere, and duplicates `bin/solr status`, which is documented!



# Solution

Remove the magic `-i` and `-info` parameters, and restore the `-h` and `-help` parameters so that `bin/solr status` looks like all the other commands!

# Tests

added a .bats test and manually.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
