### PR TITLE
tutorial-aws.adoc link fix

### DIFF
--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
@@ -253,7 +253,7 @@ Correct the path to the ZooKeeper installation as appropriate if where you put i
 +
 [source,bash,subs="attributes"]
 ----
-$ export ZOO_HOME=$PWD/zookeeper-{dep-version-zookeeper}
+$ export ZOO_HOME=$PWD/apache-zookeeper-{dep-version-zookeeper}
 # put the env variable in .bashrc
 # vim ~/.bashrc
 export ZOO_HOME=/home/ec2-user/apache-zookeeper-{dep-version-zookeeper}

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
@@ -244,7 +244,7 @@ On the node you're using to host ZooKeeper (`zookeeper-node`), download the pack
 # download stable version of ZooKeeper, here {dep-version-zookeeper}
 $ wget https://archive.apache.org/dist/zookeeper/zookeeper-{dep-version-zookeeper}/apache-zookeeper-{dep-version-zookeeper}.tar.gz
 # untar
-$ tar -zxvf zookeeper-{dep-version-zookeeper}.tar.gz
+$ tar -zxvf apache-zookeeper-{dep-version-zookeeper}.tar.gz
 ----
 +
 Add an environment variable for ZooKeeper's home directory (`ZOO_HOME`) to the `.bashrc` for the user who will be running the process.
@@ -256,7 +256,7 @@ Correct the path to the ZooKeeper installation as appropriate if where you put i
 $ export ZOO_HOME=$PWD/zookeeper-{dep-version-zookeeper}
 # put the env variable in .bashrc
 # vim ~/.bashrc
-export ZOO_HOME=/home/ec2-user/zookeeper-{dep-version-zookeeper}
+export ZOO_HOME=/home/ec2-user/apache-zookeeper-{dep-version-zookeeper}
 ----
 . Change directories to `ZOO_HOME`, and create the ZooKeeper configuration by using the template provided by ZooKeeper.
 +

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
@@ -242,7 +242,7 @@ On the node you're using to host ZooKeeper (`zookeeper-node`), download the pack
 [,console]
 ----
 # download stable version of ZooKeeper, here {dep-version-zookeeper}
-$ wget https://archive.apache.org/dist/zookeeper/zookeeper-{dep-version-zookeeper}/zookeeper-{dep-version-zookeeper}.tar.gz
+$ wget https://archive.apache.org/dist/zookeeper/zookeeper-{dep-version-zookeeper}/apache-zookeeper-{dep-version-zookeeper}.tar.gz
 # untar
 $ tar -zxvf zookeeper-{dep-version-zookeeper}.tar.gz
 ----


### PR DESCRIPTION
The link in current form does not work. It needs "apache-" in front as visible below:  This works:
https://archive.apache.org/dist/zookeeper/zookeeper-3.8.1/  https://archive.apache.org/dist/zookeeper/zookeeper-3.8.1/apache-zookeeper-3.8.1.tar.gz This does not work:
https://archive.apache.org/dist/zookeeper/zookeeper-3.8.1/zookeeper-3.8.1.tar.gz

# Description

Link fix

# Solution

Link fix

# Tests

No code changes, so no tests.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
