### PR TITLE
SOLR-17028: Upgrade build tool versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,15 +19,15 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 plugins {
-  id "base"
-  id "com.palantir.consistent-versions" version "2.16.0"
-  id "org.owasp.dependencycheck" version "8.0.1"
-  id 'ca.cutterslade.analyze' version "1.9.0"
+  id 'base'
+  id 'com.palantir.consistent-versions' version '2.16.0'
+  id 'org.owasp.dependencycheck' version '8.4.0'
+  id 'ca.cutterslade.analyze' version '1.9.1'
   id 'de.thetaphi.forbiddenapis' version '3.6' apply false
-  id "de.undercouch.download" version "5.2.0" apply false
-  id "net.ltgt.errorprone" version "3.0.1" apply false
-  id 'com.diffplug.spotless' version "6.5.2" apply false
-  id 'com.github.node-gradle.node' version '3.4.0' apply false
+  id 'de.undercouch.download' version '5.5.0' apply false
+  id 'net.ltgt.errorprone' version '3.1.0' apply false
+  id 'com.diffplug.spotless' version '6.5.2' apply false
+  id 'com.github.node-gradle.node' version '7.0.1' apply false
 }
 
 apply from: file('gradle/globals.gradle')

--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -21,11 +21,11 @@
 
 ext {
   scriptDepVersions = [
-      "apache-rat": "0.14",
-      "commons-codec": "1.15",
-      "ecj": "3.30.0",
+      "apache-rat": "0.15",
+      "commons-codec": "1.16.0",
+      "ecj": "3.33.0",
       "javacc": "7.0.12",
-      "jgit": "5.13.1.202206130422-r",
-      "flexmark": "0.64.0",
+      "jgit": "6.7.0.202309050840-r",
+      "flexmark": "0.64.8",
   ]
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17028

Builds on https://github.com/apache/solr/pull/1997 to get to latest Gradle build dependency versions.

Gradle Build Plugins:
* `org.owasp.dependencycheck` - 8.0.1 -> 8.4.0
* `ca.cutterslade.analyze` - 1.9.0 -> 1.9.1
* `de.undercouch.doownload` - 5.2.0 -> 5.5.0
* `net.ltgt.errorprone` - 3.0.1 -> 3.1.0
* `com.github.node-gradle.node` - 3.4.0 -> 7.0.1

`buildSrc` script dep versions:
* `apache-rat` - 0.14 -> 0.15
* `commons-codec` - 1.15 -> 1.16.0
* `ecj` - 3.30.0 -> 3.33.0 - Note: 3.34.0 or higher requires JDK 17+
* `jgit` - 5.13.1.202206130422-r -> 6.7.0.202309050840-r
* `flexmark` - 0.64.0 -> 0.64.8
