### PR TITLE
SOLR-16946: Updated Cluster Singleton plugins are stopped correctly when the Overseer is closed

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -136,6 +136,8 @@ Bug Fixes
 
 * SOLR-16934: Allow Solr to read client (javax.net.ssl.*) trustStores and keyStores via SecurityManager. (Houston Putman)
 
+* SOLR-16946: Updated Cluster Singleton plugins are stopped correctly when the Overseer is closed. (Paul McArthur)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/core/ClusterSingletons.java
+++ b/solr/core/src/java/org/apache/solr/core/ClusterSingletons.java
@@ -99,8 +99,8 @@ public class ClusterSingletons {
           @Override
           public void modified(
               ContainerPluginsRegistry.ApiInfo old, ContainerPluginsRegistry.ApiInfo replacement) {
-            added(replacement);
             deleted(old);
+            added(replacement);
           }
         };
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16946

# Description

When a Cluster Singleton plugin config is updated via the /cluster/plugin API, the `ClusterSingletons.modified` method calls the `added` and `deleted` methods, in that order.
This effect of this is to leave no entry for the plugin in the `singletonMap` map, because the entries are keyed by the plugin name.
The `added` method will overwrite the entry for the existing plugin, and the `deleted` method will remove the new entry that was put by the `added` method.  

# Solution

The solution is to reverse the order in which the `added` and `deleted` methods are called from the `modified` method. Removing the existing plugin from the map first, and then adding the new one means that the new one will remain in the map, and it will be found and stopped when the Overseer is closed.

This solution also has the side effect of ensuring that the 2 instances of the plugin are not running at the same time. Previously there was a very brief period between the calls to `added` and `deleted` where both instances would be in the RUNNING state.

# Tests

I have modified the portion of `TestContainerPlugin` that tests the behavior of Cluster Singletons.
In order to update the plugin config, I needed to make the `C6` test class implement `ConfigurablePlugin` (otherwise it seems there is no change detected by the update request to /cluster/plugins).
The test now updates the plugin config after is has been added, verifies that the update operation stops the plugin, clears the stopped flag and then tests it again after the Overseer is killed to ensure that closing the Overseer stops the updated plugin.
This test fails at that final step without the changes to `ClusterSingletons` in this PR. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
