### PR TITLE
SOLR-16956: fix not being able to stop a solr by port number

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1301,7 +1301,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             SOLR_PORT="$2"
-            PROVIDED_SOLR_PORT=SOLR_PORT
+            PROVIDED_SOLR_PORT="${SOLR_PORT}"
             PASS_TO_RUN_EXAMPLE+=("-p" "$SOLR_PORT")
             shift 2
         ;;

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1301,6 +1301,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             SOLR_PORT="$2"
+            PROVIDED_SOLR_PORT=SOLR_PORT
             PASS_TO_RUN_EXAMPLE+=("-p" "$SOLR_PORT")
             shift 2
         ;;

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -36,3 +36,16 @@ teardown() {
   run bash -c 'solr stop -all 2>&1'
   refute_output --partial 'forcefully killing'
 }
+
+@test "stop command for single port" {
+
+  solr start
+  solr start -p 7574
+  solr assert --started http://localhost:8983/solr --timeout 5000
+  solr assert --started http://localhost:7574/solr --timeout 5000
+  
+  run solr stop -p 7574
+  solr assert --not-started http://localhost:7574/solr --timeout 5000
+  solr assert --started http://localhost:8983/solr --timeout 5000
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16956
# Description

In doing some other testing, I noticed that `bin/solr stop -p 7574` didn't work, I get back the error message:

```
Found 2 Solr nodes running! Must either specify a port using -p or -all to stop all Solr nodes on this host.
```

# Solution

Set the PROVIDED_SOLR_PORT to the SOLR_PORT.

# Tests

extended bats tests

