### PR TITLE
SOLR-16850: Notify a user if they run Healthcheck againsts a standalone mode Solr

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -64,6 +64,8 @@ Improvements
 * SOLR-16490: `/admin/cores?action=backupcore` now has a v2 equivalent, available at
   `GET /api/cores/coreName/backups` (Sanjay Dutt via Jason Gerlowski)
 
+* SOLR-16850: If a user runs bin/solr healthcheck against standalone Solr, warn them that it only works with SolrCloud.  (Eric Pugh)
+
 Optimizations
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -64,8 +64,6 @@ Improvements
 * SOLR-16490: `/admin/cores?action=backupcore` now has a v2 equivalent, available at
   `GET /api/cores/coreName/backups` (Sanjay Dutt via Jason Gerlowski)
 
-* SOLR-16850: If a user runs bin/solr healthcheck against standalone Solr, warn them that it only works with SolrCloud.  (Eric Pugh)
-
 Optimizations
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
@@ -88,7 +88,7 @@ public class HealthcheckTool extends ToolBase {
   public void runImpl(CommandLine cli) throws Exception {
     SolrCLI.raiseLogLevelUnlessVerbose(cli);
     String zkHost = SolrCLI.getZkHost(cli);
-    if (zkHost == null){
+    if (zkHost == null) {
       CLIO.err("Healthcheck tool only works in Solr Cloud mode.");
       System.exit(1);
     }

--- a/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
@@ -88,6 +88,10 @@ public class HealthcheckTool extends ToolBase {
   public void runImpl(CommandLine cli) throws Exception {
     SolrCLI.raiseLogLevelUnlessVerbose(cli);
     String zkHost = SolrCLI.getZkHost(cli);
+    if (zkHost == null){
+      CLIO.err("Healthcheck tool only works in Solr Cloud mode.");
+      System.exit(1);
+    }
     try (CloudHttp2SolrClient cloudSolrClient =
         new CloudHttp2SolrClient.Builder(Collections.singletonList(zkHost), Optional.empty())
             .build()) {

--- a/solr/packaging/test/test_healthcheck.bats
+++ b/solr/packaging/test/test_healthcheck.bats
@@ -34,3 +34,10 @@ teardown() {
   refute_output --partial 'error'
   
 }
+
+@test "healthcheck errors on standalone solr" {
+  solr start -e films
+  run solr healthcheck -c films
+  assert_output --partial 'Healthcheck tool only works in Solr Cloud mode'
+  
+}


### PR DESCRIPTION


https://issues.apache.org/jira/browse/SOLR-16850

# Description

Alert a user, since you can use -solrUrl to point healthcheck at a standalone mode solr node.   

# Solution

No zkHost means not in SolrCloud mode!

# Tests

Bats test.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
