### PR TITLE
SOLR-16807: DenseVectorField breaks '*' copyFields

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -197,6 +197,7 @@ public class DocumentBuilder {
             if (copyFields != null) {
               used |=
                   addCopyFields(
+                      schema,
                       vectorValue,
                       sfield.getType(),
                       copyFields,
@@ -223,6 +224,7 @@ public class DocumentBuilder {
             if (copyFields != null) {
               used |=
                   addCopyFields(
+                      schema,
                       v,
                       sfield.getType(),
                       copyFields,
@@ -306,6 +308,7 @@ public class DocumentBuilder {
   }
 
   private static boolean addCopyFields(
+      final IndexSchema schema,
       final Object originalFieldValue,
       FieldType originalFieldType,
       List<CopyField> copyFields,
@@ -322,11 +325,18 @@ public class DocumentBuilder {
       // Dense Vector Fields can only be copied to same field type
       if (originalFieldType instanceof DenseVectorField
           && !(destinationField.getType() instanceof DenseVectorField)) {
-        continue; //We'll skip DenseVectorFields rather then throw Exception.
+        if (schema.getCopySources(destinationField.getName()).contains("*")) {
+          continue;
+        } else {
+          throw new SolrException(
+              SolrException.ErrorCode.BAD_REQUEST,
+              "The copy field destination must be a DenseVectorField: "
+                  + destinationField.getName());
+        }
       }
 
       // check if the copy field is a multivalued or not
-      if (!destinationField.multiValued() && destHasValues) {
+      if (!destinationField.multiValued() & destHasValues) {
         throw new SolrException(
             SolrException.ErrorCode.BAD_REQUEST,
             "Multiple values encountered for non multiValued copy field "

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -336,7 +336,7 @@ public class DocumentBuilder {
       }
 
       // check if the copy field is a multivalued or not
-      if (!destinationField.multiValued() & destHasValues) {
+      if (!destinationField.multiValued() && destHasValues) {
         throw new SolrException(
             SolrException.ErrorCode.BAD_REQUEST,
             "Multiple values encountered for non multiValued copy field "

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -322,9 +322,7 @@ public class DocumentBuilder {
       // Dense Vector Fields can only be copied to same field type
       if (originalFieldType instanceof DenseVectorField
           && !(destinationField.getType() instanceof DenseVectorField)) {
-        throw new SolrException(
-            SolrException.ErrorCode.BAD_REQUEST,
-            "The copy field destination must be a DenseVectorField: " + destinationField.getName());
+        continue; //We'll skip DenseVectorFields rather then throw Exception.
       }
 
       // check if the copy field is a multivalued or not

--- a/solr/core/src/test-files/solr/collection1/conf/schema-densevector.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-densevector.xml
@@ -32,6 +32,21 @@
   <field name="string_field" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
 
   <field name="_version_" type="plong" indexed="true" stored="true" multiValued="false" />
+  <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
+  <copyField source="*" dest="_text_"/>
+  <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
 
   <uniqueKey>id</uniqueKey>
 </schema>

--- a/solr/core/src/test-files/solr/collection1/conf/schema-vector-catchall.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-vector-catchall.xml
@@ -1,0 +1,930 @@
+<?xml version="1.0" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- The Solr schema file. This file should be named "schema.xml" and
+     should be located where the classloader for the Solr webapp can find it.
+
+     This schema is used for testing, and as such has everything and the
+     kitchen sink thrown in. See example/solr/conf/schema.xml for a
+     more concise example.
+
+  -->
+
+<schema name="test" version="1.0">
+
+    <!-- field type definitions... note that the "name" attribute is
+         just a label to be used by field definitions.  The "class"
+         attribute and any other attributes determine the real type and
+         behavior of the fieldType.
+      -->
+
+    <fieldType name="int" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="float" class="${solr.tests.FloatFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="long" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="double" class="${solr.tests.DoubleFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+
+
+    <fieldType name="tint" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tfloat" class="${solr.tests.FloatFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tlong" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tdouble" class="${solr.tests.DoubleFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+
+    <!-- Point Fields -->
+    <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+
+    <!-- Dense Vector Fields -->
+    <fieldType name="knn_vector_cosine" class="solr.DenseVectorField" vectorDimension="4" similarityFunction="cosine"/>
+    <fieldType name="knn_vector_dot_product" class="solr.DenseVectorField" vectorDimension="4" similarityFunction="dot_product"/>
+    <fieldType name="knn_vector5" class="solr.DenseVectorField" vectorDimension="5" similarityFunction="dot_product"/>
+
+    <!-- Field type demonstrating an Analyzer failure -->
+    <fieldType name="failtype1" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="0" catenateWords="0"
+                    catenateNumbers="0" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- Demonstrating ignoreCaseChange -->
+    <fieldType name="wdf_nocase" class="solr.TextField">
+        <analyzer type="">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="0" catenateWords="0"
+                    catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="0" catenateWords="0"
+                    catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="wdf_preserve" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="1" catenateWords="0"
+                    catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="1" catenateWords="0"
+                    catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+
+    <!-- HighlitText optimizes storage for (long) columns which will be highlit -->
+    <fieldType name="highlittext" class="solr.TextField" compressThreshold="345"/>
+
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
+
+    <!-- format for date is 1995-12-31T23:59:59.999Z and only the fractional
+         seconds part (.999) is optional.
+      -->
+    <fieldType name="date" class="${solr.tests.DateFieldType}" precisionStep="0" docValues="${solr.tests.numeric.dv}"/>
+    <fieldType name="tdate" class="${solr.tests.DateFieldType}" precisionStep="6" docValues="${solr.tests.numeric.dv}"/>
+    <fieldType name="tdatedv" class="${solr.tests.DateFieldType}" precisionStep="6" docValues="true"/>
+
+    <fieldType name="dateRange" class="solr.DateRangeField"/>
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+               geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
+
+    <!-- solr.TextField allows the specification of custom
+         text analyzers specified as a tokenizer and a list
+         of token filters.
+      -->
+    <fieldType name="text" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldtype name="text_payload_tv" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+            <filter class="org.apache.lucene.analysis.payloads.TokenOffsetPayloadTokenFilterFactory"/>
+        </analyzer>
+    </fieldtype>
+
+    <fieldType name="nametext" class="solr.TextField">
+        <analyzer class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
+    </fieldType>
+
+    <fieldType name="teststop" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.LetterTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" words="stopwords.txt"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.LetterTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- fieldTypes in this section isolate tokenizers and tokenfilters for testing -->
+    <fieldType name="keywordtok" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory" pattern="keyword"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="standardtok" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="lettertok" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.LetterTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="whitetok" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="HTMLstandardtok" class="solr.TextField">
+        <analyzer>
+            <charFilter class="solr.HTMLStripCharFilterFactory"/>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="HTMLwhitetok" class="solr.TextField">
+        <analyzer>
+            <charFilter class="solr.HTMLStripCharFilterFactory"/>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="standardtokfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="standardfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="lowerfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="lowerpunctfilt" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" expand="true"/>
+            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+                    catenateNumbers="1" catenateAll="1" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" expand="true"/>
+            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+                    catenateNumbers="1" catenateAll="1" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="patternreplacefilt" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory" pattern="keyword"/>
+            <filter class="solr.PatternReplaceFilterFactory"
+                    pattern="([^a-zA-Z])" replacement="_" replace="all"
+            />
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory" pattern="keyword"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="patterntok" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.PatternTokenizerFactory" pattern=","/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="porterfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <!-- fieldType name="snowballfilt" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.MockTokenizerFactory"/>
+        <filter class="solr.SnowballPorterFilterFactory"/>
+      </analyzer>
+    </fieldType -->
+    <fieldType name="engporterfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="custengporterfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="stopfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="custstopfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory" words="stopwords.txt"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="lengthfilt" class="solr.TextField">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LengthFilterFactory" min="2" max="5"/>
+        </analyzer>
+    </fieldType>
+    <fieldType name="charfilthtmlmap" class="solr.TextField">
+        <analyzer>
+            <charFilter class="solr.HTMLStripCharFilterFactory"/>
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="subword" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+                    catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0"
+                    catenateNumbers="0" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="numericsubword" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" protected="protwords.txt" splitOnNumerics="0"
+                    splitOnCaseChange="0" generateWordParts="1" generateNumberParts="0" catenateWords="0" catenateNumbers="0"
+                    catenateAll="0"/>
+            <filter class="solr.StopFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" protected="protwords.txt" splitOnNumerics="0"
+                    splitOnCaseChange="0" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1"
+                    catenateAll="0"/>
+            <filter class="solr.StopFilterFactory"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="protectedsubword" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" protected="protwords.txt" splitOnNumerics="0"
+                    splitOnCaseChange="0" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0"
+                    catenateAll="0"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+
+    <!-- more flexible in matching skus, but more chance of a false match -->
+    <fieldType name="skutype1" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+                    catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1"
+                    catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- less flexible in matching skus, but less chance of a false match -->
+    <fieldType name="skutype2" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1"
+                    catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1"
+                    catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- less flexible in matching skus, but less chance of a false match -->
+    <fieldType name="syn" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="old_synonyms.txt"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="old_synonyms.txt"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- Demonstrates How RemoveDuplicatesTokenFilter makes stemmed
+         synonyms "better"
+      -->
+    <fieldType name="dedup" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory"
+                    synonyms="old_synonyms.txt" expand="true"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+            <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory"
+                    synonyms="old_synonyms.txt" expand="true"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+            <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="unstored" class="solr.StrField" indexed="true" stored="false"/>
+
+
+    <fieldType name="textgap" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="uuid" class="solr.UUIDField"/>
+
+    <!-- Try out some point types -->
+    <fieldType name="xy" class="solr.PointType" dimension="2" subFieldType="double"  docValues="true"/>
+    <fieldType name="x" class="solr.PointType" dimension="1" subFieldType="double"/>
+    <fieldType name="tenD" class="solr.PointType" dimension="10" subFieldType="double"/>
+    <fieldType name="xyd" class="solr.PointType" dimension="2" subFieldSuffix="_d1"/>
+
+    <!-- Currency type -->
+    <fieldType name="currency" class="solr.CurrencyField" currencyConfig="currency.xml" multiValued="false"/>
+    <fieldType name="mock_currency" class="solr.CurrencyField" providerClass="solr.MockExchangeRateProvider" foo="bar"
+               multiValued="false"/>
+    <fieldType name="oer_currency"
+               class="solr.CurrencyField"
+               multiValued="false"
+               providerClass="solr.OpenExchangeRatesOrgProvider"
+               ratesFileLocation="open-exchange-rates.json"/>
+    <fieldType name="currency_CFT" class="solr.CurrencyFieldType" amountLongSuffix="_l1_ns" codeStrSuffix="_s1"
+               currencyConfig="currency.xml" multiValued="false"/>
+    <fieldType name="mock_currency_CFT" class="solr.CurrencyFieldType" amountLongSuffix="_l1_ns" codeStrSuffix="_s1"
+               providerClass="solr.MockExchangeRateProvider" foo="bar" multiValued="false"/>
+    <fieldType name="oer_currency_CFT"
+               class="solr.CurrencyFieldType"
+               amountLongSuffix="_l1_ns"
+               codeStrSuffix="_s1_ns"
+               multiValued="false"
+               providerClass="solr.OpenExchangeRatesOrgProvider"
+               ratesFileLocation="open-exchange-rates.json"/>
+
+    <!-- omitPositions example -->
+    <fieldType name="nopositions" class="solr.TextField" omitPositions="true">
+        <analyzer>
+            <tokenizer class="solr.MockTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="location" class="solr.LatLonPointSpatialField" />
+
+    <!--
+      Example of using PathHierarchyTokenizerFactory at index time, so
+      queries for paths match documents at that path, or in descendent paths
+    -->
+    <fieldType name="path" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+    <!--
+      Example of using PathHierarchyTokenizerFactory at query time, so
+      queries for paths match documents at that path, or in ancestor paths
+    -->
+    <fieldType name="ancestor_path" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="payloadDelimited" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="integer"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- CommonGrams for phrase queries -->
+    <dynamicField name="*_commongrams" type="commongrams" />
+    <fieldType name="commongrams" class="solr.TextField" indexed="true" stored="true">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.CommonGramsFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.CommonGramsQueryFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <dynamicField name="*_commongrams_stop" type="commongrams_stop" />
+    <fieldType name="commongrams_stop" class="solr.TextField" indexed="true" stored="true">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.CommonGramsFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.CommonGramsQueryFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
+        </analyzer>
+    </fieldType>
+    <copyField source="*_commongrams" dest="*_commongrams_stop" />
+
+    <fieldType name="severityType" class="${solr.tests.EnumFieldType}" enumsConfig="enumsConfig.xml" enumName="severity"/>
+
+    <fieldType name="binary" class="solr.BinaryField" />
+    <fieldType name="collation" class="solr.CollationField" language="en" />
+    <fieldType name="externalFile" class="solr.ExternalFileField" />
+    <fieldType name="icuCollation" class="solr.ICUCollationField" locale="en" />
+    <fieldType name="latLonPointSpatial" class="solr.LatLonPointSpatialField" />
+    <fieldType name="randomSort" class="solr.RandomSortField" />
+    <fieldType name="point" class="solr.PointType" subFieldSuffix="_coordinate" />
+
+    <fieldType name="sortable_text" class="solr.SortableTextField">
+        <analyzer>
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        </analyzer>
+    </fieldType>
+
+
+    <field name="id" type="string" indexed="true" stored="${solr.tests.id.stored:true}" multiValued="false" required="false" docValues="${solr.tests.id.docValues:false}"/>
+    <field name="_root_" type="string" indexed="true" stored="false"/>
+    <field name="_nest_path_" type="_nest_path_" /><fieldType name="_nest_path_" class="solr.NestPathField"/>
+
+    <field name="signatureField" type="string" indexed="true" stored="false"/>
+    <field name="uuid" type="uuid" stored="true"/>
+    <field name="name" type="nametext" indexed="true" stored="true"/>
+    <field name="text" type="text" indexed="true" stored="false"/>
+    <field name="subject" type="text" indexed="true" stored="true"/>
+    <field name="title" type="nametext" indexed="true" stored="true"/>
+    <field name="weight" type="float" indexed="true" stored="true" multiValued="false"/>
+    <field name="bday" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="title_stemmed" type="text" indexed="true" stored="false"/>
+    <field name="title_lettertok" type="lettertok" indexed="true" stored="false"/>
+
+    <field name="syn" type="syn" indexed="true" stored="true"/>
+
+    <!-- to test property inheritance and overriding -->
+    <field name="shouldbeunstored" type="unstored"/>
+    <field name="shouldbestored" type="unstored" stored="true"/>
+    <field name="shouldbeunindexed" type="unstored" indexed="false" stored="true"/>
+
+    <!-- Test spatial PointType -->
+    <field name="home" type="xy" indexed="true" stored="true" multiValued="false"/>
+    <field name="x" type="x" indexed="true" stored="true" multiValued="false"/>
+    <field name="homed" type="xyd" indexed="true" stored="true" multiValued="false"/>
+    <field name="home_ns" type="xy" indexed="true" stored="false" multiValued="false"/>
+    <field name="work" type="xy" indexed="true" stored="true" multiValued="false"/>
+
+    <!-- Test currency -->
+    <field name="amount" type="currency" indexed="true" stored="true" multiValued="false"/>
+    <field name="mock_amount" type="mock_currency" indexed="true" stored="true"/>
+    <field name="oer_amount" type="oer_currency" indexed="true" stored="true"/>
+    <field name="amount_CFT" type="currency_CFT" indexed="true" stored="true" multiValued="false"/>
+    <field name="mock_amount_CFT" type="mock_currency_CFT" indexed="true" stored="true"/>
+    <field name="oer_amount_CFT" type="oer_currency_CFT" indexed="true" stored="true"/>
+
+    <!-- test different combinations of indexed and stored -->
+    <field name="bind" type="boolean" indexed="true" stored="false"/>
+    <field name="bsto" type="boolean" indexed="false" stored="true"/>
+    <field name="bindsto" type="boolean" indexed="true" stored="true"/>
+    <field name="isto" type="int" indexed="false" stored="true"/>
+    <field name="iind" type="int" indexed="true" stored="false"/>
+    <field name="ssto" type="string" indexed="false" stored="true"/>
+    <field name="sind" type="string" indexed="true" stored="false"/>
+    <field name="sindsto" type="string" indexed="true" stored="true"/>
+
+    <!-- test combinations of term vector settings -->
+    <field name="test_basictv" type="text" termVectors="true"/>
+    <field name="test_notv" type="text" termVectors="false"/>
+    <field name="test_postv" type="text" termVectors="true" termPositions="true"/>
+    <field name="test_offtv" type="text" termVectors="true" termOffsets="true"/>
+    <field name="test_posofftv" type="text" termVectors="true"
+           termPositions="true" termOffsets="true"/>
+    <field name="test_posoffpaytv" type="text_payload_tv" termVectors="true"
+           termPositions="true" termOffsets="true" termPayloads="true"/>
+
+    <!-- test highlit field settings -->
+    <field name="test_hlt" type="highlittext" indexed="true"/>
+    <field name="test_hlt_off" type="highlittext" indexed="true"/>
+
+    <!-- fields to test individual tokenizers and tokenfilters -->
+    <field name="teststop" type="teststop" indexed="true" stored="true"/>
+    <field name="lowertok" type="lowerfilt" indexed="true" stored="true"/>
+    <field name="keywordtok" type="keywordtok" indexed="true" stored="true"/>
+    <field name="standardtok" type="standardtok" indexed="true" stored="true"/>
+    <field name="HTMLstandardtok" type="HTMLstandardtok" indexed="true" stored="true"/>
+    <field name="lettertok" type="lettertok" indexed="true" stored="true"/>
+    <field name="whitetok" type="whitetok" indexed="true" stored="true"/>
+    <field name="HTMLwhitetok" type="HTMLwhitetok" indexed="true" stored="true"/>
+    <field name="standardtokfilt" type="standardtokfilt" indexed="true" stored="true"/>
+    <field name="standardfilt" type="standardfilt" indexed="true" stored="true"/>
+    <field name="lowerfilt" type="lowerfilt" indexed="true" stored="true"/>
+    <field name="lowerfilt1" type="lowerfilt" indexed="true" stored="true"/>
+    <field name="lowerfilt1and2" type="lowerfilt" indexed="true" stored="true"/>
+    <field name="patterntok" type="patterntok" indexed="true" stored="true"/>
+    <field name="patternreplacefilt" type="patternreplacefilt" indexed="true" stored="true"/>
+    <field name="porterfilt" type="porterfilt" indexed="true" stored="true"/>
+    <field name="engporterfilt" type="engporterfilt" indexed="true" stored="true"/>
+    <field name="custengporterfilt" type="custengporterfilt" indexed="true" stored="true"/>
+    <field name="stopfilt" type="stopfilt" indexed="true" stored="true"/>
+    <field name="custstopfilt" type="custstopfilt" indexed="true" stored="true"/>
+    <field name="lengthfilt" type="lengthfilt" indexed="true" stored="true"/>
+    <field name="dedup" type="dedup" indexed="true" stored="true"/>
+    <field name="wdf_nocase" type="wdf_nocase" indexed="true" stored="true"/>
+    <field name="wdf_preserve" type="wdf_preserve" indexed="true" stored="true"/>
+
+    <field name="numberpartfail" type="failtype1" indexed="true" stored="true"/>
+
+    <field name="nullfirst" type="string" indexed="true" stored="true" sortMissingFirst="true" multiValued="false"/>
+
+    <field name="dateRange" type="dateRange" multiValued="true"/>
+
+    <field name="cat" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="price" type="float" indexed="true" stored="true" multiValued="false"/>
+    <field name="inStock" type="boolean" indexed="true" stored="true"/>
+
+    <field name="subword" type="subword" indexed="true" stored="true"/>
+    <field name="subword_offsets" type="subword" indexed="true" stored="true" termVectors="true" termOffsets="true"/>
+    <field name="numericsubword" type="numericsubword" indexed="true" stored="true"/>
+    <field name="protectedsubword" type="protectedsubword" indexed="true" stored="true"/>
+
+    <field name="sku1" type="skutype1" indexed="true" stored="true"/>
+    <field name="sku2" type="skutype2" indexed="true" stored="true"/>
+
+    <field name="textgap" type="textgap" indexed="true" stored="true"/>
+
+    <field name="timestamp" type="date" indexed="true" stored="true" docValues="true" default="NOW" multiValued="false"/>
+    <field name="multiDefault" type="string" indexed="true" stored="true" default="muLti-Default" multiValued="true"/>
+    <field name="intDefault" type="int" indexed="true" stored="true" default="42" multiValued="false"/>
+    <field name="intDvoDefault" type="int" indexed="false" stored="false" multiValued="false"
+           useDocValuesAsStored="true" docValues="true" default="42" />
+    <field name="intRemove" type="int" indexed="true" stored="true" multiValued="true"/>
+    <field name="dateRemove" type="date" indexed="true" stored="true" multiValued="true"/>
+    <field name="floatRemove" type="float" indexed="true" stored="true" multiValued="true"/>
+
+    <field name="binaryRemove" type="binary" indexed="true" stored="true" multiValued="true"/>
+    <field name="booleanRemove" type="boolean" indexed="true" stored="true" multiValued="true"/>
+    <field name="collationRemove" type="collation" indexed="true" stored="true" multiValued="true"/>
+    <field name="datePointRemove" type="pdate" indexed="true" stored="true" multiValued="true"/>
+    <field name="dateRangeRemove" type="dateRange" indexed="true" stored="true" multiValued="true"/>
+    <field name="doublePointRemove" type="pdouble" indexed="true" stored="true" multiValued="true"/>
+    <field name="externalFileRemove" type="externalFile" indexed="true" stored="true" multiValued="true"/>
+    <field name="floatPointRemove" type="pfloat" indexed="true" stored="true" multiValued="true"/>
+    <field name="icuCollationRemove" type="icuCollation" indexed="true" stored="true" multiValued="true"/>
+    <field name="intPointRemove" type="pint" indexed="true" stored="true" multiValued="true"/>
+    <field name="latLonPointSpatialRemove" type="latLonPointSpatial" indexed="true" stored="true" multiValued="true"/>
+    <field name="latLonRemove" type="location" indexed="true" stored="true" multiValued="true"/>
+    <field name="longPointRemove" type="plong" indexed="true" stored="true" multiValued="true"/>
+    <field name="point_0_coordinate" type="float" indexed="true" stored="true" multiValued="true"/>
+    <field name="point_1_coordinate" type="float" indexed="true" stored="true" multiValued="true"/>
+    <field name="pointRemove" type="point" indexed="true" stored="true" multiValued="true"/>
+    <field name="randomSortRemove" type="randomSort" indexed="true" stored="true" multiValued="true"/>
+    <field name="spatialRecursivePrefixTreeRemove" type="location_rpt" indexed="true" stored="true" multiValued="true"/>
+    <field name="stringRemove" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="textRemove" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="uuidRemove" type="uuid" indexed="true" stored="true" multiValued="true"/>
+
+    <field name="nopositionstext" type="nopositions" indexed="true" stored="true"/>
+
+    <field name="tlong" type="tlong" indexed="true" stored="true"/>
+    <field name="_version_" type="long" indexed="false" stored="false" docValues="true" multiValued="false" useDocValuesAsStored="true"/>
+
+    <field name="title_stringNoNorms" type="string" omitNorms="true" indexed="true" stored="true"/>
+
+    <field name="store" type="location" indexed="true" stored="true" docValues="true"/>
+
+    <field name="lower" type="lowerfilt" indexed="false" stored="true" multiValued="true"/>
+    <field name="_route_" type="string" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="payloadDelimited" type="payloadDelimited"/>
+
+    <field name="sortabuse_not_uninvertible" type="string" indexed="true" multiValued="false" uninvertible="false" />
+
+    <!-- EnumType -->
+    <field name="severity" type="severityType" docValues="true" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="max_chars" type="string" indexed="false" stored="true"/>
+    <field name="no_max_chars" type="string" indexed="false" stored="true"/>
+    <field name="large_max_chars" type="string" indexed="false" stored="true"/>
+
+    <!-- Dense Vector-->
+    <field name="vector" type="knn_vector_cosine" indexed="true" stored="true"/>
+    <field name="vector2" type="knn_vector_dot_product" indexed="true" stored="true"/>
+    <field name="vector3" type="knn_vector_cosine" indexed="true" stored="true"/>
+    <field name="vector4" type="knn_vector_cosine" indexed="true" stored="true"/>
+    <field name="vector5" type="knn_vector5" indexed="true" stored="true"/>
+
+    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
+         will be used if the name matches any of the patterns.
+         RESTRICTION: the glob-like pattern in the name attribute must have
+         a "*" only at the start or the end.
+         EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
+         Longer patterns will be matched first.  if equal size patterns
+         both match, the first appearing in the schema will be used.
+    -->
+    <dynamicField name="*_i" type="int" indexed="true" stored="true"/>
+    <dynamicField name="*_i1" type="int" indexed="true" stored="true" multiValued="false" sortMissingLast="true"/>
+    <dynamicField name="*_is" type="int" indexed="true" stored="true" multiValued="true" sortMissingLast="true"/>
+    <dynamicField name="*_idv" type="int" indexed="true" stored="true" docValues="true" multiValued="false"/>
+
+
+    <dynamicField name="*_s" type="string" indexed="true" stored="true"/>
+    <dynamicField name="*_s1" type="string" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_s1_ns" type="string" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_l" type="long" indexed="true" stored="true"/>
+    <dynamicField name="*_l1" type="long" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_l1_ns" type="long" indexed="true" stored="false" multiValued="false"/>
+    <dynamicField name="*_t" type="text" indexed="true" stored="true"/>
+    <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
+    <dynamicField name="*_b1" type="boolean" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_f" type="float" indexed="true" stored="true"/>
+    <dynamicField name="*_f1" type="float" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_d" type="double" indexed="true" stored="true"/>
+    <dynamicField name="*_d1" type="double" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_d1_dv" type="double" indexed="true" docValues="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
+    <dynamicField name="*_dt1" type="date" indexed="true" stored="true" multiValued="false"/>
+
+
+    <!-- some trie-coded dynamic fields for faster range queries -->
+    <dynamicField name="*_ti" type="tint" indexed="true" stored="true"/>
+    <dynamicField name="*_ti1" type="tint" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_tl" type="tlong" indexed="true" stored="true"/>
+    <dynamicField name="*_tl1" type="tlong" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_tf" type="tfloat" indexed="true" stored="true"/>
+    <dynamicField name="*_tf1" type="tfloat" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_td" type="tdouble" indexed="true" stored="true"/>
+    <dynamicField name="*_td1" type="tdouble" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_tds" type="tdouble" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_tdt" type="tdate" indexed="true" stored="true"/>
+    <dynamicField name="*_tdt1" type="tdate" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_tdtdv" type="tdatedv" indexed="true" stored="true"/>
+    <dynamicField name="*_tdtdv1" type="tdatedv" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_drf" type="dateRange" indexed="true" stored="true"/>
+
+    <dynamicField name="*_tdts" type="tdate" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_tdtdvs" type="tdatedv" indexed="true" stored="true"/>
+
+    <dynamicField name="*_sI" type="string" indexed="true" stored="false"/>
+    <dynamicField name="*_sS" type="string" indexed="false" stored="true"/>
+    <dynamicField name="t_*" type="text" indexed="true" stored="true"/>
+    <dynamicField name="tv_*" type="text" indexed="true" stored="true"
+                  termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="tv_mv_*" type="text" indexed="true" stored="true" multiValued="true"
+                  termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="tv_no_off_*" type="text" indexed="true" stored="true"
+                  termVectors="true" termPositions="true"/>
+
+    <dynamicField name="*_p" type="xyd" indexed="true" stored="true" multiValued="false"/>
+
+    <!-- special fields for dynamic copyField test -->
+    <dynamicField name="dynamic_*" type="string" indexed="true" stored="true"/>
+    <dynamicField name="*_dynamic" type="string" indexed="true" stored="true"/>
+
+    <!-- for testing to ensure that longer patterns are matched first -->
+    <dynamicField name="*aa" type="string" indexed="true" stored="true"/>
+    <dynamicField name="*aaa" type="int" indexed="false" stored="true"/>
+
+    <!-- ignored becuase not stored or indexed -->
+    <dynamicField name="*_ignored" type="text" indexed="false" stored="false"/>
+
+    <dynamicField name="*_mfacet" type="string" indexed="true" stored="false" multiValued="true"/>
+
+    <!-- Type used to index the  components for the "point" FieldType -->
+    <dynamicField name="*_coordinate" type="double" indexed="true" stored="false" omitNorms="true" docValues="false"/>
+
+    <dynamicField name="*_path" type="path" indexed="true" stored="true" omitNorms="true" multiValued="true"/>
+    <dynamicField name="*_ancestor" type="ancestor_path" indexed="true" stored="true" omitNorms="true"
+                  multiValued="true"/>
+
+    <dynamicField name="*_sev_enum" type="severityType" indexed="true" stored="true" docValues="true" multiValued="true"/>
+
+    <!-- With DocValues=true -->
+    <dynamicField name="*_i_dv" type="int" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_l_dv" type="long" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_f_dv" type="float" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_d_dv" type="double" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_dt_dv" type="date" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_f1_dv" type="float" indexed="true" stored="true" docValues="true" multiValued="false"/>
+
+    <!--  Non-stored, DocValues=true -->
+    <dynamicField name="*_i_dvo" multiValued="false" type="int" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_d_dvo" multiValued="false" type="double" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_s_dvo" multiValued="false" type="string" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_b_dvo" multiValued="false" type="boolean" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_l_dvo" multiValued="false" type="long" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_f_dvo" multiValued="false" type="float" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_dt_dvo" multiValued="false" type="date" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+
+    <dynamicField name="*_ii_dvo" multiValued="true" type="int" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+    <dynamicField name="*_dd_dvo" multiValued="true" type="double" docValues="true" indexed="false" stored="false"
+                  useDocValuesAsStored="true"/>
+
+    <!-- Indexed, but NOT uninvertible -->
+    <dynamicField name="*_s_not_uninvert" type="string" indexed="true" stored="false" docValues="false" uninvertible="false" />
+    <!-- docValues, but NOT uninvertible -->
+    <dynamicField name="*_s_not_uninvert_dv" type="string" indexed="true" stored="false" docValues="true" uninvertible="false" />
+
+
+
+    <!-- Only Stored numerics -->
+    <dynamicField name="*_i_os" type="int" indexed="false" stored="true" docValues="false"/>
+    <dynamicField name="*_l_os" type="long" indexed="false" stored="true" docValues="false"/>
+    <dynamicField name="*_f_os" type="float" indexed="false" stored="true" docValues="false"/>
+    <dynamicField name="*_d_os" type="double" indexed="false" stored="true" docValues="false"/>
+    <dynamicField name="*_dt_os" type="date" indexed="false" stored="true" docValues="false"/>
+
+    <!--  Non-stored, DocValues=true, useDocValuesAsStored=false -->
+    <field name="single_i_dvn" multiValued="false" type="int" indexed="true" stored="true"/>
+    <field name="single_d_dvn" multiValued="false" type="double" indexed="true" stored="true"/>
+    <field name="single_s_dvn" multiValued="false" type="string" indexed="true" stored="true"/>
+    <field name="copy_single_i_dvn" multiValued="false" type="int" docValues="true" indexed="true" stored="false"
+           useDocValuesAsStored="false"/>
+    <field name="copy_single_d_dvn" multiValued="false" type="double" docValues="true" indexed="true" stored="false"
+           useDocValuesAsStored="false"/>
+    <field name="copy_single_s_dvn" multiValued="false" type="string" docValues="true" indexed="true" stored="false"
+           useDocValuesAsStored="false"/>
+
+    <!-- Test point fields explicitly -->
+    <dynamicField name="*_i_p"      type="pint"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_is_p"      type="pint"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_i_ni_p"   type="pint"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_is_ni_p"   type="pint"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_l_p"      type="plong"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_ls_p"      type="plong"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_l_ni_p"   type="plong"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_ls_ni_p"   type="plong"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_f_p"      type="pfloat"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_fs_p"      type="pfloat"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_f_ni_p"   type="pfloat"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_fs_ni_p"   type="pfloat"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_d_p"      type="pdouble"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_ds_p"      type="pdouble"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_d_ni_p"   type="pdouble"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_ds_ni_p"   type="pdouble"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_sortable"  type="sortable_text" indexed="true" multiValued="false" stored="true" />
+
+    <dynamicField name="*_date_p"      type="pdate"    indexed="true"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_dates_p"     type="pdate"    indexed="true"  stored="true" docValues="true" multiValued="true"/>
+    <dynamicField name="*_date_ni_p"   type="pdate"    indexed="false"  stored="true" docValues="true" multiValued="false"/>
+    <dynamicField name="*_dates_ni_p"  type="pdate"    indexed="false"  stored="true" docValues="true" multiValued="true"/>
+
+    <copyField source="single_i_dvn" dest="copy_single_i_dvn"/>
+    <copyField source="single_d_dvn" dest="copy_single_d_dvn"/>
+    <copyField source="single_s_dvn" dest="copy_single_s_dvn"/>
+
+    <uniqueKey>id</uniqueKey>
+
+    <!-- copyField commands copy one field to another at the time a document
+          is added to the index.  It's used either to index the same field different
+          ways, or to add multiple fields to the same field for easier/faster searching.
+     -->
+    <copyField source="title" dest="title_stemmed"/>
+    <copyField source="title" dest="title_lettertok"/>
+    <copyField source="title" dest="title_stringNoNorms"/>
+
+    <copyField source="title" dest="text"/>
+    <copyField source="subject" dest="text"/>
+
+    <copyField source="lowerfilt1" dest="lowerfilt1and2"/>
+    <copyField source="lowerfilt" dest="lowerfilt1and2"/>
+
+    <copyField source="*" dest="text"/>
+    <copyField source="id" dest="range_facet_l"/>
+    <copyField source="id" dest="id_i1"/>
+    <copyField source="range_facet_f" dest="range_facet_d"/>
+    <copyField source="range_facet_f1" dest="range_facet_f1_dv"/>
+
+    <copyField source="id" dest="range_facet_l_dv"/>
+    <copyField source="id" dest="range_facet_i_dv"/>
+    <copyField source="range_facet_f" dest="range_facet_f_dv"/>
+    <copyField source="range_facet_f" dest="range_facet_d_dv"/>
+    <copyField source="bday" dest="range_facet_dt_dv"/>
+
+    <copyField source="trait_s" dest="trait_s_not_uninvert"/>
+    <copyField source="trait_s" dest="trait_s_not_uninvert_dv"/>
+    <copyField source="trait_s" dest="trait_s_not_indexed_sS"/>
+
+    <!-- dynamic destination -->
+    <copyField source="*_dynamic" dest="dynamic_*"/>
+    <copyField source="*_path" dest="*_ancestor"/>
+
+    <copyField source="title" dest="max_chars" maxChars="10"/>
+    <copyField source="title" dest="no_max_chars" />
+    <copyField source="title" dest="large_max_chars" maxChars="10000"/>
+    <copyField source="vector" dest="vector2"/>
+    <copyField source="vector3" dest="vector_f_p"/>
+    <copyField source="vector4" dest="vector5"/>
+
+
+    <!-- example of a custom similarity -->
+    <similarity class="solr.CustomSimilarityFactory">
+        <str name="echo">I am your default sim</str>
+    </similarity>
+</schema>

--- a/solr/core/src/test/org/apache/solr/update/DocumentBuilderVectorCatchAllCopyTest.java
+++ b/solr/core/src/test/org/apache/solr/update/DocumentBuilderVectorCatchAllCopyTest.java
@@ -31,8 +31,6 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.SolrCore;
 import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,16 +41,6 @@ public class DocumentBuilderVectorCatchAllCopyTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {
     initCore("solrconfig.xml", "schema-vector-catchall.xml");
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    DocumentBuilder.MIN_LENGTH_TO_MOVE_LAST = save_min_len;
-  }
-
-  @After
-  public void afterTest() {
-    DocumentBuilder.MIN_LENGTH_TO_MOVE_LAST = save_min_len;
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/update/DocumentBuilderVectorCatchAllCopyTest.java
+++ b/solr/core/src/test/org/apache/solr/update/DocumentBuilderVectorCatchAllCopyTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update;
+
+import static org.hamcrest.core.Is.is;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.core.SolrCore;
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** */
+public class DocumentBuilderVectorCatchAllCopyTest extends SolrTestCaseJ4 {
+  static final int save_min_len = DocumentBuilder.MIN_LENGTH_TO_MOVE_LAST;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig.xml", "schema-vector-catchall.xml");
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    DocumentBuilder.MIN_LENGTH_TO_MOVE_LAST = save_min_len;
+  }
+
+  @After
+  public void afterTest() {
+    DocumentBuilder.MIN_LENGTH_TO_MOVE_LAST = save_min_len;
+  }
+
+  @Test
+  public void denseVector_shouldWorkWithCatchAllCopyFields() {
+    SolrCore core = h.getCore();
+
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.addField("id", "0");
+    doc.addField("cat", "hello world");
+    doc.addField("vector", Arrays.asList(1.1f, 2.1f, 3.1f, 4.1f));
+
+    Document out = DocumentBuilder.toDocument(doc, core.getLatestSchema());
+
+    // from /solr/core/src/test-files/solr/collection1/conf/schema.xml
+    KnnVectorField expectedDestination =
+        new KnnVectorField(
+            "vector2", new float[] {1.1f, 2.1f, 3.1f, 4.1f}, VectorSimilarityFunction.DOT_PRODUCT);
+
+    MatcherAssert.assertThat(
+        ((KnnFloatVectorField) out.getField("vector2")).vectorValue(),
+        is(expectedDestination.vectorValue()));
+
+    List<IndexableField> storedFields =
+        StreamSupport.stream(out.spliterator(), false)
+            .filter(f -> (f.fieldType().stored() && f.name().equals("vector2")))
+            .collect(Collectors.toList());
+    MatcherAssert.assertThat(storedFields.size(), is(4));
+
+    MatcherAssert.assertThat(storedFields.get(0).numericValue(), is(1.1f));
+    MatcherAssert.assertThat(storedFields.get(1).numericValue(), is(2.1f));
+    MatcherAssert.assertThat(storedFields.get(2).numericValue(), is(3.1f));
+    MatcherAssert.assertThat(storedFields.get(3).numericValue(), is(4.1f));
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16807

Currently if you setup a copy field with a * source and a DenseVectorField is present in the schema indexing will fail unless the destination is a DenseVectorField. I think the better behavior is to skip the DenseVectorField during the copy. If we don't do this the * copyfield is simply broken with a DenseVectorField in the index.

This PR resolves the issue while preserving the exception in the cases where the copyField source is not *. The PR skips adding the DenseVectorField to a destination field of a different type if the source for the copyField is *.

A * source copyField was added to an existing DenseVectorField test schema, which passes. An existing test (org.apache.solr.update.DocumentBuilderTest.denseVector_incorrectCopyFieldDestinationType_shouldThrowException)  passes, which proves non * source copyFields still throw an exception as expected when DenseVectorFields are copied to non-DenseVectorFields