### PR TITLE
SOLR-17027: Removing list.toArray calls with pre sized arrays - part 2

### DIFF
--- a/solr/core/src/test/org/apache/solr/CursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/CursorPagingTest.java
@@ -1117,9 +1117,9 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
       if (null != previousFacets) {
         assertEquals(
             "Facets not the same as on previous page:\nprevious page facets: "
-                + Arrays.toString(facets.toArray(new Object[facets.size()]))
+                + Arrays.toString(facets.toArray(new Object[0]))
                 + "\ncurrent page facets: "
-                + Arrays.toString(previousFacets.toArray(new Object[previousFacets.size()])),
+                + Arrays.toString(previousFacets.toArray(new Object[0])),
             previousFacets,
             facets);
       }

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -1991,7 +1991,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
     public Doc maxDoc; // the document highest according to the "sort" param
 
     public void setMaxDoc(Comparator<Doc> comparator) {
-      Doc[] arr = docs.toArray(new Doc[docs.size()]);
+      Doc[] arr = docs.toArray(new Doc[0]);
       Arrays.sort(arr, comparator);
       maxDoc = arr.length > 0 ? arr[0] : null;
     }

--- a/solr/core/src/test/org/apache/solr/cloud/ReplicationFactorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplicationFactorTest.java
@@ -437,7 +437,7 @@ public class ReplicationFactorTest extends AbstractFullDistribZkTestBase {
   protected void addDocs(String collection, Set<Integer> docIds, int expectedRf, int retries)
       throws Exception {
 
-    Integer[] idList = docIds.toArray(new Integer[docIds.size()]);
+    Integer[] idList = docIds.toArray(new Integer[0]);
     if (idList.length == 1) {
       sendDoc(collection, idList[0]);
       return;

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPivotFacet.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPivotFacet.java
@@ -132,7 +132,7 @@ public class TestCloudPivotFacet extends AbstractFullDistribZkTestBase {
     fieldNameSet.remove("id");
     assertTrue("WTF, bogus field exists?", fieldNameSet.add("bogus_not_in_any_doc_s"));
 
-    final String[] fieldNames = fieldNameSet.toArray(new String[fieldNameSet.size()]);
+    final String[] fieldNames = fieldNameSet.toArray(new String[0]);
     Arrays.sort(fieldNames); // need determinism when picking random fields
 
     for (int i = 0; i < 5; i++) {
@@ -176,7 +176,7 @@ public class TestCloudPivotFacet extends AbstractFullDistribZkTestBase {
       if (random().nextBoolean()) {
         pivotParamValues.add(buildPivotParamValue(buildRandomPivot(fieldNames)));
       }
-      pivotP.set(FACET_PIVOT, pivotParamValues.toArray(new String[pivotParamValues.size()]));
+      pivotP.set(FACET_PIVOT, pivotParamValues.toArray(new String[0]));
 
       // keep limit low - lots of unique values, and lots of depth in pivots
       pivotP.add(FACET_LIMIT, "" + TestUtil.nextInt(random(), 1, 17));

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorCloud.java
@@ -787,7 +787,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
               update(
                       params("update.chain", "tolerant-chain-max-errors-10", "commit", "true"),
-                      docs.toArray(new SolrInputDocument[docs.size()]))
+                      docs.toArray(new SolrInputDocument[0]))
                   .process(client);
             });
 
@@ -895,7 +895,7 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
 
               update(
                       params("update.chain", "tolerant-chain-max-errors-10", "commit", "true"),
-                      docs.toArray(new SolrInputDocument[docs.size()]))
+                      docs.toArray(new SolrInputDocument[0]))
                   .process(client);
             });
 
@@ -964,12 +964,12 @@ public class TestTolerantUpdateProcessorCloud extends SolrCloudTestCase {
                     "update.chain", "tolerant-chain-max-errors-10",
                     "maxErrors", "-1",
                     "commit", "true"),
