### PR TITLE
SOLR-16825: Remove unneeded @Produces annotations

### DIFF
--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/AddReplicaPropertyApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/AddReplicaPropertyApi.java
@@ -20,12 +20,11 @@ package org.apache.solr.client.api.endpoint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import org.apache.solr.client.api.model.AddReplicaPropertyRequestBody;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
-
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.AddReplicaPropertyRequestBody;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 @Path("/collections/{collName}/shards/{shardName}/replicas/{replicaName}/properties/{propName}")
 public interface AddReplicaPropertyApi {

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/AddReplicaPropertyApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/AddReplicaPropertyApi.java
@@ -17,23 +17,20 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.apache.solr.client.api.model.AddReplicaPropertyRequestBody;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import org.apache.solr.client.api.model.AddReplicaPropertyRequestBody;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 @Path("/collections/{collName}/shards/{shardName}/replicas/{replicaName}/properties/{propName}")
 public interface AddReplicaPropertyApi {
 
   @PUT
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Adds a property to the specified replica",
       tags = {"replica-properties"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/AliasPropertyApis.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/AliasPropertyApis.java
@@ -16,30 +16,26 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import org.apache.solr.client.api.model.GetAliasPropertyResponse;
 import org.apache.solr.client.api.model.GetAllAliasPropertiesResponse;
 import org.apache.solr.client.api.model.SolrJerseyResponse;
 import org.apache.solr.client.api.model.UpdateAliasPropertiesRequestBody;
 import org.apache.solr.client.api.model.UpdateAliasPropertyRequestBody;
 
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
 /** V2 API definitions for managing and inspecting properties for collection aliases */
 @Path("/aliases/{aliasName}/properties")
 public interface AliasPropertyApis {
 
   @GET
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Get properties for a collection alias.",
       tags = {"alias-properties"})
@@ -49,7 +45,6 @@ public interface AliasPropertyApis {
 
   @GET
   @Path("/{propName}")
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Get a specific property for a collection alias.",
       tags = {"alias-properties"})
@@ -59,7 +54,6 @@ public interface AliasPropertyApis {
       throws Exception;
 
   @PUT
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Update properties for a collection alias.",
       tags = {"alias-properties"})
@@ -71,7 +65,6 @@ public interface AliasPropertyApis {
 
   @PUT
   @Path("/{propName}")
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Update a specific property for a collection alias.",
       tags = {"alias-properties"})
@@ -84,7 +77,6 @@ public interface AliasPropertyApis {
 
   @DELETE
   @Path("/{propName}")
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete a specific property for a collection alias.",
       tags = {"alias-properties"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/AliasPropertyApis.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/AliasPropertyApis.java
@@ -19,17 +19,16 @@ package org.apache.solr.client.api.endpoint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import org.apache.solr.client.api.model.GetAliasPropertyResponse;
-import org.apache.solr.client.api.model.GetAllAliasPropertiesResponse;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
-import org.apache.solr.client.api.model.UpdateAliasPropertiesRequestBody;
-import org.apache.solr.client.api.model.UpdateAliasPropertyRequestBody;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.GetAliasPropertyResponse;
+import org.apache.solr.client.api.model.GetAllAliasPropertiesResponse;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.model.UpdateAliasPropertiesRequestBody;
+import org.apache.solr.client.api.model.UpdateAliasPropertyRequestBody;
 
 /** V2 API definitions for managing and inspecting properties for collection aliases */
 @Path("/aliases/{aliasName}/properties")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteAliasApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteAliasApi.java
@@ -19,12 +19,11 @@ package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 @Path("/aliases/{aliasName}")
 public interface DeleteAliasApi {

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteAliasApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteAliasApi.java
@@ -17,22 +17,19 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 @Path("/aliases/{aliasName}")
 public interface DeleteAliasApi {
 
   @DELETE
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Deletes an alias by its name",
       tags = {"aliases"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionApi.java
@@ -19,12 +19,11 @@ package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
 
 @Path("/collections/{collectionName}")
 public interface DeleteCollectionApi {

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionApi.java
@@ -17,22 +17,19 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
 
 @Path("/collections/{collectionName}")
 public interface DeleteCollectionApi {
 
   @DELETE
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Deletes a collection from SolrCloud",
       tags = {"collections"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionBackupApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionBackupApi.java
@@ -17,29 +17,27 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.model.Constants.ASYNC;
-import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
-import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.apache.solr.client.api.model.BackupDeletionResponseBody;
+import org.apache.solr.client.api.model.PurgeUnusedFilesRequestBody;
+import org.apache.solr.client.api.model.PurgeUnusedResponse;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.BackupDeletionResponseBody;
-import org.apache.solr.client.api.model.PurgeUnusedFilesRequestBody;
-import org.apache.solr.client.api.model.PurgeUnusedResponse;
+
+import static org.apache.solr.client.api.model.Constants.ASYNC;
+import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
+import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
 
 @Path("/backups/{backupName}")
 public interface DeleteCollectionBackupApi {
 
   @Path("/versions/{backupId}")
   @DELETE
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete incremental backup point by ID",
       tags = {"collection-backups"})
@@ -54,7 +52,6 @@ public interface DeleteCollectionBackupApi {
 
   @Path("/versions")
   @DELETE
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete all incremental backup points older than the most recent N",
       tags = {"collection-backups"})
@@ -69,7 +66,6 @@ public interface DeleteCollectionBackupApi {
 
   @Path("/purgeUnused")
   @PUT
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Garbage collect orphaned incremental backup files",
       tags = {"collection-backups"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionBackupApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionBackupApi.java
@@ -17,21 +17,20 @@
 
 package org.apache.solr.client.api.endpoint;
 
+import static org.apache.solr.client.api.model.Constants.ASYNC;
+import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
+import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import org.apache.solr.client.api.model.BackupDeletionResponseBody;
-import org.apache.solr.client.api.model.PurgeUnusedFilesRequestBody;
-import org.apache.solr.client.api.model.PurgeUnusedResponse;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-
-import static org.apache.solr.client.api.model.Constants.ASYNC;
-import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
-import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
+import org.apache.solr.client.api.model.BackupDeletionResponseBody;
+import org.apache.solr.client.api.model.PurgeUnusedFilesRequestBody;
+import org.apache.solr.client.api.model.PurgeUnusedResponse;
 
 @Path("/backups/{backupName}")
 public interface DeleteCollectionBackupApi {

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionSnapshotApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionSnapshotApi.java
@@ -17,23 +17,20 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Parameter;
+import org.apache.solr.client.api.model.DeleteCollectionSnapshotResponse;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.DeleteCollectionSnapshotResponse;
 
 public interface DeleteCollectionSnapshotApi {
 
   /** This API is analogous to V1's (POST /solr/admin/collections?action=DELETESNAPSHOT) */
   @DELETE
   @Path("/collections/{collName}/snapshots/{snapshotName}")
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   DeleteCollectionSnapshotResponse deleteSnapshot(
       @Parameter(description = "The name of the collection.", required = true)
           @PathParam("collName")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionSnapshotApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteCollectionSnapshotApi.java
@@ -18,13 +18,12 @@
 package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Parameter;
-import org.apache.solr.client.api.model.DeleteCollectionSnapshotResponse;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import org.apache.solr.client.api.model.DeleteCollectionSnapshotResponse;
 
 public interface DeleteCollectionSnapshotApi {
 

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteNodeApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteNodeApi.java
@@ -17,23 +17,20 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.apache.solr.client.api.model.DeleteNodeRequestBody;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import org.apache.solr.client.api.model.DeleteNodeRequestBody;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 @Path("cluster/nodes/{nodeName}/clear/")
 public interface DeleteNodeApi {
 
   @POST
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete all replicas off of the specified SolrCloud node",
       tags = {"node"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteNodeApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteNodeApi.java
@@ -20,12 +20,11 @@ package org.apache.solr.client.api.endpoint;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import org.apache.solr.client.api.model.DeleteNodeRequestBody;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
-
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.DeleteNodeRequestBody;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 @Path("cluster/nodes/{nodeName}/clear/")
 public interface DeleteNodeApi {

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaApi.java
@@ -17,16 +17,6 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import io.swagger.v3.oas.annotations.Operation;
-import org.apache.solr.client.api.model.ScaleCollectionRequestBody;
-import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
-
-import javax.ws.rs.DELETE;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-
 import static org.apache.solr.client.api.model.Constants.ASYNC;
 import static org.apache.solr.client.api.model.Constants.COUNT_PROP;
 import static org.apache.solr.client.api.model.Constants.DELETE_DATA_DIR;
@@ -34,6 +24,15 @@ import static org.apache.solr.client.api.model.Constants.DELETE_INDEX;
 import static org.apache.solr.client.api.model.Constants.DELETE_INSTANCE_DIR;
 import static org.apache.solr.client.api.model.Constants.FOLLOW_ALIASES;
 import static org.apache.solr.client.api.model.Constants.ONLY_IF_DOWN;
+
+import io.swagger.v3.oas.annotations.Operation;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import org.apache.solr.client.api.model.ScaleCollectionRequestBody;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
 
 /**
  * V2 API definition for deleting one or more existing replicas from one or more shards.

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaApi.java
@@ -17,6 +17,16 @@
 
 package org.apache.solr.client.api.endpoint;
 
+import io.swagger.v3.oas.annotations.Operation;
+import org.apache.solr.client.api.model.ScaleCollectionRequestBody;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
 import static org.apache.solr.client.api.model.Constants.ASYNC;
 import static org.apache.solr.client.api.model.Constants.COUNT_PROP;
 import static org.apache.solr.client.api.model.Constants.DELETE_DATA_DIR;
@@ -24,17 +34,6 @@ import static org.apache.solr.client.api.model.Constants.DELETE_INDEX;
 import static org.apache.solr.client.api.model.Constants.DELETE_INSTANCE_DIR;
 import static org.apache.solr.client.api.model.Constants.FOLLOW_ALIASES;
 import static org.apache.solr.client.api.model.Constants.ONLY_IF_DOWN;
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
-import io.swagger.v3.oas.annotations.Operation;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.ScaleCollectionRequestBody;
-import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
 
 /**
  * V2 API definition for deleting one or more existing replicas from one or more shards.
@@ -46,7 +45,6 @@ public interface DeleteReplicaApi {
 
   @DELETE
   @Path("/shards/{shardName}/replicas/{replicaName}")
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete an single replica by name",
       tags = {"replicas"})
@@ -65,7 +63,6 @@ public interface DeleteReplicaApi {
 
   @DELETE
   @Path("/shards/{shardName}/replicas")
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete one or more replicas from the specified collection and shard",
       tags = {"replicas"})
@@ -84,7 +81,6 @@ public interface DeleteReplicaApi {
 
   @PUT
   @Path("/scale")
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Scale the replica count for all shards in the specified collection",
       tags = {"replicas"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaPropertyApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaPropertyApi.java
@@ -19,11 +19,10 @@ package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 /**
  * V2 API definition for removing a property from a collection replica

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaPropertyApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/DeleteReplicaPropertyApi.java
@@ -17,15 +17,13 @@
 
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
 
 /**
  * V2 API definition for removing a property from a collection replica
@@ -36,7 +34,6 @@ import org.apache.solr.client.api.model.SolrJerseyResponse;
 public interface DeleteReplicaPropertyApi {
 
   @DELETE
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Delete an existing replica property",
       tags = {"replica-properties"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListAliasesApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListAliasesApi.java
@@ -16,24 +16,20 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.apache.solr.client.api.model.GetAliasByNameResponse;
+import org.apache.solr.client.api.model.ListAliasesResponse;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import org.apache.solr.client.api.model.GetAliasByNameResponse;
-import org.apache.solr.client.api.model.ListAliasesResponse;
 
 /** V2 API definition for listing and inspecting collection aliases */
 @Path("/aliases")
 public interface ListAliasesApi {
 
   @GET
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "List the existing collection aliases.",
       tags = {"aliases"})
@@ -41,7 +37,6 @@ public interface ListAliasesApi {
 
   @GET
   @Path("/{aliasName}")
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Get details for a specific collection alias.",
       tags = {"aliases"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListAliasesApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListAliasesApi.java
@@ -18,12 +18,11 @@ package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.apache.solr.client.api.model.GetAliasByNameResponse;
-import org.apache.solr.client.api.model.ListAliasesResponse;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.GetAliasByNameResponse;
+import org.apache.solr.client.api.model.ListAliasesResponse;
 
 /** V2 API definition for listing and inspecting collection aliases */
 @Path("/aliases")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionBackupsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionBackupsApi.java
@@ -16,25 +16,23 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
-import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
-import java.io.IOException;
+import org.apache.solr.client.api.model.ListCollectionBackupsResponse;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.ListCollectionBackupsResponse;
+import java.io.IOException;
+
+import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
+import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
 
 /** V2 API definitions for collection-backup "listing". */
 @Path("/backups/{backupName}/versions")
 public interface ListCollectionBackupsApi {
 
   @GET
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "List existing incremental backups at the specified location.",
       tags = {"collection-backups"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionBackupsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionBackupsApi.java
@@ -16,17 +16,16 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import io.swagger.v3.oas.annotations.Operation;
-import org.apache.solr.client.api.model.ListCollectionBackupsResponse;
+import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
+import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
 
+import io.swagger.v3.oas.annotations.Operation;
+import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-import java.io.IOException;
-
-import static org.apache.solr.client.api.model.Constants.BACKUP_LOCATION;
-import static org.apache.solr.client.api.model.Constants.BACKUP_REPOSITORY;
+import org.apache.solr.client.api.model.ListCollectionBackupsResponse;
 
 /** V2 API definitions for collection-backup "listing". */
 @Path("/backups/{backupName}/versions")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionsApi.java
@@ -17,10 +17,9 @@
 package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.solr.client.api.model.ListCollectionsResponse;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import org.apache.solr.client.api.model.ListCollectionsResponse;
 
 @Path("/collections")
 public interface ListCollectionsApi {

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListCollectionsApi.java
@@ -16,18 +16,15 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
+import org.apache.solr.client.api.model.ListCollectionsResponse;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import org.apache.solr.client.api.model.ListCollectionsResponse;
 
 @Path("/collections")
 public interface ListCollectionsApi {
   @GET
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "List all collections in this Solr cluster",
       tags = {"collections"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListConfigsetsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListConfigsetsApi.java
@@ -17,16 +17,15 @@
 package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
+import org.apache.solr.client.api.model.ListConfigsetsResponse;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import org.apache.solr.client.api.model.ListConfigsetsResponse;
 
 /** V2 API definition for listing configsets. */
 @Path("/cluster/configs")
 public interface ListConfigsetsApi {
   @GET
-  @Produces({"application/json", "application/javabin"})
   @Operation(
       summary = "List the configsets available to Solr.",
       tags = {"configsets"})

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ListConfigsetsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ListConfigsetsApi.java
@@ -17,10 +17,9 @@
 package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.solr.client.api.model.ListConfigsetsResponse;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import org.apache.solr.client.api.model.ListConfigsetsResponse;
 
 /** V2 API definition for listing configsets. */
 @Path("/cluster/configs")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ReloadCollectionApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ReloadCollectionApi.java
@@ -17,12 +17,11 @@
 package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.solr.client.api.model.ReloadCollectionRequestBody;
-import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
-
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.ReloadCollectionRequestBody;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
 
 /** V2 API definition for reloading collections. */
 @Path("/collections/{collectionName}/reload")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ReloadCollectionApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ReloadCollectionApi.java
@@ -16,22 +16,18 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.BINARY_CONTENT_TYPE_V2;
-
 import io.swagger.v3.oas.annotations.Operation;
+import org.apache.solr.client.api.model.ReloadCollectionRequestBody;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
+
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import org.apache.solr.client.api.model.ReloadCollectionRequestBody;
-import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
 
 /** V2 API definition for reloading collections. */
 @Path("/collections/{collectionName}/reload")
 public interface ReloadCollectionApi {
   @POST
-  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, BINARY_CONTENT_TYPE_V2})
   @Operation(
       summary = "Reload all cores in the specified collection.",
       tags = {"collections"})

--- a/solr/core/src/test/org/apache/solr/handler/configsets/ListConfigSetsAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/configsets/ListConfigSetsAPITest.java
@@ -91,7 +91,7 @@ public class ListConfigSetsAPITest extends JerseyTest {
     when(mockCoreContainer.getConfigSetService()).thenReturn(configSetService);
     when(configSetService.listConfigs()).thenReturn(List.of("cs1", "cs2"));
 
-    final Response response = target("/cluster/configs").request().get();
+    final Response response = target("/cluster/configs").request("application/json").get();
     final String jsonBody = response.readEntity(String.class);
 
     assertEquals(200, response.getStatus());
@@ -108,7 +108,8 @@ public class ListConfigSetsAPITest extends JerseyTest {
     when(mockCoreContainer.getConfigSetService()).thenReturn(configSetService);
     when(configSetService.listConfigs()).thenReturn(List.of("cs1", "cs2"));
 
-    final var response = target("/cluster/configs").request().get(ListConfigsetsResponse.class);
+    final var response =
+        target("/cluster/configs").request("application/json").get(ListConfigsetsResponse.class);
 
     assertNotNull(response.configSets);
     assertNull(response.error);
@@ -132,7 +133,8 @@ public class ListConfigSetsAPITest extends JerseyTest {
     when(mockCoreContainer.getConfigSetService()).thenReturn(configSetService);
     when(configSetService.listConfigs()).thenReturn(List.of("cs1", "cs2"));
 
-    final var response = target("/cluster/configs").request().get(ListConfigsetsResponse.class);
+    final var response =
+        target("/cluster/configs").request("application/json").get(ListConfigsetsResponse.class);
     final NamedList<Object> squashedResponse = new NamedList<>();
     V2ApiUtils.squashIntoNamedList(squashedResponse, response);
     final ConfigSetAdminResponse.List solrjResponse = new ConfigSetAdminResponse.List();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16825


# Description

Many of Solr's api definitions rely on `@Produces` annotation to explicitly declare the response content types that they support.

But it turns out that this wasn't ever really necessary - Jersey can match the API invocation up with an appropriate MessageBodyWriter without the help of this annotation.  Only those APIs that want to specifically restrict their response formats need by annotated.

Ultimately it's a minor problem, but in addition to cluttering up our API definitions these annotations also are the cause of some noisy messages in our build logs. 


# Solution

All `@Produces` annotations have been removed from the `api` submodule.  We'll need this annotation for some APIs that are very selective about their response content-type (e.g. our ZooKeeper-read APIs, /export, etc.).  But almost all of its usages are removed by this PR.

# Tests

Manual testing; automated tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
