### PR TITLE
SOLR-16861: Correct(override) MDC info for `CoordinatorHttpSolrCall`

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -124,7 +124,6 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
   /**
    * Overrides the MDC context as the core set was synthetic core, which does not reflect the
    * collection being operated on
-   *
    */
   private static void setMDCLoggingContext(String collectionName) {
     MDCLoggingContext.setCollection(collectionName);

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -125,7 +125,6 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
    * Overrides the MDC context as the core set was synthetic core, which does not reflect the
    * collection being operated on
    *
-   * @param collectionName
    */
   private static void setMDCLoggingContext(String collectionName) {
     MDCLoggingContext.setCollection(collectionName);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16861

# Description

In Coordinator node, the `MDCLoggingContext` has the synthetic core info set while processing core requests, therefore log prints collection/shard/replica of the synthetic collection/core info.

It should instead have the collection it queries on set.

# Solution

Set the collection name in the `MDCLoggingContext` when `SolrCore` is obtained via `CoordinatorHttpSolrCall#getCore`

# Tests

Tested with log4j2.xml format on coordinator node to confirm the log has correct collection name tagged to it

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
