### PR TITLE
SOLR-16944 V2 API /api/node/health should be governed by "health" permission

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -128,6 +128,8 @@ Bug Fixes
 
 * PR#1826: Allow looking up Solr Package repo when that URL references a raw repository.json hosted on Github when the file is JSON but the mimetype used is text/plain. (Eric Pugh)
 
+* SOLR-16944: V2 API /api/node/health should be governed by "health" permission, not "config-read" (janhoy)
+
 * SOLR-16859: Missing Proxy support for Http2SolrClient (Alex Deparvu)
 
 Dependency Upgrades

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/NodeHealthAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/NodeHealthAPI.java
@@ -18,7 +18,7 @@
 package org.apache.solr.handler.admin.api;
 
 import static org.apache.solr.client.solrj.SolrRequest.METHOD.GET;
-import static org.apache.solr.security.PermissionNameProvider.Name.CONFIG_READ_PERM;
+import static org.apache.solr.security.PermissionNameProvider.Name.HEALTH_PERM;
 
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.handler.admin.HealthCheckHandler;
@@ -41,7 +41,7 @@ public class NodeHealthAPI {
   @EndPoint(
       path = {"/node/health"},
       method = GET,
-      permission = CONFIG_READ_PERM)
+      permission = HEALTH_PERM)
   public void getSystemInformation(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
     handler.handleRequestBody(req, rsp);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16944
