### PR TITLE
Fix the admin UI green core-size graph on nodes screen

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -219,6 +219,8 @@ Bug Fixes
 
 * SOLR-16997: OTEL configurator NPE when SOLR_HOST not set (janhoy)
 
+* PR#1963: Fix the admin UI green core-size graph on nodes screen (janhoy)
+
 * SOLR-16980: Connect to SOLR standalone with basic authentication (Alex Deparvu)
 
 Dependency Upgrades

--- a/solr/webapp/web/js/angular/controllers/cloud.js
+++ b/solr/webapp/web/js/angular/controllers/cloud.js
@@ -422,10 +422,10 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
 
               // These are the cores we _expect_ to find on this node according to the CLUSTERSTATUS
               var cores = nodes[node]['cores'];
-              var indexSizeTotal = 0;
+              var indexSizeMax = 0;
               var docsTotal = 0;
               var graphData = [];
-              for (coreId in cores) {
+              for (let coreId in cores) {
                 var core = cores[coreId];
                 if (core['shard_state'] !== 'active' || core['state'] !== 'active') {
                   // If core state is not active, display the real state, or if shard is inactive, display that
@@ -440,7 +440,7 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
                   size = (typeof size !== 'undefined') ? size : 0;
                   core['sizeInBytes'] = size;
                   core['size'] = bytesToSize(size);
-                  indexSizeTotal += size;
+                  indexSizeMax = size > indexSizeMax ? size : indexSizeMax;
                   var numDocs = coreMetric['SEARCHER.searcher.numDocs'];
                   numDocs = (typeof numDocs !== 'undefined') ? numDocs : 0;
                   core['numDocs'] = numDocs;
@@ -455,12 +455,14 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
                   core['warmupTime'] = warmupTime;
                   docsTotal += core['numDocs'];
                 }
-
+              }
+              for (let coreId in cores) {
+                var core = cores[coreId];
                 var graphObj = {};
                 graphObj['label'] = core['label'];
                 graphObj['size'] = core['sizeInBytes'];
                 graphObj['sizeHuman'] = core['size'];
-                graphObj['pct'] = (core['sizeInBytes'] / indexSizeTotal) * 100;
+                graphObj['pct'] = (core['sizeInBytes'] / indexSizeMax) * 100;
                 graphData.push(graphObj);
               }
               if (cores) {
@@ -473,9 +475,9 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
               });
               nodes[node]['graphData'] = graphData;
               nodes[node]['numDocs'] = numDocsHuman(docsTotal);
-              nodes[node]['sizeInBytes'] = indexSizeTotal;
-              nodes[node]['size'] = bytesToSize(indexSizeTotal);
-              nodes[node]['sizePerDoc'] = docsTotal === 0 ? '0b' : bytesToSize(indexSizeTotal / docsTotal);
+              nodes[node]['sizeInBytes'] = indexSizeMax;
+              nodes[node]['size'] = bytesToSize(indexSizeMax);
+              nodes[node]['sizePerDoc'] = docsTotal === 0 ? '0b' : bytesToSize(indexSizeMax / docsTotal);
 
               // Build the d3 powered bar chart
               $('#chart' + nodes[node]['id']).empty();

--- a/solr/webapp/web/js/angular/controllers/cloud.js
+++ b/solr/webapp/web/js/angular/controllers/cloud.js
@@ -422,6 +422,7 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
 
               // These are the cores we _expect_ to find on this node according to the CLUSTERSTATUS
               var cores = nodes[node]['cores'];
+              var indexSizeTotal = 0;
               var indexSizeMax = 0;
               var docsTotal = 0;
               var graphData = [];
@@ -440,6 +441,7 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
                   size = (typeof size !== 'undefined') ? size : 0;
                   core['sizeInBytes'] = size;
                   core['size'] = bytesToSize(size);
+                  indexSizeTotal = indexSizeTotal + size;
                   indexSizeMax = size > indexSizeMax ? size : indexSizeMax;
                   var numDocs = coreMetric['SEARCHER.searcher.numDocs'];
                   numDocs = (typeof numDocs !== 'undefined') ? numDocs : 0;
@@ -475,9 +477,9 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
               });
               nodes[node]['graphData'] = graphData;
               nodes[node]['numDocs'] = numDocsHuman(docsTotal);
-              nodes[node]['sizeInBytes'] = indexSizeMax;
-              nodes[node]['size'] = bytesToSize(indexSizeMax);
-              nodes[node]['sizePerDoc'] = docsTotal === 0 ? '0b' : bytesToSize(indexSizeMax / docsTotal);
+              nodes[node]['sizeInBytes'] = indexSizeTotal;
+              nodes[node]['size'] = bytesToSize(indexSizeTotal);
+              nodes[node]['sizePerDoc'] = docsTotal === 0 ? '0b' : bytesToSize(indexSizeTotal / docsTotal);
 
               // Build the d3 powered bar chart
               $('#chart' + nodes[node]['id']).empty();


### PR DESCRIPTION
The green bar should be 100% wide for the largest core, and the other should be as wide as their relative size compared to the largest core.