### PR TITLE
SOLR-16842: Remove reference to PostTool for branch_9x

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -240,7 +240,6 @@ public class SolrCLI implements CLIO {
     else if ("auth".equals(toolType)) return new AuthTool();
     else if ("export".equals(toolType)) return new ExportTool();
     else if ("package".equals(toolType)) return new PackageTool();
-    else if ("post".equals(toolType)) return new PostTool();
     else if ("version".equals(toolType)) return new VersionTool();
 
     // If you add a built-in tool to this class, add it here to avoid


### PR DESCRIPTION
# Description

A merge from master to branch_9x includes reference to `PostTool` which is not available in 9x

Details in https://github.com/apache/solr/pull/1784#issuecomment-1642461497

# Solution

Removed the reference to `PostTool`. This branch is based on branch_9x

