### PR TITLE
Port defaulting should be the same for all tools

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -148,7 +148,7 @@ fi
 : "${SOLR_START_WAIT:=$SOLR_STOP_WAIT}" # defaulting to $SOLR_STOP_WAIT for backwards compatibility reasons
 
 # Store whether a solr port was explicitly provided, for the "solr stop" command.
-PROVIDED_SOLR_PORT="${SOLR_PORT:-}"
+PROVIDED_SOLR_PORT_ENV="${SOLR_PORT:-}"
 : "${SOLR_PORT:=8983}"
 export SOLR_PORT
 
@@ -626,6 +626,7 @@ function jetty_port() {
 # run a Solr command-line tool using the SolrCLI class;
 # useful for doing cross-platform work from the command-line using Java
 function run_tool() {
+  export SOLR_PORT="$(choose_default_solr_port)"
 
   # shellcheck disable=SC2086
   "$JAVA" $SOLR_SSL_OPTS $AUTHC_OPTS ${SOLR_ZK_CREDS_AND_ACLS:-} ${SOLR_TOOL_OPTS:-} -Dsolr.install.dir="$SOLR_TIP" \
@@ -636,97 +637,75 @@ function run_tool() {
   return $?
 } # end run_tool function
 
+function get_all_running_solr_processes() {
+  # no pid files but check using ps just to be sure
+  numSolrs=$(ps auxww | grep start\.jar | grep solr\.solr\.home | grep -v grep | wc -l | sed -e 's/^[ \t]*//')
+  if [ "$numSolrs" != "0" ]; then
+    PROCESSES=($(ps auxww | grep start\.jar | grep solr\.solr\.home | grep -v grep | awk '{print $2}' | sort -r))
+    echo "${PROCESSES[@]}"
+  else
+    echo -e "\nNo Solr nodes are running.\n" >&2
+  fi
+}
+
+function get_all_running_solr_ports() {
+  for ID in $(get_all_running_solr_processes); do
+    port=$(jetty_port "$ID")
+    if [ "$port" != "" ]; then
+      echo -e "\nSolr process $ID running on port $port\n" >&2
+      echo "$port"
+    fi
+  done
+}
+
+# This chooses a default solr port if one is not provided via the command line.
+#  1. If a port is provided to the function, use that.
+#  2. If a SOLR_PORT is explicitly provided, use it.
+#  3. If there is a single SOLR process running on the machine, use that.
+function choose_default_solr_port() {
+  chosen_solr_port=""
+  explicit_solr_port="${1:-}"
+  explicit_solr_port_env="${PROVIDED_SOLR_PORT_ENV}"
+
+  if [ -n "${explicit_solr_port:-}" ]; then
+    chosen_solr_port="${explicit_solr_port}"
+  elif [ -n "${explicit_solr_port_env:-}" ]; then
+    chosen_solr_port="${explicit_solr_port_env}"
+  else
+    # no-commit - check if the SOLR_TOOL_HOST is the localhost, otherwise don't do this
+    all_solr_ports=($(get_all_running_solr_ports))
+    if [ "${#all_solr_ports[@]}" == "0" ]; then
+      chosen_solr_port="8983"
+    elif [ "${#all_solr_ports[@]}" == "1" ]; then
+      chosen_solr_port="${all_solr_ports[0]}"
+    else
+      echo -e "\n${#all_solr_ports[@]} Solr processes found, cannot choose a default process to connect to.\n" >&2
+      exit 1
+    fi
+  fi
+
+  echo "${chosen_solr_port}"
+}
+
 # get status about any Solr nodes running on this host
 function get_status() {
-  # first, see if Solr is running
-  numSolrs=$(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f | wc -l | tr -d ' ')
-  if [ "$numSolrs" != "0" ]; then
-    echo -e "\nFound $numSolrs Solr nodes: "
-    while read PIDF
-      do
-        ID=$(cat "$PIDF")
-        port=$(jetty_port "$ID")
-        if [ "$port" != "" ]; then
-          echo -e "\nSolr process $ID running on port $port"
-          run_tool status -solrUrl "$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$port/solr" "$@"
-          echo ""
-        else
-          echo -e "\nSolr process $ID from $PIDF not found."
-        fi
-    done < <(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f)
+  PROCESSES=($(get_all_running_solr_processes))
+  if [ "${#PROCESSES[@]}" != "0" ]; then
+    echo -e "\nFound ${#PROCESSES[@]} Solr nodes: "
+    for ID in $PROCESSES; do
+      port="$(jetty_port "$ID")"
+      if [ "$port" != "" ]; then
+        echo ""
+        echo "Solr process $ID running on port $port"
+        run_tool status -p "${port}" "$@"
+        echo ""
+      fi
+    done
   else
-    # no pid files but check using ps just to be sure
-    numSolrs=$(ps auxww | grep start\.jar | grep solr\.solr\.home | grep -v grep | wc -l | sed -e 's/^[ \t]*//')
-    if [ "$numSolrs" != "0" ]; then
-      echo -e "\nFound $numSolrs Solr nodes: "
-      PROCESSES=$(ps auxww | grep start\.jar | grep solr\.solr\.home | grep -v grep | awk '{print $2}' | sort -r)
-      for ID in $PROCESSES
-        do
-          port=$(jetty_port "$ID")
-          if [ "$port" != "" ]; then
-            echo ""
-            echo "Solr process $ID running on port $port"
-            run_tool status -solrUrl "$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$port/solr" "$@"
-            echo ""
-          fi
-      done
-    else
-      echo -e "\nNo Solr nodes are running.\n"
-      run_tool status "$@"
-    fi
+    run_tool status "$@"
   fi
-
+  exit
 } # end get_status
-
-function run_package() {
-  runningSolrUrl=""
-
-  numSolrs=$(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f | wc -l | tr -d ' ')
-  if [ "$numSolrs" != "0" ]; then
-    #echo -e "\nFound $numSolrs Solr nodes: "
-    while read PIDF
-      do
-        ID=$(cat "$PIDF")
-        port=$(jetty_port "$ID")
-        if [ "$port" != "" ]; then
-          #echo -e "\nSolr process $ID running on port $port"
-          runningSolrUrl="$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$port/solr"
-          break
-          CODE=$?
-          echo ""
-        else
-          echo -e "\nSolr process $ID from $PIDF not found."
-          CODE=1
-        fi
-    done < <(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f)
-  else
-    # no pid files but check using ps just to be sure
-    numSolrs=$(ps auxww | grep start\.jar | grep solr\.solr\.home | grep -v grep | wc -l | sed -e 's/^[ \t]*//')
-    if [ "$numSolrs" != "0" ]; then
-      echo -e "\nFound $numSolrs Solr nodes: "
-      PROCESSES=$(ps auxww | grep start\.jar | grep solr\.solr\.home | grep -v grep | awk '{print $2}' | sort -r)
-      for ID in $PROCESSES
-        do
-          port=$(jetty_port "$ID")
-          if [ "$port" != "" ]; then
-            echo ""
-            echo "Solr process $ID running on port $port"
-            runningSolrUrl="$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:$port/solr"
-            break
-            CODE=$?
-            echo ""
-          fi
-      done
-    else
-      echo -e "\nNo Solr nodes are running.\n"
-      exit 1
-      CODE=3
-    fi
-  fi
-
-  run_tool package -solrUrl "$runningSolrUrl" "$@"
-  #exit $?
-}
 
 # tries to gracefully stop Solr using the Jetty
 # stop command and if that fails, then uses kill -9
@@ -739,36 +718,31 @@ function stop_solr() {
   STOP_KEY="$3"
   SOLR_PID="$4"
 
-  if [ -n "$SOLR_PID"  ]; then
-    echo -e "Sending stop command to Solr running on port $SOLR_PORT ... waiting up to $SOLR_STOP_WAIT seconds to allow Jetty process $SOLR_PID to stop gracefully."
-    # shellcheck disable=SC2086
-    "$JAVA" $SOLR_SSL_OPTS $AUTHC_OPTS ${SOLR_TOOL_OPTS:-} -jar "$DIR/start.jar" "STOP.PORT=$THIS_STOP_PORT" "STOP.KEY=$STOP_KEY" --stop || true
-      (loops=0
-      while true
-      do
-        # Check if a process is running with the specified PID.
-        # -o stat will output the STAT, where Z indicates a zombie
-        # stat='' removes the header (--no-headers isn't supported on all platforms)
-        # Note the space after '$('. It is needed to avoid confusion with special bash eval syntax
-        STAT=$( (ps -o stat='' -p "$SOLR_PID" || :) | tr -d ' ')
-        if [[ "${STAT:-Z}" != "Z" ]]; then
-          slept=$((loops * 2))
-          if [ $slept -lt $SOLR_STOP_WAIT ]; then
-            sleep 2
-            loops=$((loops+1))
-          else
-            exit # subshell!
-          fi
+  echo -e "Sending stop command to Solr running on port $SOLR_PORT ... waiting up to $SOLR_STOP_WAIT seconds to allow Jetty process $SOLR_PID to stop gracefully."
+  # shellcheck disable=SC2086
+  "$JAVA" $SOLR_SSL_OPTS $AUTHC_OPTS ${SOLR_TOOL_OPTS:-} -jar "$DIR/start.jar" "STOP.PORT=$THIS_STOP_PORT" "STOP.KEY=$STOP_KEY" --stop || true
+    (loops=0
+    while true
+    do
+      # Check if a process is running with the specified PID.
+      # -o stat will output the STAT, where Z indicates a zombie
+      # stat='' removes the header (--no-headers isn't supported on all platforms)
+      # Note the space after '$('. It is needed to avoid confusion with special bash eval syntax
+      STAT=$( (ps -o stat='' -p "$SOLR_PID" || :) | tr -d ' ')
+      if [[ "${STAT:-Z}" != "Z" ]]; then
+        slept=$((loops * 2))
+        if [ $slept -lt $SOLR_STOP_WAIT ]; then
+          sleep 2
+          loops=$((loops+1))
         else
           exit # subshell!
         fi
-      done) &
-    spinner $!
-    rm -f "$SOLR_PID_DIR/solr-$SOLR_PORT.pid"
-  else
-    echo -e "No Solr nodes found to stop."
-    exit 0
-  fi
+      else
+        exit # subshell!
+      fi
+    done) &
+  spinner $!
+  rm -f "$SOLR_PID_DIR/solr-$SOLR_PORT.pid"
 
   # Note the space after '$('. It is needed to avoid confusion with special bash eval syntax
   STAT=$( (ps -o stat='' -p "$SOLR_PID" || :) | tr -d ' ')
@@ -1017,7 +991,7 @@ if [[ "$SCRIPT_CMD" == "package" ]]; then
       esac
     done
   fi
-  run_package "$@"
+  run_tool package "$@"
   exit $?
 fi
 
@@ -1037,6 +1011,21 @@ if [[ "$SCRIPT_CMD" == "auth" ]]; then
         -z|-zkhost|-zkHost)
             ZK_HOST="$2"
             AUTH_PARAMS=("${AUTH_PARAMS[@]}" "-zkHost" "$ZK_HOST")
+            shift 2
+        ;;
+        -p|-port)
+            PORT="$2"
+            AUTH_PARAMS=("${AUTH_PARAMS[@]}" "-p" "$PORT")
+            shift 2
+        ;;
+        -host|--host)
+            HOST="$2"
+            AUTH_PARAMS=("${AUTH_PARAMS[@]}" "--host" "$HOST")
+            shift 2
+        ;;
+        -urlScheme)
+            SCHEME="$2"
+            AUTH_PARAMS=("${AUTH_PARAMS[@]}" "-urlScheme" "$SCHEME")
             shift 2
         ;;
         -t|-type)
