### PR TITLE
SOLR-16812: Support toggling STRREF feature. 

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/loader/CborLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/CborLoader.java
@@ -127,7 +127,7 @@ public class CborLoader {
   }
 
   public static ContentStreamLoader createLoader(SolrParams p) {
-    CBORFactory factory = new CBORFactory();
+    CBORFactory factory = CBORFactory.builder().enable(CBORGenerator.Feature.STRINGREF).build();
     return new ContentStreamLoader() {
       @Override
       public void load(

--- a/solr/core/src/java/org/apache/solr/response/CborResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/CborResponseWriter.java
@@ -32,15 +32,19 @@ import org.apache.solr.request.SolrQueryRequest;
  */
 public class CborResponseWriter extends BinaryResponseWriter {
   final CBORFactory cborFactory;
+  final CBORFactory cborFactoryCompact;
 
   public CborResponseWriter() {
-    cborFactory = CBORFactory.builder().enable(CBORGenerator.Feature.STRINGREF).build();
+    cborFactoryCompact = CBORFactory.builder().enable(CBORGenerator.Feature.STRINGREF).build();
+    cborFactory = CBORFactory.builder().build();
   }
 
   @Override
   public void write(OutputStream out, SolrQueryRequest req, SolrQueryResponse response)
       throws IOException {
-    WriterImpl writer = new WriterImpl(cborFactory, out, req, response);
+    boolean useStringRef = req.getParams().getBool("string_ref", true);
+    WriterImpl writer =
+        new WriterImpl(useStringRef ? cborFactoryCompact : cborFactory, out, req, response);
     writer.writeResponse();
     writer.gen.flush();
   }

--- a/solr/solr-ref-guide/modules/query-guide/pages/response-writers.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/response-writers.adoc
@@ -397,7 +397,9 @@ MA147LL/A,"electronics,music",Apple 60 GB iPod with Video Playback Black,10,399.
 
 == CBOR Response Writer
 
-Solr supports CBOR format which is more compact and fast.
+Solr supports CBOR response format which is more compact and fast. Use the `wt=cbor` parameter to get responses in CBOR.
+
+If your client does not support the STRINGREF feature of CBOR, use `wt=cbor&str_ref=false`
 
 === Example Python program
 


### PR DESCRIPTION
Support toggling STRREF feature. It's a relatively new feature and it may not be supported on all platforms

A new boolean parameter `string_ref` is introduced. The default is true. use `string_ref=false` to toggle it to false