### PR TITLE
Fix a typo in move-replica API documentation

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/replica-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/replica-management.adoc
@@ -339,7 +339,7 @@ http://localhost:8983/solr/admin/collections?action=MOVEREPLICA&collection=test&
 
 [source,bash]
 ----
-curl -X POST http://localhost:8983/api/collections/techproducts/shards -H 'Content-Type: application/json' -d '
+curl -X POST http://localhost:8983/api/collections/techproducts -H 'Content-Type: application/json' -d '
   {
     "move-replica":{
       "replica":"core_node6",


### PR DESCRIPTION
Fixed path in move-replica API (v2) documentation.