### PR TITLE
SOLR-16905: fix(java security policy): allow access to configured value of allowPaths

### DIFF
--- a/gradle/testing/randomization/policies/solr-tests.policy
+++ b/gradle/testing/randomization/policies/solr-tests.policy
@@ -50,7 +50,7 @@ grant {
   permission java.net.SocketPermission "[::1]:4", "connect,resolve";
   permission java.net.SocketPermission "[::1]:6", "connect,resolve";
   permission java.net.SocketPermission "[::1]:8", "connect,resolve";
-  
+
   // Basic permissions needed for Lucene to work:
   permission java.util.PropertyPermission "*", "read,write";
 
@@ -161,15 +161,15 @@ grant {
   // Needed by zookeeper to configure SASL Auth in tests
   permission javax.security.auth.AuthPermission "createLoginContext.Server";
   permission javax.security.auth.AuthPermission "createLoginContext.Client";
-  
+
   // may only be necessary with Java 7?
   permission javax.security.auth.PrivateCredentialPermission "javax.security.auth.kerberos.KeyTab * \"*\"", "read";
   permission javax.security.auth.PrivateCredentialPermission "sun.security.jgss.krb5.Krb5Util$KeysFromKeyTab * \"*\"", "read";
-  
+
   permission javax.security.auth.kerberos.ServicePermission "*", "initiate";
   permission javax.security.auth.kerberos.ServicePermission "*", "accept";
   permission javax.security.auth.kerberos.DelegationPermission "\"*\" \"krbtgt/EXAMPLE.COM@EXAMPLE.COM\"";
-  
+
   // java 8 accessibility requires this perm - should not after 8 I believe (rrd4j is the root reason we hit an accessibility code path)
   permission java.awt.AWTPermission "*";
 
@@ -210,6 +210,9 @@ grant {
 
   permission java.io.FilePermission "${solr.log.dir}", "read,write,delete,readlink";
   permission java.io.FilePermission "${solr.log.dir}${/}-", "read,write,delete,readlink";
+
+  permission java.io.FilePermission "${solr.allowPaths}", "read,write,delete,readlink";
+  permission java.io.FilePermission "${solr.allowPaths}${/}-", "read,write,delete,readlink";
 
   permission java.io.FilePermission "${log4j.configurationFile}", "read,write,delete,readlink";
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -81,6 +81,8 @@ Bug Fixes
 
 * SOLR-16906: Correctly capture REPLICATION metrics in Prometheus config (Daisuke Aritomo via Houston Putman)
 
+* SOLR-16905: Allow access to specified "solr.allowPaths" in Security Manager (daylicron, Houston Putman)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/packaging/test/test_security_manager.bats
+++ b/solr/packaging/test/test_security_manager.bats
@@ -34,6 +34,7 @@ teardown() {
   mkdir -p "${backup_dir}"
   backup_dir="$(cd -P "${backup_dir}" && pwd)"
 
+  export SOLR_SECURITY_MANAGER_ENABLED=true
   run solr start -c -Dsolr.allowPaths="${backup_dir}"
   run solr create_collection -c COLL_NAME
   run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}"

--- a/solr/packaging/test/test_security_manager.bats
+++ b/solr/packaging/test/test_security_manager.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load bats_helper
+
+setup() {
+  common_clean_setup
+}
+
+teardown() {
+  # save a snapshot of SOLR_HOME for failed tests
+  save_home_on_failure
+
+  delete_all_collections
+  SOLR_STOP_WAIT=1 solr stop -all >/dev/null 2>&1
+}
+
+@test "allowPaths - backup" {
+  backup_dir="${BATS_TEST_TMPDIR}/backup-dir"
+  mkdir -p "${backup_dir}"
+  backup_dir="$(cd -P "${backup_dir}" && pwd)"
+
+  run solr start -c -Dsolr.allowPaths="${backup_dir}"
+  run solr create_collection -c COLL_NAME
+  run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}"
+  assert_output --partial '"status":0'
+
+  run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}-not-permissioned"
+  assert_output --partial 'access denied'
+}

--- a/solr/packaging/test/test_security_manager.bats
+++ b/solr/packaging/test/test_security_manager.bats
@@ -30,12 +30,18 @@ teardown() {
 }
 
 @test "allowPaths - backup" {
+  # Make a test tmp dir, as the security policy includes TMP, so that might already contain the BATS_TEST_TMPDIR
+  test_tmp_dir="${BATS_TEST_TMPDIR}/tmp"
+  mkdir -p "${test_tmp_dir}"
+  test_tmp_dir="$(cd -P "${test_tmp_dir}" && pwd)"
+
   backup_dir="${BATS_TEST_TMPDIR}/backup-dir"
   mkdir -p "${backup_dir}"
   backup_dir="$(cd -P "${backup_dir}" && pwd)"
 
   export SOLR_SECURITY_MANAGER_ENABLED=true
-  run solr start -c -Dsolr.allowPaths="${backup_dir}"
+  export SOLR_OPTS="-Dsolr.allowPaths=${backup_dir} -Djava.io.tmpdir=${test_tmp_dir}"
+  run solr start -c
   run solr create_collection -c COLL_NAME
   run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}"
   assert_output --partial '"status":0'

--- a/solr/packaging/test/test_security_manager.bats
+++ b/solr/packaging/test/test_security_manager.bats
@@ -39,6 +39,9 @@ teardown() {
   run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}"
   assert_output --partial '"status":0'
 
-  run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}-not-permissioned"
+  # Solr is not permissioned for this directory, so it should fail
+  backup_dir_other="${backup_dir}-other"
+  mkdir -p "${backup_dir_other}"
+  run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test-fail&collection=COLL_NAME&location=file://${backup_dir_other}"
   assert_output --partial 'access denied'
 }

