### PR TITLE
SOLR-16979: Randomize port number of Solr in BATS tests

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -204,6 +204,8 @@ Other Changes
 
 * SOLR-16623: new SolrJettyTestRule for tests needing HTTP or Jetty. (David Smiley, Joshua Ouma)
 
+* SOLR-16979: BATS integration tests now mostly start solr instances on a randomly selected port, and do extra cleanup (janhoy)
+
 ==================  9.3.0 ==================
 
 Upgrade Notes

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -44,6 +44,7 @@ import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.OS;
 import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
@@ -253,7 +254,9 @@ public class RunExampleTool extends ToolBase {
 
     boolean isCloudMode = cli.hasOption('c');
     String zkHost = cli.getOptionValue('z');
-    int port = Integer.parseInt(cli.getOptionValue('p', "8983"));
+    int port =
+        Integer.parseInt(
+            cli.getOptionValue('p', SystemUtils.getEnvironmentVariable("SOLR_PORT", "8983")));
     Map<String, Object> nodeStatus =
         startSolr(new File(exDir, "solr"), isCloudMode, cli, port, zkHost, 30);
 
@@ -436,7 +439,10 @@ public class RunExampleTool extends ToolBase {
 
     boolean prompt = !cli.hasOption("noprompt");
     int numNodes = 2;
-    int[] cloudPorts = new int[] {8983, 7574, 8984, 7575};
+    int defaultPort =
+        Integer.parseInt(
+            cli.getOptionValue('p', SystemUtils.getEnvironmentVariable("SOLR_PORT", "8983")));
+    int[] cloudPorts = new int[] {defaultPort, defaultPort + 1, defaultPort + 2, defaultPort + 3};
     File cloudDir = new File(exampleDir, "cloud");
     if (!cloudDir.isDirectory()) cloudDir.mkdir();
 

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -238,6 +238,7 @@ task integrationTests(type: BatsTask) {
   def integrationTestOutput = "$buildDir/test-output"
   def solrHome = "$integrationTestOutput/solr-home"
   def solrTestFailuresDir = "$integrationTestOutput/failure-snapshots"
+  def solrPort = new Random().nextInt(10000, 50000)
 
   inputs.dir(distDir)
   outputs.dir(integrationTestOutput)
@@ -250,11 +251,18 @@ task integrationTests(type: BatsTask) {
 
     // TODO - if quiet then don't tee
     standardOutput = new TeeOutputStream(System.out, new FileOutputStream("$integrationTestOutput/test-output.txt"))
-
+    println("Runnin BATS tests with Solr base port ${solrPort}")
   }
 
   environment SOLR_TIP: distDir.toString()
   environment SOLR_HOME: solrHome
+  environment SOLR_PID_DIR: solrHome
+  environment SOLR_PORT: solrPort
+  environment SOLR2_PORT: solrPort + 1
+  environment SOLR3_PORT: solrPort + 2
+  environment SOLR_PORT_8983: 8983
+  environment SOLR_PORT_7574: 7574
+  environment ZK_PORT: solrPort + 1000
   environment SOLR_LOGS_DIR: "$solrHome/logs"
   environment TEST_OUTPUT_DIR: integrationTestOutput
   environment TEST_FAILURE_DIR: solrTestFailuresDir

--- a/solr/packaging/test/README.md
+++ b/solr/packaging/test/README.md
@@ -31,7 +31,7 @@ Individual test files can be selected by specifying the `--tests [test_file.bats
  The `--tests` option may be repeated to select multiple test files to run.
  Wildcarding or specifying individual test methods is currently not supported.
 
-Tests do not currently randomize ports or directories, so they cannot be run
+Most tests use a random port, but the examples use hardcoded ports. For this reason, tests cannot be run
  in parallel. They may also fail if you already have an external cluster up.
 
 ## Writing Tests

--- a/solr/packaging/test/bats_helper.bash
+++ b/solr/packaging/test/bats_helper.bash
@@ -58,8 +58,12 @@ save_home_on_failure() {
     fi
 }
 
+shutdown_all() {
+  solr stop -all >/dev/null 2>&1
+}
+
 delete_all_collections() {
-  local collection_list="$(solr zk ls /collections -z localhost:9983)"
+  local collection_list="$(solr zk ls /collections -z localhost:${ZK_PORT})"
   for collection in $collection_list; do
     if [[ -n $collection ]]; then
       solr delete -c $collection >/dev/null 2>&1
@@ -69,7 +73,7 @@ delete_all_collections() {
 
 config_exists() {
   local config_name=$1
-  local config_list=$(solr zk ls /configs -z localhost:9983)
+  local config_list=$(solr zk ls /configs -z localhost:${ZK_PORT})
 
   for config in $config_list; do
     if [[ $(echo $config | tr -d " ") == $config_name ]]; then
@@ -82,7 +86,7 @@ config_exists() {
 
 collection_exists() {
   local coll_name=$1
-  local coll_list=$(solr zk ls /collections -z localhost:9983)
+  local coll_list=$(solr zk ls /collections -z localhost:${ZK_PORT})
 
   for coll in $coll_list; do
     if [[ $(echo $coll | tr -d " ") == $coll_name ]]; then

--- a/solr/packaging/test/test_assert.bats
+++ b/solr/packaging/test/test_assert.bats
@@ -31,25 +31,25 @@ teardown() {
 @test "assert for non cloud mode" {
   run solr start
 
-  run solr assert --not-cloud http://localhost:8983/solr
+  run solr assert --not-cloud http://localhost:${SOLR_PORT}/solr
   assert_output --partial "needn't include Solr's context-root"
   refute_output --partial "ERROR"
 
-  run solr assert --cloud http://localhost:8983
+  run solr assert --cloud http://localhost:${SOLR_PORT}
   assert_output --partial "ERROR: Solr is not running in cloud mode"
 
-  run ! solr assert --cloud http://localhost:8983/solr -e
+  run ! solr assert --cloud http://localhost:${SOLR_PORT}/solr -e
 }
 
 @test "assert for cloud mode" {
   run solr start -c
 
-  run solr assert --cloud http://localhost:8983
+  run solr assert --cloud http://localhost:${SOLR_PORT}
   refute_output --partial "ERROR"
 
-  run solr assert --not-cloud http://localhost:8983/solr
+  run solr assert --not-cloud http://localhost:${SOLR_PORT}/solr
   assert_output --partial "needn't include Solr's context-root"
   assert_output --partial "ERROR: Solr is not running in standalone mode"
 
-  run ! solr assert --not-cloud http://localhost:8983 -e
+  run ! solr assert --not-cloud http://localhost:${SOLR_PORT} -e
 }

--- a/solr/packaging/test/test_create_collection.bats
+++ b/solr/packaging/test/test_create_collection.bats
@@ -41,34 +41,34 @@ teardown() {
 @test "create collection" {
   run solr create -c COLL_NAME
   assert_output --partial "Created collection 'COLL_NAME'"
-  assert_output --partial "assuming solrUrl is http://localhost:8983"
+  assert_output --partial "assuming solrUrl is http://localhost:${SOLR_PORT}"
 }
 
 @test "create collection using solrUrl" {
-  run solr create -c COLL_NAME -solrUrl http://localhost:8983
+  run solr create -c COLL_NAME -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
-  refute_output --partial "assuming solrUrl is http://localhost:8983"
+  refute_output --partial "assuming solrUrl is http://localhost:${SOLR_PORT}"
 }
 
 @test "create collection using legacy solrUrl" {
-  run solr create -c COLL_NAME -solrUrl http://localhost:8983/solr
+  run solr create -c COLL_NAME -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "needn't include Solr's context-root"
-  refute_output --partial "assuming solrUrl is http://localhost:8983"
+  refute_output --partial "assuming solrUrl is http://localhost:${SOLR_PORT}"
 }
 
 @test "create collection using Zookeeper" {
-  run solr create -c COLL_NAME -zkHost localhost:9983
+  run solr create -c COLL_NAME -zkHost localhost:${ZK_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
 }
 
 @test "reject d option with invalid config dir" {
-  run ! solr create -c COLL_NAME -d /asdf  -solrUrl http://localhost:8983/solr
+  run ! solr create -c COLL_NAME -d /asdf  -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Specified configuration directory /asdf not found!"
 }
 
 @test "accept d option with builtin config" {
-  run solr create -c COLL_NAME -d sample_techproducts_configs -solrUrl http://localhost:8983/solr
+  run solr create -c COLL_NAME -d sample_techproducts_configs -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"
 }
 
@@ -78,34 +78,34 @@ teardown() {
   test -d $source_configset_dir
   cp -r "${source_configset_dir}" "${dest_configset_dir}"
 
-  run solr create -c COLL_NAME -d "${dest_configset_dir}" -solrUrl http://localhost:8983/solr
+  run solr create -c COLL_NAME -d "${dest_configset_dir}" -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"
 }
 
 @test "accept n option as config name" {
-  run solr create -c COLL_NAME -n other_conf_name -solrUrl http://localhost:8983/solr
+  run solr create -c COLL_NAME -n other_conf_name -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "config-set 'other_conf_name'"
 }
 
 @test "allow config reuse when n option specifies same config" {
-  run -0 solr create -c COLL_NAME_1 -n shared_config -solrUrl http://localhost:8983/solr
+  run -0 solr create -c COLL_NAME_1 -n shared_config -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME_1'"
   assert_output --partial "config-set 'shared_config'"
 
-  run -0 solr create -c COLL_NAME_2 -n shared_config -solrUrl http://localhost:8983/solr
+  run -0 solr create -c COLL_NAME_2 -n shared_config -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME_2'"
   assert_output --partial "config-set 'shared_config'"
 }
 
 @test "create multisharded collections when s provided" {
-  run -0 solr create -c COLL_NAME -s 2 -solrUrl http://localhost:8983/solr
+  run -0 solr create -c COLL_NAME -s 2 -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "2 shard(s)"
 }
 
 @test "create replicated collections when rf provided" {
-  run -0 solr create -c COLL_NAME -rf 2 -solrUrl http://localhost:8983/solr
+  run -0 solr create -c COLL_NAME -rf 2 -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "2 replica(s)"
 }

--- a/solr/packaging/test/test_delete_collection.bats
+++ b/solr/packaging/test/test_delete_collection.bats
@@ -50,7 +50,7 @@ teardown() {
   solr create -c "COLL_NAME"
   assert collection_exists "COLL_NAME"
 
-  solr delete -c "COLL_NAME" -solrUrl http://localhost:8983
+  solr delete -c "COLL_NAME" -solrUrl http://localhost:${SOLR_PORT}
   refute collection_exists "COLL_NAME"
 }
 

--- a/solr/packaging/test/test_example_noprompt.bats
+++ b/solr/packaging/test/test_example_noprompt.bats
@@ -30,5 +30,6 @@ teardown() {
 
 @test "SOLR-16755 test works with noprompt" {
   solr start -e cloud -noprompt
-  solr assert --started http://localhost:8983/solr --timeout 10000
+  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 10000
+  solr assert --started http://localhost:${SOLR2_PORT}/solr --timeout 10000
 }

--- a/solr/packaging/test/test_export.bats
+++ b/solr/packaging/test/test_export.bats
@@ -30,32 +30,32 @@ teardown() {
 
 @test "Check export command" {
   run solr start -c -e techproducts
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output"
 
   refute_output --partial 'Unrecognized option'
   assert_output --partial 'Export complete'
 
   assert [ -e ${BATS_TEST_TMPDIR}/output.json ]
 
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test"
   assert [ -e techproducts.json ]
   rm techproducts.json
 
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test" -format javabin
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -format javabin
   assert [ -e techproducts.javabin ]
   rm techproducts.javabin
 
   # old pattern of putting a suffix on the out that controlled the format no longer supported ;-).
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output.javabin"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output.javabin"
   assert [ -e ${BATS_TEST_TMPDIR}/output.javabin.json ]
 
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}"
   assert [ -e ${BATS_TEST_TMPDIR}/techproducts.json ]
 
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test" -format jsonl -out "${BATS_TEST_TMPDIR}/output"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -format jsonl -out "${BATS_TEST_TMPDIR}/output"
   assert [ -e ${BATS_TEST_TMPDIR}/output.jsonl ]
 
-  run solr export -url "http://localhost:8983/solr/techproducts" -query "*:* -id:test" -limit 10 -compress -format jsonl -out "${BATS_TEST_TMPDIR}/output"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -limit 10 -compress -format jsonl -out "${BATS_TEST_TMPDIR}/output"
   assert [ -e ${BATS_TEST_TMPDIR}/output.jsonl.gz ]
   assert_output --partial 'Total Docs exported: 10'
 
@@ -64,7 +64,7 @@ teardown() {
 @test "export fails on non cloud mode" {
   run solr start
   run solr create -c COLL_NAME
-  run solr export -url "http://localhost:8983/solr/COLL_NAME"
+  run solr export -url "http://localhost:${SOLR_PORT}/solr/COLL_NAME"
   refute_output --partial 'Export complete'
   assert_output --partial "ERROR: Couldn't initialize a HttpClusterStateProvider"
 }

--- a/solr/packaging/test/test_extraction.bats
+++ b/solr/packaging/test/test_extraction.bats
@@ -47,11 +47,11 @@ teardown() {
       "class": "solr.extraction.ExtractingRequestHandler",
       "defaults":{ "lowernames": "true", "captureAttr":"true"}
     }
-  }' 'http://localhost:8983/solr/gettingstarted/config'
+  }' 'http://localhost:${SOLR_PORT}/solr/gettingstarted/config'
 
-  curl 'http://localhost:8983/solr/gettingstarted/update/extract?literal.id=doc1&commit=true' -F "myfile=@${SOLR_TIP}/example/exampledocs/solr-word.pdf"
+  curl "http://localhost:${SOLR_PORT}/solr/gettingstarted/update/extract?literal.id=doc1&commit=true" -F "myfile=@${SOLR_TIP}/example/exampledocs/solr-word.pdf"
   
-  run curl 'http://localhost:8983/solr/gettingstarted/select?q=id:doc1'
+  run curl "http://localhost:${SOLR_PORT}/solr/gettingstarted/select?q=id:doc1"
   assert_output --partial '"numFound":1'
 }
 
@@ -70,15 +70,15 @@ teardown() {
       "class": "solr.extraction.ExtractingRequestHandler",
       "defaults":{ "lowernames": "true", "captureAttr":"true"}
     }
-  }' 'http://localhost:8983/solr/content_extraction/config'
+  }' 'http://localhost:${SOLR_PORT}/solr/content_extraction/config'
   
   # We filter to pdf to invoke the Extract handler.
-  run solr post -filetypes pdf -commit -url http://localhost:8983/solr/content_extraction/update ${SOLR_TIP}/example/exampledocs
+  run solr post -filetypes pdf -commit -url http://localhost:${SOLR_PORT}/solr/content_extraction/update ${SOLR_TIP}/example/exampledocs
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'
   
-  run curl 'http://localhost:8983/solr/content_extraction/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/content_extraction/select?q=*:*"
   assert_output --partial '"numFound":1'
 }
 
@@ -97,14 +97,14 @@ teardown() {
       "class": "solr.extraction.ExtractingRequestHandler",
       "defaults":{ "lowernames": "true", "captureAttr":"true"}
     }
-  }' 'http://localhost:8983/solr/website_extraction/config'
+  }' 'http://localhost:${SOLR_PORT}/solr/website_extraction/config'
   
   # Change to -recursive 1 to crawl multiple pages, but may be too slow.
-  run solr post -mode web -commit -url http://localhost:8983/solr/website_extraction/update -recursive 0 -delay 1 https://solr.apache.org/
+  run solr post -mode web -commit -url http://localhost:${SOLR_PORT}/solr/website_extraction/update -recursive 0 -delay 1 https://solr.apache.org/
 
   assert_output --partial 'POSTed web resource https://solr.apache.org (depth: 0)'
   refute_output --partial 'ERROR'
   
-  run curl 'http://localhost:8983/solr/website_extraction/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/website_extraction/select?q=*:*"
   assert_output --partial '"numFound":1'
 }

--- a/solr/packaging/test/test_modules.bats
+++ b/solr/packaging/test/test_modules.bats
@@ -32,7 +32,7 @@ teardown() {
 @test "SQL Module" {
   run solr start -c -Dsolr.modules=sql
   run solr create -c COLL_NAME
-  run solr api -get http://localhost:8983/solr/COLL_NAME/sql?stmt=select+id+from+COLL_NAME+limit+10
+  run solr api -get http://localhost:${SOLR_PORT}/solr/COLL_NAME/sql?stmt=select+id+from+COLL_NAME+limit+10
   assert_output --partial '"docs":'
   assert_output --partial '"EOF":true'
   assert_output --partial '"RESPONSE_TIME":'
@@ -52,7 +52,7 @@ teardown() {
     -Dsolr.kerberos.cookie.domain=test
 
   # Upload the custom security.json and wait for Solr to try to load it
-  solr zk cp "${security_json}" zk:security.json -z localhost:9983
+  solr zk cp "${security_json}" zk:security.json -z localhost:${ZK_PORT}
   sleep 1
 
   run cat "${SOLR_LOGS_DIR}/solr.log"

--- a/solr/packaging/test/test_packages.bats
+++ b/solr/packaging/test/test_packages.bats
@@ -84,5 +84,5 @@ teardown() {
 #  run solr package deploy solr-splainer -y -cluster
 #  assert_output --partial "Deployment successful"
   
-#  run -0 curl --fail http://localhost:8983/v2/splainer/index.html
+#  run -0 curl --fail http://localhost:${SOLR_PORT}/v2/splainer/index.html
 # }

--- a/solr/packaging/test/test_placement_plugin.bats
+++ b/solr/packaging/test/test_placement_plugin.bats
@@ -31,7 +31,7 @@ teardown() {
 
 @test "Affinity placement plugin using sysprop" {
   run solr start -c -Dsolr.placementplugin.default=affinity
-  solr assert -c http://localhost:8983/solr -t 3000
+  solr assert -c http://localhost:${SOLR_PORT}/solr -t 3000
   run solr create -c COLL_NAME
   collection_exists COLL_NAME
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to affinity'
@@ -40,7 +40,7 @@ teardown() {
 @test "Random placement plugin using ENV" {
   export SOLR_PLACEMENTPLUGIN_DEFAULT=random
   run solr start -c
-  solr assert -c http://localhost:8983/solr -t 3000
+  solr assert -c http://localhost:${SOLR_PORT}/solr -t 3000
   run solr create -c COLL_NAME
   collection_exists COLL_NAME
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to random'

--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -57,7 +57,7 @@ teardown() {
   run solr create -c monitors -d _default
   assert_output --partial "Created collection 'monitors'"
   
-  run solr post -type application/xml -url http://localhost:8983/solr/monitors/update ${SOLR_TIP}/example/exampledocs/monitor.xml
+  run solr post -type application/xml -url http://localhost:${SOLR_PORT}/solr/monitors/update ${SOLR_TIP}/example/exampledocs/monitor.xml
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'
@@ -67,29 +67,29 @@ teardown() {
   
   solr create -c monitors_no_type -d _default
   
-  run solr post -url http://localhost:8983/solr/monitors_no_type/update -commit ${SOLR_TIP}/example/exampledocs/monitor.xml
+  run solr post -url http://localhost:${SOLR_PORT}/solr/monitors_no_type/update -commit ${SOLR_TIP}/example/exampledocs/monitor.xml
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'
-  run curl 'http://localhost:8983/solr/monitors_no_type/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/monitors_no_type/select?q=*:*"
   assert_output --partial '"numFound":1'
   
   solr create -c books_no_type -d _default
   
-  run solr post -url http://localhost:8983/solr/books_no_type/update -commit ${SOLR_TIP}/example/exampledocs/books.json
+  run solr post -url http://localhost:${SOLR_PORT}/solr/books_no_type/update -commit ${SOLR_TIP}/example/exampledocs/books.json
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'
-  run curl 'http://localhost:8983/solr/books_no_type/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/books_no_type/select?q=*:*"
   assert_output --partial '"numFound":4'
   
   solr create -c books_csv_no_type -d _default
   
-  run solr post -url http://localhost:8983/solr/books_csv_no_type/update -commit ${SOLR_TIP}/example/exampledocs/books.csv
+  run solr post -url http://localhost:${SOLR_PORT}/solr/books_csv_no_type/update -commit ${SOLR_TIP}/example/exampledocs/books.csv
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'
-  run curl 'http://localhost:8983/solr/books_csv_no_type/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/books_csv_no_type/select?q=*:*"
   assert_output --partial '"numFound":10'  
 }
 
@@ -98,11 +98,11 @@ teardown() {
   solr create -c mixed_content -d _default
   
   # We filter to xml,json,and csv as we don't want to invoke the Extract handler.
-  run solr post -filetypes xml,json,csv -url http://localhost:8983/solr/mixed_content/update -commit ${SOLR_TIP}/example/exampledocs
+  run solr post -filetypes xml,json,csv -url http://localhost:${SOLR_PORT}/solr/mixed_content/update -commit ${SOLR_TIP}/example/exampledocs
 
   assert_output --partial '16 files indexed.'
   refute_output --partial 'ERROR'
-  run curl 'http://localhost:8983/solr/mixed_content/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/mixed_content/select?q=*:*"
   assert_output --partial '"numFound":46'
 }
 
@@ -116,9 +116,9 @@ teardown() {
       "class": "solr.extraction.ExtractingRequestHandler",
       "defaults":{ "lowernames": "true", "captureAttr":"true"}
     }
-  }' 'http://localhost:8983/solr/webcrawl/config'
+  }' "http://localhost:${SOLR_PORT}/solr/webcrawl/config"
   
-  run solr post -mode web -url http://localhost:8983/webcrawl/update -recursive 1 -delay 1 https://solr.apache.org
+  run solr post -mode web -url http://localhost:${SOLR_PORT}/webcrawl/update -recursive 1 -delay 1 https://solr.apache.org
   assert_output --partial 'Entering crawl at level 0'
 }
 
@@ -127,7 +127,7 @@ teardown() {
   run solr create -c monitors2 -d _default
   assert_output --partial "Created collection 'monitors2'"
   
-  run solr post -url http://localhost:8983/solr/monitors2/update -type application/xml -commit -optimize ${SOLR_TIP}/example/exampledocs/monitor.xml
+  run solr post -url http://localhost:${SOLR_PORT}/solr/monitors2/update -type application/xml -commit -optimize ${SOLR_TIP}/example/exampledocs/monitor.xml
 
   assert_output --partial '1 files indexed.'
   assert_output --partial 'COMMITting Solr index'
@@ -141,26 +141,26 @@ teardown() {
   run solr create -c test_args -d _default
   assert_output --partial "Created collection 'test_args'"
   
-  run solr post -url http://localhost:8983/solr/test_args/update -mode args -type application/xml -out -commit "<delete><query>*:*</query></delete>"
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -type application/xml -out -commit "<delete><query>*:*</query></delete>"
   assert_output --partial '<int name="status">0</int>'
   
   # confirm default type
-  run solr post -url http://localhost:8983/solr/test_args/update -mode args -out -commit "{'delete': {'query': '*:*'}}"
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -out -commit "{'delete': {'query': '*:*'}}"
   assert_output --partial '"status":0'
   
   # confirm we don't get back output without -out
-  run solr post -url http://localhost:8983/solr/test_args/update -mode args -commit "{'delete': {'query': '*:*'}}"
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -commit "{'delete': {'query': '*:*'}}"
   refute_output --partial '"status":0'
   
-  run solr post -url http://localhost:8983/solr/test_args/update -mode args -commit -type text/csv -out $'id,value\nROW1,0.47' 
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -commit -type text/csv -out $'id,value\nROW1,0.47'
   assert_output --partial '"status":0'
-  run curl 'http://localhost:8983/solr/test_args/select?q=id:ROW1'
+  run curl "http://localhost:${SOLR_PORT}/solr/test_args/select?q=id:ROW1"
   assert_output --partial '"numFound":1'
 }
 
 # function used because run echo | solr ends up being (run echo) | solr and we loose the output capture.
 capture_echo_to_solr() {
-    echo "{'commit': {}}" | solr post -url http://localhost:8983/solr/test_stdin/update -mode stdin -type application/json -out
+    echo "{'commit': {}}" | solr post -url http://localhost:${SOLR_PORT}/solr/test_stdin/update -mode stdin -type application/json -out
 }
 
 @test "stdin mode" {

--- a/solr/packaging/test/test_postlogs.bats
+++ b/solr/packaging/test/test_postlogs.bats
@@ -42,11 +42,11 @@ teardown() {
   run solr create -c COLL_NAME
   assert_output --partial "Created collection 'COLL_NAME'"
 
-  run postlogs http://localhost:8983/solr/COLL_NAME ${SOLR_LOGS_DIR}/solr.log
+  run postlogs http://localhost:${SOLR_PORT}/solr/COLL_NAME ${SOLR_LOGS_DIR}/solr.log
   assert_output --partial 'Sending last batch'
   assert_output --partial 'Committed'
 
-  run curl 'http://localhost:8983/solr/COLL_NAME/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/COLL_NAME/select?q=*:*"
   refute_output --partial '"numFound":0'
 }
 
@@ -54,10 +54,10 @@ teardown() {
   run solr create -c COLL_NAME
   assert_output --partial "Created collection 'COLL_NAME'"
 
-  run solr postlogs -url http://localhost:8983/solr/COLL_NAME -rootdir ${SOLR_LOGS_DIR}/solr.log
+  run solr postlogs -url http://localhost:${SOLR_PORT}/solr/COLL_NAME -rootdir ${SOLR_LOGS_DIR}/solr.log
   assert_output --partial 'Sending last batch'
   assert_output --partial 'Committed'
 
-  run curl 'http://localhost:8983/solr/COLL_NAME/select?q=*:*'
+  run curl "http://localhost:${SOLR_PORT}/solr/COLL_NAME/select?q=*:*"
   refute_output --partial '"numFound":0'
 }

--- a/solr/packaging/test/test_security_manager.bats
+++ b/solr/packaging/test/test_security_manager.bats
@@ -43,12 +43,12 @@ teardown() {
   export SOLR_OPTS="-Dsolr.allowPaths=${backup_dir} -Djava.io.tmpdir=${test_tmp_dir}"
   run solr start -c
   run solr create -c COLL_NAME
-  run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}"
+  run solr api -get "http://localhost:${SOLR_PORT}/solr/admin/collections?action=BACKUP&name=test&collection=COLL_NAME&location=file://${backup_dir}"
   assert_output --partial '"status":0'
 
   # Solr is not permissioned for this directory, so it should fail
   backup_dir_other="${backup_dir}-other"
   mkdir -p "${backup_dir_other}"
-  run solr api -get "http://localhost:8983/solr/admin/collections?action=BACKUP&name=test-fail&collection=COLL_NAME&location=file://${backup_dir_other}"
+  run solr api -get "http://localhost:${SOLR_PORT}/solr/admin/collections?action=BACKUP&name=test-fail&collection=COLL_NAME&location=file://${backup_dir_other}"
   assert_output --partial 'access denied'
 }

--- a/solr/packaging/test/test_ssl.bats
+++ b/solr/packaging/test/test_ssl.bats
@@ -51,12 +51,12 @@ teardown() {
   export SOLR_HOST=localhost
 
   solr start -c
-  solr assert --started https://localhost:8983/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
 
-  run solr api -get 'https://localhost:8983/solr/test/select?q=*:*'
+  run solr api -get 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*'
   assert_output --partial '"numFound":0'
 }
 
@@ -84,23 +84,23 @@ teardown() {
   export SOLR_HOST=localhost
 
   solr start -c
-  solr assert --started https://localhost:8983/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
 
   # Just test that curl can connect via insecure or via a custom host header
-  run curl --http2 --cacert "$ssl_dir/solr-ssl.pem" -k 'https://localhost:8983/solr/test/select?q=*:*'
+  run curl --http2 --cacert "$ssl_dir/solr-ssl.pem" -k 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*'
   assert_output --partial '"numFound":0'
 
-  run curl --http2 --cacert "$ssl_dir/solr-ssl.pem" -H "Host: test.solr.apache.org" 'https://127.0.0.1:8983/solr/test/select?q=*:*'
+  run curl --http2 --cacert "$ssl_dir/solr-ssl.pem" -H "Host: test.solr.apache.org" 'https://127.0.0.1:${SOLR_PORT}/solr/test/select?q=*:*'
   assert_output --partial '"numFound":0'
 
   # This is a client setting, so we don't need to restart Solr to make sure that it fails
   export SOLR_SSL_CHECK_PEER_NAME=true
 
   # This should fail the peername check
-  run ! solr api -get 'https://localhost:8983/solr/test/select?q=*:*'
+  run ! solr api -get 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*'
   assert_output --partial 'Server refused connection'
 }
 
@@ -128,16 +128,16 @@ teardown() {
 
   solr start -c
   solr auth enable -type basicAuth -credentials name:password
-  solr assert --started https://localhost:8983/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
 
-  run curl -u name:password --basic --cacert "$ssl_dir/solr-ssl.pem" 'https://localhost:8983/solr/admin/collections?action=CREATE&collection.configName=_default&name=test&numShards=2&replicationFactor=1&router.name=compositeId&wt=json'
+  run curl -u name:password --basic --cacert "$ssl_dir/solr-ssl.pem" 'https://localhost:${SOLR_PORT}/solr/admin/collections?action=CREATE&collection.configName=_default&name=test&numShards=2&replicationFactor=1&router.name=compositeId&wt=json'
   assert_output --partial '"status":0'
 
-  run curl -u name:password --basic --http2 --cacert "$ssl_dir/solr-ssl.pem" 'https://localhost:8983/solr/test/select?q=*:*'
+  run curl -u name:password --basic --http2 --cacert "$ssl_dir/solr-ssl.pem" 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*'
   assert_output --partial '"numFound":0'
 
   # When the Jenkins box "curl" supports --fail-with-body, add "--fail-with-body" and change "run" to "run !", to expect a failure
-  run curl --http2 --cacert "$ssl_dir/solr-ssl.pem" 'https://localhost:8983/solr/test/select?q=*:*'
+  run curl --http2 --cacert "$ssl_dir/solr-ssl.pem" 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*'
   assert_output --partial 'Error 401 Authentication'
 }
 
@@ -190,12 +190,12 @@ teardown() {
   export SOLR_SSL_TRUST_STORE=
   export SOLR_SSL_TRUST_STORE_PASSWORD=
 
-  solr assert --started https://localhost:8983/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
 
-  run solr api -get 'https://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS'
+  run solr api -get 'https://localhost:${SOLR_PORT}/solr/admin/collections?action=CLUSTERSTATUS'
   assert_output --partial '"urlScheme":"https"'
 }
 
@@ -298,7 +298,7 @@ teardown() {
   export SOLR_HOST=localhost
 
   solr start -c
-  solr start -c -z localhost:9983 -p 8984
+  solr start -c -z localhost:${ZK_PORT} -p ${SOLR2_PORT}
 
   # Test Client connections, which do not need the server keystore/truststore
   (
@@ -307,16 +307,16 @@ teardown() {
     export SOLR_SSL_TRUST_STORE=
     export SOLR_SSL_TRUST_STORE_PASSWORD=
 
-    solr assert --started https://localhost:8983/solr --timeout 5000
-    solr assert --started https://localhost:8984/solr --timeout 5000
+    solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+    solr assert --started https://localhost:${SOLR2_PORT}/solr --timeout 5000
 
     run solr create -c test -s 2
     assert_output --partial "Created collection 'test'"
 
-    run solr api -get 'https://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS'
+    run solr api -get 'https://localhost:${SOLR_PORT}/solr/admin/collections?action=CLUSTERSTATUS'
     assert_output --partial '"urlScheme":"https"'
 
-    run solr api -get 'https://localhost:8984/solr/test/select?q=*:*&rows=0'
+    run solr api -get 'https://localhost:${SOLR2_PORT}/solr/test/select?q=*:*&rows=0'
     assert_output --partial '"numFound":0'
 
     (
@@ -324,7 +324,7 @@ teardown() {
       export SOLR_SSL_CLIENT_KEY_STORE=
       export SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
 
-      run ! solr api -get 'https://localhost:8983/solr/test/select?q=*:*&rows=0'
+      run ! solr api -get 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0'
       assert_output --partial 'Server refused connection'
     )
   )
@@ -332,12 +332,12 @@ teardown() {
   # Turn on client hostname verification, and start a new Solr node since the property is a server setting.
   # Test that it fails because the client cert does not use "localhost"
   export SOLR_SSL_CLIENT_HOSTNAME_VERIFICATION=true
-  solr start -c -z localhost:9983 -p 8985
+  solr start -c -z localhost:${ZK_PORT} -p ${SOLR3_PORT}
 
   # We can't check if the server has come up, because we can't connect to it, so just wait
   sleep 5
 
-  run ! solr api -get 'https://localhost:8985/solr/test/select?q=*:*&rows=0'
+  run ! solr api -get 'https://localhost:${SOLR3_PORT}/solr/test/select?q=*:*&rows=0'
   assert_output --partial 'Server refused connection'
 }
 
@@ -437,36 +437,36 @@ teardown() {
   export SOLR_HOST=localhost
 
   solr start -c
-  solr start -c -z localhost:9983 -p 8984
+  solr start -c -z localhost:${ZK_PORT} -p ${SOLR2_PORT}
 
   export SOLR_SSL_KEY_STORE=
   export SOLR_SSL_KEY_STORE_PASSWORD=
   export SOLR_SSL_TRUST_STORE=
   export SOLR_SSL_TRUST_STORE_PASSWORD=
 
-  solr assert --started https://localhost:8983/solr --timeout 5000
-  solr assert --started https://localhost:8984/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR2_PORT}/solr --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
 
-  run solr api -get 'https://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS'
+  run solr api -get 'https://localhost:${SOLR_PORT}/solr/admin/collections?action=CLUSTERSTATUS'
   assert_output --partial '"urlScheme":"https"'
 
-  run solr api -get 'https://localhost:8984/solr/test/select?q=*:*&rows=0'
+  run solr api -get 'https://localhost:${SOLR2_PORT}/solr/test/select?q=*:*&rows=0'
   assert_output --partial '"numFound":0'
 
   export SOLR_SSL_CLIENT_KEY_STORE=
   export SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
 
   # mTLS requires a keyStore, so just using the truststore would fail if mTLS was "NEED"ed, however it is only "WANT"ed, so its ok
-  run solr api -get 'https://localhost:8983/solr/test/select?q=*:*&rows=0'
+  run solr api -get 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0'
   assert_output --partial '"numFound":0'
 
   export SOLR_SSL_CLIENT_TRUST_STORE=
   export SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD=
 
   # TLS cannot work if a truststore and keystore are not provided (either Server or Client)
-  run solr api -get 'https://localhost:8983/solr/test/select?q=*:*&rows=0'
+  run solr api -get 'https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0'
   assert_output --partial 'Server refused connection'
 }

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -30,9 +30,9 @@ teardown() {
 
 @test "SOLR-11740 check 'solr stop' connection" {
   solr start
-  solr start -p 7574
-  solr assert --started http://localhost:8983/solr --timeout 5000
-  solr assert --started http://localhost:7574/solr --timeout 5000
+  solr start -p ${SOLR2_PORT}
+  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR2_PORT}/solr --timeout 5000
   run bash -c 'solr stop -all 2>&1'
   refute_output --partial 'forcefully killing'
 }
@@ -40,12 +40,12 @@ teardown() {
 @test "stop command for single port" {
 
   solr start
-  solr start -p 7574
-  solr assert --started http://localhost:8983/solr --timeout 5000
-  solr assert --started http://localhost:7574/solr --timeout 5000
+  solr start -p ${SOLR2_PORT}
+  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR2_PORT}/solr --timeout 5000
   
-  run solr stop -p 7574
-  solr assert --not-started http://localhost:7574/solr --timeout 5000
-  solr assert --started http://localhost:8983/solr --timeout 5000
+  run solr stop -p ${SOLR2_PORT}
+  solr assert --not-started http://localhost:${SOLR2_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
 
 }

--- a/solr/packaging/test/test_status.bats
+++ b/solr/packaging/test/test_status.bats
@@ -45,7 +45,7 @@ teardown() {
   run solr status -solrUrl http://localhost:9999/solr
   assert_output --partial "needn't include Solr's context-root"
   assert_output --partial "Found 1 Solr nodes:"
-  assert_output --partial "running on port 8983"
+  assert_output --partial "running on port ${SOLR_PORT}"
 }
 
 @test "status help flag outputs message highlighting not to use solrUrl." {

--- a/solr/packaging/test/test_zk.bats
+++ b/solr/packaging/test/test_zk.bats
@@ -38,24 +38,24 @@ teardown() {
 
 @test "listing out files" {
   sleep 1
-  run solr zk ls / -z localhost:9983
+  run solr zk ls / -z localhost:${ZK_PORT}
   assert_output --partial "aliases.json"
 }
 
 @test "copying files around" {
   touch myfile.txt
   # Umm, what is solr cp?  It's like bin/solr zk cp but not?
-  run solr cp -src myfile.txt -dst zk:/myfile.txt -z localhost:9983
-  assert_output --partial "Copying from 'myfile.txt' to 'zk:/myfile.txt'. ZooKeeper at localhost:9983"
+  run solr cp -src myfile.txt -dst zk:/myfile.txt -z localhost:${ZK_PORT}
+  assert_output --partial "Copying from 'myfile.txt' to 'zk:/myfile.txt'. ZooKeeper at localhost:${ZK_PORT}"
   sleep 1
-  run solr zk ls / -z localhost:9983
+  run solr zk ls / -z localhost:${ZK_PORT}
   assert_output --partial "myfile.txt"
 
   touch myfile2.txt
-  run solr zk cp myfile2.txt zk:myfile2.txt -z localhost:9983
-  assert_output --partial "Copying from 'myfile2.txt' to 'zk:myfile2.txt'. ZooKeeper at localhost:9983"
+  run solr zk cp myfile2.txt zk:myfile2.txt -z localhost:${ZK_PORT}
+  assert_output --partial "Copying from 'myfile2.txt' to 'zk:myfile2.txt'. ZooKeeper at localhost:${ZK_PORT}"
   sleep 1
-  run solr zk ls / -z localhost:9983
+  run solr zk ls / -z localhost:${ZK_PORT}
   assert_output --partial "myfile2.txt"
 
   rm myfile.txt
@@ -66,12 +66,12 @@ teardown() {
   local source_configset_dir="${SOLR_TIP}/server/solr/configsets/sample_techproducts_configs"
   test -d $source_configset_dir
 
-  run solr zk upconfig -d ${source_configset_dir} -n techproducts2 -z localhost:9983
+  run solr zk upconfig -d ${source_configset_dir} -n techproducts2 -z localhost:${ZK_PORT}
   assert_output --partial "Uploading"
   refute_output --partial "ERROR"
 
   sleep 1
-  run curl "http://localhost:8983/api/cluster/configs?omitHeader=true"
+  run curl "http://localhost:${SOLR_PORT}/api/cluster/configs?omitHeader=true"
   assert_output --partial '"configSets":["_default","techproducts2"]'
 
 }

--- a/solr/packaging/test/test_zz_cleanup.bats
+++ b/solr/packaging/test/test_zz_cleanup.bats
@@ -19,36 +19,20 @@ load bats_helper
 
 setup_file() {
   common_clean_setup
-  solr start -c
 }
 
 teardown_file() {
   common_setup
-  solr stop -all
 }
 
-setup() {
-  common_setup
-}
-
-teardown() {
-  # save a snapshot of SOLR_HOME for failed tests
-  save_home_on_failure
-
-  delete_all_collections
-}
-
-@test "setting property" {
-  solr create -c COLL_NAME
-
-  run solr config -c COLL_NAME -action set-property -property updateHandler.autoCommit.maxDocs -value 100 -solrUrl http://localhost:${SOLR_PORT}/solr
-  assert_output --partial "Successfully set-property updateHandler.autoCommit.maxDocs to 100"
-}
-
-@test "short form of setting property" {
-  solr create -c COLL_NAME
-
-  run solr config -c COLL_NAME -property updateHandler.autoCommit.maxDocs -value 100
-  assert_output --partial "Successfully set-property updateHandler.autoCommit.maxDocs to 100"
-  assert_output --partial "assuming solrUrl is http://localhost:${SOLR_PORT}."
+@test "Cleaning up..." {
+  echo "Making sure all solr instances are stopped"
+  run solr stop -p ${SOLR3_PORT}
+  run solr stop -p ${SOLR2_PORT}
+  run solr stop -p ${SOLR_PORT}
+  run solr stop -p ${SOLR_PORT_8983}
+  run solr stop -p ${SOLR_PORT_7574}
+  run solr stop -all
+  run solr status
+  assert_output --partial "No Solr nodes are running"
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16979

* Assign a random `$SOLR_PORT` for bats tests (through env var)
* Make `solr -e techproducts` respect `$SOLR_PORT`. The `cloud` example uses `$SOLR_PORT+{0..3}` for each node.
* Set `SOLR_PID_DIR` explicitly, to make `solr stop -all` find the pid files
* Add a dummy cleanup test at the very end that explicitly shuts down solr on every known port

The last dummy test is perhaps not necessary, if we get the `solr stop -all` work in all cases, but wanted to make sure solr is always stopped in Jenkins even if a test fails. That has not worked very well until now.