### PR TITLE
SOLR-16871: Fix for duplicated replica added from first coordinator node

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -124,17 +124,18 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
             }
           }
         }
-        synchronized(CoordinatorHttpSolrCall.class) {
-          //get docCollection again to ensure we get the fresh state
-          syntheticColl = zkStateReader.getClusterState().getCollectionOrNull(syntheticCollectionName);
+        synchronized (CoordinatorHttpSolrCall.class) {
+          // get docCollection again to ensure we get the fresh state
+          syntheticColl =
+              zkStateReader.getClusterState().getCollectionOrNull(syntheticCollectionName);
           List<Replica> nodeNameSyntheticReplicas =
-                  syntheticColl.getReplicas(solrCall.cores.getZkController().getNodeName());
+              syntheticColl.getReplicas(solrCall.cores.getZkController().getNodeName());
           if (nodeNameSyntheticReplicas == null || nodeNameSyntheticReplicas.isEmpty()) {
             // this node does not have a replica. add one
             if (log.isInfoEnabled()) {
               log.info(
-                      "this node does not have a replica of the synthetic collection: {} , adding replica ",
-                      syntheticCollectionName);
+                  "this node does not have a replica of the synthetic collection: {} , adding replica ",
+                  syntheticCollectionName);
             }
 
             addReplica(syntheticCollectionName, solrCall.cores);
@@ -145,25 +146,25 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
           // hence creating a calling loop
           try {
             zkStateReader.waitForState(
-                    syntheticCollectionName,
-                    10,
-                    TimeUnit.SECONDS,
-                    docCollection -> {
-                      for (Replica nodeNameSyntheticReplica :
-                              docCollection.getReplicas(solrCall.cores.getZkController().getNodeName())) {
-                        if (nodeNameSyntheticReplica.getState() == Replica.State.ACTIVE) {
-                          return true;
-                        }
-                      }
-                      return false;
-                    });
+                syntheticCollectionName,
+                10,
+                TimeUnit.SECONDS,
+                docCollection -> {
+                  for (Replica nodeNameSyntheticReplica :
+                      docCollection.getReplicas(solrCall.cores.getZkController().getNodeName())) {
+                    if (nodeNameSyntheticReplica.getState() == Replica.State.ACTIVE) {
+                      return true;
+                    }
+                  }
+                  return false;
+                });
           } catch (Exception e) {
             throw new SolrException(
-                    SolrException.ErrorCode.SERVER_ERROR,
-                    "Failed to wait for active replica for synthetic collection ["
-                            + syntheticCollectionName
-                            + "]",
-                    e);
+                SolrException.ErrorCode.SERVER_ERROR,
+                "Failed to wait for active replica for synthetic collection ["
+                    + syntheticCollectionName
+                    + "]",
+                e);
           }
         }
 

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -124,42 +124,47 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
             }
           }
         }
