### PR TITLE
SOLR-16265: Fix NPE for req in Http2SolrClient

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -528,34 +528,35 @@ public class Http2SolrClient extends SolrClient {
       InputStreamResponseListener listener = new InputStreamResponseListener();
       req = makeRequestAndSend(solrRequest, url, listener, false);
       Response response = listener.get(idleTimeoutMillis, TimeUnit.MILLISECONDS);
+      url = req.getURI().toString();
       InputStream is = listener.getInputStream();
       assert ObjectReleaseTracker.track(is);
-      return processErrorsAndResponse(solrRequest, response, is, req.getURI().toString());
+      return processErrorsAndResponse(solrRequest, response, is, url);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       abortCause = e;
       throw new RuntimeException(e);
     } catch (TimeoutException e) {
       throw new SolrServerException(
-          "Timeout occurred while waiting response from server at: " + req.getURI(), e);
+          "Timeout occurred while waiting response from server at: " + url, e);
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       abortCause = cause;
       if (cause instanceof ConnectException) {
-        throw new SolrServerException("Server refused connection at: " + req.getURI(), cause);
+        throw new SolrServerException("Server refused connection at: " + url, cause);
       }
       if (cause instanceof SolrServerException) {
         throw (SolrServerException) cause;
       } else if (cause instanceof IOException) {
         throw new SolrServerException(
-            "IOException occurred when talking to server at: " + req.getURI(), cause);
+            "IOException occurred when talking to server at: " + url, cause);
       }
       throw new SolrServerException(cause.getMessage(), cause);
     } catch (SolrServerException | RuntimeException sse) {
       abortCause = sse;
       throw sse;
     } finally {
-      if (abortCause != null) {
+      if (abortCause != null && req != null) {
         req.abort(abortCause);
       }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16265

Fixing error seen below when passing a bad url to the client.

> ERROR: Cannot invoke "org.eclipse.jetty.client.api.Request.abort(java.lang.Throwable)" because "req" is null