### PR TITLE
SOLR-16991: Fix bug: Concurrent requests failing JWT Auth intermittently

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -209,6 +209,8 @@ Bug Fixes
 
 * SOLR-16701: Fix race condition on PRS enabled collection deletion (Patson Luk)
 
+* SOLR-16991: Fix bug: Concurrent requests failing JWT authentication intermittently (Lamine Idjeraoui, janhoy)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -209,7 +209,7 @@ Bug Fixes
 
 * SOLR-16701: Fix race condition on PRS enabled collection deletion (Patson Luk)
 
-* SOLR-16991: Fix bug: Concurrent requests failing JWT authentication intermittently (Lamine Idjeraoui, janhoy)
+* SOLR-16991: Concurrent requests failing JWT authentication in Admin UI intermittently (Lamine Idjeraoui, janhoy)
 
 Dependency Upgrades
 ---------------------

--- a/solr/webapp/web/js/angular/app.js
+++ b/solr/webapp/web/js/angular/app.js
@@ -592,6 +592,10 @@ solrAdminApp.controller('MainController', function($scope, $route, $rootScope, $
     $scope.http401 = sessionStorage.getItem("http401");
   };
 
+  $scope.showHideMenu = function() {
+    $scope.http401 = sessionStorage.getItem("http401");
+  };
+
   $scope.isMultiDestAlias = function(selectedColl) {
     return selectedColl && selectedColl.type === 'alias' && selectedColl.collections.includes(',');
   };

--- a/solr/webapp/web/js/angular/controllers/login.js
+++ b/solr/webapp/web/js/angular/controllers/login.js
@@ -18,7 +18,7 @@
 solrAdminApp.controller('LoginController',
     ['$scope', '$routeParams', '$rootScope', '$location', '$window', 'AuthenticationService', 'Constants',
       function ($scope, $routeParams, $rootScope, $location, $window, AuthenticationService, Constants) {
-        $scope.resetMenu("login", Constants.IS_ROOT_PAGE);
+        $scope.showHideMenu();
         $scope.subPath = $routeParams.route;
         $rootScope.exceptions = {};
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16991
 
# Description

There's an intermittent failure in JWT authentication, with a roughly 20% failure rate (depends on the network latency). Upon investigating, I identified a race condition due to simultaneous HTTP requests within the authentication process. 
Here's the chain of events:

1.   The user initiates the OAuth/IdProvider authentication process. Once completed, they are redirected back to Solr.

2.   _LoginController_ is then activated to handle the response from the IdProvider.

3.   _LoginController_ calls "[resetMenu](https://github.com/apache/solr/blob/51c1a785c4611d0103f7b73c8adefa028d608bcd/solr/webapp/web/js/angular/controllers/login.js#L21)" method which triggers requests to the "admin/info/system" and "admin/cores" endpoints. These requests are bound to fail as the _auth.header_ hasn't been set yet.

4.  The authentication process continues with the processing of the IdProvider's response. If successful, the _auth.header_ [is set](https://github.com/apache/solr/blob/51c1a785c4611d0103f7b73c8adefa028d608bcd/solr/webapp/web/js/angular/controllers/login.js#L151).

5.  The response from step 3 is received and returns a 401 error, causing the _auth.header_ to be [unset](https://github.com/apache/solr/blob/51c1a785c4611d0103f7b73c8adefa028d608bcd/solr/webapp/web/js/angular/app.js#L440) in _app.js_.

6.  This results in the session being terminated and the entire authentication process failing.

This race condition, where requests are made before setting the authentication header and their subsequent failure clears an already set header, leads to the observed intermittent authentication issues.

Is the "resetMenu" call necessary ? My inclination is that this is useless because why would you need to reset the menu in the middle of an authentication process? All we need is either show or hide the menu depending on the existence or not of an active  user session. The menu would be reset after the user is authenticated.


# Solution


Replaced the call to resetMenu with a call to a newly added method showHideMenu and it worked nicely.

```
$scope.showHideMenu = function() {
    $scope.http401 = sessionStorage.getItem("http401");
  };

```
# Tests

Local and remote tests.
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
