### PR TITLE
SOLR-16981: bin/solr stop improvements

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -147,8 +147,6 @@ fi
 : "${SOLR_STOP_WAIT:=180}"
 : "${SOLR_START_WAIT:=$SOLR_STOP_WAIT}" # defaulting to $SOLR_STOP_WAIT for backwards compatibility reasons
 
-# Store whether a solr port was explicitly provided, for the "solr stop" command.
-PROVIDED_SOLR_PORT="${SOLR_PORT:-}"
 : "${SOLR_PORT:=8983}"
 export SOLR_PORT
 
@@ -412,7 +410,7 @@ function print_usage() {
     echo ""
   elif [ "$CMD" == "stop" ]; then
     echo ""
-    echo "Usage: solr stop [-k key] [-p port] [-V]"
+    echo "Usage: solr stop [-k key] [-p port] [-all] [-V]"
     echo ""
     echo "  -k <key>      Stop key; default is solrrocks"
     echo ""


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16981

```
bin/solr stop -h

Usage: solr stop [-k key] [-p port] [-all] [-V]

  -k <key>      Stop key; default is solrrocks

  -p <port>     Specify the port the Solr HTTP listener is bound to

  -all          Find and stop all running Solr servers on this host

  -V/-verbose   Verbose messages from this script

  NOTE: To see if any Solr servers are running, do: solr status
```

The behavior with only `solr stop` is not clearly documented, but it can be seen from [script comments](https://github.com/apache/solr/blob/main/solr/bin/solr#L1469-L1470) that the intent is that a pure `solr stop` will check PIDs, and if exactly one is found, it will stop it. If more are found, it will abort and ask user to pass `-all`.

However, if the `SOLR_HOME` env var is set (as it e.g. is in docker), and the running solr is on another port, the `solr stop` command will output "No process found for Solr node running on 8983". Thus it is interpreted the same way as if `solr stop -p 8983` was passed. I feel this is confusing, and this PR fixes it by requiring an explicit `-p` switch for that behavior.

We can also explore how the `stop -all` command can have a fallback to use `ps` as the `status` command has, if no PIDs are found...