### PR TITLE
Ref Guide: Clearer instructions for placing security.json.

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/authentication-and-authorization-plugins.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/authentication-and-authorization-plugins.adoc
@@ -29,8 +29,8 @@ Solr includes some plugins out of the box, and additional plugins can be develop
 
 All authentication, authorization and audit logging plugins can work with Solr whether it is running as a cluster or a single-node installation.
 All related configuration, including users and permission rules, are stored in a file named `security.json`.
-When running Solr as a user-managed cluster or a single-node installation, this file must be in the `$SOLR_HOME` directory (usually `server/solr`).
-When using SolrCloud, this file must be located in ZooKeeper.
+When using SolrCloud, this file must be located at the root of the ZooKeeper structure.
+When running Solr in standalone mode (without ZooKeeper), this file must be in the `$SOLR_HOME` directory. When manually running Solr from an extracted archive, this will most likely be `server/solr`. If the service installer script is used, its default location will be `/var/data/solr`, which can be changed with options given to the service installer.
 
 == Configuring security.json
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/authentication-and-authorization-plugins.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/authentication-and-authorization-plugins.adoc
@@ -29,7 +29,7 @@ Solr includes some plugins out of the box, and additional plugins can be develop
 
 All authentication, authorization and audit logging plugins can work with Solr whether it is running as a cluster or a single-node installation.
 All related configuration, including users and permission rules, are stored in a file named `security.json`.
-When using SolrCloud, this file must be located at the root of the ZooKeeper structure.
+When using SolrCloud, this file must be located at the chroot of the ZooKeeper structure.  If no chroot was given, then it must be at the root.
 When running Solr in standalone mode (without ZooKeeper), this file must be in the `$SOLR_HOME` directory. When manually running Solr from an extracted archive, this will most likely be `server/solr`. If the service installer script is used, its default location will be `/var/solr/data`, which can be changed with options given to the service installer.
 
 == Configuring security.json

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/authentication-and-authorization-plugins.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/authentication-and-authorization-plugins.adoc
@@ -30,7 +30,7 @@ Solr includes some plugins out of the box, and additional plugins can be develop
 All authentication, authorization and audit logging plugins can work with Solr whether it is running as a cluster or a single-node installation.
 All related configuration, including users and permission rules, are stored in a file named `security.json`.
 When using SolrCloud, this file must be located at the root of the ZooKeeper structure.
-When running Solr in standalone mode (without ZooKeeper), this file must be in the `$SOLR_HOME` directory. When manually running Solr from an extracted archive, this will most likely be `server/solr`. If the service installer script is used, its default location will be `/var/data/solr`, which can be changed with options given to the service installer.
+When running Solr in standalone mode (without ZooKeeper), this file must be in the `$SOLR_HOME` directory. When manually running Solr from an extracted archive, this will most likely be `server/solr`. If the service installer script is used, its default location will be `/var/solr/data`, which can be changed with options given to the service installer.
 
 == Configuring security.json
 


### PR DESCRIPTION
# Description

Improve the section of the authentication page to make it easier for users to find their solr home, so they know where to place the security.json file.

# Checklist

This is a simple documentation text change, not a code change or a change to the ref guide structure.  Aside from having another committer review it, there's really no need to exhaustively test it.
