### PR TITLE
SOLR-16392: Convert v2 shard, replica deletion to JAX-RS 

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/JerseyResource.java
+++ b/solr/core/src/java/org/apache/solr/api/JerseyResource.java
@@ -22,6 +22,7 @@ import static org.apache.solr.jersey.RequestContextKeys.SOLR_JERSEY_RESPONSE;
 import java.util.function.Supplier;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.jersey.CatchAllExceptionMapper;
 import org.apache.solr.jersey.SolrJerseyResponse;
 import org.apache.solr.servlet.HttpSolrCall;
@@ -94,5 +95,12 @@ public class JerseyResource {
       containerRequestContext.setProperty(SOLR_JERSEY_RESPONSE, instance);
     }
     return instance;
+  }
+
+  protected void ensureRequiredParameterProvided(String parameterName, Object parameterValue) {
+    if (parameterValue == null) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST, "Missing required parameter: " + parameterName);
+    }
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -111,9 +111,6 @@ import static org.apache.solr.common.params.CoreAdminParams.BACKUP_LOCATION;
 import static org.apache.solr.common.params.CoreAdminParams.BACKUP_PURGE_UNUSED;
 import static org.apache.solr.common.params.CoreAdminParams.BACKUP_REPOSITORY;
 import static org.apache.solr.common.params.CoreAdminParams.DATA_DIR;
-import static org.apache.solr.common.params.CoreAdminParams.DELETE_DATA_DIR;
-import static org.apache.solr.common.params.CoreAdminParams.DELETE_INDEX;
-import static org.apache.solr.common.params.CoreAdminParams.DELETE_INSTANCE_DIR;
 import static org.apache.solr.common.params.CoreAdminParams.INSTANCE_DIR;
 import static org.apache.solr.common.params.CoreAdminParams.MAX_NUM_BACKUP_POINTS;
 import static org.apache.solr.common.params.CoreAdminParams.ULOG_DIR;
