### PR TITLE
Update forbiddenapis to 3.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
   id "com.palantir.consistent-versions" version "2.11.0"
   id "org.owasp.dependencycheck" version "8.0.1"
   id 'ca.cutterslade.analyze' version "1.9.0"
-  id 'de.thetaphi.forbiddenapis' version '3.5' apply false
+  id 'de.thetaphi.forbiddenapis' version '3.6' apply false
   id "de.undercouch.download" version "5.2.0" apply false
   id "net.ltgt.errorprone" version "3.0.1" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -235,6 +235,8 @@ Dependency Upgrades
 
 * SOLR-16985: Upgrade Lucene to 9.8.0 (Alex Deparvu, Christine Poerschke)
 
+* PR#xxxx: Update forbiddenapis to 3.6 to support Java 21/22 and commons-io up to 2.14.0 (Uwe Schindler)
+
 Other Changes
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -235,7 +235,7 @@ Dependency Upgrades
 
 * SOLR-16985: Upgrade Lucene to 9.8.0 (Alex Deparvu, Christine Poerschke)
 
-* PR#xxxx: Update forbiddenapis to 3.6 to support Java 21/22 and commons-io up to 2.14.0 (Uwe Schindler)
+* PR#1971: Update forbiddenapis to 3.6 to support Java 21/22 and commons-io up to 2.14.0 (Uwe Schindler)
 
 Other Changes
 ---------------------


### PR DESCRIPTION
This is usual maintenance:
-  to support Java 21/22
-  Allow upgrading of commons-io to 2.14.0