-                docs.toArray(new SolrInputDocument[docs.size()]))
+                docs.toArray(new SolrInputDocument[0]))
             .process(client);
     assertUpdateTolerantErrors(
         "many docs from shard2 fail, but req should succeed",
         rsp,
-        expectedErrs.toArray(new ExpectedErr[expectedErrs.size()]));
+        expectedErrs.toArray(new ExpectedErr[0]));
     assertQueryDocIds(
         client,
         true,

--- a/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTolerantUpdateProcessorRandomCloud.java
@@ -277,7 +277,7 @@ public class TestTolerantUpdateProcessorRandomCloud extends SolrCloudTestCase {
       assertUpdateTolerantErrors(
           client.toString() + " => " + expectedErrors,
           rsp,
-          expectedErrors.toArray(new ExpectedErr[expectedErrors.size()]));
+          expectedErrors.toArray(new ExpectedErr[0]));
 
       if (log.isInfoEnabled()) {
         log.info("END ITER #{}, expecting #docs: {}", i, expectedDocIds.cardinality());

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
@@ -226,7 +226,7 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
         debug.add("true");
         all = true;
       }
-      q.set("debug", debug.toArray(new String[debug.size()]));
+      q.set("debug", debug.toArray(new String[0]));
 
       QueryResponse r = client.query(q);
       try {

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
@@ -654,14 +654,14 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
           SHARD1,
           CommonParams.FL,
           ShardRequest.PURPOSE_GET_TOP_IDS,
-          reqAndIdScoreFields.toArray(new String[reqAndIdScoreFields.size()]));
+          reqAndIdScoreFields.toArray(new String[0]));
       assertParamsEquals(
           trackingQueue,
           COLLECTION,
           SHARD2,
           CommonParams.FL,
           ShardRequest.PURPOSE_GET_TOP_IDS,
-          reqAndIdScoreFields.toArray(new String[reqAndIdScoreFields.size()]));
+          reqAndIdScoreFields.toArray(new String[0]));
     } else {
       // we are assuming there are facet refinement or distributed idf requests here
       assertTrue(
@@ -679,14 +679,14 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
           SHARD1,
           CommonParams.FL,
           ShardRequest.PURPOSE_GET_TOP_IDS,
-          idScoreFields.toArray(new String[idScoreFields.size()]));
+          idScoreFields.toArray(new String[0]));
       assertParamsEquals(
           trackingQueue,
           COLLECTION,
           SHARD2,
           CommonParams.FL,
           ShardRequest.PURPOSE_GET_TOP_IDS,
-          idScoreFields.toArray(new String[idScoreFields.size()]));
+          idScoreFields.toArray(new String[0]));
 
       // only originally requested fields must be requested in GET_FIELDS request
       assertParamsEquals(
@@ -695,14 +695,14 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
           SHARD1,
           CommonParams.FL,
           ShardRequest.PURPOSE_GET_FIELDS,
-          fls.toArray(new String[fls.size()]));
+          fls.toArray(new String[0]));
       assertParamsEquals(
           trackingQueue,
           COLLECTION,
           SHARD2,
           CommonParams.FL,
           ShardRequest.PURPOSE_GET_FIELDS,
-          fls.toArray(new String[fls.size()]));
+          fls.toArray(new String[0]));
     }
 
     return response;

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedSpellCheckComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedSpellCheckComponentTest.java
@@ -431,6 +431,6 @@ public class DistributedSpellCheckComponentTest extends BaseDistributedSearchTes
     if (addlParams != null) {
       params.addAll(Arrays.asList(addlParams));
     }
-    return params.toArray(new Object[params.size()]);
+    return params.toArray(new Object[0]);
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedSuggestComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedSuggestComponentTest.java
@@ -146,6 +146,6 @@ public class DistributedSuggestComponentTest extends BaseDistributedSearchTestCa
     if (addlParams != null) {
       params.addAll(Arrays.asList(addlParams));
     }
-    return params.toArray(new Object[params.size()]);
+    return params.toArray(new Object[0]);
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedTermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedTermsComponentTest.java
@@ -196,7 +196,7 @@ public class DistributedTermsComponentTest extends BaseDistributedSearchTestCase
             params.add("terms.maxcount");
             params.add(random().nextInt(4) - 1);
           }
-          q = params.toArray(new Object[params.size()]);
+          q = params.toArray(new Object[0]);
           break;
         }
       }

--- a/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/StatsComponentTest.java
@@ -1683,7 +1683,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
               "true",
               "stats.field",
               "{!key=k " + exclude + stat + "=" + expect.input + "}a_i"),
