### PR TITLE
SOLR-16954: Fix test failure in UPDATE circuit breaker

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
@@ -89,7 +89,7 @@ public class CPUCircuitBreaker extends CircuitBreaker {
 
   @Override
   public String getErrorMessage() {
-    return "CPU Circuit Breaker triggered as seen CPU usage is above allowed threshold."
+    return "CPU Circuit Breaker triggered as seen CPU usage is above allowed threshold. "
         + "Seen CPU usage "
         + seenCPUUsage.get()
         + " and allocated threshold "

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
@@ -89,7 +89,7 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
 
   @Override
   public String getErrorMessage() {
-    return "Memory Circuit Breaker triggered as JVM heap usage values are greater than allocated threshold."
+    return "Memory Circuit Breaker triggered as JVM heap usage values are greater than allocated threshold. "
         + "Seen JVM heap memory usage "
         + seenMemory.get()
         + " and allocated threshold "

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-pluggable-circuitbreaker.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-pluggable-circuitbreaker.xml
@@ -79,6 +79,13 @@
   </query>
 
   <circuitBreaker class="solr.MemoryCircuitBreaker">
+    <double  name="threshold">99</double>
+    <arr name="requestTypes">
+      <str>update</str>
+    </arr>
+  </circuitBreaker>
+
+  <circuitBreaker class="solr.MemoryCircuitBreaker">
     <double  name="threshold">80</double>
 <!-- Default is query
     <arr name="requestTypes">

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-pluggable-circuitbreaker.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-pluggable-circuitbreaker.xml
@@ -79,13 +79,6 @@
   </query>
 
   <circuitBreaker class="solr.MemoryCircuitBreaker">
-    <double  name="threshold">75</double>
-    <arr name="requestTypes">
-      <str>update</str>
-    </arr>
-  </circuitBreaker>
-
-  <circuitBreaker class="solr.MemoryCircuitBreaker">
     <double  name="threshold">80</double>
 <!-- Default is query
     <arr name="requestTypes">


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16954

The tests ran fine both on localhost and github actions, but on Jenkins this one tripped during indexing content in `indexDocs()`. Must be some difference in memory handling, perhaps how many tests are ran in parallel in Jeknins vs GitHub actions/Crave, or the `-Xmx` setting??

Output from [failing test](https://ci-builds.apache.org/job/Solr/job/Solr-Check-main/7905/testReport/org.apache.solr.util/TestCircuitBreaker/classMethod/):
> Seen JVM heap memory usage 383.848.016 and allocated threshold 383.778.816

383Mb threshold suggests that the VM is ran with 512Mb RAM, which makes sense.