### PR TITLE
SOLR-17013: Always use 127.0.0.1 for ZK instead of localhost in tests

### DIFF
--- a/solr/modules/hadoop-auth/src/test-files/krb5-template.conf
+++ b/solr/modules/hadoop-auth/src/test-files/krb5-template.conf
@@ -3,6 +3,7 @@
     default_realm = _REALM_
     udp_preference_limit = _UDP_LIMIT_
     allow_weak_crypto = true
+    dns_canonicalize_hostname = false
     #_KDC_TCP_PORT_
     #_KDC_UDP_PORT_
 [realms]

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/SaslZkACLProviderTest.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/SaslZkACLProviderTest.java
@@ -39,6 +39,7 @@ import org.apache.solr.common.cloud.ZkACLProvider;
 import org.apache.solr.util.BadZookeeperThreadsFilter;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.client.ZooKeeperSaslClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -66,13 +67,14 @@ public class SaslZkACLProviderTest extends SolrTestCaseJ4 {
     assumeFalse(
         "FIXME: SOLR-7040: This test fails under IBM J9", Constants.JAVA_VENDOR.startsWith("IBM"));
     System.setProperty("solrcloud.skip.autorecovery", "true");
-    System.setProperty("hostName", "localhost");
+    System.setProperty("hostName", "127.0.0.1");
   }
 
   @AfterClass
   public static void afterClass() {
     System.clearProperty("solrcloud.skip.autorecovery");
     System.clearProperty("hostName");
+    System.clearProperty(ZKClientConfig.ZOOKEEPER_SERVER_PRINCIPAL);
   }
 
   @Override
@@ -226,7 +228,8 @@ public class SaslZkACLProviderTest extends SolrTestCaseJ4 {
         System.setProperty("zookeeper.kerberos.removeHostFromPrincipal", "true");
         File keytabFile = kdcDir.resolve("keytabs").toFile();
         String zkClientPrincipal = "solr";
-        String zkServerPrincipal = "zookeeper/localhost";
+        String zkServerPrincipal = "zookeeper/127.0.0.1";
+        System.setProperty(ZKClientConfig.ZOOKEEPER_SERVER_PRINCIPAL, zkServerPrincipal);
 
         kerberosTestServices =
             KerberosTestServices.builder()

--- a/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
@@ -21,10 +21,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -562,18 +560,7 @@ public class ZkTestServer {
                     }
 
                     public void setClientPort(int clientPort) {
-                      if (clientPortAddress != null) {
-                        try {
-                          this.clientPortAddress =
-                              new InetSocketAddress(
-                                  InetAddress.getByName(clientPortAddress.getHostName()),
-                                  clientPort);
-                        } catch (UnknownHostException e) {
-                          throw new RuntimeException(e);
-                        }
-                      } else {
-                        this.clientPortAddress = new InetSocketAddress(clientPort);
-                      }
+                      this.clientPortAddress = new InetSocketAddress("127.0.0.1", clientPort);
                       log.info("client port: {}", this.clientPortAddress);
                     }
                   };


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17013