-          testXpaths.toArray(new String[testXpaths.size()]));
+          testXpaths.toArray(new String[0]));
     }
 
     // test all the possible combinations (of all possible sizes) of stats params
@@ -1714,7 +1714,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
         assertQ(
             "ask for and get only: " + combo,
             req("q", "*:*", "stats", "true", "stats.field", paras.toString()),
-            testXpaths.toArray(new String[testXpaths.size()]));
+            testXpaths.toArray(new String[0]));
       }
     }
   }
@@ -2342,7 +2342,7 @@ public class StatsComponentTest extends SolrTestCaseJ4 {
 
     public StatSetCombinations(int comboSize, EnumSet<Stat> universe) {
       // NOTE: should not need to sort, EnumSet uses natural ordering
-      all = universe.toArray(new Stat[universe.size()]);
+      all = universe.toArray(new Stat[0]);
       intCombos = new Combinations(all.length, comboSize);
     }
 

--- a/solr/core/src/test/org/apache/solr/handler/tagger/RandomizedTaggerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/RandomizedTaggerTest.java
@@ -81,7 +81,7 @@ public class RandomizedTaggerTest extends TaggerTestCase {
     }
 
     // BUILD NAMES
-    buildNames(names.toArray(new String[names.size()]));
+    buildNames(names.toArray(new String[0]));
 
     // QUERY LOOP
     for (int tTries = 0; tTries < 10 * RANDOM_MULTIPLIER; tTries++) {
@@ -137,7 +137,7 @@ public class RandomizedTaggerTest extends TaggerTestCase {
     }
 
     // assert
-    assertTags(reqDoc(input), testTags.toArray(new TestTag[testTags.size()]));
+    assertTags(reqDoc(input), testTags.toArray(new TestTag[0]));
   }
 
   private String randomString() {

--- a/solr/core/src/test/org/apache/solr/metrics/reporters/SolrGraphiteReporterTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/reporters/SolrGraphiteReporterTest.java
@@ -76,7 +76,7 @@ public class SolrGraphiteReporterTest extends SolrTestCaseJ4 {
       assertTrue(reporter instanceof SolrGraphiteReporter);
       Thread.sleep(5000);
       assertTrue(mock.lines.size() >= 3);
-      String[] frozenLines = mock.lines.toArray(new String[mock.lines.size()]);
+      String[] frozenLines = mock.lines.toArray(new String[0]);
       for (String line : frozenLines) {
         assertTrue(line, line.startsWith("test.solr.node.CONTAINER.cores."));
       }

--- a/solr/core/src/test/org/apache/solr/request/SimpleFacetsTest.java
+++ b/solr/core/src/test/org/apache/solr/request/SimpleFacetsTest.java
@@ -82,7 +82,7 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
         fieldsAndValuesList.add("bday_drf");
         fieldsAndValuesList.add(fieldsAndValuesList.get(idx + 1)); // copy
       }
-      fieldsAndValues = fieldsAndValuesList.toArray(new String[fieldsAndValuesList.size()]);
+      fieldsAndValues = fieldsAndValuesList.toArray(new String[0]);
 
       pendingDocs.add(fieldsAndValues);
     } while (random().nextInt(100) <= random_dupe_percent);

--- a/solr/core/src/test/org/apache/solr/request/TestWriterPerf.java
+++ b/solr/core/src/test/org/apache/solr/request/TestWriterPerf.java
@@ -73,7 +73,7 @@ public class TestWriterPerf extends SolrTestCaseJ4 {
   void index(Object... olst) {
     ArrayList<String> lst = new ArrayList<>();
     for (Object o : olst) lst.add(o.toString());
-    assertU(adoc(lst.toArray(new String[lst.size()])));
+    assertU(adoc(lst.toArray(new String[0])));
   }
 
   void makeIndex() {

--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -3108,9 +3108,11 @@ public class TestPointFields extends SolrTestCaseJ4 {
     if (!Boolean.getBoolean("enable.update.log")) {
       return;
     }
-	  String[] dates = getRandomLongs(3, false, MAX_DATE_EPOCH_MILLIS).stream()
-			  .map(Instant::ofEpochMilli)
-			  .map(Object::toString).toArray(String[]::new);
+    String[] dates =
+        getRandomLongs(3, false, MAX_DATE_EPOCH_MILLIS).stream()
+            .map(Instant::ofEpochMilli)
+            .map(Object::toString)
+            .toArray(String[]::new);
     doTestMultiValuedPointFieldsAtomicUpdates("number_p_dt_mv", "date", dates);
     doTestMultiValuedPointFieldsAtomicUpdates("number_p_dt_ni_mv_dv", "date", dates);
     doTestMultiValuedPointFieldsAtomicUpdates("number_p_dt_dv_ns_mv", "date", dates);

--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -3108,12 +3108,9 @@ public class TestPointFields extends SolrTestCaseJ4 {
     if (!Boolean.getBoolean("enable.update.log")) {
       return;
     }
-    List<String> datesList =
-        getRandomLongs(3, false, MAX_DATE_EPOCH_MILLIS).stream()
-            .map(Instant::ofEpochMilli)
-            .map(Object::toString)
-            .collect(Collectors.toList());
-    String[] dates = datesList.toArray(new String[datesList.size()]);
+	  String[] dates = getRandomLongs(3, false, MAX_DATE_EPOCH_MILLIS).stream()
+			  .map(Instant::ofEpochMilli)
+			  .map(Object::toString).toArray(String[]::new);
     doTestMultiValuedPointFieldsAtomicUpdates("number_p_dt_mv", "date", dates);
     doTestMultiValuedPointFieldsAtomicUpdates("number_p_dt_ni_mv_dv", "date", dates);
     doTestMultiValuedPointFieldsAtomicUpdates("number_p_dt_dv_ns_mv", "date", dates);

--- a/solr/core/src/test/org/apache/solr/schema/TestSortableTextField.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestSortableTextField.java
@@ -532,7 +532,7 @@ public class TestSortableTextField extends SolrTestCaseJ4 {
     // check all our expected docs can be found (with the expected values)
     assertU(commit());
     xpaths.add("//*[@numFound='" + xpaths.size() + "']");
-    assertQ(req("q", "*:*", "fl", "*"), xpaths.toArray(new String[xpaths.size()]));
+    assertQ(req("q", "*:*", "fl", "*"), xpaths.toArray(new String[0]));
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/search/RankQueryTestPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/RankQueryTestPlugin.java
@@ -757,7 +757,7 @@ public class RankQueryTestPlugin extends QParserPlugin {
               }
             }
           });
-      ScoreDoc[] scoreDocs = list.toArray(new ScoreDoc[list.size()]);
+      ScoreDoc[] scoreDocs = list.toArray(new ScoreDoc[0]);
       return new TopDocs(new TotalHits(list.size(), TotalHits.Relation.EQUAL_TO), scoreDocs);
     }
 
@@ -824,7 +824,7 @@ public class RankQueryTestPlugin extends QParserPlugin {
               }
             }
           });
