### PR TITLE
SOLR-16733: Fail 'test' tasks using JDK20 on Mac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ apply from: file('gradle/java/javac.gradle')
 apply from: file('gradle/testing/defaults-tests.gradle')
 apply from: file('gradle/testing/randomization.gradle')
 apply from: file('gradle/testing/fail-on-no-tests.gradle')
+apply from: file('gradle/testing/fail-on-unsupported-jdk.gradle')
 apply from: file('gradle/testing/alternative-jdk-support.gradle')
 apply from: file('gradle/java/jar-manifest.gradle')
 

--- a/gradle/testing/fail-on-unsupported-jdk.gradle
+++ b/gradle/testing/fail-on-unsupported-jdk.gradle
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+configure(rootProject) {
+  task ensureJdkSupported() {
+    doFirst {
+      if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac") && rootProject.runtimeJavaVersion == JavaVersion.VERSION_20) {
+        throw new GradleException("Tests cannot be run with JDK20 on Mac; see SOLR-16733 for more details.")
+      }
+    }
+  }
+
+  allprojects {
+    tasks.withType(Test) {
+        dependsOn ":ensureJdkSupported"
+    }
+  }
+}

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -201,24 +201,20 @@ allprojects {
         // Enable security manager, if requested. We could move the selection of security manager and security policy
         // to each project's build/ configuration but it seems compact enough to keep it here for now.
         if (Boolean.parseBoolean(testOptionsResolved["tests.useSecurityManager"])) {
-          if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac") && rootProject.runtimeJavaVersion == JavaVersion.VERSION_20) {
-            logger.warn("SecurityManager was requested for tests, but cannot be used with JDK20 on Mac.  See SOLR-16733 for more details.")
-          } else {
-            def commonSolrDir = project(':solr').layout.projectDirectory
-            def javaSecurityPolicy = layout.projectDirectory.file("${resources}/policies/solr-tests.policy")
-            jvmArgumentProviders.add(
-                    new SecurityArgumentProvider(
-                            commonSolrDir: commonSolrDir,
-                            javaSecurityPolicy: javaSecurityPolicy
-                    )
-            )
-            systemProperty 'java.security.manager', "org.apache.lucene.tests.util.TestSecurityManager"
+          def commonSolrDir = project(':solr').layout.projectDirectory
+          def javaSecurityPolicy = layout.projectDirectory.file("${resources}/policies/solr-tests.policy")
+          jvmArgumentProviders.add(
+              new SecurityArgumentProvider(
+                  commonSolrDir: commonSolrDir,
+                  javaSecurityPolicy: javaSecurityPolicy
+              )
+          )
+          systemProperty 'java.security.manager', "org.apache.lucene.tests.util.TestSecurityManager"
 
-            def gradleUserHome = project.gradle.getGradleUserHomeDir()
-            systemProperty 'gradle.lib.dir', Paths.get(project.class.location.toURI()).parent.toAbsolutePath().toString().replace('\\', '/')
-            systemProperty 'gradle.worker.jar', Paths.get("${gradleUserHome}/caches/${gradle.gradleVersion}/workerMain/gradle-worker.jar").toAbsolutePath().toString()
-            systemProperty 'gradle.user.home', gradleUserHome.toPath().toAbsolutePath().toString()
-          }
+          def gradleUserHome = project.gradle.getGradleUserHomeDir()
+          systemProperty 'gradle.lib.dir', Paths.get(project.class.location.toURI()).parent.toAbsolutePath().toString().replace('\\', '/')
+          systemProperty 'gradle.worker.jar', Paths.get("${gradleUserHome}/caches/${gradle.gradleVersion}/workerMain/gradle-worker.jar").toAbsolutePath().toString()
+          systemProperty 'gradle.user.home', gradleUserHome.toPath().toAbsolutePath().toString()
         }
 
         doFirst {

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -92,11 +92,7 @@ allprojects {
           [propName: 'tests.asserts', value: "true", description: "Enables or disables assertions mode."],
           [propName: 'tests.infostream', value: false, description: "Enables or disables infostream logs."],
           [propName: 'tests.leaveTemporary', value: false, description: "Leave temporary directories after tests complete."],
-          [propName: 'tests.useSecurityManager',
-           value: { ->
-            !(org.gradle.api.JavaVersion.current() == JavaVersion.VERSION_20 && System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac"))
-           },
-           description: "Control security manager in tests."],
+          [propName: 'tests.useSecurityManager', value: true, description: "Control security manager in tests.", buildOnly: true],
           // component randomization
           [propName: 'tests.codec', value: "random", description: "Sets the codec tests should run with."],
           [propName: 'tests.directory', value: "random", description: "Sets the Directory implementation tests should run with."],

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -201,20 +201,24 @@ allprojects {
         // Enable security manager, if requested. We could move the selection of security manager and security policy
         // to each project's build/ configuration but it seems compact enough to keep it here for now.
         if (Boolean.parseBoolean(testOptionsResolved["tests.useSecurityManager"])) {
-          def commonSolrDir = project(':solr').layout.projectDirectory
-          def javaSecurityPolicy = layout.projectDirectory.file("${resources}/policies/solr-tests.policy")
-          jvmArgumentProviders.add(
-              new SecurityArgumentProvider(
-                  commonSolrDir: commonSolrDir,
-                  javaSecurityPolicy: javaSecurityPolicy
-              )
-          )
-          systemProperty 'java.security.manager', "org.apache.lucene.tests.util.TestSecurityManager"
+          if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac") && rootProject.runtimeJavaVersion == JavaVersion.VERSION_20) {
+            logger.warn("SecurityManager was requested for tests, but cannot be used with JDK20 on Mac.  See SOLR-16733 for more details.")
+          } else {
+            def commonSolrDir = project(':solr').layout.projectDirectory
+            def javaSecurityPolicy = layout.projectDirectory.file("${resources}/policies/solr-tests.policy")
+            jvmArgumentProviders.add(
+                    new SecurityArgumentProvider(
+                            commonSolrDir: commonSolrDir,
+                            javaSecurityPolicy: javaSecurityPolicy
+                    )
+            )
+            systemProperty 'java.security.manager', "org.apache.lucene.tests.util.TestSecurityManager"
 
-          def gradleUserHome = project.gradle.getGradleUserHomeDir()
-          systemProperty 'gradle.lib.dir', Paths.get(project.class.location.toURI()).parent.toAbsolutePath().toString().replace('\\', '/')
-          systemProperty 'gradle.worker.jar', Paths.get("${gradleUserHome}/caches/${gradle.gradleVersion}/workerMain/gradle-worker.jar").toAbsolutePath().toString()
-          systemProperty 'gradle.user.home', gradleUserHome.toPath().toAbsolutePath().toString()
+            def gradleUserHome = project.gradle.getGradleUserHomeDir()
+            systemProperty 'gradle.lib.dir', Paths.get(project.class.location.toURI()).parent.toAbsolutePath().toString().replace('\\', '/')
+            systemProperty 'gradle.worker.jar', Paths.get("${gradleUserHome}/caches/${gradle.gradleVersion}/workerMain/gradle-worker.jar").toAbsolutePath().toString()
+            systemProperty 'gradle.user.home', gradleUserHome.toPath().toAbsolutePath().toString()
+          }
         }
 
         doFirst {

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -92,7 +92,11 @@ allprojects {
           [propName: 'tests.asserts', value: "true", description: "Enables or disables assertions mode."],
           [propName: 'tests.infostream', value: false, description: "Enables or disables infostream logs."],
           [propName: 'tests.leaveTemporary', value: false, description: "Leave temporary directories after tests complete."],
-          [propName: 'tests.useSecurityManager', value: true, description: "Control security manager in tests.", buildOnly: true],
+          [propName: 'tests.useSecurityManager',
+           value: { ->
+            !(org.gradle.api.JavaVersion.current() == JavaVersion.VERSION_20 && System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac"))
+           },
+           description: "Control security manager in tests."],
           // component randomization
           [propName: 'tests.codec', value: "random", description: "Sets the codec tests should run with."],
           [propName: 'tests.directory', value: "random", description: "Sets the Directory implementation tests should run with."],


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16733


# Description

Many (> 700!) tests fail with this OS/JDK combination due to a JDK bug that crops up when the Security Manager is used.

Disabling the Security Manager in this case isn't ideal, but is really kindof necessary to test this OS/Java combination in any meaningful way.

# Solution

~~This PR makes a change to randomization.gradle to skip enabling the SecurityManager if the known problem OS/Java combination is present.  A warning is logged as a breadcrumb to avoid misleading users who wanted to run tests with SecurityManager, including a pointer to SOLR-16733.~~

Rather than disabling the Security Manager in these cases, feedback below has suggested failing the test run entirely before it really kicks off.  If JDK20+Mac+SecurityManager is fundamentally broken, we shouldn't fail loudly so folks don't get the wrong impression.  That is the approach this PR now takes.

# Tests

Manual testing - install JDK20 and run a command similar to:

```
export "RUNTIME_JAVA_HOME=<locationOfJdk20>" ; ./gradlew --info clean test --tests "TestRestoreCore"
```

The 'test' task should fail without this PR but pass with it incorporated.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
