### PR TITLE
SOLR-16922: Scripts wrongly prohibit embedded zookeeper when solr port is between 55535 and 64535

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -96,6 +96,8 @@ Bug Fixes
 
 * SOLR-16905: Allow access to specified "solr.allowPaths" in Security Manager (daylicron, Houston Putman)
 
+* SOLR-16922: Scripts wrongly prohibit embedded zookeeper when solr port is between 55535 and 64535 (Tiziano Degaetano, Colvin Cowie)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1633,7 +1633,7 @@ if [ "${SOLR_MODE:-}" == 'solrcloud' ]; then
   if [ -n "${ZK_HOST:-}" ]; then
     CLOUD_MODE_OPTS+=("-DzkHost=$ZK_HOST")
   else
-    if [ $SOLR_PORT -gt 55535 ]; then
+    if [ $SOLR_PORT -gt 64535 ]; then
       echo -e "\nZK_HOST is not set and Solr port is $SOLR_PORT, which would result in an invalid embedded Zookeeper port!\n"
       exit 1
     fi

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1009,7 +1009,7 @@ IF "%SOLR_MODE%"=="solrcloud" (
   IF NOT "%ZK_HOST%"=="" (
     set "CLOUD_MODE_OPTS=!CLOUD_MODE_OPTS! -DzkHost=%ZK_HOST%"
   ) ELSE (
-    IF %SOLR_PORT% GTR 55535 (
+    IF %SOLR_PORT% GTR 64535 (
       set "SCRIPT_ERROR=ZK_HOST is not set and Solr port is %SOLR_PORT%, which would result in an invalid embedded Zookeeper port!"
       goto err
     )


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16922

Set the max port to be `64535` (`1_000` less than the max port number `65535`, as embedded zookeeper is started on `SOLR_PORT + 1_000`, not `+ 10_000` (used by RMI which has a separate check)