### PR TITLE
SOLR-16916: JSON boolean queries when solrconfig defType is set to edismax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __pycache__
 # Ignore gradle wrapper
 gradle/wrapper/gradle-wrapper.jar
 .gradletasknamecache
+
+.vscode/
+.tool-versions

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -33,6 +33,7 @@ import org.apache.solr.handler.component.SearchHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.macro.MacroExpander;
+import org.apache.solr.search.QueryParsing;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 
@@ -217,6 +218,8 @@ public class RequestUtil {
         if ("query".equals(key)) {
           out = "q";
           isQuery = true;
+          String[] queryParsers = {"lucene"};
+          newMap.put(QueryParsing.DEFTYPE, queryParsers);
         } else if ("filter".equals(key)) {
           out = "fq";
           arr = true;

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-tlog-edismax.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-tlog-edismax.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<config>
+
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}">
+    <!-- used to keep RAM reqs down for HdfsDirectoryFactory -->
+    <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool>
+    <int name="solr.hdfs.blockcache.blocksperbank">${solr.hdfs.blockcache.blocksperbank:1024}</int>
+    <str name="solr.hdfs.home">${solr.hdfs.home:}</str>
+    <str name="solr.hdfs.confdir">${solr.hdfs.confdir:}</str>
+    <str name="solr.hdfs.blockcache.global">${solr.hdfs.blockcache.global:true}</str>
+  </directoryFactory>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+  <requestDispatcher>
+    <requestParsers />
+  </requestDispatcher>
+
+  <dataDir>${solr.data.dir:}</dataDir>
+
+  <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- an update processor the explicitly excludes distrib to test
+       clean errors when people attempt atomic updates w/o it
+  -->
+  <updateRequestProcessorChain name="nodistrib" >
+   <processor class="solr.NoOpDistributingUpdateProcessorFactory" />
+   <processor class="solr.RunUpdateProcessorFactory" />
+ </updateRequestProcessorChain>
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="qf">id</str>
+    </lst>
+  </requestHandler>
+
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <!-- autocommit pending docs if certain criteria are met -->
+    <autoCommit>
+      <maxSize>${solr.autoCommit.maxSize:}</maxSize>
+    </autoCommit>
+    <updateLog class="${solr.tests.ulog:solr.UpdateLog}">
+      <str name="dir">${solr.ulog.dir:}</str>
+      <str name="maxNumLogsToKeep">${solr.ulog.maxNumLogsToKeep:10}</str>
+      <str name="numRecordsToKeep">${solr.ulog.numRecordsToKeep:100}</str>
+      <int name="tlogDfsReplication">${solr.ulog.tlogDfsReplication:2}</int>
+    </updateLog>
+
+
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:-1}</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+    <autoSoftCommit>
+      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+    </autoSoftCommit>
+  </updateHandler>
+
+  <updateRequestProcessorChain name="distrib-dup-test-chain-explicit">
+    <!-- explicit test using processors before and after distrib -->
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_A_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.DistributedUpdateProcessorFactory" />
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_B_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <updateRequestProcessorChain name="distrib-dup-test-chain-implicit">
+    <!-- implicit test w/o distrib declared-->
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_A_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.RegexReplaceProcessorFactory">
+      <str name="fieldName">regex_dup_B_s</str>
+      <str name="pattern">x</str>
+      <str name="replacement">x_x</str>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <query>
+    <filterCache
+      size="512"
+      initialSize="512"
+      autowarmCount="0" />
+
+    <queryResultCache
+      size="512"
+      initialSize="512"
+      autowarmCount="0" />
+
+    <documentCache
+      size="512"
+      initialSize="512"
+      autowarmCount="0" />
+
+    <cache name="perSegFilter"
+      class="solr.CaffeineCache"
+      size="10"
+      initialSize="0"
+      autowarmCount="10"
+      regenerator="solr.NoOpRegenerator" />
+
+  </query>
+
+  <valueSourceParser name="nvl" class="org.apache.solr.search.function.NvlValueSourceParser">
+    <float name="nvlFloatValue">0.0</float>
+  </valueSourceParser>
+  <valueSourceParser name="agg_debug" class="org.apache.solr.search.facet.DebugAgg$Parser">
+  </valueSourceParser>
+
+
+</config>

--- a/solr/core/src/test/org/apache/solr/search/json/TestJsonRequestWithEdismaxDefType.java
+++ b/solr/core/src/test/org/apache/solr/search/json/TestJsonRequestWithEdismaxDefType.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.json;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.solr.JSONTestUtil;
+import org.apache.solr.SolrTestCaseHS;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@LuceneTestCase.SuppressCodecs({
+  "Lucene3x",
+  "Lucene40",
+  "Lucene41",
+  "Lucene42",
+  "Lucene45",
+  "Appending"
+})
+public class TestJsonRequestWithEdismaxDefType extends SolrTestCaseHS {
+
+  private static SolrInstances servers; // for distributed testing
+
+  @SuppressWarnings("deprecation")
+  @BeforeClass
+  public static void beforeTests() throws Exception {
+    systemSetPropertySolrDisableUrlAllowList("true");
+    System.setProperty("solr.enableStreamBody", "true");
+    JSONTestUtil.failRepeatedKeys = true;
+    initCore("solrconfig-tlog-edismax.xml", "schema_latest.xml");
+  }
+
+  @SuppressWarnings("deprecation")
+  @AfterClass
+  public static void afterTests() throws Exception {
+    JSONTestUtil.failRepeatedKeys = false;
+    systemClearPropertySolrDisableUrlAllowList();
+  }
+
+  @Test
+  public void testLocalJsonRequest() throws Exception {
+    doJsonRequest(Client.localClient);
+  }
+
+  public static void doJsonRequest(Client client) throws Exception {
+    addDocs(client);
+
+    client.testJQ(
+        params(
+            "json",
+            "{\"query\":{\"bool\":{\"should\":[{\"lucene\":{\"query\":\"id:1\"}}, \"id:2\"]}}, \"params\":{\"debug\":\"true\"}}"),
+        "response/numFound==2");
+  }
+
+  private static void addDocs(Client client) throws Exception {
+    client.deleteByQuery("*:*", null);
+    client.add(sdoc("id", "1", "cat_s", "A", "where_s", "NY"), null);
+    client.add(sdoc("id", "2", "cat_s", "B", "where_s", "NJ"), null);
+    client.add(sdoc("id", "3"), null);
+    client.commit();
+    client.add(sdoc("id", "4", "cat_s", "A", "where_s", "NJ"), null);
+    client.add(sdoc("id", "5", "cat_s", "B", "where_s", "NJ"), null);
+    client.commit();
+    client.add(sdoc("id", "6", "cat_s", "B", "where_s", "NY"), null);
+    client.commit();
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16916

# Description

As discussed on [this solr-users thread](https://lists.apache.org/thread/3t25858oh6wcf74j868nk8l9801v21q4), if your requestHandler has a default defType of "edismax", you are unable to send boolean queries using the JSON Query DSL syntax.  This PR resolves the issue.


# Solution

We took the approach recommended by @dsmiley [in the jira ticket](https://issues.apache.org/jira/browse/SOLR-16916) (thanks, @dsmiley !)

# Tests

We created a new JUnit test based on the existing JSON Query tests, but with a different solrconfig.xml.  We confirmed that without our fix, the test fails, and with the fix, the test passes.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
