### PR TITLE
SOLR-16390: Tweak clusterprop APIs to be more REST-ful

### DIFF
--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ClusterPropertyApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ClusterPropertyApi.java
@@ -1,0 +1,40 @@
+package org.apache.solr.client.api.endpoint;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.model.UpdateClusterPropertyRequestBody;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import java.util.Map;
+
+/** V2 API definitions for modifying cluster-level properties. */
+@Path("/cluster/properties")
+public interface ClusterPropertyApi {
+
+    @PUT
+    @Path("/{propName}")
+    @Operation(
+            summary = "Create or update a single cluster property",
+            tags = {"cluster-properties"})
+    SolrJerseyResponse updateClusterProperty(
+            @PathParam("propName") String propName,
+            UpdateClusterPropertyRequestBody requestBody)
+            throws Exception;
+
+    @DELETE
+    @Path("/{propName}")
+    @Operation(
+            summary = "Delete a single cluster property",
+            tags = {"cluster-properties"})
+    SolrJerseyResponse deleteClusterProperty(@PathParam("propName") String propName)
+            throws Exception;
+
+    @PUT
+    @Operation(
+            summary = "Update one or more cluster properties",
+            tags = {"cluster-properties"})
+    SolrJerseyResponse updateClusterProperties(Map<String, Object> requestBody) throws Exception;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/UpdateClusterPropertyRequestBody.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/UpdateClusterPropertyRequestBody.java
@@ -1,0 +1,8 @@
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class UpdateClusterPropertyRequestBody {
+    @JsonProperty(required = true)
+    public Object value;
+}

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -171,6 +171,7 @@ import org.apache.solr.handler.admin.api.AdminAPIBase;
 import org.apache.solr.handler.admin.api.AliasProperty;
 import org.apache.solr.handler.admin.api.BalanceReplicas;
 import org.apache.solr.handler.admin.api.BalanceShardUniqueAPI;
+import org.apache.solr.handler.admin.api.ClusterProperty;
 import org.apache.solr.handler.admin.api.CollectionProperty;
 import org.apache.solr.handler.admin.api.CollectionStatusAPI;
 import org.apache.solr.handler.admin.api.CreateAliasAPI;
@@ -1368,6 +1369,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         CreateCollectionBackupAPI.class,
         CreateShard.class,
         DeleteAlias.class,
+        ClusterProperty.class,
         DeleteCollectionBackup.class,
         DeleteCollection.class,
         DeleteReplica.class,

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/ClusterProperty.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/ClusterProperty.java
@@ -1,0 +1,75 @@
+package org.apache.solr.handler.admin.api;
+
+import org.apache.solr.client.api.endpoint.ClusterPropertyApi;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.model.UpdateClusterPropertyRequestBody;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.ClusterProperties;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.jersey.PermissionName;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.security.PermissionNameProvider;
+
+import javax.inject.Inject;
+import java.util.Map;
+
+/**
+ * V2 API implementations for modifying cluster-level properties
+ *
+ * <p>These APIs are analogous to the v1 /admin/collections?action=CLUSTERPROP command.
+ */
+public class ClusterProperty extends AdminAPIBase implements ClusterPropertyApi {
+
+    @Inject
+    public ClusterProperty(
+            CoreContainer coreContainer,
+            SolrQueryRequest solrQueryRequest,
+            SolrQueryResponse solrQueryResponse) {
+        super(coreContainer, solrQueryRequest, solrQueryResponse);
+    }
+
+    @Override
+    @PermissionName(PermissionNameProvider.Name.COLL_EDIT_PERM)
+    public SolrJerseyResponse updateClusterProperty(String propName, UpdateClusterPropertyRequestBody requestBody) throws Exception {
+        if (requestBody == null) {
+            throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Missing required request body");
+        }
+        final SolrJerseyResponse response = instantiateJerseyResponse(SolrJerseyResponse.class);
+
+        final var clusterProperties = readCurrentClusterProperties();
+        clusterProperties.setClusterProperty(propName, requestBody.value);
+        return response;
+    }
+
+    @Override
+    @PermissionName(PermissionNameProvider.Name.COLL_EDIT_PERM)
+    public SolrJerseyResponse deleteClusterProperty(String propName) throws Exception {
+        final SolrJerseyResponse response = instantiateJerseyResponse(SolrJerseyResponse.class);
+
+        final var clusterProperties = readCurrentClusterProperties();
+        clusterProperties.setClusterProperty(propName, null);
+        return response;
+    }
+
+    @Override
+    @PermissionName(PermissionNameProvider.Name.COLL_EDIT_PERM)
+    public SolrJerseyResponse updateClusterProperties(Map<String, Object> requestBody) throws Exception {
+        if (requestBody == null) {
+            throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Missing required request body");
+        }
+        final SolrJerseyResponse response = instantiateJerseyResponse(SolrJerseyResponse.class);
+
+        final var clusterProperties = readCurrentClusterProperties();
+        try {
+            clusterProperties.setClusterProperties(requestBody);
+        } catch (Exception e) {
+            throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error in API", e);
+        }
+        return response;
+    }
+
+    private ClusterProperties readCurrentClusterProperties() {
+        return new ClusterProperties(coreContainer.getZkController().getZkClient());
+    }
+}

--- a/solr/solrj/src/resources/java-template/api.mustache
+++ b/solr/solrj/src/resources/java-template/api.mustache
@@ -100,7 +100,12 @@ public class {{classname}} {
                 {{/isBodyParam}}
                 {{/requiredParams}}
                 {{#bodyParam}}
-                    this.requestBody = new {{baseName}}();
+                {{#isMap}}
+                    this.requestBody = new HashMap<>();
+                {{/isMap}}
+                {{^isMap}}
+                    this.requestBody = new {{{dataType}}}();
+                {{/isMap}}
                     addHeader("Content-type", "application/json");
                 {{/bodyParam}}
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16390


# Description

Solr has slowly been modifying its v2 APIs to align around a more REST-ful model. Many APIs have already been through this re-alignment but many more remain, including a handful of "collection-admin" APIs.

# Solution

This PR chips away at this gap by tweaking Solr's "clusterprop" APIs to be more REST-ful:
  - single property creation+update is now available at `PUT /api/cluster/properties/propName {...}`
  - bulk property creation+update is now available at `PUT /api/cluster/properties {...}`
  - single property deletion is now available at `DELETE /api/cluster/properties/propName`

# Tests

TODO

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