-        List<Replica> nodeNameSyntheticReplicas =
-            syntheticColl.getReplicas(solrCall.cores.getZkController().getNodeName());
-        if (nodeNameSyntheticReplicas == null || nodeNameSyntheticReplicas.isEmpty()) {
-          // this node does not have a replica. add one
-          if (log.isInfoEnabled()) {
-            log.info(
-                "this node does not have a replica of the synthetic collection: {} , adding replica ",
-                syntheticCollectionName);
+        synchronized(CoordinatorHttpSolrCall.class) {
+          //get docCollection again to ensure we get the fresh state
+          syntheticColl = zkStateReader.getClusterState().getCollectionOrNull(syntheticCollectionName);
+          List<Replica> nodeNameSyntheticReplicas =
+                  syntheticColl.getReplicas(solrCall.cores.getZkController().getNodeName());
+          if (nodeNameSyntheticReplicas == null || nodeNameSyntheticReplicas.isEmpty()) {
+            // this node does not have a replica. add one
+            if (log.isInfoEnabled()) {
+              log.info(
+                      "this node does not have a replica of the synthetic collection: {} , adding replica ",
+                      syntheticCollectionName);
+            }
+
+            addReplica(syntheticCollectionName, solrCall.cores);
           }
 
-          addReplica(syntheticCollectionName, solrCall.cores);
-        }
-        // still have to ensure that it's active, otherwise super.getCoreByCollection
-        // will return null and then CoordinatorHttpSolrCall will call getCore again
-        // hence creating a calling loop
-        try {
-          zkStateReader.waitForState(
-              syntheticCollectionName,
-              10,
-              TimeUnit.SECONDS,
-              docCollection -> {
-                for (Replica nodeNameSyntheticReplica :
-                    docCollection.getReplicas(solrCall.cores.getZkController().getNodeName())) {
-                  if (nodeNameSyntheticReplica.getState() == Replica.State.ACTIVE) {
-                    return true;
-                  }
-                }
-                return false;
-              });
-        } catch (Exception e) {
-          throw new SolrException(
-              SolrException.ErrorCode.SERVER_ERROR,
-              "Failed to wait for active replica for synthetic collection ["
-                  + syntheticCollectionName
-                  + "]",
-              e);
+          // still have to ensure that it's active, otherwise super.getCoreByCollection
+          // will return null and then CoordinatorHttpSolrCall will call getCore again
+          // hence creating a calling loop
+          try {
+            zkStateReader.waitForState(
+                    syntheticCollectionName,
+                    10,
+                    TimeUnit.SECONDS,
+                    docCollection -> {
+                      for (Replica nodeNameSyntheticReplica :
+                              docCollection.getReplicas(solrCall.cores.getZkController().getNodeName())) {
+                        if (nodeNameSyntheticReplica.getState() == Replica.State.ACTIVE) {
+                          return true;
+                        }
+                      }
+                      return false;
+                    });
+          } catch (Exception e) {
+            throw new SolrException(
+                    SolrException.ErrorCode.SERVER_ERROR,
+                    "Failed to wait for active replica for synthetic collection ["
+                            + syntheticCollectionName
+                            + "]",
+                    e);
+          }
         }
 
         core = solrCall.getCoreByCollection(syntheticCollectionName, isPreferLeader);
@@ -212,12 +217,9 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
   private static void addReplica(String syntheticCollectionName, CoreContainer cores) {
     SolrQueryResponse rsp = new SolrQueryResponse();
     try {
-      String coreName =
-          syntheticCollectionName + "_" + cores.getZkController().getNodeName().replace(':', '_');
       CollectionAdminRequest.AddReplica addReplicaRequest =
           CollectionAdminRequest.addReplicaToShard(syntheticCollectionName, "shard1")
               // we are fixing the name, so that no two replicas are created in the same node
-              .setCoreName(coreName)
               .setNode(cores.getZkController().getNodeName());
       addReplicaRequest.setWaitForFinalState(true);
       cores
@@ -228,18 +230,6 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
             SolrException.ErrorCode.SERVER_ERROR,
             "Could not auto-create collection: " + Utils.toJSONString(rsp.getValues()));
       }
-    } catch (SolrException e) {
-      if (e.getMessage().contains("replica with the same core name already exists")) {
-        // another request has already created a replica for this synthetic collection
-        if (log.isInfoEnabled()) {
-          log.info(
-              "A replica is already created in this node for synthetic collection: {}",
-              syntheticCollectionName);
-        }
-        return;
-      }
-      throw e;
-
     } catch (Exception e) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16871

# Description

PR https://github.com/apache/solr/pull/1762 fixes various race condition for coordinator node. One of the fixes restricts the name of the synthetic core to ensure at most 1 core is created per coordinator node.

Unfortunately unit test cases failed because it could still add 2 cores for the first coordinator node (1st from collection creation with default naming scheme, and then 2nd from addReplica call with a different name)

For example this is the list of replicas on a failed run of `TestCoordinatorRole#testConcurrentAccess` which is supposed to only create 4 cores, one of each for the 4 coordinator nodes:

```
core_node2:{
  "core":".sys.COORDINATOR-COLL-conf_shard1_replica_n1",
  "leader":"true",
  "node_name":"127.0.0.1:49656_solr",
  "base_url":"https://127.0.0.1:49656/solr",
  "state":"active",
  "type":"NRT",
  "force_set_state":"false"}, 
core_node3:{
  "node_name":"127.0.0.1:49656_solr",
  "base_url":"https://127.0.0.1:49656/solr",
  "core":".sys.COORDINATOR-COLL-conf_127.0.0.1_49656_solr",
  "state":"active",
  "type":"NRT",
  "force_set_state":"false"}, 
core_node4:{
  "node_name":"127.0.0.1:49647_solr",
  "base_url":"https://127.0.0.1:49647/solr",
  "core":".sys.COORDINATOR-COLL-conf_127.0.0.1_49647_solr",
  "state":"active",
  "type":"NRT",
  "force_set_state":"false"}, 
core_node5:{
  "node_name":"127.0.0.1:49650_solr",
  "base_url":"https://127.0.0.1:49650/solr",
  "core":".sys.COORDINATOR-COLL-conf_127.0.0.1_49650_solr",
  "state":"active",
  "type":"NRT",
  "force_set_state":"false"}, 
core_node6:{
  "node_name":"127.0.0.1:49653_solr",
  "base_url":"https://127.0.0.1:49653/solr",
  "core":".sys.COORDINATOR-COLL-conf_127.0.0.1_49653_solr",
  "state":"active",
  "type":"NRT",
  "force_set_state":"false"}]
```



# Solution

Instead of restricting the core name, which is hard to get it right, perhaps we can synchronize the replica block. This block should be rarely called - only once per collection on first query after node start, and the replica creation is even less frequent - only very first time on a coordinator node that encounters a new config. So I think it's probably better to simply synchronize the block.

# Tests

Re-ran the test cases 10 times and ensure that they all passed
`./gradlew :solr:core:beast -Ptests.dups=10 --tests "org.apache.solr.search.TestCoordinatorRole.testConcurrentAccess"`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
