### PR TITLE
SOLR-17048: Update solrj dep on 'api' module

### DIFF
--- a/solr/solrj/build.gradle
+++ b/solr/solrj/build.gradle
@@ -30,7 +30,7 @@ description = 'Solrj - Solr Java Client'
 dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
-  implementation project(":solr:api")
+  api project(":solr:api")
 
   implementation 'org.slf4j:slf4j-api'
   runtimeOnly 'org.slf4j:jcl-over-slf4j'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17048



# Description

Solr 9.4 introduced a new 'api' module consumed by various other parts of Solr.  The solrj module declared an 'implementation' dependency on this new module which worked for Solr's own build, but isn't actually sufficient to have the dependency picked up transitively in client apps, leading to a variety of ClassDefNotFound's.

# Solution

This commit updates SolrJ's declaration of its 'api' dependency to list it as an "api" type dependency.  This should prevent any client-side ClassDefNotFound problems related to these jar contents.

(Users of 9.4 can workaround this problem by adding an explicit dependency on solr-api in their apps, as in:

```
<dependency>
    <groupId>org.apache.solr</groupId>
    <artifactId>solr-api</artifactId>
    <version>9.4.0</version>
</dependency>
```
)

# Tests

Existing tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
