### PR TITLE
SOLR-16877: Update BackupManager.java to prevent NPE on empty zk node

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/backup/BackupManager.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/BackupManager.java
@@ -345,6 +345,10 @@ public class BackupManager {
           log.debug("Writing file {}", filePath);
           // ConfigSetService#downloadFileFromConfig requires '/' in fle path separator
           byte[] data = configSetService.downloadFileFromConfig(configName, filePath);
+          // replace empty zk node (data==null) with empty array
+          if (data == null) {
+            data = new byte[0];
+          }
           try (OutputStream os = repository.createOutput(uri)) {
             os.write(data);
           }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/SolrZkClient.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/SolrZkClient.java
@@ -453,6 +453,9 @@ public class SolrZkClient implements Closeable {
     metrics.reads.increment();
     if (result != null) {
       metrics.bytesRead.add(result.length);
+    } else {
+      // prevent NPE with empty zk node
+      result = new byte[0];
     }
     return result;
   }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/SolrZkClient.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/SolrZkClient.java
@@ -453,9 +453,6 @@ public class SolrZkClient implements Closeable {
     metrics.reads.increment();
     if (result != null) {
       metrics.bytesRead.add(result.length);
-    } else {
-      // prevent NPE with empty zk node
-      result = new byte[0];
     }
     return result;
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16877

# Description

Prevent NPE upon trying to write empty zk node to file.

# Solution

ConfigSetService.downloadFileFromConfig is allowed to return null (I reverted my first approach to prevent this return of null). With latest approach, BackupManager.downloadConfigToRepo(...) is updated to detect data==null and replace it by an empty byte[].

# Tests

No tests added. Only functional test executed.

# Checklist

Please review the following and check all that apply:

- [ x ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ x ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ x ] I have developed this patch against the `main` branch.
- [ x ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
