### PR TITLE
SOLR-16898: Remove a println statement from JSONTestUtil

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/JSONTestUtil.java
+++ b/solr/test-framework/src/java/org/apache/solr/JSONTestUtil.java
@@ -77,7 +77,6 @@ public class JSONTestUtil {
     int pos = pathAndExpected.indexOf("==");
     String path = pos >= 0 ? pathAndExpected.substring(0, pos) : null;
     String expected = pos >= 0 ? pathAndExpected.substring(pos + 2) : pathAndExpected;
-    System.out.println("IN-PUT: " + input);
     return match(path, input, expected, delta);
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16898

# Description

It's found that a possibly debug statement https://github.com/apache/solr/commit/e5ca599f51f859834efde2e190ba1e3f17cbb4b1#diff-1098b7bd3712859836c1915cc5af5190782fb27183e5750d4bbf1d2d3e229c92R80 creates a large amount of log for our test case in https://github.com/cowpaths/fullstory-solr/actions/runs/5591120540/jobs/10221763319 and caused GC limit exception hence test failure

# Solution

We should remove such println assuming that's leftover from debugging

# Tests

No new tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
