### PR TITLE
SOLR-16928: Add missing unit tests for RegexFileFilter and StrUtils.t…

### DIFF
--- a/solr/core/src/test/org/apache/solr/util/RegexFileFilterTest.java
+++ b/solr/core/src/test/org/apache/solr/util/RegexFileFilterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.util;
+
+import java.io.File;
+import org.apache.solr.SolrTestCase;
+import org.junit.Test;
+
+public class RegexFileFilterTest extends SolrTestCase {
+
+  private final RegexFileFilter endsWithDotTxt = new RegexFileFilter(".*\\.txt$");
+  private final RegexFileFilter alphaWithTxtOrPdfExt = new RegexFileFilter("^[a-z]+\\.(txt|pdf)$");
+
+  @Test
+  public void testAcceptTrue() {
+    assertTrue(endsWithDotTxt.accept(new File("/foo/bar/baz.txt")));
+    assertTrue(endsWithDotTxt.accept(new File("/baz.txt")));
+    assertTrue(endsWithDotTxt.accept(new File("~/baz.txt")));
+    assertTrue(endsWithDotTxt.accept(new File("~/1234-abc_.txt")));
+    assertTrue(endsWithDotTxt.accept(new File(".txt")));
+    assertTrue(alphaWithTxtOrPdfExt.accept(new File("/foo/bar.txt")));
+    assertTrue(alphaWithTxtOrPdfExt.accept(new File("/foo/baz.pdf")));
+  }
+
+  @Test
+  public void testAcceptFalse() {
+    assertFalse(endsWithDotTxt.accept(new File("/foo/bar.tx")));
+    assertFalse(endsWithDotTxt.accept(new File("/foo/bar.txts")));
+    assertFalse(endsWithDotTxt.accept(new File("/foo/bar.exe")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("/foo/bar/b4z.txt")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("/foo/bar/baz.jpg")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("~/foo-bar.txt")));
+    assertFalse(alphaWithTxtOrPdfExt.accept(new File("~/foobar123.txt")));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -109,6 +109,13 @@ public class TestUtils extends SolrTestCaseJ4 {
     assertEquals("/h/s", arr.get(0));
   }
 
+  public void testToLower() {
+    assertEquals(List.of(), StrUtils.toLower(List.of()));
+    assertEquals(List.of(""), StrUtils.toLower(List.of("")));
+    assertEquals(List.of("foo"), StrUtils.toLower(List.of("foo")));
+    assertEquals(List.of("bar", "baz-123"), StrUtils.toLower(List.of("BAR", "Baz-123")));
+  }
+
   public void testNamedLists() {
     SimpleOrderedMap<Integer> map = new SimpleOrderedMap<>();
     map.add("test", 10);


### PR DESCRIPTION
…oLower (#1837)

* SOLR-16928: Add missing unit tests for RegexFileFilter and StrUtils.toLower

* SOLR-16928: Add license to RegexFileFilterTest

https://issues.apache.org/jira/browse/SOLR-16928

