### PR TITLE
SOLR-16953: Grouped fields are handled in edismax clauses

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -72,7 +72,7 @@ public class ExtendedDismaxQParser extends QParser {
    * A field we can't ever find in any schema, so we can safely tell DisjunctionMaxQueryParser to
    * use it as our defaultField, and map aliases from it to any field in our schema.
    */
-  private static String IMPOSSIBLE_FIELD_NAME = "\uFFFC\uFFFC\uFFFC";
+  private static final String IMPOSSIBLE_FIELD_NAME = "\uFFFC\uFFFC\uFFFC";
 
   /** shorten the class references for utilities */
   private static class U extends SolrPluginUtils {
@@ -80,26 +80,26 @@ public class ExtendedDismaxQParser extends QParser {
   }
 
   /** shorten the class references for utilities */
-  private static interface DMP extends DisMaxParams {
+  private interface DMP extends DisMaxParams {
     /**
      * User fields. The fields that can be used by the end user to create field-specific queries.
      */
-    public static String UF = "uf";
+    String UF = "uf";
 
     /**
      * Lowercase Operators. If set to true, 'or' and 'and' will be considered OR and AND, otherwise
      * lowercase operators will be considered terms to search for.
      */
-    public static String LOWERCASE_OPS = "lowercaseOperators";
+    String LOWERCASE_OPS = "lowercaseOperators";
 
     /**
      * Multiplicative boost. Boost functions which scores are going to be multiplied to the score of
      * the main query (instead of just added, like with bf)
      */
-    public static String MULT_BOOST = "boost";
+    String MULT_BOOST = "boost";
 
     /** If set to true, stopwords are removed from the query. */
-    public static String STOPWORDS = "stopwords";
+    String STOPWORDS = "stopwords";
   }
 
   private ExtendedDismaxConfiguration config;
@@ -727,27 +727,23 @@ public class ExtendedDismaxQParser extends QParser {
 
   public List<Clause> splitIntoClauses(String s, boolean ignoreQuote) {
     ArrayList<Clause> lst = new ArrayList<>(4);
-    Clause clause;
 
     int pos = 0;
     int end = s.length();
-    char ch = 0;
-    int start;
-    boolean disallowUserField;
     Deque<String> groupedFields = new LinkedList<>(); // field:(token1 token2)
 
     while (pos < end) {
-      clause = new Clause();
-      disallowUserField = true;
+      Clause clause = new Clause();
+      boolean disallowUserField = true;
 
-      ch = s.charAt(pos);
+      char ch = s.charAt(pos);
 
       while (Character.isWhitespace(ch)) {
         if (++pos >= end) break;
         ch = s.charAt(pos);
       }
 
-      start = pos;
+      int start = pos;
 
       if ((ch == '+' || ch == '-') && (pos + 1) < end) {
         clause.must = ch;

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.search;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -23,7 +24,6 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -730,7 +730,7 @@ public class ExtendedDismaxQParser extends QParser {
 
     int pos = 0;
     int end = s.length();
-    Deque<String> groupedFields = new LinkedList<>(); // field:(token1 token2)
+    Deque<String> groupedFields = new ArrayDeque<>(); // field:(token1 token2)
 
     while (pos < end) {
       Clause clause = new Clause();
@@ -755,6 +755,10 @@ public class ExtendedDismaxQParser extends QParser {
       boolean implicitField = false;
       if (clause.field == null && !groupedFields.isEmpty()) {
         clause.field = groupedFields.peek();
+        // ArrayDeque does not support null values, so we use empty strings.
+        if (clause.field.isEmpty()) {
+          clause.field = null;
+        }
         implicitField = true;
       }
 
@@ -774,7 +778,7 @@ public class ExtendedDismaxQParser extends QParser {
       } else if (s.charAt(pos) == '(') {
         // For a sequence of terms grouped with a field "field:(term1 term2)", keep
         // track of the field name so we can apply it to all the terms
-        groupedFields.push(implicitField ? null : clause.field);
+        groupedFields.push(implicitField || clause.field == null ? "" : clause.field);
       }
 
       char inString = 0;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16953

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

`ExtendedDismaxParser` generates _boosts_ queries from parameter `pf` for unwanted terms when using grouped fields (queries similar to `field:(term1 term2 term3)` ).
`term1` is skipped as expected, but `term2` and `term3`, are unexpectedly added in the generated boost query. This is because the field is not added to `term2` and `term3` in the output of `splitIntoClauses()` method.

# Solution

In `splitIntoClauses()`, set the field to all clauses that are created when parsing terms with a grouped field.
In the example, we set the field to `term1`, `term2` and `term3`.

# Tests

Added two cases in `TestExtendedDismaxParser` to ensure generated clauses are correct and we return records in the correct order.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