@@ -764,16 +761,8 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     DELETESHARD_OP(
         DELETESHARD,
         (req, rsp, h) -> {
-          Map<String, Object> map =
-              copy(req.getParams().required(), null, COLLECTION_PROP, SHARD_ID_PROP);
-          copy(
-              req.getParams(),
-              map,
-              DELETE_INDEX,
-              DELETE_DATA_DIR,
-              DELETE_INSTANCE_DIR,
-              FOLLOW_ALIASES);
-          return map;
+          DeleteShardAPI.invokeWithV1Params(h.coreContainer, req, rsp);
+          return null;
         }),
     FORCELEADER_OP(
         FORCELEADER,
@@ -1789,6 +1778,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         DeleteCollectionAPI.class,
         DeleteReplicaAPI.class,
         DeleteReplicaPropertyAPI.class,
+        DeleteShardAPI.class,
         InstallShardDataAPI.class,
         ListCollectionsAPI.class,
         ReplaceNodeAPI.class,
@@ -1808,7 +1798,6 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     apis.addAll(AnnotatedApi.getApis(new SplitShardAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new CreateShardAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new AddReplicaAPI(this)));
-    apis.addAll(AnnotatedApi.getApis(new DeleteShardAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new SyncShardAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new ForceLeaderAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new BalanceShardUniqueAPI(this)));

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -27,7 +27,6 @@ import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.CREA
 import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.CREATE_NODE_SET_SHUFFLE;
 import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.NUM_SLICES;
 import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.ONLY_ACTIVE_NODES;
-import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.ONLY_IF_DOWN;
 import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.REQUESTID;
 import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.SHARD_UNIQUE;
 import static org.apache.solr.common.SolrException.ErrorCode.BAD_REQUEST;
@@ -43,7 +42,6 @@ import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
 import static org.apache.solr.common.cloud.ZkStateReader.TLOG_REPLICAS;
 import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
 import static org.apache.solr.common.params.CollectionAdminParams.COLL_CONF;
-import static org.apache.solr.common.params.CollectionAdminParams.COUNT_PROP;
 import static org.apache.solr.common.params.CollectionAdminParams.CREATE_NODE_SET_PARAM;
 import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
 import static org.apache.solr.common.params.CollectionAdminParams.PROPERTY_NAME;
@@ -824,19 +822,8 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     DELETEREPLICA_OP(
         DELETEREPLICA,
         (req, rsp, h) -> {
-          Map<String, Object> map = copy(req.getParams().required(), null, COLLECTION_PROP);
-
-          return copy(
-              req.getParams(),
-              map,
-              DELETE_INDEX,
-              DELETE_DATA_DIR,
-              DELETE_INSTANCE_DIR,
-              COUNT_PROP,
-              REPLICA_PROP,
-              SHARD_ID_PROP,
-              ONLY_IF_DOWN,
-              FOLLOW_ALIASES);
+          DeleteReplicaAPI.invokeWithV1Params(h.coreContainer, req, rsp);
+          return null;
         }),
     MIGRATE_OP(
         MIGRATE,
@@ -1800,6 +1787,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         CreateCollectionBackupAPI.class,
         DeleteAliasAPI.class,
         DeleteCollectionAPI.class,
+        DeleteReplicaAPI.class,
         DeleteReplicaPropertyAPI.class,
         InstallShardDataAPI.class,
         ListCollectionsAPI.class,
@@ -1823,7 +1811,6 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     apis.addAll(AnnotatedApi.getApis(new DeleteShardAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new SyncShardAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new ForceLeaderAPI(this)));
-    apis.addAll(AnnotatedApi.getApis(new DeleteReplicaAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new BalanceShardUniqueAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new MigrateDocsAPI(this)));
     apis.addAll(AnnotatedApi.getApis(new ModifyCollectionAPI(this)));

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteReplicaAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteReplicaAPI.java
@@ -17,54 +17,202 @@
 
 package org.apache.solr.handler.admin.api;
 
-import static org.apache.solr.client.solrj.SolrRequest.METHOD.DELETE;
-import static org.apache.solr.common.params.CommonParams.ACTION;
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.ONLY_IF_DOWN;
+import static org.apache.solr.common.SolrException.ErrorCode.BAD_REQUEST;
+import static org.apache.solr.common.cloud.ZkStateReader.COLLECTION_PROP;
+import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
+import static org.apache.solr.common.params.CollectionAdminParams.COUNT_PROP;
+import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_DATA_DIR;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INDEX;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INSTANCE_DIR;
 import static org.apache.solr.common.params.CoreAdminParams.REPLICA;
-import static org.apache.solr.common.params.CoreAdminParams.SHARD;
-import static org.apache.solr.handler.ClusterAPI.wrapParams;
 import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
 
-import org.apache.solr.api.EndPoint;
-import org.apache.solr.common.cloud.ZkStateReader;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.params.CollectionParams;
-import org.apache.solr.handler.admin.CollectionsHandler;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.handler.api.V2ApiUtils;
+import org.apache.solr.jersey.PermissionName;
+import org.apache.solr.jersey.SubResponseAccumulatingJerseyResponse;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 
 /**
- * V2 API for deleting an existing replica from a shard.
+ * V2 APIs for deleting one or more existing replicas from a shard.
  *
- * <p>This API (DELETE /v2/collections/collectionName/shards/shardName/replicaName is analogous to
- * the v1 /admin/collections?action=DELETEREPLICA command.
+ * <p>These APIs are analogous to the v1 /admin/collections?action=DELETEREPLICA command.
  */
-public class DeleteReplicaAPI {
+@Path("/collections/{collectionName}/shards/{shardName}/replicas")
+public class DeleteReplicaAPI extends AdminAPIBase {
 
-  private final CollectionsHandler collectionsHandler;
-
-  public DeleteReplicaAPI(CollectionsHandler collectionsHandler) {
-    this.collectionsHandler = collectionsHandler;
+  @Inject
+  public DeleteReplicaAPI(
+      CoreContainer coreContainer,
+      SolrQueryRequest solrQueryRequest,
+      SolrQueryResponse solrQueryResponse) {
+    super(coreContainer, solrQueryRequest, solrQueryResponse);
   }
 
-  @EndPoint(
-      path = {
-        "/c/{collection}/shards/{shard}/{replica}",
-        "/collections/{collection}/shards/{shard}/{replica}"
-      },
-      method = DELETE,
-      permission = COLL_EDIT_PERM)
-  public void deleteReplica(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    req =
-        wrapParams(
-            req,
-            ACTION,
-            CollectionParams.CollectionAction.DELETEREPLICA.toString(),
-            ZkStateReader.COLLECTION_PROP,
-            req.getPathTemplateValues().get(ZkStateReader.COLLECTION_PROP),
-            SHARD,
-            req.getPathTemplateValues().get(SHARD),
-            REPLICA,
-            req.getPathTemplateValues().get(REPLICA));
+  @javax.ws.rs.DELETE
+  @Path("/{replicaName}")
+  @PermissionName(COLL_EDIT_PERM)
+  public SubResponseAccumulatingJerseyResponse deleteReplicaByName(
+      @PathParam("collectionName") String collectionName,
+      @PathParam("shardName") String shardName,
+      @PathParam("replicaName") String replicaName,
+      // Optional params below
+      @QueryParam(FOLLOW_ALIASES) Boolean followAliases,
+      @QueryParam(DELETE_INSTANCE_DIR) Boolean deleteInstanceDir,
+      @QueryParam(DELETE_DATA_DIR) Boolean deleteDataDir,
+      @QueryParam(DELETE_INDEX) Boolean deleteIndex,
+      @QueryParam(ONLY_IF_DOWN) Boolean onlyIfDown,
+      @QueryParam(ASYNC) String asyncId)
+      throws Exception {
+    final var response = instantiateJerseyResponse(SubResponseAccumulatingJerseyResponse.class);
+    fetchAndValidateZooKeeperAwareCoreContainer();
+    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
 
-    collectionsHandler.handleRequestBody(req, rsp);
+    ensureRequiredParameterProvided(COLLECTION_PROP, collectionName);
+    ensureRequiredParameterProvided(SHARD_ID_PROP, shardName);
+    ensureRequiredParameterProvided(REPLICA, replicaName);
+
+    final ZkNodeProps remoteMessage =
+        createRemoteMessage(
+            collectionName,
+            shardName,
+            replicaName,
+            null,
+            followAliases,
+            deleteInstanceDir,
+            deleteDataDir,
+            deleteIndex,
+            onlyIfDown,
+            asyncId);
+    submitRemoteMessageAndHandleResponse(
+        response, CollectionParams.CollectionAction.DELETEREPLICA, remoteMessage, asyncId);
+    return response;
+  }
+
+  @DELETE
+  @PermissionName(COLL_EDIT_PERM)
+  public SubResponseAccumulatingJerseyResponse deleteReplicasByCount(
+      @PathParam("collectionName") String collectionName,
+      @PathParam("shardName") String shardName,
+      @QueryParam(COUNT_PROP) Integer numToDelete,
+      // Optional params below
+      @QueryParam(FOLLOW_ALIASES) Boolean followAliases,
+      @QueryParam(DELETE_INSTANCE_DIR) Boolean deleteInstanceDir,
+      @QueryParam(DELETE_DATA_DIR) Boolean deleteDataDir,
+      @QueryParam(DELETE_INDEX) Boolean deleteIndex,
+      @QueryParam(ONLY_IF_DOWN) Boolean onlyIfDown,
+      @QueryParam(ASYNC) String asyncId)
+      throws Exception {
+    final var response = instantiateJerseyResponse(SubResponseAccumulatingJerseyResponse.class);
+    fetchAndValidateZooKeeperAwareCoreContainer();
+    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
+
+    ensureRequiredParameterProvided(COLLECTION_PROP, collectionName);
+    ensureRequiredParameterProvided(SHARD_ID_PROP, shardName);
+    ensureRequiredParameterProvided(COUNT_PROP, numToDelete);
+
+    final ZkNodeProps remoteMessage =
+        createRemoteMessage(
+            collectionName,
+            shardName,
+            null,
+            numToDelete,
+            followAliases,
+            deleteInstanceDir,
+            deleteDataDir,
+            deleteIndex,
+            onlyIfDown,
+            asyncId);
+    submitRemoteMessageAndHandleResponse(
+        response, CollectionParams.CollectionAction.DELETEREPLICA, remoteMessage, asyncId);
+    return response;
+  }
+
+  public static ZkNodeProps createRemoteMessage(
+      String collectionName,
+      String shardName,
+      String replicaName,
+      Integer numReplicasToDelete,
+      Boolean followAliases,
+      Boolean deleteInstanceDir,
+      Boolean deleteDataDir,
+      Boolean deleteIndex,
+      Boolean onlyIfDown,
+      String asyncId) {
+    final Map<String, Object> remoteMessage = new HashMap<>();
+    remoteMessage.put(QUEUE_OPERATION, CollectionParams.CollectionAction.DELETEREPLICA.toLower());
+    remoteMessage.put(COLLECTION_PROP, collectionName);
+    remoteMessage.put(SHARD_ID_PROP, shardName);
+    insertIfNotNull(remoteMessage, REPLICA, replicaName);
+    insertIfNotNull(remoteMessage, COUNT_PROP, numReplicasToDelete);
+    insertIfNotNull(remoteMessage, FOLLOW_ALIASES, followAliases);
+    insertIfNotNull(remoteMessage, DELETE_INSTANCE_DIR, deleteInstanceDir);
+    insertIfNotNull(remoteMessage, DELETE_DATA_DIR, deleteDataDir);
+    insertIfNotNull(remoteMessage, DELETE_INDEX, deleteIndex);
+    insertIfNotNull(remoteMessage, ONLY_IF_DOWN, onlyIfDown);
+    insertIfNotNull(remoteMessage, ASYNC, asyncId);
+
+    return new ZkNodeProps(remoteMessage);
+  }
+
+  public static void invokeWithV1Params(
+      CoreContainer coreContainer,
+      SolrQueryRequest solrQueryRequest,
+      SolrQueryResponse solrQueryResponse)
+      throws Exception {
+    final var v1Params = solrQueryRequest.getParams();
+    v1Params.required().check(COLLECTION_PROP, SHARD_ID_PROP);
+
+    final var deleteReplicaApi =
+        new DeleteReplicaAPI(coreContainer, solrQueryRequest, solrQueryResponse);
+    final var v2Response = invokeApiMethod(deleteReplicaApi, v1Params);
+    V2ApiUtils.squashIntoSolrResponseWithoutHeader(solrQueryResponse, v2Response);
+  }
+
+  private static SubResponseAccumulatingJerseyResponse invokeApiMethod(
+      DeleteReplicaAPI deleteReplicaApi, SolrParams v1Params) throws Exception {
+    if (v1Params.get(REPLICA) != null) {
+      return deleteReplicaApi.deleteReplicaByName(
+          v1Params.get(COLLECTION_PROP),
+          v1Params.get(SHARD_ID_PROP),
+          v1Params.get(REPLICA),
+          v1Params.getBool(FOLLOW_ALIASES),
+          v1Params.getBool(DELETE_INSTANCE_DIR),
+          v1Params.getBool(DELETE_DATA_DIR),
+          v1Params.getBool(DELETE_INDEX),
+          v1Params.getBool(ONLY_IF_DOWN),
+          v1Params.get(ASYNC));
+    } else if (v1Params.get(COUNT_PROP) != null) {
+      return deleteReplicaApi.deleteReplicasByCount(
+          v1Params.get(COLLECTION_PROP),
+          v1Params.get(SHARD_ID_PROP),
+          v1Params.getInt(COUNT_PROP),
+          v1Params.getBool(FOLLOW_ALIASES),
+          v1Params.getBool(DELETE_INSTANCE_DIR),
+          v1Params.getBool(DELETE_DATA_DIR),
+          v1Params.getBool(DELETE_INDEX),
+          v1Params.getBool(ONLY_IF_DOWN),
+          v1Params.get(ASYNC));
+    } else {
+      throw new SolrException(
+          BAD_REQUEST,
+          "DELETEREPLICA requires either " + COUNT_PROP + " or " + REPLICA + " parameters");
+    }
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteReplicaAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteReplicaAPI.java
@@ -65,7 +65,7 @@ public class DeleteReplicaAPI extends AdminAPIBase {
     super(coreContainer, solrQueryRequest, solrQueryResponse);
   }
 
-  @javax.ws.rs.DELETE
+  @DELETE
   @Path("/{replicaName}")
   @PermissionName(COLL_EDIT_PERM)
   public SubResponseAccumulatingJerseyResponse deleteReplicaByName(

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteReplicaAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteReplicaAPI.java
@@ -81,12 +81,11 @@ public class DeleteReplicaAPI extends AdminAPIBase {
       @QueryParam(ASYNC) String asyncId)
       throws Exception {
     final var response = instantiateJerseyResponse(SubResponseAccumulatingJerseyResponse.class);
-    fetchAndValidateZooKeeperAwareCoreContainer();
-    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
-
     ensureRequiredParameterProvided(COLLECTION_PROP, collectionName);
     ensureRequiredParameterProvided(SHARD_ID_PROP, shardName);
     ensureRequiredParameterProvided(REPLICA, replicaName);
+    fetchAndValidateZooKeeperAwareCoreContainer();
+    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
 
     final ZkNodeProps remoteMessage =
         createRemoteMessage(
@@ -120,12 +119,11 @@ public class DeleteReplicaAPI extends AdminAPIBase {
       @QueryParam(ASYNC) String asyncId)
       throws Exception {
     final var response = instantiateJerseyResponse(SubResponseAccumulatingJerseyResponse.class);
-    fetchAndValidateZooKeeperAwareCoreContainer();
-    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
-
     ensureRequiredParameterProvided(COLLECTION_PROP, collectionName);
     ensureRequiredParameterProvided(SHARD_ID_PROP, shardName);
     ensureRequiredParameterProvided(COUNT_PROP, numToDelete);
+    fetchAndValidateZooKeeperAwareCoreContainer();
+    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
 
     final ZkNodeProps remoteMessage =
         createRemoteMessage(

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteShardAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteShardAPI.java
@@ -70,11 +70,10 @@ public class DeleteShardAPI extends AdminAPIBase {
       @QueryParam(FOLLOW_ALIASES) Boolean followAliases)
       throws Exception {
     final var response = instantiateJerseyResponse(SubResponseAccumulatingJerseyResponse.class);
-    fetchAndValidateZooKeeperAwareCoreContainer();
-    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
-
     ensureRequiredParameterProvided(COLLECTION_PROP, collectionName);
     ensureRequiredParameterProvided(SHARD_ID_PROP, shardName);
+    fetchAndValidateZooKeeperAwareCoreContainer();
+    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
 
     final ZkNodeProps remoteMessage =
         createRemoteMessage(

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteShardAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteShardAPI.java
@@ -17,18 +17,28 @@
 
 package org.apache.solr.handler.admin.api;
 
-import static org.apache.solr.client.solrj.SolrRequest.METHOD.DELETE;
-import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
-import static org.apache.solr.common.params.CommonParams.ACTION;
-import static org.apache.solr.common.params.CoreAdminParams.SHARD;
-import static org.apache.solr.handler.ClusterAPI.wrapParams;
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.common.cloud.ZkStateReader.COLLECTION_PROP;
+import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
+import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_DATA_DIR;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INDEX;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INSTANCE_DIR;
 import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.solr.api.EndPoint;
+import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.params.CollectionParams;
-import org.apache.solr.handler.admin.CollectionsHandler;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.handler.api.V2ApiUtils;
+import org.apache.solr.jersey.PermissionName;
+import org.apache.solr.jersey.SubResponseAccumulatingJerseyResponse;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 
@@ -38,25 +48,84 @@ import org.apache.solr.response.SolrQueryResponse;
  * <p>This API (DELETE /v2/collections/collectionName/shards/shardName) is analogous to the v1
  * /admin/collections?action=DELETESHARD command.
  */
-public class DeleteShardAPI {
-  private final CollectionsHandler collectionsHandler;
+@Path("/collections/{collectionName}/shards/{shardName}/replicas")
+public class DeleteShardAPI extends AdminAPIBase {
 
-  public DeleteShardAPI(CollectionsHandler collectionsHandler) {
-    this.collectionsHandler = collectionsHandler;
+  @Inject
+  public DeleteShardAPI(
+      CoreContainer coreContainer,
+      SolrQueryRequest solrQueryRequest,
+      SolrQueryResponse solrQueryResponse) {
+    super(coreContainer, solrQueryRequest, solrQueryResponse);
   }
 
-  @EndPoint(
-      path = {"/c/{collection}/shards/{shard}", "/collections/{collection}/shards/{shard}"},
-      method = DELETE,
-      permission = COLL_EDIT_PERM)
-  public void deleteShard(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    final Map<String, String> pathParams = req.getPathTemplateValues();
+  @DELETE
+  @PermissionName(COLL_EDIT_PERM)
+  public SubResponseAccumulatingJerseyResponse deleteShard(
+      @PathParam("collectionName") String collectionName,
+      @PathParam("shardName") String shardName,
+      @QueryParam(DELETE_INSTANCE_DIR) Boolean deleteInstanceDir,
+      @QueryParam(DELETE_DATA_DIR) Boolean deleteDataDir,
+      @QueryParam(DELETE_INDEX) Boolean deleteIndex,
+      @QueryParam(FOLLOW_ALIASES) Boolean followAliases)
+      throws Exception {
+    final var response = instantiateJerseyResponse(SubResponseAccumulatingJerseyResponse.class);
+    fetchAndValidateZooKeeperAwareCoreContainer();
+    recordCollectionForLogAndTracing(collectionName, solrQueryRequest);
 
-    final Map<String, Object> addedV1Params = new HashMap<>();
-    addedV1Params.put(ACTION, CollectionParams.CollectionAction.DELETESHARD.toLower());
-    addedV1Params.put(COLLECTION, pathParams.get(COLLECTION));
-    addedV1Params.put(SHARD, pathParams.get(SHARD));
+    ensureRequiredParameterProvided(COLLECTION_PROP, collectionName);
+    ensureRequiredParameterProvided(SHARD_ID_PROP, shardName);
 
-    collectionsHandler.handleRequestBody(wrapParams(req, addedV1Params), rsp);
+    final ZkNodeProps remoteMessage =
+        createRemoteMessage(
+            collectionName,
+            shardName,
+            deleteInstanceDir,
+            deleteDataDir,
+            deleteIndex,
+            followAliases);
+    submitRemoteMessageAndHandleResponse(
+        response, CollectionParams.CollectionAction.DELETESHARD, remoteMessage, null);
+    return response;
+  }
+
+  public static ZkNodeProps createRemoteMessage(
+      String collectionName,
+      String shardName,
+      Boolean deleteInstanceDir,
+      Boolean deleteDataDir,
+      Boolean deleteIndex,
+      Boolean followAliases) {
+    final Map<String, Object> remoteMessage = new HashMap<>();
+    remoteMessage.put(QUEUE_OPERATION, CollectionParams.CollectionAction.DELETESHARD.toLower());
+    remoteMessage.put(COLLECTION_PROP, collectionName);
+    remoteMessage.put(SHARD_ID_PROP, shardName);
+    insertIfNotNull(remoteMessage, FOLLOW_ALIASES, followAliases);
+    insertIfNotNull(remoteMessage, DELETE_INSTANCE_DIR, deleteInstanceDir);
+    insertIfNotNull(remoteMessage, DELETE_DATA_DIR, deleteDataDir);
+    insertIfNotNull(remoteMessage, DELETE_INDEX, deleteIndex);
+
+    return new ZkNodeProps(remoteMessage);
+  }
+
+  public static void invokeWithV1Params(
+      CoreContainer coreContainer,
+      SolrQueryRequest solrQueryRequest,
+      SolrQueryResponse solrQueryResponse)
+      throws Exception {
+    final var v1Params = solrQueryRequest.getParams();
+    v1Params.required().check(COLLECTION_PROP, SHARD_ID_PROP);
+
+    final var deleteShardApi =
+        new DeleteShardAPI(coreContainer, solrQueryRequest, solrQueryResponse);
+    final var v2Response =
+        deleteShardApi.deleteShard(
+            v1Params.get(COLLECTION_PROP),
+            v1Params.get(SHARD_ID_PROP),
+            v1Params.getBool(DELETE_INSTANCE_DIR),
+            v1Params.getBool(DELETE_DATA_DIR),
+            v1Params.getBool(DELETE_INDEX),
+            v1Params.getBool(FOLLOW_ALIASES));
+    V2ApiUtils.squashIntoSolrResponseWithoutHeader(solrQueryResponse, v2Response);
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteReplicaAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteReplicaAPITest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.admin.api;
+
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.ONLY_IF_DOWN;
+import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
+import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
+import static org.apache.solr.common.params.CollectionAdminParams.COUNT_PROP;
+import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
+import static org.apache.solr.common.params.CollectionAdminParams.REPLICA;
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_DATA_DIR;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INDEX;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INSTANCE_DIR;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
+import org.junit.Test;
+
+/** Unit tests for {@link DeleteReplicaAPI} */
+public class DeleteReplicaAPITest extends SolrTestCaseJ4 {
+  @Test
+  public void testReportsErrorIfCollectionNameMissing() {
+    final SolrException thrown =
+        expectThrows(
+            SolrException.class,
+            () -> {
+              final var api = new DeleteReplicaAPI(null, null, null);
+              api.deleteReplicaByName(
+                  null, "someShard", "someReplica", null, null, null, null, null, null);
+            });
+
+    assertEquals(400, thrown.code());
+    assertEquals("Missing required parameter: collection", thrown.getMessage());
+  }
+
+  @Test
+  public void testReportsErrorIfShardNameMissing() {
+    final SolrException thrown =
+        expectThrows(
+            SolrException.class,
+            () -> {
+              final var api = new DeleteReplicaAPI(null, null, null);
+              api.deleteReplicaByName(
+                  "someCollection", null, "someReplica", null, null, null, null, null, null);
+            });
+
+    assertEquals(400, thrown.code());
+    assertEquals("Missing required parameter: shard", thrown.getMessage());
+  }
+
+  @Test
+  public void testReportsErrorIfReplicaNameMissingWhenDeletingByName() {
+    final SolrException thrown =
+        expectThrows(
+            SolrException.class,
+            () -> {
+              final var api = new DeleteReplicaAPI(null, null, null);
+              api.deleteReplicaByName(
+                  "someCollection", "someShard", null, null, null, null, null, null, null);
+            });
+
+    assertEquals(400, thrown.code());
+    assertEquals("Missing required parameter: replica", thrown.getMessage());
+  }
+
+  @Test
+  public void testCreateRemoteMessageAllProperties() {
+    final var remoteMessage =
+        DeleteReplicaAPI.createRemoteMessage(
+                "someCollName",
+                "someShardName",
+                "someReplicaName",
+                123,
+                true,
+                false,
+                true,
+                false,
+                true,
+                "someAsyncId")
+            .getProperties();
+
+    assertEquals(11, remoteMessage.size());
+    assertEquals("deletereplica", remoteMessage.get(QUEUE_OPERATION));
+    assertEquals("someCollName", remoteMessage.get(COLLECTION));
+    assertEquals("someShardName", remoteMessage.get(SHARD_ID_PROP));
+    assertEquals("someReplicaName", remoteMessage.get(REPLICA));
+    assertEquals(Integer.valueOf(123), remoteMessage.get(COUNT_PROP));
+    assertEquals(Boolean.TRUE, remoteMessage.get(FOLLOW_ALIASES));
+    assertEquals(Boolean.FALSE, remoteMessage.get(DELETE_INSTANCE_DIR));
+    assertEquals(Boolean.TRUE, remoteMessage.get(DELETE_DATA_DIR));
+    assertEquals(Boolean.FALSE, remoteMessage.get(DELETE_INDEX));
+    assertEquals(Boolean.TRUE, remoteMessage.get(ONLY_IF_DOWN));
+    assertEquals("someAsyncId", remoteMessage.get(ASYNC));
+  }
+
+  @Test
+  public void testMissingValuesExcludedFromRemoteMessage() {
+    final var remoteMessage =
+        DeleteReplicaAPI.createRemoteMessage(
+                "someCollName",
+                "someShardName",
+                "someReplicaName",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null)
+            .getProperties();
+
+    assertEquals(4, remoteMessage.size());
+    assertEquals("deletereplica", remoteMessage.get(QUEUE_OPERATION));
+    assertEquals("someCollName", remoteMessage.get(COLLECTION));
+    assertEquals("someShardName", remoteMessage.get(SHARD_ID_PROP));
+    assertEquals("someReplicaName", remoteMessage.get(REPLICA));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteShardAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/DeleteShardAPITest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.admin.api;
+
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
+import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
+import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_DATA_DIR;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INDEX;
+import static org.apache.solr.common.params.CoreAdminParams.DELETE_INSTANCE_DIR;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
+import org.junit.Test;
+
+/** Unit tests for {@link DeleteShardAPI} */
+public class DeleteShardAPITest extends SolrTestCaseJ4 {
+  @Test
+  public void testReportsErrorIfCollectionNameMissing() {
+    final SolrException thrown =
+        expectThrows(
+            SolrException.class,
+            () -> {
+              final var api = new DeleteShardAPI(null, null, null);
+              api.deleteShard(null, "someShard", null, null, null, null);
+            });
+
+    assertEquals(400, thrown.code());
+    assertEquals("Missing required parameter: collection", thrown.getMessage());
+  }
+
+  @Test
+  public void testReportsErrorIfShardNameMissing() {
+    final SolrException thrown =
+        expectThrows(
+            SolrException.class,
+            () -> {
+              final var api = new DeleteShardAPI(null, null, null);
+              api.deleteShard("someCollection", null, null, null, null, null);
+            });
+
+    assertEquals(400, thrown.code());
+    assertEquals("Missing required parameter: shard", thrown.getMessage());
+  }
+
+  @Test
+  public void testCreateRemoteMessageAllProperties() {
+    final var remoteMessage =
+        DeleteShardAPI.createRemoteMessage(
+                "someCollName", "someShardName", true, false, true, false)
+            .getProperties();
+
+    assertEquals(7, remoteMessage.size());
+    assertEquals("deleteshard", remoteMessage.get(QUEUE_OPERATION));
+    assertEquals("someCollName", remoteMessage.get(COLLECTION));
+    assertEquals("someShardName", remoteMessage.get(SHARD_ID_PROP));
+    assertEquals(Boolean.TRUE, remoteMessage.get(DELETE_INSTANCE_DIR));
+    assertEquals(Boolean.FALSE, remoteMessage.get(DELETE_DATA_DIR));
+    assertEquals(Boolean.TRUE, remoteMessage.get(DELETE_INDEX));
+    assertEquals(Boolean.FALSE, remoteMessage.get(FOLLOW_ALIASES));
+  }
+
+  @Test
+  public void testMissingValuesExcludedFromRemoteMessage() {
+    final var remoteMessage =
+        DeleteShardAPI.createRemoteMessage("someCollName", "someShardName", null, null, null, null)
+            .getProperties();
+
+    assertEquals(3, remoteMessage.size());
+    assertEquals("deleteshard", remoteMessage.get(QUEUE_OPERATION));
+    assertEquals("someCollName", remoteMessage.get(COLLECTION));
+    assertEquals("someShardName", remoteMessage.get(SHARD_ID_PROP));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/V2ShardsAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/V2ShardsAPIMappingTest.java
@@ -17,14 +17,12 @@
 
 package org.apache.solr.handler.admin.api;
 
-import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.ONLY_IF_DOWN;
 import static org.apache.solr.common.cloud.ZkStateReader.NRT_REPLICAS;
 import static org.apache.solr.common.cloud.ZkStateReader.PULL_REPLICAS;
 import static org.apache.solr.common.cloud.ZkStateReader.REPLICATION_FACTOR;
 import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
 import static org.apache.solr.common.cloud.ZkStateReader.TLOG_REPLICAS;
 import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
-import static org.apache.solr.common.params.CollectionAdminParams.COUNT_PROP;
 import static org.apache.solr.common.params.CollectionAdminParams.CREATE_NODE_SET_PARAM;
 import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
 import static org.apache.solr.common.params.CollectionParams.NAME;
@@ -37,13 +35,8 @@ import static org.apache.solr.common.params.CommonAdminParams.SPLIT_METHOD;
 import static org.apache.solr.common.params.CommonAdminParams.WAIT_FOR_FINAL_STATE;
 import static org.apache.solr.common.params.CommonParams.ACTION;
 import static org.apache.solr.common.params.CommonParams.TIMING;
-import static org.apache.solr.common.params.CoreAdminParams.DELETE_DATA_DIR;
-import static org.apache.solr.common.params.CoreAdminParams.DELETE_INDEX;
-import static org.apache.solr.common.params.CoreAdminParams.DELETE_INSTANCE_DIR;
-import static org.apache.solr.common.params.CoreAdminParams.REPLICA;
 import static org.apache.solr.common.params.CoreAdminParams.SHARD;
 
-import java.util.Locale;
 import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -72,7 +65,6 @@ public class V2ShardsAPIMappingTest extends V2ApiMappingTest<CollectionsHandler>
     apiBag.registerObject(new DeleteShardAPI(collectionsHandler));
     apiBag.registerObject(new SyncShardAPI(collectionsHandler));
     apiBag.registerObject(new ForceLeaderAPI(collectionsHandler));
-    apiBag.registerObject(new DeleteReplicaAPI(collectionsHandler));
   }
 
   @Override
@@ -244,34 +236,5 @@ public class V2ShardsAPIMappingTest extends V2ApiMappingTest<CollectionsHandler>
     assertEquals("tlog", v1Params.get("type"));
     assertEquals("foo1", v1Params.get("property.foo"));
     assertEquals("bar1", v1Params.get("property.bar"));
-  }
-
-  // really this is a replica API, but since there's only 1 API on the replica path, it's included
-  // here for simplicity.
-  @Test
-  public void testDeleteReplicaAllProperties() throws Exception {
-    final ModifiableSolrParams v2QueryParams = new ModifiableSolrParams();
-    v2QueryParams.add("deleteIndex", "true");
-    v2QueryParams.add("deleteDataDir", "true");
-    v2QueryParams.add("deleteInstanceDir", "true");
-    v2QueryParams.add("followAliases", "true");
-    v2QueryParams.add("count", "4");
-    v2QueryParams.add("onlyIfDown", "true");
-    final SolrParams v1Params =
-        captureConvertedV1Params(
-            "/collections/collName/shards/shard1/someReplica", "DELETE", v2QueryParams);
-
-    assertEquals(
-        CollectionParams.CollectionAction.DELETEREPLICA.lowerName,
-        v1Params.get(ACTION).toLowerCase(Locale.ROOT));
-    assertEquals("collName", v1Params.get(COLLECTION));
-    assertEquals("shard1", v1Params.get(SHARD_ID_PROP));
-    assertEquals("someReplica", v1Params.get(REPLICA));
-    assertEquals("true", v1Params.get(DELETE_INDEX));
-    assertEquals("true", v1Params.get(DELETE_DATA_DIR));
-    assertEquals("true", v1Params.get(DELETE_INSTANCE_DIR));
-    assertEquals("true", v1Params.get(FOLLOW_ALIASES));
-    assertEquals("4", v1Params.get(COUNT_PROP));
-    assertEquals("true", v1Params.get(ONLY_IF_DOWN));
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/V2ShardsAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/V2ShardsAPIMappingTest.java
@@ -39,7 +39,6 @@ import static org.apache.solr.common.params.CoreAdminParams.SHARD;
 
 import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.CoreAdminParams;
-import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.handler.admin.CollectionsHandler;
 import org.apache.solr.handler.admin.V2ApiMappingTest;
@@ -62,7 +61,6 @@ public class V2ShardsAPIMappingTest extends V2ApiMappingTest<CollectionsHandler>
     apiBag.registerObject(new SplitShardAPI(collectionsHandler));
     apiBag.registerObject(new CreateShardAPI(collectionsHandler));
     apiBag.registerObject(new AddReplicaAPI(collectionsHandler));
-    apiBag.registerObject(new DeleteShardAPI(collectionsHandler));
     apiBag.registerObject(new SyncShardAPI(collectionsHandler));
     apiBag.registerObject(new ForceLeaderAPI(collectionsHandler));
   }
@@ -97,25 +95,6 @@ public class V2ShardsAPIMappingTest extends V2ApiMappingTest<CollectionsHandler>
     assertEquals(CollectionParams.CollectionAction.SYNCSHARD.lowerName, v1Params.get(ACTION));
     assertEquals("collName", v1Params.get(COLLECTION));
     assertEquals("shardName", v1Params.get(SHARD));
-  }
-
-  @Test
-  public void testDeleteShardAllProperties() throws Exception {
-    final ModifiableSolrParams v2QueryParams = new ModifiableSolrParams();
-    v2QueryParams.add("deleteIndex", "true");
-    v2QueryParams.add("deleteDataDir", "true");
-    v2QueryParams.add("deleteInstanceDir", "true");
-    v2QueryParams.add("followAliases", "true");
-    final SolrParams v1Params =
-        captureConvertedV1Params("/collections/collName/shards/shardName", "DELETE", v2QueryParams);
-
-    assertEquals(CollectionParams.CollectionAction.DELETESHARD.lowerName, v1Params.get(ACTION));
-    assertEquals("collName", v1Params.get(COLLECTION));
-    assertEquals("shardName", v1Params.get(SHARD));
-    assertEquals("true", v1Params.get("deleteIndex"));
-    assertEquals("true", v1Params.get("deleteDataDir"));
-    assertEquals("true", v1Params.get("deleteInstanceDir"));
-    assertEquals("true", v1Params.get("followAliases"));
   }
 
   @Test

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/replica-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/replica-management.adoc
@@ -451,9 +451,9 @@ Request ID to track this action which will be xref:configuration-guide:collectio
 [[deletereplica]]
 == DELETEREPLICA: Delete a Replica
 
-Deletes a named replica from the specified collection and shard.
+Deletes a named replica (or a particular number of unnamed replicas) from the specified collection and shard.
 
-If the corresponding core is up and running the core is unloaded, the entry is removed from the clusterstate, and (by default) delete the instanceDir and dataDir.
+If the corresponding core is up and running the core is unloaded, the entry is removed from the clusterstate, and (by default) the instanceDir and dataDir are deleted.
 If the node/core is down, the entry is taken off the clusterstate and if the core comes up later it is automatically unregistered.
 
 [.dynamic-tabs]
@@ -472,17 +472,21 @@ http://localhost:8983/solr/admin/collections?action=DELETEREPLICA&collection=tec
 ====
 [.tab-label]*V2 API*
 
+The v2 API has two distinct endpoints for replica-deletion, depending on how the replicas are specified.
+
+To delete a replica by name:
+
 
 [source,bash]
 ----
-curl -X DELETE http://localhost:8983/api/collections/techproducts/shards/shard1/core_node2
+curl -X DELETE http://localhost:8983/api/collections/techproducts/shards/shard1/replicas/core_node2
 ----
 
-To run a DELETE asynchronously then append the `async` parameter:
+To delete a specified number of (unnamed) replicas:
 
 [source,bash]
 ----
-curl -X DELETE http://localhost:8983/api/collections/techproducts/shards/shard1/core_node2?async=aaaa
+curl -X DELETE "http://localhost:8983/api/collections/techproducts/shards/shard1/replicas?count=3"
 ----
 ====
 --
@@ -497,6 +501,8 @@ s|Required |Default: none
 |===
 +
 The name of the collection.
+Provided as a query parameter or a path parameter in v1 and v2 requests, respectively.
+
 
 `shard`::
 +
@@ -506,6 +512,8 @@ s|Required |Default: none
 |===
 +
 The name of the shard that includes the replica to be removed.
+Provided as a query parameter or a path parameter in v1 and v2 requests, respectively.
+
 
 `replica`::
 +
@@ -515,6 +523,7 @@ The name of the shard that includes the replica to be removed.
 |===
 +
 The name of the replica to remove.
+Provided as a query parameter or a path parameter in v1 and v2 requests, respectively.
 +
 If `count` is used instead, this parameter is not required.
 Otherwise, this parameter must be supplied.
@@ -571,6 +580,15 @@ Set this to `false` to prevent the index directory from being deleted.
 |===
 +
 When set to `true`, no action will be taken if the replica is active.
+
+`followAliases`::
++
+[%autowidth,frame=none]
+|===
+|Optional |Default: false
+|===
++
+A flag that allows treating the collection parameter as an alias for the actual collection name to be resolved.
 
 `async`::
 +

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
@@ -473,13 +473,6 @@ http://localhost:8983/solr/admin/collections?action=DELETESHARD&shard=shard1&col
 ----
 curl -X DELETE http://localhost:8983/api/collections/techproducts/shards/shard1
 ----
-
-To run a DELETE asynchronously then append the `async` parameter:
-
-[source,bash]
-----
-curl -X DELETE http://localhost:8983/api/collections/techproducts/shards/shard1?async=aaaa
-----
 ====
 --
 
@@ -493,6 +486,7 @@ s|Required |Default: none
 |===
 +
 The name of the collection that includes the shard to be deleted.
+Provided as a query parameter or a path parameter in v1 and v2 requests, respectively.
 
 `shard`::
 +
@@ -502,6 +496,8 @@ s|Required |Default: none
 |===
 +
 The name of the shard to be deleted.
+Provided as a query parameter or a path parameter in v1 and v2 requests, respectively.
+
 
 `deleteInstanceDir`::
 +
@@ -533,14 +529,14 @@ Set this to `false` to prevent the data directory from being deleted.
 By default Solr will delete the index of each replica that is deleted.
 Set this to `false` to prevent the index directory from being deleted.
 
-`async`::
+`followAliases`::
 +
 [%autowidth,frame=none]
 |===
-|Optional |Default: none
+|Optional |Default: false
 |===
 +
-Request ID to track this action which will be xref:configuration-guide:collections-api.adoc#asynchronous-calls[processed asynchronously].
+A flag that allows treating the collection parameter as an alias for the actual collection name to be resolved.
 
 === DELETESHARD Response
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16392

# Description

Solr is slowly migrating its v2 API definitions over to the JAX-RS framework.  Some APIs have already been converted, but many remain: including the APIs for replica and shard deletion.

# Solution

This PR migrates the v2 delete-replica and delete-shard APIs over to JAX-RS.  No user-visible changes were made to the v2 delete-shard endpoint.  Delete-replica however has been split into two separate endpoints (one to delete a single named replica, and one to delete a specified number of (unnamed) replicas.  The v2 APIs now appear as below:

- "Delete shard" - `DELETE /api/collections/collName/shards/shardName` (no changes)
- "Delete named replica" - `DELETE /api/collections/collName/shards/shardName/replicas/replicaName`
- "Delete multiple replicas" - `DELETE /api/collections/collName/shards/shardName/replicas?count=3`

# Tests

See `DeleteReplicaAPITest` and `DeleteShardAPITest`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