-      ScoreDoc[] scoreDocs = list.toArray(new ScoreDoc[list.size()]);
+      ScoreDoc[] scoreDocs = list.toArray(new ScoreDoc[0]);
       return new TopDocs(new TotalHits(list.size(), TotalHits.Relation.EQUAL_TO), scoreDocs);
     }
 

--- a/solr/core/src/test/org/apache/solr/search/TestFiltering.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFiltering.java
@@ -539,7 +539,7 @@ public class TestFiltering extends SolrTestCaseJ4 {
           }
         }
 
-        SolrQueryRequest sreq = req(params.toArray(new String[params.size()]));
+        SolrQueryRequest sreq = req(params.toArray(new String[0]));
         long expected = model.answer.cardinality();
         long expectedMultiSelect = model.multiSelect.cardinality();
         long expectedFacetQuery = model.facetQuery.cardinality();

--- a/solr/core/src/test/org/apache/solr/search/TestFiltersQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFiltersQueryCaching.java
@@ -214,7 +214,6 @@ public class TestFiltersQueryCaching extends SolrTestCaseJ4 {
     List<String> request = new ArrayList<>();
     request.addAll(List.of("q", "*:*", "indent", "true", "fq", "{!filters param=$fqs}"));
     request.addAll(fqsArgs);
-    assertJQ(
-        req(request.toArray(new String[0])), "/response/numFound==" + expectNumFound);
+    assertJQ(req(request.toArray(new String[0])), "/response/numFound==" + expectNumFound);
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestFiltersQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFiltersQueryCaching.java
@@ -215,6 +215,6 @@ public class TestFiltersQueryCaching extends SolrTestCaseJ4 {
     request.addAll(List.of("q", "*:*", "indent", "true", "fq", "{!filters param=$fqs}"));
     request.addAll(fqsArgs);
     assertJQ(
-        req(request.toArray(new String[request.size()])), "/response/numFound==" + expectNumFound);
+        req(request.toArray(new String[0])), "/response/numFound==" + expectNumFound);
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestRangeQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRangeQuery.java
@@ -170,7 +170,7 @@ public class TestRangeQuery extends SolrTestCaseJ4 {
         fields.add(entry.getKey());
         fields.add(entry.getValue()[j]);
       }
-      assertU(adoc(fields.toArray(new String[fields.size()])));
+      assertU(adoc(fields.toArray(new String[0])));
     }
 
     assertU(commit());

