### PR TITLE
SOLR-16933: Include full query response in API tool

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -138,6 +138,8 @@ Bug Fixes
 
 * SOLR-16946: Updated Cluster Singleton plugins are stopped correctly when the Overseer is closed. (Paul McArthur)
 
+* SOLR-16933: Include the full query response when using the API tool, and fix serialization issues for SolrDocumentList. (Houston Putman) 
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/cli/ApiTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ApiTool.java
@@ -23,11 +23,10 @@ import java.util.List;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.impl.NoOpResponseParser;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
-import org.noggit.CharArr;
-import org.noggit.JSONWriter;
 
 /**
  * Supports api command in the bin/solr script.
@@ -77,20 +76,23 @@ public class ApiTool extends ToolBase {
     String solrUrl = getSolrUrlFromUri(uri);
     String path = uri.getPath();
     try (var solrClient = SolrCLI.getSolrClient(solrUrl)) {
-      NamedList<Object> response =
-          solrClient.request(
-              // For path parameter we need the path without the root so from the second / char
-              // (because root can be configured)
-              // E.g URL is http://localhost:8983/solr/admin/info/system path is
-              // /solr/admin/info/system and the path without root is /admin/info/system
-              new GenericSolrRequest(
-                  SolrRequest.METHOD.GET,
-                  path.substring(path.indexOf("/", path.indexOf("/") + 1)),
-                  getSolrParamsFromUri(uri)));
-      // pretty-print the response to stdout
-      CharArr arr = new CharArr();
-      new JSONWriter(arr, 2).write(response.asMap());
-      return arr.toString();
+      // For path parameter we need the path without the root so from the second / char
+      // (because root can be configured)
+      // E.g URL is http://localhost:8983/solr/admin/info/system path is
+      // /solr/admin/info/system and the path without root is /admin/info/system
+      var req =
+          new GenericSolrRequest(
+              SolrRequest.METHOD.GET,
+              path.substring(path.indexOf("/", path.indexOf("/") + 1)),
+              getSolrParamsFromUri(uri) // .add("indent", "true")
+              );
+      // Using the "smart" solr parsers won't work, because they decode into Solr objects.
+      // When trying to re-write into JSON, the JSONWriter doesn't have the right info to print it
+      // correctly.
+      // All we want to do is pass the JSON response to the user, so do that.
+      req.setResponseParser(new NoOpResponseParser("json"));
+      NamedList<Object> response = solrClient.request(req);
+      return (String) response.get("response");
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/cli/CreateTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/CreateTool.java
@@ -38,6 +38,7 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.client.solrj.impl.NoOpResponseParser;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
@@ -48,8 +49,6 @@ import org.apache.solr.common.params.CollectionAdminParams;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.ConfigSetService;
-import org.noggit.CharArr;
-import org.noggit.JSONWriter;
 
 /** Supports create command in the bin/solr script. */
 public class CreateTool extends ToolBase {
@@ -287,19 +286,18 @@ public class CreateTool extends ToolBase {
 
     NamedList<Object> response;
     try {
-      response =
-          cloudSolrClient.request(
-              CollectionAdminRequest.createCollection(
-                  collectionName, confName, numShards, replicationFactor));
+      var req =
+          CollectionAdminRequest.createCollection(
+              collectionName, confName, numShards, replicationFactor);
+      req.setResponseParser(new NoOpResponseParser("json"));
+      response = cloudSolrClient.request(req);
     } catch (SolrServerException sse) {
       throw new Exception(
           "Failed to create collection '" + collectionName + "' due to: " + sse.getMessage());
     }
 
     if (cli.hasOption(SolrCLI.OPTION_VERBOSE.getOpt())) {
-      CharArr arr = new CharArr();
-      new JSONWriter(arr, 2).write(response.asMap());
-      echo(arr.toString());
+      echo((String) response.get("response"));
     } else {
       String endMessage =
           String.format(

--- a/solr/core/src/test/org/apache/solr/cli/ApiToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/ApiToolTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Locale;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.client.solrj.request.AbstractUpdateRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -89,12 +90,16 @@ public class ApiToolTest extends SolrCloudTestCase {
             cluster.getJettySolrRunner(0).getBaseUrl()
                 + "/"
                 + COLLECTION_NAME
-                + "/select?q=*:*&rows=1&fl=id");
-    assertNull("request response is null", response);
-    //    Object queryResponse = response.get("response");
-    //    assertNotNull("query response is null", queryResponse);
-    //    assertTrue("query response is not a namedList: " + queryResponse + ", type: " +
-    // queryResponse.getClass().getName(), queryResponse instanceof SolrDocumentList);
-    //    assertEquals(0, ((SolrDocumentList)queryResponse).getNumFound());
+                + "/select?q=*:*&rows=1&fl=id&sort=id+asc");
+    // Fields that could be missed because of serialization
+    assertFindInJson(response, "\"numFound\":1000,");
+    // Correct formatting
+    assertFindInJson(response, "\"docs\":[{");
+  }
+
+  private void assertFindInJson(String json, String find) {
+    assertTrue(
+        String.format(Locale.ROOT, "Could not find string %s in response: \n%s", find, json),
+        json.contains(find));
   }
 }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/NodeValueFetcher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/NodeValueFetcher.java
@@ -139,7 +139,7 @@ public class NodeValueFetcher {
 
     try {
       SimpleSolrResponse rsp = ctx.invokeWithRetry(solrNode, CommonParams.METRICS_PATH, params);
-      NamedList<?> metrics = (NamedList<?>) rsp.nl.get("metrics");
+      NamedList<?> metrics = (NamedList<?>) rsp.getResponse().get("metrics");
       if (metrics != null) {
         for (Tags t : Tags.values()) {
           ctx.tags.put(t.tagName, t.extractResult(metrics));

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientNodeStateProvider.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientNodeStateProvider.java
@@ -194,7 +194,8 @@ public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter
       SimpleSolrResponse rsp = ctx.invokeWithRetry(solrNode, CommonParams.METRICS_PATH, params);
       metricsKeyVsTag.forEach(
           (key, tags) -> {
-            Object v = Utils.getObjectByPath(rsp.nl, true, Arrays.asList("metrics", key));
+            Object v =
+                Utils.getObjectByPath(rsp.getResponse(), true, Arrays.asList("metrics", key));
             for (Object tag : tags) {
               if (tag instanceof Function) {
                 @SuppressWarnings({"unchecked"})
@@ -296,7 +297,7 @@ public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter
               .withResponseParser(new BinaryResponseParser())
               .build()) {
         NamedList<Object> rsp = client.request(request);
-        request.response.nl = rsp;
+        request.response.setResponse(rsp);
         return request.response;
       }
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/SimpleSolrResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/SimpleSolrResponse.java
@@ -16,32 +16,4 @@
  */
 package org.apache.solr.client.solrj.response;
 
-import org.apache.solr.client.solrj.SolrResponse;
-import org.apache.solr.common.util.NamedList;
-
-public class SimpleSolrResponse extends SolrResponse {
-
-  public long elapsedTime;
-
-  public NamedList<Object> nl;
-
-  @Override
-  public long getElapsedTime() {
-    return elapsedTime;
-  }
-
-  @Override
-  public NamedList<Object> getResponse() {
-    return nl;
-  }
-
-  @Override
-  public void setResponse(NamedList<Object> rsp) {
-    nl = rsp;
-  }
-
-  @Override
-  public void setElapsedTime(long elapsedTime) {
-    this.elapsedTime = elapsedTime;
-  }
-}
+public class SimpleSolrResponse extends SolrResponseBase {}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/SimpleSolrResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/SimpleSolrResponse.java
@@ -16,4 +16,32 @@
  */
 package org.apache.solr.client.solrj.response;
 
-public class SimpleSolrResponse extends SolrResponseBase {}
+import org.apache.solr.client.solrj.SolrResponse;
+import org.apache.solr.common.util.NamedList;
+
+public class SimpleSolrResponse extends SolrResponse {
+
+  public long elapsedTime;
+
+  public NamedList<Object> nl;
+
+  @Override
+  public long getElapsedTime() {
+    return elapsedTime;
+  }
+
+  @Override
+  public NamedList<Object> getResponse() {
+    return nl;
+  }
+
+  @Override
+  public void setResponse(NamedList<Object> rsp) {
+    nl = rsp;
+  }
+
+  @Override
+  public void setElapsedTime(long elapsedTime) {
+    this.elapsedTime = elapsedTime;
+  }
+}

--- a/solr/solrj/src/java/org/apache/solr/common/IteratorWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/IteratorWriter.java
@@ -104,7 +104,7 @@ public interface IteratorWriter extends JSONWriter.Writable {
                 writer.writeValueSeparator();
               }
               writer.indent();
-              write(writer);
+              writer.write(o);
               return this;
             }
           });

--- a/solr/solrj/src/java/org/apache/solr/common/SolrDocumentList.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrDocumentList.java
@@ -16,7 +16,9 @@
  */
 package org.apache.solr.common;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 
 /**
  * Represent a list of SolrDocuments returned from a search. This includes position and offset
@@ -24,7 +26,24 @@ import java.util.ArrayList;
  *
  * @since solr 1.3
  */
-public class SolrDocumentList extends ArrayList<SolrDocument> {
+public class SolrDocumentList extends ArrayList<SolrDocument> implements MapWriter {
+
+  @Override
+  public void writeMap(EntryWriter ew) throws IOException {
+    ew.put("numFound", numFound);
+    ew.put("start", start);
+
+    if (maxScore != null) {
+      ew.put("maxScore", maxScore);
+    }
+
+    if (numFoundExact != null) {
+      ew.put("numFoundExact", numFoundExact);
+    }
+    final Iterator<SolrDocument> docs = iterator();
+    ew.put("docs", (IteratorWriter) iw -> docs.forEachRemaining(iw::addNoEx));
+  }
+
   private long numFound = 0;
   private long start = 0;
   private Float maxScore = null;

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -479,15 +479,19 @@ public class Utils {
         Object o = getVal(obj, s, -1);
         if (o == null) return null;
         if (idx > -1) {
-          if (o instanceof MapWriter) {
+          if (o instanceof List) {
+            List<?> l = (List<?>) o;
+            o = idx < l.size() ? l.get(idx) : null;
+          } else if (o instanceof IteratorWriter) {
+            o = getValueAt((IteratorWriter) o, idx);
+          } else if (o instanceof MapWriter) {
             o = getVal(o, null, idx);
           } else if (o instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) o;
             o = getVal(new MapWriterMap(map), null, idx);
           } else {
-            List<?> l = (List<?>) o;
-            o = idx < l.size() ? l.get(idx) : null;
+            return null;
           }
         }
         if (!isMapLike(o)) return null;

--- a/solr/solrj/src/java/org/noggit/JSONWriter.java
+++ b/solr/solrj/src/java/org/noggit/JSONWriter.java
@@ -21,6 +21,7 @@ package org.noggit;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 public class JSONWriter {
@@ -70,6 +71,8 @@ public class JSONWriter {
     // perfect hashing.
     if (o == null) {
       writeNull();
+    } else if (o instanceof Writable) {
+      ((Writable) o).write(this);
     } else if (o instanceof String) {
       writeString((String) o);
     } else if (o instanceof Number) {
@@ -90,8 +93,6 @@ public class JSONWriter {
       write(((Boolean) o).booleanValue());
     } else if (o instanceof CharSequence) {
       writeString((CharSequence) o);
-    } else if (o instanceof Writable) {
-      ((Writable) o).write(this);
     } else if (o instanceof Object[]) {
       write(Arrays.asList((Object[]) o));
     } else if (o instanceof int[]) {
@@ -152,6 +153,20 @@ public class JSONWriter {
       }
       if (sz > 1) indent();
       write(o);
+    }
+    endArray();
+  }
+
+  public void write(Iterator<?> val) {
+    startArray();
+    boolean first = true;
+    while (val.hasNext()) {
+      if (first) {
+        first = false;
+      } else {
+        writeValueSeparator();
+      }
+      write(val.next());
     }
     endArray();
   }

--- a/solr/solrj/src/java/org/noggit/JSONWriter.java
+++ b/solr/solrj/src/java/org/noggit/JSONWriter.java
@@ -89,6 +89,8 @@ public class JSONWriter {
       write((Map<?, ?>) o);
     } else if (o instanceof Collection) {
       write((Collection<?>) o);
+    } else if (o instanceof Iterator) {
+      write((Iterator<?>) o);
     } else if (o instanceof Boolean) {
       write(((Boolean) o).booleanValue());
     } else if (o instanceof CharSequence) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16933

So the initial issue here is that the SolrDocumentList serialization used to only be really handled by the `SolrRequestWriter` (solr core only), and if you tried to use a general JSON serializer (`JSONWriter`), it would try to serialize the `SolrDocumentList` as an ArrayList of SolrDocuments, because it extends `ArrayList<SolrDocument>`. This meant that the `numFound`, `numFoundExact`, `start`, etc. fields were lost.

Two solutions here:

1. `SolrDocumentList` now extends `MapWriter`, so that it will serialize correctly even when used with a "dumb" serializer.
2. The CLI tools that just print output from the APIs they call (`ApiTool`, `CreateTool`, `DeleteTool`), should use the `NoOpResponseParser("json")`, and just plainly echo the output of the API, without de-serializing and re-serializing.

In the end # 2 is what actually fixes this, but # 1 is a good thing to include so that in the future people don't hit snags trying to serialize a Solr Query response with `JSONWriter`.

(The indentation of JSONWriter with the SolrDocumentList is not ideal, but it works. And it doesn't really matter as we aren't reserializing anymore.)