### PR TITLE
Reduce logging level for slice -> shard mapping in RTG

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -1115,7 +1115,7 @@ public class RealTimeGetComponent extends SearchComponent {
     // the mappings.
 
     for (int i = 0; i < rb.slices.length; i++) {
-      log.info("LOOKUP_SLICE:{}={}", rb.slices[i], rb.shards[i]);
+      log.trace("LOOKUP_SLICE:{}={}", rb.slices[i], rb.shards[i]);
       if (lookup.equals(rb.slices[i]) || slice.equals(rb.slices[i])) {
         return new String[] {rb.shards[i]};
       }


### PR DESCRIPTION
It's strange to be logging this (multiple lines per request) at info level. Seems like some leftover when testing/debugging
