### PR TITLE
SOLR-16860: Remove collection -> synthetic core mapping in Coordinator Node upon collection deletion

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -271,6 +271,8 @@ Bug Fixes
 
 * SOLR-16809: The configuration for hiding sensitive sysProp information has been joined under `-Dsolr.hiddenSysProps` and `SOLR_HIDDEN_SYS_PROPS`. (Houston Putman, David Smiley)
 
+* SOLR-16860: Remove watch and synthetic core mapping from Coordinator node upon collection deletion. (Patson Luk)
+
 Dependency Upgrades
 ---------------------
 * PR#1494: Upgrade forbiddenapis to 3.5 (Uwe Schindler)

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -105,7 +105,16 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
               .cores
               .getZkController()
               .getZkStateReader()
-              .registerDocCollectionWatcher(collectionName, collection -> collection == null);
+              .registerDocCollectionWatcher(
+                  collectionName,
+                  collection -> {
+                    if (collection == null) {
+                      factory.collectionVsCoreNameMapping.remove(collectionName);
+                      return true;
+                    } else {
+                      return false;
+                    }
+                  });
           if (log.isDebugEnabled()) {
             log.debug("coordinator node, returns synthetic core: {}", core.getName());
           }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16860

# Description

Similar to #1752 , the mapping of collection -> synthetic core should be removed from Coordinator Node upon collection deletion. Otherwise query to such deleted collection would not throw `SolrException` of `Collection not found`.

# Solution

Remove the collection from `collectionVsCoreNameMapping` on zk notification on collection removal

# Tests

Added extra test condition in `AddWatch`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
