### PR TITLE
SOLR-17004: ZkStateReader waitForState should check clusterState before using watchers

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -21,7 +21,8 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+
+* SOLR-17004: ZkStateReader waitForState should check clusterState before using watchers (Kevin Risden)
 
 Bug Fixes
 ---------------------

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -484,16 +484,14 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     List<SolrCmdDistributor.Node> leaders = new ArrayList<>(slices.size());
     for (Slice slice : slices) {
       String sliceName = slice.getName();
-      Replica leader = slice.getLeader();
-      if (leader == null) {
-        try {
-          leader = zkController.getZkStateReader().getLeaderRetry(collection, sliceName);
-        } catch (InterruptedException e) {
-          throw new SolrException(
-              SolrException.ErrorCode.SERVICE_UNAVAILABLE,
-              "Exception finding leader for shard " + sliceName,
-              e);
-        }
+      Replica leader;
+      try {
+        leader = zkController.getZkStateReader().getLeaderRetry(collection, sliceName);
+      } catch (InterruptedException e) {
+        throw new SolrException(
+            SolrException.ErrorCode.SERVICE_UNAVAILABLE,
+            "Exception finding leader for shard " + sliceName,
+            e);
       }
 
       // TODO: What if leaders changed in the meantime?
@@ -621,10 +619,7 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     String shardId = cloudDesc.getShardId();
 
     try {
-      Replica leaderReplica = clusterState.getCollection(collection).getLeader(shardId);
-      if (leaderReplica == null) {
-        leaderReplica = zkController.getZkStateReader().getLeaderRetry(collection, shardId);
-      }
+      Replica leaderReplica = zkController.getZkStateReader().getLeaderRetry(collection, shardId);
       isLeader = leaderReplica.getName().equals(cloudDesc.getCoreNodeName());
 
       // TODO: what if we are no longer the leader?
@@ -764,10 +759,9 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     String shardId = slice.getName();
 
     try {
-      Replica leaderReplica = slice.getLeader();
-      if (leaderReplica == null) {
-        leaderReplica = zkController.getZkStateReader().getLeaderRetry(collection, shardId);
-      }
+      // Not equivalent to getLeaderProps, which  retries to find a leader.
+      // Replica leader = slice.getLeader();
+      Replica leaderReplica = zkController.getZkStateReader().getLeaderRetry(collection, shardId);
       isLeader = leaderReplica.getName().equals(cloudDesc.getCoreNodeName());
 
       if (!isLeader) {

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
@@ -80,9 +80,11 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
               .getCloudDescriptor()
               .getShardId());
       jetty.stop();
-      int numExpectedNodes = 6 - (i+1);
+      int numExpectedNodes = 6 - (i + 1);
       waitForState(
-          "Expected to see " + numExpectedNodes + " nodes available for " + collection, collection, (n, c) -> n.size() == numExpectedNodes);
+          "Expected to see " + numExpectedNodes + " nodes available for " + collection,
+          collection,
+          (n, c) -> n.size() == numExpectedNodes);
       stoppedRunners.add(jetty);
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
@@ -80,6 +80,9 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
               .getCloudDescriptor()
               .getShardId());
       jetty.stop();
+      int numExpectedNodes = 6 - (i+1);
+      waitForState(
+          "Expected to see " + numExpectedNodes + " nodes available for " + collection, collection, (n, c) -> n.size() == numExpectedNodes);
       stoppedRunners.add(jetty);
     }
 
@@ -87,7 +90,7 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
       runner.start();
     }
     waitForState(
-        "Expected to see nodes come back " + collection, collection, (n, c) -> n.size() == 6);
+        "Expected to see nodes come back for " + collection, collection, (n, c) -> n.size() == 6);
     CollectionAdminRequest.deleteCollection(collection).process(cluster.getSolrClient());
 
     // testLeaderElectionAfterClientTimeout
@@ -99,6 +102,7 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
     // timeout the leader
     String leader = getLeader(collection);
     JettySolrRunner jetty = getRunner(leader);
+    assertNotNull(jetty);
     cluster.expireZkSession(jetty);
 
     for (int i = 0; i < 60; i++) { // wait till leader is changed

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
@@ -79,13 +79,15 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
               .getCoreDescriptor()
               .getCloudDescriptor()
               .getShardId());
+      String jettyNodeName = jetty.getNodeName(); // must get before shutdown
       jetty.stop();
-      int numExpectedNodes = 6 - (i + 1);
-      waitForState(
-          "Expected to see " + numExpectedNodes + " nodes available for " + collection,
-          collection,
-          (n, c) -> n.size() == numExpectedNodes);
       stoppedRunners.add(jetty);
+      waitForState(
+          "Leader should not be " + jettyNodeName,
+          collection,
+          (n, c) ->
+              c.getLeader("shard1") != null
+                  && !jettyNodeName.equals(c.getLeader("shard1").getNodeName()));
     }
 
     for (JettySolrRunner runner : stoppedRunners) {

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1800,6 +1800,7 @@ public class ZkStateReader implements SolrCloseable {
       throw new AlreadyClosedException();
     }
 
+    // Check predicate against known clusterState before trying to add watchers
     if (clusterState != null) {
       Set<String> liveNodes = clusterState.getLiveNodes();
       DocCollection docCollection = clusterState.getCollectionOrNull(collection);
@@ -1864,6 +1865,7 @@ public class ZkStateReader implements SolrCloseable {
       throw new AlreadyClosedException();
     }
 
+    // Check predicate against known clusterState before trying to add watchers
     if (clusterState != null) {
       DocCollection docCollection = clusterState.getCollectionOrNull(collection);
       if (docCollection != null) {

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -938,15 +938,11 @@ public class ZkStateReader implements SolrCloseable {
       throws InterruptedException {
 
     // Try to get from cluster state without retry first, otherwise fallback to retry logic
-    if (clusterState != null) {
-      DocCollection docCollection = clusterState.getCollectionOrNull(collection);
-      if (docCollection != null) {
-        Replica leader = docCollection.getLeader(shard);
-        if (leader != null) {
-          log.debug("leader found for {}/{} to be {}", collection, shard, leader);
-          return leader;
-        }
-      }
+    Replica leaderReplica = getLeader(collection, shard);
+    if (leaderReplica != null) {
+      log.debug(
+          "leader found from clusterState for {}/{} to be {}", collection, shard, leaderReplica);
+      return leaderReplica;
     }
 
     AtomicReference<Replica> leader = new AtomicReference<>();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17004

# Description

Trying to get the leader with retry ends up using a lot of watches and locks on collection state watchers. This ends up being contentious and slows down processing. In most cases we can pull the leader right from the `clusterState` and fall back to the slower logic if the leader is not setup yet.

# Solution

Update waitForState to check the predicate against the known clusterState before falling back to the retry logic.