### PR TITLE
SOLR-17009 json.wrf parameter ignored in JacksonJsonWriter

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -256,6 +256,8 @@ Bug Fixes
 
 * SOLR-16644: Fixing the entropy warning threshold using scaling based on poolsize (Raghavan Muthuregunathan)
 
+* SOLR-17009: json.wrf parameter ignored in JacksonJsonWriter (Alex Deparvu)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
@@ -79,7 +79,13 @@ public class JacksonJsonWriter extends BinaryResponseWriter {
 
     @Override
     public void writeResponse() throws IOException {
+      if (wrapperFunction != null) {
+        writeStr(null, wrapperFunction + "(", false);
+      }
       super.writeNamedList(null, rsp.getValues());
+      if (wrapperFunction != null) {
+        writeStr(null, ")", false);
+      }
       gen.close();
     }
 

--- a/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.response;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrDocument;
@@ -313,5 +315,36 @@ public class JSONWriterTest extends SolrTestCaseJ4 {
     assertEquals("arrmap", JSONWriter.JSON_NL_ARROFMAP);
     assertEquals("arrntv", JSONWriter.JSON_NL_ARROFNTV);
     assertEquals("json.wrf", JSONWriter.JSON_WRAPPER_FUNCTION);
+  }
+
+  @Test
+  public void testWfrJacksonJsonWriter() throws IOException {
+    SolrQueryRequest req = req("wt", "json", JSONWriter.JSON_WRAPPER_FUNCTION, "testFun");
+    SolrQueryResponse rsp = new SolrQueryResponse();
+    rsp.add("param0", "v0");
+    rsp.add("param1", 42);
+
+    JacksonJsonWriter w = new JacksonJsonWriter();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    w.write(baos, req, rsp);
+    String received = new String(baos.toByteArray());
+    String expected = "testFun( {\n  \"param0\":\"v0\",\n  \"param1\":42\n} )";
+    jsonEq(expected, received);
+    req.close();
+  }
+
+  @Test
+  public void testWfrJSONWriter() throws IOException {
+    SolrQueryRequest req = req("wt", "json", JSONWriter.JSON_WRAPPER_FUNCTION, "testFun");
+    SolrQueryResponse rsp = new SolrQueryResponse();
+    rsp.add("param0", "v0");
+    rsp.add("param1", 42);
+
+    JSONResponseWriter w = new JSONResponseWriter();
+    StringWriter buf = new StringWriter();
+    w.write(buf, req, rsp);
+    String expected = "testFun({\n  \"param0\":\"v0\",\n  \"param1\":42})";
+    jsonEq(expected, buf.toString());
+    req.close();
   }
 }

--- a/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrDocument;

--- a/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
@@ -326,7 +326,7 @@ public class JSONWriterTest extends SolrTestCaseJ4 {
     JacksonJsonWriter w = new JacksonJsonWriter();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     w.write(baos, req, rsp);
-    String received = new String(baos.toByteArray());
+    String received = new String(baos.toByteArray(), StandardCharsets.UTF_8);
     String expected = "testFun( {\n  \"param0\":\"v0\",\n  \"param1\":42\n} )";
     jsonEq(expected, received);
     req.close();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17009

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Please provide a short description of the changes you're making with this pull request.

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
