### PR TITLE
SOLR-16958: Fix spurious warning about LATEST luceneMatchVersion

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -151,6 +151,8 @@ Bug Fixes
 * SOLR-16916: Use of the JSON Query DSL should ignore the defType parameter
   (Christina Chortaria, Max Kadel, Ryan Laddusaw, Jane Sandberg, David Smiley)
 
+* SOLR-16958: Fix spurious warning about LATEST luceneMatchVersion (Colvin Cowie)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -420,7 +420,9 @@ public class SolrConfig implements MapSerializable {
           pe);
     }
 
-    if (Objects.equals(version, Version.LATEST) && !versionWarningAlreadyLogged.getAndSet(true)) {
+    // The use of == is intentional here because the latest matchVersion will be equal() to
+    // Version.LATEST, but will not be == to Version.LATEST
+    if (version == Version.LATEST && !versionWarningAlreadyLogged.getAndSet(true)) {
       log.warn(
           "You should not use LATEST as luceneMatchVersion property: "
               + "if you use this setting, and then Solr upgrades to a newer release of Lucene, "


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16958

Switch back to the use of `==` to check whether the supplied version is `LATEST` or the actual latest version (e.g. `9.7.0`).