### PR TITLE
Make small improvements to integration tests

### DIFF
--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -280,7 +280,7 @@ class BatsTask extends Exec {
 
     // Note: tests to run must be listed after all other arguments
     // Additional debugging output: -x, --verbose-run
-    setArgs(['--print-output-on-failure'] + (testFiles.empty ? testDir : testFiles))
+    setArgs(['-T', '--print-output-on-failure'] + (testFiles.empty ? testDir : testFiles))
 
     super.exec()
   }

--- a/solr/packaging/test/test_bats.bats
+++ b/solr/packaging/test/test_bats.bats
@@ -30,6 +30,7 @@ setup_file() {
 teardown_file() {
   # set up paths, not preserved from setup
   common_setup
+  sleep 3
 
   # Conversely, on shutdown, we do need this to execute strictly
   # because using "run" will eat filing test exit codes

--- a/solr/packaging/test/test_create.bats
+++ b/solr/packaging/test/test_create.bats
@@ -25,7 +25,6 @@ teardown() {
   # save a snapshot of SOLR_HOME for failed tests
   save_home_on_failure
 
-  delete_all_collections
   solr stop -all >/dev/null 2>&1
 }
 

--- a/solr/packaging/test/test_example_noprompt.bats
+++ b/solr/packaging/test/test_example_noprompt.bats
@@ -28,7 +28,7 @@ teardown() {
   solr stop -all >/dev/null 2>&1
 }
 
-@test "SOLR16755 test works with noprompt" {
+@test "SOLR-16755 test works with noprompt" {
   solr start -e cloud -noprompt
   solr assert --started http://localhost:8983/solr --timeout 10000
 }

--- a/solr/packaging/test/test_placement_plugin.bats
+++ b/solr/packaging/test/test_placement_plugin.bats
@@ -37,7 +37,7 @@ teardown() {
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to affinity'
 }
 
-@test "Affinity placement plugin using ENV" {
+@test "Random placement plugin using ENV" {
   export SOLR_PLACEMENTPLUGIN_DEFAULT=random
   run solr start -c
   solr assert -c http://localhost:8983/solr -t 3000

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -28,7 +28,7 @@ teardown() {
   solr stop -all >/dev/null 2>&1
 }
 
-@test "SOLR11740 check f" {
+@test "SOLR-11740 check 'solr stop' connection" {
   solr start
   solr start -p 7574
   solr assert --started http://localhost:8983/solr --timeout 5000


### PR DESCRIPTION
- Fix some of the test names
- Add timing information to test output
- Fix `test_bats.bats` so that it waits for the server to start before trying to stop it. This should probably be fixed somewhere else, but I tried a lot of things and none helped.
- `test_create.bats` is faster by removing an unnecessary `delete_all_collections`