--- a/solr/core/src/test/org/apache/solr/search/TestSort.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSort.java
@@ -311,7 +311,7 @@ public class TestSort extends SolrTestCaseJ4 {
         }
         if (r.nextBoolean()) sfields.add(new SortField(null, SortField.Type.SCORE));
 
-        Sort sort = new Sort(sfields.toArray(new SortField[sfields.size()]));
+        Sort sort = new Sort(sfields.toArray(new SortField[0]));
 
         final String nullRep =
             luceneSort || (sortMissingFirst && !reverse) || (sortMissingLast && reverse)

--- a/solr/core/src/test/org/apache/solr/search/function/TestMinMaxOnMultiValuedField.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestMinMaxOnMultiValuedField.java
@@ -1055,7 +1055,7 @@ public class TestMinMaxOnMultiValuedField extends SolrTestCaseJ4 {
     }
     assertQ(
         req("q", "*:*", "rows", "" + sortedDocs.size(), "sort", sort),
-        xpaths.toArray(new String[xpaths.size()]));
+        xpaths.toArray(new String[0]));
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/uninverting/TestDocTermOrds.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestDocTermOrds.java
@@ -152,7 +152,7 @@ public class TestDocTermOrds extends SolrTestCase {
         terms.add(new BytesRef(s));
       }
     }
-    final BytesRef[] termsArray = terms.toArray(new BytesRef[terms.size()]);
+    final BytesRef[] termsArray = terms.toArray(new BytesRef[0]);
     Arrays.sort(termsArray);
 
     final int NUM_DOCS = atLeast(100);
@@ -240,7 +240,7 @@ public class TestDocTermOrds extends SolrTestCase {
       prefixes.add(TestUtil.randomRealisticUnicodeString(random()));
       // prefixes.add(_TestUtil.randomSimpleString(random));
     }
-    final String[] prefixesArray = prefixes.toArray(new String[prefixes.size()]);
+    final String[] prefixesArray = prefixes.toArray(new String[0]);
 
     final int NUM_TERMS = atLeast(20);
     final Set<BytesRef> terms = new HashSet<>();
@@ -254,7 +254,7 @@ public class TestDocTermOrds extends SolrTestCase {
         terms.add(new BytesRef(s));
       }
     }
-    final BytesRef[] termsArray = terms.toArray(new BytesRef[terms.size()]);
+    final BytesRef[] termsArray = terms.toArray(new BytesRef[0]);
     Arrays.sort(termsArray);
 
     final int NUM_DOCS = atLeast(100);

--- a/solr/modules/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
+++ b/solr/modules/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
@@ -666,7 +666,7 @@ public class OpenNLPExtractNamedEntitiesUpdateProcessorFactory extends UpdateReq
           List<Integer> startOffsets,
           List<Integer> endOffsets,
           List<Pair<String, String>> entitiesWithType) {
-        for (Span span : nerTaggerOp.getNames(terms.toArray(new String[terms.size()]))) {
+        for (Span span : nerTaggerOp.getNames(terms.toArray(new String[0]))) {
           String text =
               fullText.substring(
                   startOffsets.get(span.getStart()), endOffsets.get(span.getEnd() - 1));

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrTable.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrTable.java
@@ -883,7 +883,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
       }
     }
 
-    return adjustedSorts.toArray(new FieldComparator[adjustedSorts.size()]);
+    return adjustedSorts.toArray(new FieldComparator[0]);
   }
 
   private TupleStream handleStats(

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/MultipleFieldComparator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/MultipleFieldComparator.java
@@ -145,6 +145,6 @@ public class MultipleFieldComparator implements StreamComparator {
       }
     }
 
