### PR TITLE
SOLR-16968: The MemoryCircuitBreaker now uses average heap usage

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -123,6 +123,8 @@ Improvements
 
 * SOLR-16970: SOLR_OPTS is now able to override options set by the Solr control scripts, "bin/solr" and "bin/solr.cmd". (Houston Putman)
 
+* SOLR-16968: The MemoryCircuitBreaker now uses average heap usage over the last 30 seconds (janhoy, Christine Poerschke)
+
 * SOLR-14886: Suppress stack traces in query response (Isabelle Giguere via Alex Deparvu)
 
 * SOLR-16461: `/solr/coreName/replication?command=backup` now has a v2 equivalent, available at

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -1088,9 +1088,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
       solrMetricsContext = coreMetricManager.getSolrMetricsContext();
       this.coreMetricManager.loadReporters();
 
-      // init pluggable circuit breakers
-      initPlugins(null, CircuitBreaker.class);
-
       if (updateHandler == null) {
         directoryFactory = initDirectoryFactory();
         recoveryStrategyBuilder = initRecoveryStrategyBuilder();
@@ -1114,6 +1111,9 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
       // initialize core metrics
       initializeMetrics(solrMetricsContext, null);
+
+      // init pluggable circuit breakers, after metrics because some circuit breakers use metrics
+      initPlugins(null, CircuitBreaker.class);
 
       SolrFieldCacheBean solrFieldCacheBean = new SolrFieldCacheBean();
       // this is registered at the CONTAINER level because it's not core-specific - for now we
@@ -1763,6 +1763,17 @@ public class SolrCore implements SolrInfoBean, Closeable {
     log.info("CLOSING SolrCore {}", this);
 
     ExecutorUtil.shutdownAndAwaitTermination(coreAsyncTaskExecutor);
+
+    // Close circuit breakers that may have background threads, before metrics because some circuit
+    // breakers use metrics
+    try {
+      getCircuitBreakerRegistry().close();
+    } catch (Throwable e) {
+      log.error("Exception closing circuit breakers", e);
+      if (e instanceof Error) {
+        throw (Error) e;
+      }
+    }
 
     // stop reporting metrics
     try {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/AveragingMetricProvider.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/AveragingMetricProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.util.circuitbreaker;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import java.io.Closeable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.solr.common.util.ExecutorUtil;
+import org.apache.solr.common.util.SolrNamedThreadFactory;
+import org.apache.solr.logging.CircularList;
+
+/** Averages the metric value over a period of time */
+public class AveragingMetricProvider implements Closeable {
+  private final CircularList<Double> samplesRingBuffer;
+  private ScheduledExecutorService executor;
+  private final AtomicDouble currentAverageValue = new AtomicDouble(-1);
+
+  /**
+   * Creates an instance with an executor that runs every sampleInterval seconds and averages over
+   * numSamples samples.
+   *
+   * @param metricProvider metric provider that will provide a value
+   * @param numSamples number of samples to calculate average for
+   * @param sampleInterval interval between each sample
+   */
+  public AveragingMetricProvider(
+      MetricProvider metricProvider, int numSamples, long sampleInterval) {
+    this.samplesRingBuffer = new CircularList<>(numSamples);
+    executor =
+        Executors.newSingleThreadScheduledExecutor(
+            new SolrNamedThreadFactory(
+                "AveragingMetricProvider-" + metricProvider.getClass().getSimpleName()));
+    executor.scheduleWithFixedDelay(
+        () -> {
+          samplesRingBuffer.add(metricProvider.getMetricValue());
+          currentAverageValue.set(
+              samplesRingBuffer.toList().stream()
+                  .mapToDouble(Double::doubleValue)
+                  .average()
+                  .orElse(-1));
+        },
+        0,
+        sampleInterval,
+        TimeUnit.SECONDS);
+  }
+
+  /**
+   * Return current average. This is a cached value, so calling this method will not incur any
+   * calculations
+   */
+  public double getMetricValue() {
+    return currentAverageValue.get();
+  }
+
+  @Override
+  public void close() {
+    ExecutorUtil.shutdownAndAwaitTermination(executor);
+  }
+
+  /** Interface to provide the metric value. */
+  public interface MetricProvider {
+    double getMetricValue();
+  }
+}

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -17,6 +17,8 @@
 
 package org.apache.solr.util.circuitbreaker;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -41,7 +43,7 @@ import org.apache.solr.util.plugin.NamedListInitializedPlugin;
  *
  * @lucene.experimental
  */
-public abstract class CircuitBreaker implements NamedListInitializedPlugin {
+public abstract class CircuitBreaker implements NamedListInitializedPlugin, Closeable {
   // Only query requests are checked by default
   private Set<SolrRequestType> requestTypes = Set.of(SolrRequestType.QUERY);
   private final List<SolrRequestType> SUPPORTED_TYPES =
@@ -59,6 +61,11 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin {
 
   /** Get error message when the circuit breaker triggers */
   public abstract String getErrorMessage();
+
+  @Override
+  public void close() throws IOException {
+    // Nothing to do by default
+  }
 
   /**
    * Set the request types for which this circuit breaker should be checked. If not called, the

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.util.circuitbreaker;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import org.apache.solr.common.util.NamedList;
 import org.slf4j.Logger;
@@ -73,6 +74,19 @@ public class CircuitBreakerManager extends CircuitBreaker {
     if (cpuEnabled) {
       cpuCB = new CPUCircuitBreaker();
       cpuCB.setThreshold(cpuThreshold);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      if (memEnabled) {
+        memCB.close();
+      }
+    } finally {
+      if (cpuEnabled) {
+        cpuCB.close();
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
@@ -17,32 +17,64 @@
 
 package org.apache.solr.util.circuitbreaker;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import org.apache.solr.util.RefCounted;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks the current JVM heap usage and triggers if it exceeds the defined percentage of the
- * maximum heap size allocated to the JVM. This circuit breaker is a part of the default
- * CircuitBreakerRegistry so is checked for every request -- hence it is realtime. Once the memory
- * usage goes below the threshold, it will start allowing queries again.
+ * Tracks the current JVM heap usage and triggers if a moving heap usage average over 30 seconds
+ * exceeds the defined percentage of the maximum heap size allocated to the JVM. Once the average
+ * memory usage goes below the threshold, it will start allowing queries again.
  *
  * <p>The memory threshold is defined as a percentage of the maximum memory allocated -- see
- * memThreshold in solrconfig.xml.
+ * memThreshold in <code>solrconfig.xml</code>.
  */
 public class MemoryCircuitBreaker extends CircuitBreaker {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
+  // One shared provider / executor for all instances of this class
+  private static RefCounted<AveragingMetricProvider> averagingMetricProvider;
 
   private long heapMemoryThreshold;
 
   private static final ThreadLocal<Long> seenMemory = ThreadLocal.withInitial(() -> 0L);
   private static final ThreadLocal<Long> allowedMemory = ThreadLocal.withInitial(() -> 0L);
 
+  /** Creates an instance which averages over 6 samples during last 30 seconds. */
   public MemoryCircuitBreaker() {
+    this(6, 5);
+  }
+
+  /**
+   * Constructor that allows override of sample interval for which the memory usage is fetched. This
+   * is provided for testing, not intended for general use because the average metric provider
+   * implementation is the same for all instances of the class.
+   *
+   * @param numSamples number of samples to calculate average for
+   * @param sampleInterval interval between each sample
+   */
+  protected MemoryCircuitBreaker(int numSamples, int sampleInterval) {
     super();
+    synchronized (MemoryCircuitBreaker.class) {
+      if (averagingMetricProvider == null || averagingMetricProvider.getRefcount() == 0) {
+        averagingMetricProvider =
+            new RefCounted<>(
+                new AveragingMetricProvider(
+                    () -> MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed(),
+                    numSamples,
+                    sampleInterval)) {
+              @Override
+              protected void close() {
+                get().close();
+              }
+            };
+      }
+      averagingMetricProvider.incref();
+    }
   }
 
   public void setThreshold(double thresholdValueInPercentage) {
@@ -60,20 +92,21 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
     }
   }
 
-  // TODO: An optimization can be to trip the circuit breaker for a duration of time
-  // after the circuit breaker condition is matched. This will optimize for per call
-  // overhead of calculating the condition parameters but can result in false positives.
   @Override
   public boolean isTripped() {
 
     long localAllowedMemory = getCurrentMemoryThreshold();
-    long localSeenMemory = calculateLiveMemoryUsage();
+    long localSeenMemory = getAvgMemoryUsage();
 
     allowedMemory.set(localAllowedMemory);
 
     seenMemory.set(localSeenMemory);
 
     return (localSeenMemory >= localAllowedMemory);
+  }
+
+  protected long getAvgMemoryUsage() {
+    return (long) averagingMetricProvider.get().getMetricValue();
   }
 
   @Override
@@ -89,17 +122,12 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
     return heapMemoryThreshold;
   }
 
-  /**
-   * Calculate the live memory usage for the system. This method has package visibility to allow
-   * using for testing.
-   *
-   * @return Memory usage in bytes.
-   */
-  protected long calculateLiveMemoryUsage() {
-    // NOTE: MemoryUsageGaugeSet provides memory usage statistics but we do not use them
-    // here since it will require extra allocations and incur cost, hence it is cheaper to use
-    // MemoryMXBean directly. Ideally, this call should not add noticeable
-    // latency to a query -- but if it does, please signify on SOLR-14588
-    return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
+  @Override
+  public void close() throws IOException {
+    synchronized (MemoryCircuitBreaker.class) {
+      if (averagingMetricProvider != null && averagingMetricProvider.getRefcount() > 0) {
+        averagingMetricProvider.decref();
+      }
+    }
   }
 }

--- a/solr/core/src/test/org/apache/solr/util/BaseTestCircuitBreaker.java
+++ b/solr/core/src/test/org/apache/solr/util/BaseTestCircuitBreaker.java
@@ -19,6 +19,7 @@ package org.apache.solr.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final CircuitBreaker dummyMemBreaker = new MemoryCircuitBreaker();
+  private static final CircuitBreaker dummyCBManager = new CircuitBreakerManager();
 
   protected static void indexDocs() {
     removeAllExistingCircuitBreakers();
@@ -60,11 +63,13 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
   @Override
   public void tearDown() throws Exception {
     super.tearDown();
+    dummyMemBreaker.close();
+    dummyCBManager.close();
   }
 
   @After
   public void after() {
-    h.getCore().getCircuitBreakerRegistry().deregisterAll();
+    removeAllExistingCircuitBreakers();
   }
 
   public void testCBAlwaysTrips() {
@@ -114,9 +119,10 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
   }
 
   public void testBadRequestType() {
+
     expectThrows(
         IllegalArgumentException.class,
-        () -> new MemoryCircuitBreaker().setRequestTypes(List.of("badRequestType")));
+        () -> dummyMemBreaker.setRequestTypes(List.of("badRequestType")));
   }
 
   public void testBuildingMemoryPressure() {
@@ -261,17 +267,21 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
         "//lst[@name='process']/double[@name='time']");
   }
 
-  public void testErrorCode() {
+  public void testErrorCode() throws Exception {
     assertEquals(
         SolrException.ErrorCode.SERVICE_UNAVAILABLE,
-        CircuitBreaker.getErrorCode(List.of(new CircuitBreakerManager())));
+        CircuitBreaker.getErrorCode(List.of(dummyCBManager)));
     assertEquals(
         SolrException.ErrorCode.TOO_MANY_REQUESTS,
-        CircuitBreaker.getErrorCode(List.of(new MemoryCircuitBreaker())));
+        CircuitBreaker.getErrorCode(List.of(dummyMemBreaker)));
   }
 
   private static void removeAllExistingCircuitBreakers() {
-    h.getCore().getCircuitBreakerRegistry().deregisterAll();
+    try {
+      h.getCore().getCircuitBreakerRegistry().deregisterAll();
+    } catch (IOException e) {
+      fail("Failed to unload circuit breakers");
+    }
   }
 
   private static class MockCircuitBreaker extends MemoryCircuitBreaker {
@@ -289,10 +299,12 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
   }
 
   private static class FakeMemoryPressureCircuitBreaker extends MemoryCircuitBreaker {
+    public FakeMemoryPressureCircuitBreaker() {
+      super(1, 1);
+    }
 
     @Override
-    protected long calculateLiveMemoryUsage() {
-      // Return a number large enough to trigger a pushback from the circuit breaker
+    protected long getAvgMemoryUsage() {
       return Long.MAX_VALUE;
     }
   }
@@ -301,11 +313,12 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
     private AtomicInteger count;
 
     public BuildingUpMemoryPressureCircuitBreaker() {
+      super(1, 1);
       this.count = new AtomicInteger(0);
     }
 
     @Override
-    protected long calculateLiveMemoryUsage() {
+    protected long getAvgMemoryUsage() {
       int localCount = count.getAndIncrement();
 
       if (localCount >= 4) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16968

Introduced a new utility class `AveragingMetricProvider` that will cache the average for a `double` value provided by the breaker. Uses a scheduled executor every 5 seconds, which is shared by all instances of this class. This same utility can be used by other CBs to achieve the same, but I started with `MemoryCircuitBreaker`.

As this requires some cleanup of executor threads, CircuitBreaker now implements `Closeable` and the registry will close all CBs on close, which is also called from `CoreContainer#doClose`. I also added some synchonization on the map, which isn't really necessary in normal runtime, but I figured useful for tests.

*NOTE* that this may conflict with other in-flight CB PRs...