### PR TITLE
SOLR-16978: Be case insensitive when parsing booleans from text

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -216,6 +216,8 @@ Other Changes
 
 * SOLR-16979: BATS integration tests now start solr instances on a randomly selected port (janhoy)
 
+* SOLR-16978: Be case insensitive when parsing booleans from text (Tomás Fernández Löbbe)
+
 ==================  9.3.0 ==================
 
 Upgrade Notes

--- a/solr/core/src/test/org/apache/solr/core/TestSolrXml.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrXml.java
@@ -303,11 +303,11 @@ public class TestSolrXml extends SolrTestCaseJ4 {
 
   public void testFailAtConfigParseTimeWhenBoolTypeIsExpectedAndValueIsInvalidString() {
     String solrXml =
-        "<solr><solrcloud><bool name=\"genericCoreNodeNames\">NOT_A_BOOLEAN</bool></solrcloud></solr>";
+        "<solr><solrcloud><bool name=\"genericCoreNodeNames\">FOO</bool></solrcloud></solr>";
 
     SolrException thrown =
         assertThrows(SolrException.class, () -> SolrXmlConfig.fromString(solrHome, solrXml));
-    assertEquals("invalid boolean value: NOT_A_BOOLEAN", thrown.getMessage());
+    assertEquals("invalid boolean value: FOO", thrown.getMessage());
   }
 
   public void testFailAtConfigParseTimeWhenIntTypeIsExpectedAndBoolTypeIsGiven() {

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -39,82 +39,11 @@ import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
-import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.Utils;
 import org.junit.Assert;
 
 /** */
 public class TestUtils extends SolrTestCaseJ4 {
-
-  public void testJoin() {
-    assertEquals("a|b|c", StrUtils.join(asList("a", "b", "c"), '|'));
-    assertEquals("a,b,c", StrUtils.join(asList("a", "b", "c"), ','));
-    assertEquals("a\\,b,c", StrUtils.join(asList("a,b", "c"), ','));
-    assertEquals("a,b|c", StrUtils.join(asList("a,b", "c"), '|'));
-
-    assertEquals("a\\\\b|c", StrUtils.join(asList("a\\b", "c"), '|'));
-  }
-
-  public void testEscapeTextWithSeparator() {
-    assertEquals("a", StrUtils.escapeTextWithSeparator("a", '|'));
-    assertEquals("a", StrUtils.escapeTextWithSeparator("a", ','));
-
-    assertEquals("a\\|b", StrUtils.escapeTextWithSeparator("a|b", '|'));
-    assertEquals("a|b", StrUtils.escapeTextWithSeparator("a|b", ','));
-    assertEquals("a,b", StrUtils.escapeTextWithSeparator("a,b", '|'));
-    assertEquals("a\\,b", StrUtils.escapeTextWithSeparator("a,b", ','));
-    assertEquals("a\\\\b", StrUtils.escapeTextWithSeparator("a\\b", ','));
-
-    assertEquals("a\\\\\\,b", StrUtils.escapeTextWithSeparator("a\\,b", ','));
-  }
-
-  public void testSplitEscaping() {
-    List<String> arr = StrUtils.splitSmart("\\r\\n:\\t\\f\\b", ":", true);
-    assertEquals(2, arr.size());
-    assertEquals("\r\n", arr.get(0));
-    assertEquals("\t\f\b", arr.get(1));
-
-    arr = StrUtils.splitSmart("\\r\\n:\\t\\f\\b", ":", false);
-    assertEquals(2, arr.size());
-    assertEquals("\\r\\n", arr.get(0));
-    assertEquals("\\t\\f\\b", arr.get(1));
-
-    arr = StrUtils.splitWS("\\r\\n \\t\\f\\b", true);
-    assertEquals(2, arr.size());
-    assertEquals("\r\n", arr.get(0));
-    assertEquals("\t\f\b", arr.get(1));
-
-    arr = StrUtils.splitWS("\\r\\n \\t\\f\\b", false);
-    assertEquals(2, arr.size());
-    assertEquals("\\r\\n", arr.get(0));
-    assertEquals("\\t\\f\\b", arr.get(1));
-
-    arr = StrUtils.splitSmart("\\:foo\\::\\:bar\\:", ":", true);
-    assertEquals(2, arr.size());
-    assertEquals(":foo:", arr.get(0));
-    assertEquals(":bar:", arr.get(1));
-
-    arr = StrUtils.splitWS("\\ foo\\  \\ bar\\ ", true);
-    assertEquals(2, arr.size());
-    assertEquals(" foo ", arr.get(0));
-    assertEquals(" bar ", arr.get(1));
-
-    arr = StrUtils.splitFileNames("/h/s,/h/\\,s,");
-    assertEquals(2, arr.size());
-    assertEquals("/h/s", arr.get(0));
-    assertEquals("/h/,s", arr.get(1));
-
-    arr = StrUtils.splitFileNames("/h/s");
-    assertEquals(1, arr.size());
-    assertEquals("/h/s", arr.get(0));
-  }
-
-  public void testToLower() {
-    assertEquals(List.of(), StrUtils.toLower(List.of()));
-    assertEquals(List.of(""), StrUtils.toLower(List.of("")));
-    assertEquals(List.of("foo"), StrUtils.toLower(List.of("foo")));
-    assertEquals(List.of("bar", "baz-123"), StrUtils.toLower(List.of("BAR", "Baz-123")));
-  }
 
   public void testNamedLists() {
     SimpleOrderedMap<Integer> map = new SimpleOrderedMap<>();

--- a/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
@@ -267,10 +267,11 @@ public class StrUtils {
    */
   public static boolean parseBool(String s) {
     if (s != null) {
-      if (s.startsWith("true") || s.startsWith("on") || s.startsWith("yes")) {
+      String lowerS = s.toLowerCase(Locale.ROOT);
+      if (lowerS.startsWith("true") || lowerS.startsWith("on") || lowerS.startsWith("yes")) {
         return true;
       }
-      if (s.startsWith("false") || s.startsWith("off") || s.equals("no")) {
+      if (lowerS.startsWith("false") || lowerS.startsWith("off") || lowerS.equals("no")) {
         return false;
       }
     }
@@ -285,10 +286,11 @@ public class StrUtils {
    */
   public static boolean parseBool(String s, boolean def) {
     if (s != null) {
-      if (s.startsWith("true") || s.startsWith("on") || s.startsWith("yes")) {
+      String lowerS = s.toLowerCase(Locale.ROOT);
+      if (lowerS.startsWith("true") || lowerS.startsWith("on") || lowerS.startsWith("yes")) {
         return true;
       }
-      if (s.startsWith("false") || s.startsWith("off") || s.equals("no")) {
+      if (lowerS.startsWith("false") || lowerS.startsWith("off") || lowerS.equals("no")) {
         return false;
       }
     }

--- a/solr/solrj/src/test/org/apache/solr/common/util/StrUtilsTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/StrUtilsTest.java
@@ -16,12 +16,11 @@
  */
 package org.apache.solr.common.util;
 
-import java.util.List;
+import static java.util.Arrays.asList;
 
+import java.util.List;
 import org.apache.solr.SolrTestCase;
 import org.apache.solr.common.SolrException;
-
-import static java.util.Arrays.asList;
 
 public class StrUtilsTest extends SolrTestCase {
 

--- a/solr/solrj/src/test/org/apache/solr/common/util/StrUtilsTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/StrUtilsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.util;
+
+import java.util.List;
+
+import org.apache.solr.SolrTestCase;
+import org.apache.solr.common.SolrException;
+
+import static java.util.Arrays.asList;
+
+public class StrUtilsTest extends SolrTestCase {
+
+  public void testParseBool() {
+    assertTrue(StrUtils.parseBool("true"));
+    assertTrue(StrUtils.parseBool("True"));
+    assertTrue(StrUtils.parseBool("TRUE"));
+    assertTrue(StrUtils.parseBool("true  "));
+    assertTrue(StrUtils.parseBool("trueAbc"));
+
+    assertTrue(StrUtils.parseBool("on"));
+    assertTrue(StrUtils.parseBool("ON"));
+    assertTrue(StrUtils.parseBool("on   "));
+    assertTrue(StrUtils.parseBool("onABC"));
+
+    assertTrue(StrUtils.parseBool("yes"));
+    assertTrue(StrUtils.parseBool("YES"));
+    assertTrue(StrUtils.parseBool("yes   "));
+    assertTrue(StrUtils.parseBool("yesABC"));
+
+    assertFalse(StrUtils.parseBool("false"));
+    assertFalse(StrUtils.parseBool("False"));
+    assertFalse(StrUtils.parseBool("FALSE"));
+    assertFalse(StrUtils.parseBool("false  "));
+    assertFalse(StrUtils.parseBool("falseAbc"));
+
+    assertFalse(StrUtils.parseBool("off"));
+    assertFalse(StrUtils.parseBool("OFF"));
+    assertFalse(StrUtils.parseBool("off   "));
+    assertFalse(StrUtils.parseBool("offAbc"));
+
+    assertFalse(StrUtils.parseBool("no"));
+    assertFalse(StrUtils.parseBool("NO"));
+
+    assertThrows(SolrException.class, () -> StrUtils.parseBool("foo"));
+    assertThrows(SolrException.class, () -> StrUtils.parseBool(""));
+    assertThrows(SolrException.class, () -> StrUtils.parseBool(null));
+  }
+
+  public void testParseBoolWithDefault() {
+    assertTrue(StrUtils.parseBool("true", false));
+    assertTrue(StrUtils.parseBool("True", false));
+    assertTrue(StrUtils.parseBool("TRUE", false));
+    assertTrue(StrUtils.parseBool("true  ", false));
+    assertTrue(StrUtils.parseBool("trueAbc", false));
+
+    assertTrue(StrUtils.parseBool("on", false));
+    assertTrue(StrUtils.parseBool("ON", false));
+    assertTrue(StrUtils.parseBool("on   ", false));
+    assertTrue(StrUtils.parseBool("onABC", false));
+
+    assertTrue(StrUtils.parseBool("yes", false));
+    assertTrue(StrUtils.parseBool("YES", false));
+    assertTrue(StrUtils.parseBool("yes   ", false));
+    assertTrue(StrUtils.parseBool("yesABC", false));
+
+    assertFalse(StrUtils.parseBool("false", true));
+    assertFalse(StrUtils.parseBool("False", true));
+    assertFalse(StrUtils.parseBool("FALSE", true));
+    assertFalse(StrUtils.parseBool("false  ", true));
+    assertFalse(StrUtils.parseBool("falseAbc", true));
+
+    assertFalse(StrUtils.parseBool("off", true));
+    assertFalse(StrUtils.parseBool("OFF", true));
+    assertFalse(StrUtils.parseBool("off   ", true));
+    assertFalse(StrUtils.parseBool("offAbc", true));
+
+    assertFalse(StrUtils.parseBool("no", true));
+    assertFalse(StrUtils.parseBool("NO", true));
+    assertFalse(StrUtils.parseBool("foo", false));
+    assertFalse(StrUtils.parseBool("", false));
+    assertFalse(StrUtils.parseBool(null, false));
+  }
+
+  public void testJoin() {
+    assertEquals("a|b|c", StrUtils.join(asList("a", "b", "c"), '|'));
+    assertEquals("a,b,c", StrUtils.join(asList("a", "b", "c"), ','));
+    assertEquals("a\\,b,c", StrUtils.join(asList("a,b", "c"), ','));
+    assertEquals("a,b|c", StrUtils.join(asList("a,b", "c"), '|'));
+
+    assertEquals("a\\\\b|c", StrUtils.join(asList("a\\b", "c"), '|'));
+  }
+
+  public void testEscapeTextWithSeparator() {
+    assertEquals("a", StrUtils.escapeTextWithSeparator("a", '|'));
+    assertEquals("a", StrUtils.escapeTextWithSeparator("a", ','));
+
+    assertEquals("a\\|b", StrUtils.escapeTextWithSeparator("a|b", '|'));
+    assertEquals("a|b", StrUtils.escapeTextWithSeparator("a|b", ','));
+    assertEquals("a,b", StrUtils.escapeTextWithSeparator("a,b", '|'));
+    assertEquals("a\\,b", StrUtils.escapeTextWithSeparator("a,b", ','));
+    assertEquals("a\\\\b", StrUtils.escapeTextWithSeparator("a\\b", ','));
+
+    assertEquals("a\\\\\\,b", StrUtils.escapeTextWithSeparator("a\\,b", ','));
+  }
+
+  public void testSplitEscaping() {
+    List<String> arr = StrUtils.splitSmart("\\r\\n:\\t\\f\\b", ":", true);
+    assertEquals(2, arr.size());
+    assertEquals("\r\n", arr.get(0));
+    assertEquals("\t\f\b", arr.get(1));
+
+    arr = StrUtils.splitSmart("\\r\\n:\\t\\f\\b", ":", false);
+    assertEquals(2, arr.size());
+    assertEquals("\\r\\n", arr.get(0));
+    assertEquals("\\t\\f\\b", arr.get(1));
+
+    arr = StrUtils.splitWS("\\r\\n \\t\\f\\b", true);
+    assertEquals(2, arr.size());
+    assertEquals("\r\n", arr.get(0));
+    assertEquals("\t\f\b", arr.get(1));
+
+    arr = StrUtils.splitWS("\\r\\n \\t\\f\\b", false);
+    assertEquals(2, arr.size());
+    assertEquals("\\r\\n", arr.get(0));
+    assertEquals("\\t\\f\\b", arr.get(1));
+
+    arr = StrUtils.splitSmart("\\:foo\\::\\:bar\\:", ":", true);
+    assertEquals(2, arr.size());
+    assertEquals(":foo:", arr.get(0));
+    assertEquals(":bar:", arr.get(1));
+
+    arr = StrUtils.splitWS("\\ foo\\  \\ bar\\ ", true);
+    assertEquals(2, arr.size());
+    assertEquals(" foo ", arr.get(0));
+    assertEquals(" bar ", arr.get(1));
+
+    arr = StrUtils.splitFileNames("/h/s,/h/\\,s,");
+    assertEquals(2, arr.size());
+    assertEquals("/h/s", arr.get(0));
+    assertEquals("/h/,s", arr.get(1));
+
+    arr = StrUtils.splitFileNames("/h/s");
+    assertEquals(1, arr.size());
+    assertEquals("/h/s", arr.get(0));
+  }
+
+  public void testToLower() {
+    assertEquals(List.of(), StrUtils.toLower(List.of()));
+    assertEquals(List.of(""), StrUtils.toLower(List.of("")));
+    assertEquals(List.of("foo"), StrUtils.toLower(List.of("foo")));
+    assertEquals(List.of("bar", "baz-123"), StrUtils.toLower(List.of("BAR", "Baz-123")));
+  }
+}


### PR DESCRIPTION
The translation between V1 parameters into the new code based in V2 APIs is using `StrUtils.getBool(String param)` to parse from string. This `StrUtils.getBool` is intended to be more flexible than `Boolean.parseBoolean()`, and accepts things like `yes`/`no`, `on`/`off`, but it's case sensitive.

This PR makes it case insensitive. Note that this code is often used for reading configuration files, so those will also now be case insensitive when this is merged. 
An alternative could be to have a new method to be case insensitive and use that one for the API parameters, but really, if this code is supposed to be more flexible than `Boolean.parseBoolean()`, I think make it case insensitive is the right way to go.

I was also a bit surprised that this code uses `startsWith`, for the most part, which sounds strange to me (maybe intended to allow trailing whitespaces? I'm not sure), but that could be a discussion for a different PR (changing that would be a breaking change)