@@ -1143,17 +1132,7 @@ if [[ "$SCRIPT_CMD" == "auth" ]]; then
 
   AUTH_PARAMS=("${AUTH_PARAMS[@]}" "-solrIncludeFile" "$SOLR_INCLUDE")
 
-  if [ -z "${AUTH_PORT:-}" ]; then
-    for ID in $(ps auxww | grep java | grep start\.jar | awk '{print $2}' | sort -r)
-      do
-        port=$(jetty_port "$ID")
-        if [ "$port" != "" ]; then
-          AUTH_PORT=$port
-          break
-        fi
-      done
-  fi
-  run_tool auth "${AUTH_PARAMS[@]}" -solrUrl "$SOLR_URL_SCHEME://$SOLR_TOOL_HOST:${AUTH_PORT:-8983}/solr" -authConfDir "$SOLR_HOME" $VERBOSE
+  run_tool auth "${AUTH_PARAMS[@]}" -authConfDir "$SOLR_HOME" $VERBOSE
   exit $?
 fi
 
@@ -1302,7 +1281,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             SOLR_PORT="$2"
-            PROVIDED_SOLR_PORT="${SOLR_PORT}"
+            PROVIDED_PORT="$2"
             PASS_TO_RUN_EXAMPLE+=("-p" "$SOLR_PORT")
             shift 2
         ;;
