### PR TITLE
logging, MDC: collection for action=DELETE

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
@@ -113,7 +113,9 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
 
   @Override
   public OverseerSolrResponse processMessage(ZkNodeProps message, String operation) {
-    MDCLoggingContext.setCollection(message.getStr(COLLECTION));
+    // sometimes overseer messages have the collection name in 'name' field, not 'collection'
+    MDCLoggingContext.setCollection(
+        message.getStr(COLLECTION) != null ? message.getStr(COLLECTION) : message.getStr(NAME));
     MDCLoggingContext.setShard(message.getStr(SHARD_ID_PROP));
     MDCLoggingContext.setReplica(message.getStr(REPLICA_PROP));
     log.debug("OverseerCollectionMessageHandler.processMessage : {} , {}", operation, message);


### PR DESCRIPTION
Logging MDC "collection" is sometimes not set for certain admin API commands like DELETE.

----
Been using this for awhile.  I don't love that an assumption is made that perhaps isn't necessarily true?  Although I like it better than not setting MDC.  I wish there was an internal standardization at some layer that would *always* put the collection being operated on into a consistent spot, lower level than the surface layer API.
