### PR TITLE
SOLR-16507: SplitShardCmd shouldn't use NodeStateProvider

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -257,6 +257,8 @@ Other Changes
 
 * SOLR-16715: Replace new HashMap(int) and new HashSet(int) with CollectionUtil.newHashMap / CollectionUtil.newHashSet (Kevin Risden)
 
+* SOLR-16507: Change SplitShardCmd to not use NodeStateProvider (Vinayak Hegde, David Smiley)
+
 * SOLR-15703: replace all SolrException.log usage in Solr to just call log.error(...) directly (Kevin Risden)
 
 * SOLR-16604: Use Solr Client Builders directly in unit tests instead of delegating to SolrTestCaseJ4. (Eric Pugh, David Smiley)


### PR DESCRIPTION
Back-porting SOLR-16507 to 9x.  SplitShardCmd is then identical to main branch.  main CHANGES.txt already has this, including CHANGES.txt in the 9.3 section.