### PR TITLE
Clean up some deprecations and warnings in jwt-auth module

### DIFF
--- a/solr/modules/jwt-auth/build.gradle
+++ b/solr/modules/jwt-auth/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   implementation 'org.apache.httpcomponents:httpclient'
   implementation 'org.apache.httpcomponents:httpcore'
   implementation 'org.eclipse.jetty:jetty-client'
+  implementation 'org.eclipse.jetty:jetty-http'
   implementation 'org.eclipse.jetty.toolchain:jetty-servlet-api'
   implementation 'com.google.guava:guava'
   implementation 'org.slf4j:slf4j-api'

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
@@ -257,9 +257,9 @@ public class JWTAuthPlugin extends AuthenticationPlugin
     issuerConfigs.addAll(parseIssuers(pluginConfig));
     verificationKeyResolver = new JWTVerificationkeyResolver(issuerConfigs, requireIssuer);
 
-    if (issuerConfigs.size() > 0 && getPrimaryIssuer().getAuthorizationEndpoint() != null) {
+    if (!issuerConfigs.isEmpty() && getPrimaryIssuer().getAuthorizationEndpoint() != null) {
       adminUiScope = (String) pluginConfig.get(PARAM_ADMINUI_SCOPE);
-      if (adminUiScope == null && requiredScopes.size() > 0) {
+      if (adminUiScope == null && !requiredScopes.isEmpty()) {
         adminUiScope = requiredScopes.get(0);
         log.warn(
             "No adminUiScope given, using first scope in 'scope' list as required scope for accessing Admin UI");
@@ -384,7 +384,7 @@ public class JWTAuthPlugin extends AuthenticationPlugin
    * @return JWTIssuerConfig object for the primary issuer
    */
   JWTIssuerConfig getPrimaryIssuer() {
-    if (issuerConfigs.size() == 0) {
+    if (issuerConfigs.isEmpty()) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "No issuers configured");
     }
     return issuerConfigs.get(0);
@@ -690,7 +690,7 @@ public class JWTAuthPlugin extends AuthenticationPlugin
                 }
               }
             }
-            if (finalRoles.size() > 0) {
+            if (!finalRoles.isEmpty()) {
               return new JWTAuthenticationResponse(
                   AuthCode.AUTHENTICATED,
                   new JWTPrincipalWithUserRoles(
@@ -972,7 +972,7 @@ public class JWTAuthPlugin extends AuthenticationPlugin
     Object userToken = request.getAttributes().get(Http2SolrClient.REQ_PRINCIPAL_KEY);
     if (userToken instanceof JWTPrincipal) {
       JWTPrincipal jwtPrincipal = (JWTPrincipal) userToken;
-      request.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtPrincipal.getToken());
+      request.headers(h -> h.put(HttpHeaders.AUTHORIZATION, "Bearer " + jwtPrincipal.getToken()));
       return true;
     }
     return false;

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTVerificationkeyResolver.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTVerificationkeyResolver.java
@@ -59,9 +59,9 @@ import org.slf4j.LoggerFactory;
 public class JWTVerificationkeyResolver implements VerificationKeyResolver {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private VerificationJwkSelector verificationJwkSelector = new VerificationJwkSelector();
+  private final VerificationJwkSelector verificationJwkSelector = new VerificationJwkSelector();
 
-  private Map<String, JWTIssuerConfig> issuerConfigs = new HashMap<>();
+  private final Map<String, JWTIssuerConfig> issuerConfigs = new HashMap<>();
   private final boolean requireIssuer;
 
   /**
@@ -73,10 +73,7 @@ public class JWTVerificationkeyResolver implements VerificationKeyResolver {
   public JWTVerificationkeyResolver(
       Collection<JWTIssuerConfig> issuerConfigs, boolean requireIssuer) {
     this.requireIssuer = requireIssuer;
-    issuerConfigs.forEach(
-        ic -> {
-          this.issuerConfigs.put(ic.getIss(), ic);
-        });
+    issuerConfigs.forEach(ic -> this.issuerConfigs.put(ic.getIss(), ic));
   }
 
   @Override

--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginIntegrationTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginIntegrationTest.java
@@ -86,7 +86,6 @@ import org.junit.Test;
  */
 @SolrTestCaseJ4.SuppressSSL
 public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
-  private final String COLLECTION = "jwtColl";
 
   private static String mockOAuthToken;
   private static Path pemFilePath;
@@ -143,7 +142,7 @@ public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
   }
 
   @Test
-  public void mockOAuth2ServerWrongPEMInTruststore() throws Exception {
+  public void mockOAuth2ServerWrongPEMInTruststore() {
     // JWTAuthPlugin throws SSLHandshakeException when fetching JWK, so this trips cluster init
     assertThrows(Exception.class, () -> configureClusterMockOauth(2, wrongPemFilePath, 2000));
   }
@@ -209,6 +208,7 @@ public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
     String baseUrl = cluster.getRandomJetty(random()).getBaseUrl().toString();
     CloseableHttpClient cl = HttpClientUtil.createClient(null);
 
+    String COLLECTION = "jwtColl";
     createCollection(cluster, COLLECTION);
 
     // Missing token
@@ -524,8 +524,10 @@ public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
           TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
       trustManagerFactory.init(keystore);
 
-      MockWebServerWrapper mockWebServerWrapper = new MockWebServerWrapper();
-      MockWebServer mockWebServer = mockWebServerWrapper.getMockWebServer();
+      MockWebServer mockWebServer;
+      try (MockWebServerWrapper mockWebServerWrapper = new MockWebServerWrapper()) {
+        mockWebServer = mockWebServerWrapper.getMockWebServer();
+      }
       SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
       sslContext.init(
           keyManagerFactory.getKeyManagers(), /*trustManagerFactory.getTrustManagers()*/

--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginTest.java
@@ -636,11 +636,7 @@ public class JWTAuthPluginTest extends SolrTestCaseJ4 {
     authConf.put("trustedCerts", trustedPemCert);
     authConf.put("trustedCertsFile", "/path/to/cert.pem");
     plugin = new JWTAuthPlugin();
-    expectThrows(
-        SolrException.class,
-        () -> {
-          plugin.init(authConf);
-        });
+    expectThrows(SolrException.class, () -> plugin.init(authConf));
   }
 
   @Test
@@ -656,12 +652,11 @@ public class JWTAuthPluginTest extends SolrTestCaseJ4 {
     expectThrows(
         SolrException.class,
         CertificateException.class,
-        () -> {
-          CryptoKeys.parseX509Certs(
-              new ByteArrayInputStream(
-                  ("-----BEGIN CERTIFICATE-----\n" + "foo\n" + "-----END CERTIFICATE-----\n")
-                      .getBytes(StandardCharsets.UTF_8)));
-        });
+        () ->
+            CryptoKeys.parseX509Certs(
+                new ByteArrayInputStream(
+                    ("-----BEGIN CERTIFICATE-----\n" + "foo\n" + "-----END CERTIFICATE-----\n")
+                        .getBytes(StandardCharsets.UTF_8))));
   }
 
   @Test

--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTIssuerConfigTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTIssuerConfigTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.noggit.JSONUtil;
 
+@SuppressWarnings("HttpUrlsUsage")
 public class JWTIssuerConfigTest extends SolrTestCase {
   private JWTIssuerConfig testIssuer;
   private Map<String, Object> testIssuerConfigMap;
@@ -153,7 +154,7 @@ public class JWTIssuerConfigTest extends SolrTestCase {
 
     JWTIssuerConfig issuerConfig = new JWTIssuerConfig(issuerConfigMap);
 
-    SolrException e = expectThrows(SolrException.class, () -> issuerConfig.getHttpsJwks());
+    SolrException e = expectThrows(SolrException.class, issuerConfig::getHttpsJwks);
     assertEquals(400, e.code());
     assertEquals(
         "jwksUrl is using http protocol. HTTPS required for IDP communication. Please use SSL or start your nodes with -Dsolr.auth.jwt.allowOutboundHttp=true to allow HTTP for test purposes.",

--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTVerificationkeyResolverTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTVerificationkeyResolverTest.java
@@ -43,6 +43,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 /** Tests the multi jwks resolver that can fetch keys from multiple JWKs */
+@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class JWTVerificationkeyResolverTest extends SolrTestCaseJ4 {
   private JWTVerificationkeyResolver resolver;
 
@@ -117,6 +118,7 @@ public class JWTVerificationkeyResolverTest extends SolrTestCaseJ4 {
     resolver.resolveKey(k5.getJws(), null);
   }
 
+  @SuppressWarnings("NewClassNamingConvention")
   public static class KeyHolder {
     private final RsaJsonWebKey key;
     private final String kid;


### PR DESCRIPTION
(Jo JIRA)

Basically followed recommendations from IDEA.
We still use Apache HTTPClient in some tests, did not cross that bridge now

