### PR TITLE
SOLR-16842: Experiment with removing version as a official Tool

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -342,7 +342,7 @@ function print_usage() {
   if [ -z "${CMD:-}" ]; then
     echo ""
     echo "Usage: solr COMMAND OPTIONS"
-    echo "       where COMMAND is one of: start, stop, restart, status, healthcheck, create, create_core, create_collection, delete, version, zk, auth, assert, config, export, api, package"
+    echo "       where COMMAND is one of: start, stop, restart, status, healthcheck, create, create_core, create_collection, delete, zk, auth, assert, config, export, api, package"
     echo ""
     echo "  Standalone server example (start Solr running in the background on port 8984):"
     echo ""
@@ -941,8 +941,9 @@ if [ $# -eq 1 ]; then
         print_usage ""
         exit
     ;;
-    -version|-v|version)
-        run_tool version
+    -version|-v)
+        # Pass in -version as the first parameter to SolrCLI to get version information back
+        run_tool -version
         exit
     ;;
   esac

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -229,7 +229,6 @@ IF "%1"=="-h" goto usage
 IF "%1"=="--help" goto usage
 IF "%1"=="/?" goto usage
 IF "%1"=="status" goto get_status
-IF "%1"=="version" goto get_version
 IF "%1"=="-v" goto get_version
 IF "%1"=="-version" goto get_version
 IF "%1"=="assert" goto run_solrcli
@@ -312,7 +311,7 @@ goto done
 :script_usage
 @echo.
 @echo Usage: solr COMMAND OPTIONS
-@echo        where COMMAND is one of: start, stop, restart, status, healthcheck, create, create_core, create_collection, delete, version, zk, auth, assert, config, export, api, package
+@echo        where COMMAND is one of: start, stop, restart, status, healthcheck, create, create_core, create_collection, delete, zk, auth, assert, config, export, api, package
 @echo.
 @echo   Standalone server example (start Solr running in the background on port 8984):
 @echo.
@@ -1578,7 +1577,7 @@ goto done
 "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
   -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
   -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-  org.apache.solr.cli.SolrCLI version
+  org.apache.solr.cli.SolrCLI -version
 goto done
 
 :parse_create_args

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -137,12 +137,9 @@ public class SolrCLI implements CLIO {
       exit(1);
     }
 
-    if (Arrays.asList("-v", "-version", "version").contains(args[0])) {
-      // Simple version tool, no need for its own class
-      if (args.length != 1) {
-        CLIO.err("Version tool does not accept any parameters!");
-      }
-      CLIO.out("Solr version is: " + SolrVersion.LATEST.toString());
+    if (Arrays.asList("-v", "-version").contains(args[0])) {
+      // Output the version of Solr
+      CLIO.out("Solr version is: " + SolrVersion.LATEST);
       exit(0);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16842

# Description

this removes `bin/solr version` but preserves `bin/solr -v` and `bin/solr -version`.   This I think makes things more consistent...  If the version tool did something more then put out the specific version ,then maybe I'd want to keep it...  As is, we don't actually have a VersionTool or any tests for it..

# Solution

Remove it as a official tool, but preserve the -v and -version commands.

# Tests

manual.

I am hoping @Willdotwhite will run the `bin/solr.cmd` versions of the commands and confirm my edits worked!

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
