### PR TITLE
SOLR-16928: Add missing unit tests for RegexFileFilter and StrUtils.toLower

### DIFF
--- a/solr/core/src/test/org/apache/solr/util/RegexFileFilterTest.java
+++ b/solr/core/src/test/org/apache/solr/util/RegexFileFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.util;
 
 import java.io.File;

--- a/solr/core/src/test/org/apache/solr/util/RegexFileFilterTest.java
+++ b/solr/core/src/test/org/apache/solr/util/RegexFileFilterTest.java
@@ -1,0 +1,33 @@
+package org.apache.solr.util;
+
+import java.io.File;
+import org.apache.solr.SolrTestCase;
+import org.junit.Test;
+
+public class RegexFileFilterTest extends SolrTestCase {
+
+  private final RegexFileFilter endsWithDotTxt = new RegexFileFilter(".*\\.txt$");
+  private final RegexFileFilter alphaWithTxtOrPdfExt = new RegexFileFilter("^[a-z]+\\.(txt|pdf)$");
+
+  @Test
+  public void testAcceptTrue() {
+    assertTrue(endsWithDotTxt.accept(new File("/foo/bar/baz.txt")));
+    assertTrue(endsWithDotTxt.accept(new File("/baz.txt")));
+    assertTrue(endsWithDotTxt.accept(new File("~/baz.txt")));
+    assertTrue(endsWithDotTxt.accept(new File("~/1234-abc_.txt")));
+    assertTrue(endsWithDotTxt.accept(new File(".txt")));
+    assertTrue(alphaWithTxtOrPdfExt.accept(new File("/foo/bar.txt")));
+    assertTrue(alphaWithTxtOrPdfExt.accept(new File("/foo/baz.pdf")));
+  }
+
+  @Test
+  public void testAcceptFalse() {
+    assertFalse(endsWithDotTxt.accept(new File("/foo/bar.tx")));
+    assertFalse(endsWithDotTxt.accept(new File("/foo/bar.txts")));
+    assertFalse(endsWithDotTxt.accept(new File("/foo/bar.exe")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("/foo/bar/b4z.txt")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("/foo/bar/baz.jpg")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("~/foo-bar.txt")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("~/foobar123.txt")));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -109,6 +109,13 @@ public class TestUtils extends SolrTestCaseJ4 {
     assertEquals("/h/s", arr.get(0));
   }
 
+  public void testToLower() {
+    assertEquals(List.of(), StrUtils.toLower(List.of()));
+    assertEquals(List.of(""), StrUtils.toLower(List.of("")));
+    assertEquals(List.of("foo"), StrUtils.toLower(List.of("foo")));
+    assertEquals(List.of("bar", "baz-123"), StrUtils.toLower(List.of("BAR", "Baz-123")));
+  }
+
   public void testNamedLists() {
     SimpleOrderedMap<Integer> map = new SimpleOrderedMap<>();
     map.add("test", 10);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16928

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Adding some unit tests that cover the `RegexFileFilter` class and the `StrUtils.toLower` method

# Solution

N/A

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
