### PR TITLE
SOLR-16958: Fix spurious warning about LATEST luceneMatchVersion

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -151,6 +151,8 @@ Bug Fixes
 * SOLR-16916: Use of the JSON Query DSL should ignore the defType parameter
   (Christina Chortaria, Max Kadel, Ryan Laddusaw, Jane Sandberg, David Smiley)
 
+* SOLR-16958: Fix spurious warning about LATEST luceneMatchVersion (Colvin Cowie)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -409,6 +409,7 @@ public class SolrConfig implements MapSerializable {
 
   private static final AtomicBoolean versionWarningAlreadyLogged = new AtomicBoolean(false);
 
+  @SuppressWarnings("ReferenceEquality") // Use of == is intentional here
   public static final Version parseLuceneVersionString(final String matchVersion) {
     final Version version;
     try {
@@ -420,7 +421,9 @@ public class SolrConfig implements MapSerializable {
           pe);
     }
 
-    if (Objects.equals(version, Version.LATEST) && !versionWarningAlreadyLogged.getAndSet(true)) {
+    // The use of == is intentional here because the latest 'V.V.V' version will be equal() to
+    // Version.LATEST, but will not be == to Version.LATEST unless 'LATEST' was supplied.
+    if (version == Version.LATEST && !versionWarningAlreadyLogged.getAndSet(true)) {
       log.warn(
           "You should not use LATEST as luceneMatchVersion property: "
               + "if you use this setting, and then Solr upgrades to a newer release of Lucene, "


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16958

Switch back to the use of `==` to check whether the supplied version is `LATEST` or the actual latest version (e.g. `9.7.0`).
