### PR TITLE
SOLR-16823: mark as deprecated the bin/solr zk -upconfig equivalents of bin/solr zk upconfig

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1339,6 +1339,7 @@ if [[ "$SCRIPT_CMD" == "zk" ]]; then
       case "${1:-}" in
         -upconfig|upconfig|-downconfig|downconfig|cp|rm|mv|ls|mkroot)
             if [ "${1:0:1}" == "-" ]; then
+              echo "The use of $1 is deprecated.   Please use ${1:1} instead."
               ZK_OP=${1:1}
             else
               ZK_OP=$1


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16823
# Description
echo out to users that -upconfig should be upconfig for the various zk commands.

# Solution
I will commit and backport to 9x, and remove the support from main.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