@@ -1450,46 +1429,15 @@ fi
 if [[ "$SCRIPT_CMD" == "stop" ]]; then
   if $stop_all; then
     none_stopped=true
-    find "$SOLR_PID_DIR" -name "solr-*.pid" -type f | while read PIDF
-      do
-        NEXT_PID=$(cat "$PIDF")
+    all_solr_pids=($(get_all_running_solr_processes))
+    if [ "0" != "${#all_solr_pids[@]}" ]; then
+      for NEXT_PID in "${all_solr_pids[@]}"; do
         port=$(jetty_port "$NEXT_PID")
-        if [ "$port" != "" ]; then
-          stop_solr "$SOLR_SERVER_DIR" "$port" "$STOP_KEY" "$NEXT_PID"
-          none_stopped=false
-        fi
-        rm -f "$PIDF"
-    done
-    # TODO: none_stopped doesn't get reflected across the subshell
-    # This can be uncommented once we find a clean way out of it
-    # if $none_stopped; then
-    #   echo -e "\nNo Solr nodes found to stop.\n"
-    # fi
-    exit
-  elif [[ -z "${PROVIDED_SOLR_PORT:-}" ]]; then
-    # not stopping all and don't have a port, but if we can find a single pid file for Solr, then use that
-    none_stopped=true
-    numSolrs=$(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f | wc -l | tr -d ' ')
-    if [ "$numSolrs" -eq 1 ]; then
-      # only do this if there is only 1 node running, otherwise they must provide the -p or -all
-      PID="$(cat "$(find "$SOLR_PID_DIR" -name "solr-*.pid" -type f)")"
-      CHECK_PID=$(ps -o pid='' -p "$PID" | tr -d ' ')
-      if [ "$CHECK_PID" != "" ]; then
-        port=$(jetty_port "$CHECK_PID")
-        if [ "$port" != "" ]; then
-          stop_solr "$SOLR_SERVER_DIR" "$port" "$STOP_KEY" "$CHECK_PID"
-          none_stopped=false
-        fi
-      fi
-    fi
-
-    if $none_stopped; then
-      if [ "$numSolrs" -gt 0 ]; then
-        echo -e "\nFound $numSolrs Solr nodes running! Must either specify a port using -p or -all to stop all Solr nodes on this host.\n"
-      else
-        echo -e "\nNo Solr nodes found to stop.\n"
-      fi
-      exit 1
+        echo stop_solr "$SOLR_SERVER_DIR" "$port" "$STOP_KEY" "$NEXT_PID"
+        stop_solr "$SOLR_SERVER_DIR" "$port" "$STOP_KEY" "$NEXT_PID"
+      done
+    else
+      echo -e "No Solr nodes found to stop."
     fi
     exit
   fi
