### PR TITLE
SOLR-16945: Add multi-threaded warming support for CaffeineCache and QuerySenderListener

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SolrCache.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrCache.java
@@ -38,6 +38,7 @@ public interface SolrCache<K, V> extends SolrInfoBean {
   String INITIAL_SIZE_PARAM = "initialSize";
   String CLEANUP_THREAD_PARAM = "cleanupThread";
   String ASYNC_PARAM = "async";
+  String AUTOWARM_THREADS_PARAM = "autowarmThreads";
 
   /**
    * The initialization routine. Instance specific arguments are passed in the <code>args</code>

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
@@ -85,6 +85,9 @@ Disabling the async option may use slightly less memory per cache entry at the e
 The async cache provides most significant improvement with many concurrent queries requesting the same result set that has not yet been cached, as an alternative to larger cache sizes or increased auto-warming counts.
 However, the async cache will not prevent data races for time-limited queries, since those are expected to provide partial results.
 
+The `autowarmThreads` attribute controls the number of threads used for warming. By default (or if using `autowarmThreads="0"` or `autowarmThreads="1"`) only a single thread is used for warming.
+If a negative value is specified (e.g. `autowarmThreads="-1")` then the number of threads will be set to the number of available processors (as returned by `Runtime.getRuntime().availableProcessors()`).
+
 All caches can be disabled using the parameter `enabled` with a value of `false`.
 Caches can also be disabled on a query-by-query basis with the `cache` parameter, as described in the section xref:query-guide:common-query-parameters.adoc#cache-local-parameter[cache Local Parameter].
 
@@ -134,6 +137,15 @@ The filter cache is a good candidate for enabling `async` computation.
              async="true"/>
 ----
 
+The filter cache might also be a good candidate for enabling multi-threaded warming via `autowarmThreads` if you have a larger cache with a large value for `autowarmCount`.
+
+[source,xml]
+----
+<filterCache class="solr.CaffeineCache"
+             size="8192"
+             autowarmCount="8192"
+             autowarmThreads="4"/>
+----
 
 === Query Result Cache
 
@@ -342,6 +354,34 @@ A key best practice is to modify these defaults before taking your application t
 
 There is no point in auto-warming your Searcher with the query string "static firstSearcher warming in solrconfig.xml" if that is not relevant to your search application.
 ====
+
+### Multi-threaded listener warming
+
+If you have a large list of queries you are running via the listeners you might want to enable multi-threading listener warming by specifying the `<int name="threads">` element:
+
+[source,xml]
+----
+<listener event="newSearcher" class="solr.QuerySenderListener">
+  <int name="threads">4</int>
+  <arr name="queries">
+  <!--
+    <lst><str name="q">solr</str><str name="sort">price asc</str></lst>
+    <lst><str name="q">rocks</str><str name="sort">weight asc</str></lst>
+   -->
+   <!-- lots of additional queries here... -->
+  </arr>
+</listener>
+
+<listener event="firstSearcher" class="solr.QuerySenderListener">
+  <int name="threads">4</int>
+  <arr name="queries">
+    <lst><str name="q">static firstSearcher warming in solrconfig.xml</str></lst>
+    <!-- lots of additional queries here... -->
+  </arr>
+</listener>
+----
+
+By default (or if using `<int name="threads">0</int>` or `<int name="threads">1</int>`) only a single thread is used. If a negative value is specified (e.g. `<int name="threads">-1</int>)` then the number of threads will be set to the number of available processors (as returned by `Runtime.getRuntime().availableProcessors()`).
 
 ### Managing warming queries with the Config API
 

--- a/solr/solrj/src/java/org/apache/solr/common/params/EventParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/EventParams.java
@@ -20,6 +20,7 @@ public interface EventParams {
   /** Event param for things like newSearcher, firstSearcher* */
   public static final String EVENT = "event";
 
+  public static final String THREADS = "threads";
   public static final String NEW_SEARCHER = "newSearcher";
   public static final String FIRST_SEARCHER = "firstSearcher";
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16945

# Description

This adds opt-in multi-threaded warming support to CaffeineCache and QuerySenderListener.

# Solution

The implementation for both CaffeineCache and QuerySenderListener are basically the same. They both now make use of an `ExecutorUtil.MDCAwareThreadPoolExecutor` with the user configured number of threads to run any warming queries. If multi-threaded warming was not configured (or the number of threads is set to 0 or 1) then the existing single-threaded implementation is used. If a negative number of threads are specified then `Runtime.getRuntime().availableProcessors()` is used for the number of threads. The multi-threaded implementation is opt-in.

# Tests

I've run manual tests on this change to verify the single-threaded and multi-threaded code paths are working as expected based on logging messages showing the threads used for the warming queries and based on the total time it takes to run the warming with various numbers of threads.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