--- a/solr/server/etc/security.policy
+++ b/solr/server/etc/security.policy
@@ -58,7 +58,7 @@ grant {
   permission java.net.SocketPermission "[::1]:4", "connect,resolve";
   permission java.net.SocketPermission "[::1]:6", "connect,resolve";
   permission java.net.SocketPermission "[::1]:8", "connect,resolve";
-  
+
   // Basic permissions needed for Lucene to work:
   permission java.util.PropertyPermission "*", "read,write";
 
@@ -159,15 +159,15 @@ grant {
 
   // SASL/Kerberos related properties for Solr tests
   permission javax.security.auth.PrivateCredentialPermission "javax.security.auth.kerberos.KerberosTicket * \"*\"", "read";
-  
+
   // may only be necessary with Java 7?
   permission javax.security.auth.PrivateCredentialPermission "javax.security.auth.kerberos.KeyTab * \"*\"", "read";
   permission javax.security.auth.PrivateCredentialPermission "sun.security.jgss.krb5.Krb5Util$KeysFromKeyTab * \"*\"", "read";
-  
+
   permission javax.security.auth.kerberos.ServicePermission "*", "initiate";
   permission javax.security.auth.kerberos.ServicePermission "*", "accept";
   permission javax.security.auth.kerberos.DelegationPermission "\"*\" \"krbtgt/EXAMPLE.COM@EXAMPLE.COM\"";
-  
+
   // java 8 accessibility requires this perm - should not after 8 I believe (rrd4j is the root reason we hit an accessibility code path)
   permission java.awt.AWTPermission "*";
 
@@ -210,6 +210,9 @@ grant {
 
   permission java.io.FilePermission "${solr.log.dir}", "read,write,delete,readlink";
   permission java.io.FilePermission "${solr.log.dir}${/}-", "read,write,delete,readlink";
+
+  permission java.io.FilePermission "${solr.allowPaths}", "read,write,delete,readlink";
+  permission java.io.FilePermission "${solr.allowPaths}${/}-", "read,write,delete,readlink";
 
   permission java.io.FilePermission "${log4j.configurationFile}", "read,write,delete,readlink";
 


### PR DESCRIPTION
* SOLR-16905: Java Security Manager rules don't inclue "solr.allowPaths" property

# Description

Since solr 9 java security policy is enabled by default. When you configure the allowPaths property, acces will be denied by java security policy.

# Solution

To grant acces this creates a policy for that.

Additionally my IDE deletes Spaces of empty lines, thats why there are changes on multiple lines.

# Tests

Unfortunately I don't know how to write tests for this

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