@@ -1533,6 +1481,7 @@ if [[ "$SCRIPT_CMD" == "start" ]]; then
 else
   # either stop or restart
   # see if Solr is already running
+  SOLR_PORT="$(choose_default_solr_port "${PROVIDED_PORT-}")"
   SOLR_PID=$(solr_pid_by_port "$SOLR_PORT")
   if [ -z "$SOLR_PID" ]; then
     # not found using the pid file ... but use ps to ensure not found

--- a/solr/core/src/java/org/apache/solr/cli/ApiTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ApiTool.java
@@ -56,8 +56,14 @@ public class ApiTool extends ToolBase {
             .argName("URL")
             .hasArg()
             .required(true)
-            .desc("Send a GET request to a Solr API endpoint.")
-            .build());
+            .desc("Send a GET request to a Solr API endpoint, or path to use with the default Solr URL.")
+            .build(),
+        SolrCLI.OPTION_ZKHOST,
+        SolrCLI.OPTION_SOLRURL,
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
+        SolrCLI.OPTION_VERBOSE);
   }
 
   @Override
@@ -65,7 +71,7 @@ public class ApiTool extends ToolBase {
     String response = null;
     String getUrl = cli.getOptionValue("get");
     if (getUrl != null) {
-      response = callGet(getUrl);
+      response = callGet(cli, getUrl);
     }
     if (response != null) {
       // pretty-print the response to stdout
@@ -73,7 +79,15 @@ public class ApiTool extends ToolBase {
     }
   }
 
-  protected String callGet(String url) throws Exception {
+  protected String callGet(CommandLine cli, String url) throws Exception {
+    if (!url.startsWith("http")) {
+      // Assume the url is a path and query string
+      if (!url.startsWith("/")) {
+        url = "/" + url;
+      }
+      url = SolrCLI.normalizeSolrUrl(cli) + url;
+    }
+    System.out.println("LOOK HERE - " + url);
     URI uri = new URI(url.replace("+", "%20"));
     String solrUrl = getSolrUrlFromUri(uri);
     String path = uri.getPath();

--- a/solr/core/src/java/org/apache/solr/cli/AuthTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/AuthTool.java
@@ -119,6 +119,9 @@ public class AuthTool extends ToolBase {
                 "This is where any authentication related configuration files, if any, would be placed.")
             .build(),
         SolrCLI.OPTION_SOLRURL,
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
         SolrCLI.OPTION_ZKHOST,
         SolrCLI.OPTION_VERBOSE);
   }

--- a/solr/core/src/java/org/apache/solr/cli/ConfigTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ConfigTool.java
@@ -79,6 +79,9 @@ public class ConfigTool extends ToolBase {
             .desc("Set the property to this value; accepts JSON objects and strings.")
             .build(),
         SolrCLI.OPTION_SOLRURL,
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
         SolrCLI.OPTION_ZKHOST);
   }
 

