### PR TITLE
SOLR-16901: Fix gradle workflow for non-signed official images

### DIFF
--- a/solr/distribution/build.gradle
+++ b/solr/distribution/build.gradle
@@ -59,7 +59,7 @@ configurations {
 
 dependencies {
   changesHtml project(path: ":solr:documentation", configuration: "changesHtml")
-  docker project(path: ':solr:docker', configuration: project.ext.withSignedArtifacts ? 'packagingOfficial' : 'packagingLocal')
+  docker project(path: ':solr:docker', configuration: 'packagingOfficial')
 }
 
 def fullDistTarTask = rootProject.getTasksByName("fullDistTar", true)[0]
@@ -126,7 +126,7 @@ task assembleRelease(type: Sync) {
   })
 
   from(configurations.docker, {
-    include 'Dockerfile.*'
+    include 'Dockerfile.official*'
     into "docker"
   })
 

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -471,13 +471,19 @@ if (''.equals(releaseGpgFingerprint)) {
 
           // *NOW* we can actually run our docker build command...
           logger.lifecycle('Running docker build on Dockerfile.official...');
+          def downloadHost = "mock-downloads.apache.org"
+          // We are not signing, so do not use an apache.org host, as that will check the
+          // GPG signature, which will not be created.
+          if (!project(":solr:distribution").ext.withSignedArtifacts) {
+            downloadHost = "mock-downloads.test.org"
+          }
           exec {
             standardInput = file("${dockerfilesDirPath}/Dockerfile.official-${lowerVariant}").newDataInputStream()
             commandLine 'docker', 'build',
-                '--add-host', "mock-downloads.apache.org:${mockServerIp}",
+                '--add-host', "${downloadHost}:${mockServerIp}",
                 '--no-cache', // force fresh downloads from our current network
                 "--iidfile", imageIdFileOfficial(variant),
-                '--build-arg', "SOLR_DOWNLOAD_SERVER=http://mock-downloads.apache.org:9876",
+                '--build-arg', "SOLR_DOWNLOAD_SERVER=http://${downloadHost}:9876",
                 '--tag', officialDockerImageName(variant),
                 '-'
           }


### PR DESCRIPTION
[SOLR-16901](https://issues.apache.org/jira/browse/SOLR-16901)

Testing:

```
$ ./gradlew assembleRelease -Psign=false -x signJarsPublication
$ ./gradlew testBuildDockerfileOfficial -Psign=false
```