### PR TITLE
Fix lib names in analysis-extras module README.md

### DIFF
--- a/solr/modules/analysis-extras/README.md
+++ b/solr/modules/analysis-extras/README.md
@@ -29,15 +29,15 @@ lemmatization, phrase chunking, and named-entity recognition.
 Each of the jars below relies upon including `/modules/analysis-extras/lib/solr-analysis-extras-X.Y.Z.jar`
 in the `solrconfig.xml`
 
-* ICU relies upon `lib/lucene-analyzers-icu-X.Y.jar`
+* ICU relies upon `lib/lucene-analysis-icu-X.Y.jar`
 and `lib/icu4j-X.Y.jar`
 
-* Smartcn relies upon `lib/lucene-analyzers-smartcn-X.Y.jar`
+* Smartcn relies upon `lib/lucene-analysis-smartcn-X.Y.jar`
 
-* Stempel relies on `lib/lucene-analyzers-stempel-X.Y.jar`
+* Stempel relies on `lib/lucene-analysis-stempel-X.Y.jar`
 
-* Morfologik relies on `lib/lucene-analyzers-morfologik-X.Y.jar`
+* Morfologik relies on `lib/lucene-analysis-morfologik-X.Y.jar`
 and `lib/morfologik-*.jar`
 
-* OpenNLP relies on `lib/lucene-analyzers-opennlp-X.Y.jar`
+* OpenNLP relies on `lib/lucene-analysis-opennlp-X.Y.jar`
 and `lib/opennlp-*.jar`


### PR DESCRIPTION
Not creating a JIRA issue, since this is something minor that wouldn't make it into release notes.

# Description

It seems like the lucene-analyzers .jar files were renamed at somepoint, and the README docs are out-of-date.

```
solr@2bbdbb1f5b80:/opt/solr/modules/analysis-extras/lib$ ls
icu4j-70.1.jar                        lucene-analysis-smartcn-9.4.2.jar  morfologik-stemming-2.1.9.jar
lucene-analysis-icu-9.4.2.jar         lucene-analysis-stempel-9.4.2.jar  morfologik-ukrainian-search-4.9.1.jar
lucene-analysis-morfologik-9.4.2.jar  morfologik-fsa-2.1.9.jar           opennlp-tools-1.9.4.jar
lucene-analysis-opennlp-9.4.2.jar     morfologik-polish-2.1.9.jar        solr-analysis-extras-9.2.1.jar
```

They _used_ to be called `lucene-analyzers-*`, but are now `lucene-analysis-*`.

# Solution

I updated the names in the README.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
    - Skipped since minor
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [NA] I have run `./gradlew check`.
- [NA] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