--- a/solr/core/src/java/org/apache/solr/cli/CreateTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/CreateTool.java
@@ -73,6 +73,9 @@ public class CreateTool extends ToolBase {
     return List.of(
         SolrCLI.OPTION_ZKHOST,
         SolrCLI.OPTION_SOLRURL,
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
         Option.builder("c")
             .longOpt("name")
             .argName("NAME")
@@ -131,7 +134,7 @@ public class CreateTool extends ToolBase {
 
   protected void createCore(CommandLine cli, SolrClient solrClient) throws Exception {
     String coreName = cli.getOptionValue("name");
-    String solrUrl = cli.getOptionValue("solrUrl", SolrCLI.getDefaultSolrUrl());
+    String solrUrl = cli.getOptionValue("solrUrl", SolrCLI.getDefaultSolrUrl(cli));
 
     final String solrInstallDir = System.getProperty("solr.install.dir");
     final String confDirName = cli.getOptionValue("confdir", SolrCLI.DEFAULT_CONFIG_SET);
@@ -346,7 +349,7 @@ public class CreateTool extends ToolBase {
     if (confDirectoryName.equals("_default")
         && (confName.equals("") || confName.equals("_default"))) {
       final String collectionName = cli.getOptionValue("collection");
-      final String solrUrl = cli.getOptionValue("solrUrl", SolrCLI.getDefaultSolrUrl());
+      final String solrUrl = cli.getOptionValue("solrUrl", SolrCLI.getDefaultSolrUrl(cli));
       final String curlCommand =
           String.format(
               Locale.ROOT,

--- a/solr/core/src/java/org/apache/solr/cli/DeleteTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/DeleteTool.java
@@ -64,6 +64,9 @@ public class DeleteTool extends ToolBase {
   public List<Option> getOptions() {
     return List.of(
         SolrCLI.OPTION_SOLRURL,
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
         Option.builder("c")
             .longOpt("name")
             .argName("NAME")

--- a/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
@@ -60,6 +60,9 @@ public class HealthcheckTool extends ToolBase {
     return List.of(
         SolrCLI.OPTION_SOLRURL,
         SolrCLI.OPTION_ZKHOST,
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
         Option.builder("c")
             .longOpt("name")
             .argName("NAME")

--- a/solr/core/src/java/org/apache/solr/cli/PackageTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PackageTool.java
@@ -310,6 +310,18 @@ public class PackageTool extends ToolBase {
   public List<Option> getOptions() {
     return List.of(
         SolrCLI.OPTION_SOLRURL,
+        // Cannot use the default OPTION_SOLRPORT, because -p is already taken by PARAMS
+        Option.builder("port")
+            .longOpt("port")
+            .argName("PORT")
+            .hasArg()
+            .required(false)
+            .desc(
+                "Solr Port, which will be used, along with SOLR_TOOL_HOST and SOLR_URL_SCHEME, to determine the Solr URL to connect to if a solrURL is not provided; defaults to: "
+                    + SolrCLI.getSolrPort(null)
+                    + '.')
+            .build(),
+        SolrCLI.OPTION_URLSCHEME,
         Option.builder("collections")
             .argName("COLLECTIONS")
             .hasArg()

--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -75,6 +75,9 @@ public class StatusTool extends ToolBase {
             .required(false)
             .desc("Property set by calling scripts, not meant for user configuration.")
             .build(),
+        SolrCLI.OPTION_SOLRPORT,
+        SolrCLI.OPTION_SOLRHOST,
+        SolrCLI.OPTION_URLSCHEME,
         OPTION_MAXWAITSECS);
   }
 

--- a/solr/core/src/test/org/apache/solr/cli/ApiToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/ApiToolTest.java
@@ -87,6 +87,7 @@ public class ApiToolTest extends SolrCloudTestCase {
 
     String response =
         tool.callGet(
+            null,
             cluster.getJettySolrRunner(0).getBaseUrl()
                 + "/"
                 + COLLECTION_NAME

--- a/solr/packaging/test/bats_helper.bash
+++ b/solr/packaging/test/bats_helper.bash
@@ -66,7 +66,7 @@ delete_all_collections() {
   local collection_list="$(solr zk ls /collections -z localhost:${ZK_PORT})"
   for collection in $collection_list; do
     if [[ -n $collection ]]; then
-      solr delete -c $collection >/dev/null 2>&1
+      solr delete -c $collection -z localhost:${ZK_PORT} >/dev/null 2>&1
     fi
   done
 }

--- a/solr/packaging/test/test_config.bats
+++ b/solr/packaging/test/test_config.bats
@@ -45,6 +45,30 @@ teardown() {
   assert_output --partial "Successfully set-property updateHandler.autoCommit.maxDocs to 100"
 }
 
+@test "setting property with default url" {
+  solr create -c COLL_NAME
+
+  run solr config -c COLL_NAME -action set-property -property updateHandler.autoCommit.maxDocs -value 100
+  assert_output --partial "Successfully set-property updateHandler.autoCommit.maxDocs to 100"
+}
+
+@test "setting property with port scanning" {
+  solr create -c COLL_NAME
+
+  export SOLR_PORT=
+  run solr config -c COLL_NAME -action set-property -property updateHandler.autoCommit.maxDocs -value 100
+  assert_output --partial "Successfully set-property updateHandler.autoCommit.maxDocs to 100"
+}
+
+@test "setting property with explicit port" {
+  solr create -c COLL_NAME
+
+  tmp_port=$SOLR_PORT
+  export SOLR_PORT=
+  run solr config -p ${tmp_port} -c COLL_NAME -action set-property -property updateHandler.autoCommit.maxDocs -value 100
+  assert_output --partial "Successfully set-property updateHandler.autoCommit.maxDocs to 100"
+}
+
 @test "short form of setting property" {
   solr create -c COLL_NAME
 

--- a/solr/packaging/test/test_create_collection.bats
+++ b/solr/packaging/test/test_create_collection.bats
@@ -50,6 +50,33 @@ teardown() {
   refute_output --partial "assuming solrUrl is http://localhost:${SOLR_PORT}"
 }
 
+@test "create collection using port" {
+  tmp_port=${SOLR_PORT}
+  export SOLR_PORT=3090
+  run solr create -c COLL_NAME -p "${tmp_port}"
+  assert_output --partial "Created collection 'COLL_NAME'"
+  refute_output --partial "assuming solrUrl is http://localhost:${SOLR_PORT}"
+}
+
+@test "create collection with -p and --host" {
+  tmp_port=${SOLR_PORT}
+  export SOLR_PORT=
+  export SOLR_HOST=
+  export SOLR_TOOL_HOST=
+
+  run solr create -c "COLL_NAME" -p ${tmp_port} --host localhost
+  assert_output --partial "Created collection 'COLL_NAME'"
+  assert_output --partial "assuming solrUrl is http://localhost:${tmp_port}"
+}
+
+@test "create collection with port scanning" {
+  tmp_port=${SOLR_PORT}
+  export SOLR_PORT=
+  run solr create -c COLL_NAME
+  assert_output --partial "Created collection 'COLL_NAME'"
+  assert_output --partial "assuming solrUrl is http://localhost:${tmp_port}"
+}
+
 @test "create collection using legacy solrUrl" {
   run solr create -c COLL_NAME -solrUrl http://localhost:${SOLR_PORT}/solr
   assert_output --partial "Created collection 'COLL_NAME'"

--- a/solr/packaging/test/test_delete_collection.bats
+++ b/solr/packaging/test/test_delete_collection.bats
@@ -54,6 +54,29 @@ teardown() {
   refute collection_exists "COLL_NAME"
 }
 
+@test "can delete collections with -p and --host" {
+  solr create -c "COLL_NAME"
+  assert collection_exists "COLL_NAME"
+
+  tmp_port=${SOLR_PORT}
+  export SOLR_PORT=
+  export SOLR_HOST=
+  export SOLR_TOOL_HOST=
+
+  solr delete -c "COLL_NAME" -p ${tmp_port} --host localhost
+  refute collection_exists "COLL_NAME"
+}
+
+@test "can delete collections with port scanning" {
+  solr create -c "COLL_NAME"
+  assert collection_exists "COLL_NAME"
+
+  export SOLR_PORT=
+
+  solr delete -c "COLL_NAME"
+  refute collection_exists "COLL_NAME"
+}
+
 @test "collection delete also deletes zk config" {
   solr create -c "COLL_NAME"
   assert config_exists "COLL_NAME"

--- a/solr/packaging/test/test_packages.bats
+++ b/solr/packaging/test/test_packages.bats
@@ -29,7 +29,12 @@ teardown() {
 }
 
 @test "package detects no running solr" {
-  # not sure this is actually a good thing..  we may not want this..
+  # When a SOLR_PORT variable is set, it shouldn't look for running Solr processes
+  run solr package
+  refute_output --partial "No Solr nodes are running."
+
+  # When a SOLR_PORT variable is not set, it should look for running Solr processes
+  export SOLR_PORT=
   run solr package
   assert_output --partial "No Solr nodes are running."
 }

--- a/solr/packaging/test/test_ssl.bats
+++ b/solr/packaging/test/test_ssl.bats
@@ -112,7 +112,7 @@ teardown() {
   export SOLR_SSL_CHECK_PEER_NAME=true
 
   # This should fail the peername check
-  run ! solr api -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*"
+  run ! solr api -verbose -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*"
   assert_output --partial 'Server refused connection'
 
   # Restart the server enabling the SNI hostcheck
@@ -337,10 +337,10 @@ teardown() {
     run solr create -c test -s 2
     assert_output --partial "Created collection 'test'"
 
-    run solr api -get "https://localhost:${SOLR_PORT}/solr/admin/collections?action=CLUSTERSTATUS"
+    run solr api -get "solr/admin/collections?action=CLUSTERSTATUS"
     assert_output --partial '"urlScheme":"https"'
 
-    run solr api -get "https://localhost:${SOLR2_PORT}/solr/test/select?q=*:*&rows=0"
+    run solr api -get "/solr/test/select?q=*:*&rows=0" -p "${SOLR2_PORT}"
     assert_output --partial '"numFound":0'
 
     (
@@ -348,7 +348,7 @@ teardown() {
       export SOLR_SSL_CLIENT_KEY_STORE=
       export SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
 
-      run ! solr api -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0"
+      run ! solr api -verbose -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0"
       assert_output --partial 'Server refused connection'
     )
   )
@@ -361,7 +361,7 @@ teardown() {
   # We can't check if the server has come up, because we can't connect to it, so just wait
   sleep 5
 
-  run ! solr api -get "https://localhost:${SOLR3_PORT}/solr/test/select?q=*:*&rows=0"
+  run ! solr api -verbose -get "https://localhost:${SOLR3_PORT}/solr/test/select?q=*:*&rows=0"
   assert_output --partial 'Server refused connection'
 }
 
@@ -491,6 +491,6 @@ teardown() {
   export SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD=
 
   # TLS cannot work if a truststore and keystore are not provided (either Server or Client)
-  run solr api -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0"
+  run ! solr api -verbose -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*&rows=0"
   assert_output --partial 'Server refused connection'
 }

--- a/solr/packaging/test/test_status.bats
+++ b/solr/packaging/test/test_status.bats
@@ -43,7 +43,6 @@ teardown() {
 @test "status shell script ignores passed in -solrUrl cli parameter from user" {
   solr start
   run solr status -solrUrl http://localhost:9999/solr
-  assert_output --partial "needn't include Solr's context-root"
   assert_output --partial "Found 1 Solr nodes:"
   assert_output --partial "running on port ${SOLR_PORT}"
 }


### PR DESCRIPTION
If Solr processes need to be found, port scanning will always be used.

I need to make a JIRA for this, but this has been exhausting, so it can wait till later.

Basically any Solr tool accepts `-p`, `-host` and `-urlScheme`, and can default the Solr URL from that. If a port is not provided, it will use `SOLR_PORT` if that is explicitly set beforehand. Otherwise, it will scan processes for a Solr Port. If more than one process is found, it will fail.

Similarly the tools (`stop -all`, `status`) that find all running Solr instances will use port scanning instead of PIDs.

This is somewhat back-incompat, for tools that use to use port scanning instead of `SOLR_PORT`, but I think this is acceptable. This can also wait for 10.0 if we want to, but I don't think that's necessary.

This is a WIP and likely needs more tests, and possibly there are some tools that I forgot.