### PR TITLE
SOLR-16823: remove the old backcompat formats for bin/solr zk -upconfig and -downconfig

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -33,6 +33,8 @@ Deprecation Removals
 
 * SOLR-16661: Removed deprecated 'analytics' component (janhoy)
 
+* SOLR-16823: Remove backcompatiblity of -upconfig and -downconfig for bin/solr zk upconfig and downconfig commands.  (Eric Pugh)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -569,9 +569,9 @@ function print_usage() {
     echo ""
     echo "             -V/-verbose        Enable more verbose output for this script."
     echo ""
-    echo "         upconfig uploads a configset from the local machine to Zookeeper. (Backcompat: -upconfig)"
+    echo "         upconfig uploads a configset from the local machine to Zookeeper."
     echo ""
-    echo "         downconfig downloads a configset from Zookeeper to the local machine. (Backcompat: -downconfig)"
+    echo "         downconfig downloads a configset from Zookeeper to the local machine."
     echo ""
     echo "             -n <configName>    Name of the configset in Zookeeper that will be the destination of"
     echo "                                  'upconfig' and the source for 'downconfig'."
@@ -1337,15 +1337,6 @@ if [[ "$SCRIPT_CMD" == "zk" ]]; then
   if [ $# -gt 0 ]; then
     while true; do
       case "${1:-}" in
-        -upconfig|upconfig|-downconfig|downconfig|cp|rm|mv|ls|mkroot)
-            if [ "${1:0:1}" == "-" ]; then
-              echo "The use of $1 is deprecated.   Please use ${1:1} instead."
-              ZK_OP=${1:1}
-            else
-              ZK_OP=$1
-            fi
-            shift 1
-        ;;
         -z|-zkhost|-zkHost)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
               print_short_zk_usage "$SCRIPT_CMD" "ZooKeeper connection string is required when using the $1 option!"

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1337,6 +1337,10 @@ if [[ "$SCRIPT_CMD" == "zk" ]]; then
   if [ $# -gt 0 ]; then
     while true; do
       case "${1:-}" in
+        upconfig|downconfig|cp|rm|mv|ls|mkroot)
+            ZK_OP=$1
+            shift 1
+        ;;      
         -z|-zkhost|-zkHost)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
               print_short_zk_usage "$SCRIPT_CMD" "ZooKeeper connection string is required when using the $1 option!"

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -550,9 +550,9 @@ echo                             overrides the 'ZK_HOST=...'' defined in solr.in
 echo.
 echo             -V              Enable more verbose output.
 echo.
-echo         upconfig uploads a configset from the local machine to Zookeeper. (Backcompat: -upconfig)
+echo         upconfig uploads a configset from the local machine to Zookeeper.
 echo.
-echo         downconfig downloads a configset from Zookeeper to the local machine. (Backcompat: -downconfig)
+echo         downconfig downloads a configset from Zookeeper to the local machine.
 echo.
 echo             -n configName   Name of the configset in Zookeeper that will be the destination of
 echo                             'upconfig' and the source for 'downconfig'.
@@ -1769,13 +1769,9 @@ goto done
 
 REM Clumsy to do the state machine thing for -d and -n, but that's required for back-compat
 :parse_zk_args
-IF "%1"=="-upconfig" (
-  goto set_zk_op
-) ELSE IF "%1"=="-V" (
+IF "%1"=="-V" (
   goto set_zk_verbose
 ) ELSE IF "%1"=="upconfig" (
-  goto set_zk_op
-) ELSE IF "%1"=="-downconfig" (
   goto set_zk_op
 ) ELSE IF "%1"=="downconfig" (
   goto set_zk_op
@@ -1877,13 +1873,6 @@ IF "!ZK_OP!"=="" (
 IF "!ZK_HOST!"=="" (
   set "ERROR_MSG=Must specify -z zkHost"
   goto zk_short_usage
-)
-
-IF "!ZK_OP!"=="-upconfig" (
-  set ZK_OP="upconfig"
-)
-IF "!ZK_OP!"=="-downconfig" (
-  set ZK_OP="downconfig"
 )
 
 IF "!ZK_OP!"=="upconfig" (


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16823


# Description

Remove the bin/solr and bin/solr.cmd zk -upconfig and -downconfig special handling in favour of the standard bin/solr zk upconfig and bin/solr zk downconfig commands.

# Solution

Remove special handling logic.  This is only meant to be committed to `main`.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