-    return new MultipleFieldComparator(newComps.toArray(new StreamComparator[newComps.size()]));
+    return new MultipleFieldComparator(newComps.toArray(new StreamComparator[0]));
   }
 }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
@@ -653,7 +653,7 @@ public class GatherNodesStream extends TupleStream implements Expressible {
       }
 
       List<String> laggedWindow = windowList.subList(lag, windowList.size());
-      return laggedWindow.toArray(new String[laggedWindow.size()]);
+      return laggedWindow.toArray(new String[0]);
     } catch (ParseException e) {
       log.warn("Unparseable date:{}", String.valueOf(start));
       return new String[0];
@@ -684,7 +684,7 @@ public class GatherNodesStream extends TupleStream implements Expressible {
       }
 
       List<String> laggedWindow = windowList.subList(lag, windowList.size());
-      return laggedWindow.toArray(new String[laggedWindow.size()]);
+      return laggedWindow.toArray(new String[0]);
     } catch (ParseException e) {
       log.warn("Unparseable date:{}", String.valueOf(start));
       return new String[0];

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/FacetStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/FacetStream.java
@@ -480,7 +480,7 @@ public class FacetStream extends TupleStream implements Expressible, ParallelMet
       sorts.add(buff.toString());
     }
 
-    return sorts.toArray(new String[sorts.size()]);
+    return sorts.toArray(new String[0]);
   }
 
   private void init(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -91,7 +91,7 @@ public class LBHttpSolrClient extends LBSolrClient {
     this.httpSolrClientBuilder = builder.httpSolrClientBuilder;
     this.httpClient =
         builder.httpClient == null
-            ? constructClient(builder.baseSolrUrls.toArray(new String[builder.baseSolrUrls.size()]))
+            ? constructClient(builder.baseSolrUrls.toArray(new String[0]))
             : builder.httpClient;
     this.connectionTimeoutMillis = builder.connectionTimeoutMillis;
     this.soTimeoutMillis = builder.socketTimeoutMillis;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/LukeRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/LukeRequest.java
@@ -111,7 +111,7 @@ public class LukeRequest extends SolrRequest<LukeResponse> {
   public SolrParams getParams() {
     ModifiableSolrParams params = new ModifiableSolrParams();
     if (fields != null && fields.size() > 0) {
-      params.add(CommonParams.FL, fields.toArray(new String[fields.size()]));
+      params.add(CommonParams.FL, fields.toArray(new String[0]));
     }
     if (numTerms >= 0) {
       params.add("numTerms", numTerms + "");

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
@@ -148,7 +148,7 @@ public class DocCollection extends ZkNodeProps implements Iterable<Slice> {
         }
       }
     }
-    this.activeSlicesArr = activeSlices.values().toArray(new Slice[activeSlices.size()]);
+    this.activeSlicesArr = activeSlices.values().toArray(new Slice[0]);
     this.router = router;
     this.znode = getCollectionPath(name);
     assert name != null && slices != null;

--- a/solr/test-framework/src/java/org/apache/solr/cloud/IpTables.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/IpTables.java
@@ -54,7 +54,7 @@ public class IpTables {
   public static void unblockAllPorts() throws IOException, InterruptedException {
     if (ENABLED) {
       log.info("Unblocking any ports previously blocked with iptables...");
-      final Integer[] ports = BLOCK_PORTS.toArray(new Integer[BLOCK_PORTS.size()]);
+      final Integer[] ports = BLOCK_PORTS.toArray(new Integer[0]);
       for (Integer port : ports) {
         IpTables.unblockPort(port);
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17027
fixing all List.toArray calls which use a pre-sized Array, use empty Array instead

Follow up to https://github.com/apache/solr/pull/2003