### PR TITLE
SOLR-16925: Fix indentation for JacksonJsonWriter

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -194,6 +194,8 @@ Bug Fixes
 
 * SOLR-16931: ReRankScaler explain breaks with debug=true and in distributed mode (Joel Bernstein)
 
+* SOLR-16925: Fix indentation for JacksonJsonWriter (Houston Putman)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
@@ -32,7 +32,7 @@ import org.apache.solr.request.SolrQueryRequest;
 public class JacksonJsonWriter extends BinaryResponseWriter {
 
   protected final JsonFactory jsonfactory;
-  protected static final PrettyPrinter pretty =
+  protected static final DefaultPrettyPrinter pretty =
       new DefaultPrettyPrinter()
           .withoutSpacesInObjectEntries()
           .withArrayIndenter(DefaultPrettyPrinter.NopIndenter.instance);
@@ -71,7 +71,7 @@ public class JacksonJsonWriter extends BinaryResponseWriter {
       try {
         gen = j.createGenerator(out, JsonEncoding.UTF8);
         if (doIndent) {
-          gen.setPrettyPrinter(pretty);
+          gen.setPrettyPrinter(pretty.createInstance());
         }
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
@@ -19,7 +19,6 @@ package org.apache.solr.response;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import java.io.IOException;
 import java.io.OutputStream;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16925

`PrettyPrinter` is stateful, so we need a new instance every time.