### PR TITLE
SOLR-17050: Save models as compacted json

### DIFF
--- a/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
+++ b/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
@@ -426,7 +426,8 @@ public abstract class ManagedResourceStorage {
     }
 
     /**
-     * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+     * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines
+     *     but no spaces, -1=no indent at all.
      */
     public JsonStorage(StorageIO storageIO, SolrResourceLoader loader, int indentSize) {
       super(storageIO, loader);
@@ -477,6 +478,7 @@ public abstract class ManagedResourceStorage {
   protected StorageIO storageIO;
   protected SolrResourceLoader loader;
   protected int indentSize = 2;
+
   protected ManagedResourceStorage(StorageIO storageIO, SolrResourceLoader loader) {
     this.storageIO = storageIO;
     this.loader = loader;

--- a/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
+++ b/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
@@ -426,6 +426,14 @@ public abstract class ManagedResourceStorage {
     }
 
     /**
+     * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+     */
+    public JsonStorage(StorageIO storageIO, SolrResourceLoader loader, int indentSize) {
+      super(storageIO, loader);
+      this.indentSize = indentSize;
+    }
+
+    /**
      * Determines the relative path (from the storage root) for the given resource. In this case, it
      * returns a file named with the .json extension.
      */
@@ -441,7 +449,7 @@ public abstract class ManagedResourceStorage {
 
     @Override
     public void store(String resourceId, Object toStore) throws IOException {
-      String json = toJSONString(toStore);
+      String json = toJSONString(toStore, indentSize);
       String storedResourceId = getStoredResourceId(resourceId);
       OutputStreamWriter writer = null;
       try {
@@ -468,7 +476,7 @@ public abstract class ManagedResourceStorage {
 
   protected StorageIO storageIO;
   protected SolrResourceLoader loader;
-
+  protected int indentSize = 2;
   protected ManagedResourceStorage(StorageIO storageIO, SolrResourceLoader loader) {
     this.storageIO = storageIO;
     this.loader = loader;

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -294,4 +294,21 @@ public class TestUtils extends SolrTestCaseJ4 {
     assertEquals(
         2L, Utils.getObjectByPath(sink, true, List.of(DEFAULTS, COLLECTION_PROP, NRT_REPLICAS)));
   }
+
+  @SuppressWarnings({"unchecked"})
+  public void testToJson() {
+    Map<String, Object> object =
+            (Map<String, Object>) Utils.fromJSONString("{k2:v2, k1: {a:b, p:r, k21:{xx:yy}}}");
+
+    assertEquals("{\"k2\":\"v2\",\"k1\":{\"a\":\"b\",\"p\":\"r\",\"k21\":{\"xx\":\"yy\"}}}",new String(Utils.toJSON(object,-1)));
+    String formatedJson =
+            "{\n" +
+                    "  \"k2\":\"v2\",\n" +
+                    "  \"k1\":{\n"+
+                    "    \"a\":\"b\",\n" +
+                    "    \"p\":\"r\",\n" +
+                    "    \"k21\":{\"xx\":\"yy\"}}}";
+
+    assertEquals(formatedJson,new String(Utils.toJSON(object)));
+  }
 }

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -302,7 +302,7 @@ public class TestUtils extends SolrTestCaseJ4 {
 
     assertEquals(
         "{\"k2\":\"v2\",\"k1\":{\"a\":\"b\",\"p\":\"r\",\"k21\":{\"xx\":\"yy\"}}}",
-        new String(Utils.toJSON(object, -1)));
+        new String(Utils.toJSON(object, -1), UTF_8));
     String formatedJson =
         "{\n"
             + "  \"k2\":\"v2\",\n"
@@ -311,6 +311,6 @@ public class TestUtils extends SolrTestCaseJ4 {
             + "    \"p\":\"r\",\n"
             + "    \"k21\":{\"xx\":\"yy\"}}}";
 
-    assertEquals(formatedJson, new String(Utils.toJSON(object)));
+    assertEquals(formatedJson, new String(Utils.toJSON(object), UTF_8));
   }
 }

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -298,17 +298,19 @@ public class TestUtils extends SolrTestCaseJ4 {
   @SuppressWarnings({"unchecked"})
   public void testToJson() {
     Map<String, Object> object =
-            (Map<String, Object>) Utils.fromJSONString("{k2:v2, k1: {a:b, p:r, k21:{xx:yy}}}");
+        (Map<String, Object>) Utils.fromJSONString("{k2:v2, k1: {a:b, p:r, k21:{xx:yy}}}");
 
-    assertEquals("{\"k2\":\"v2\",\"k1\":{\"a\":\"b\",\"p\":\"r\",\"k21\":{\"xx\":\"yy\"}}}",new String(Utils.toJSON(object,-1)));
+    assertEquals(
+        "{\"k2\":\"v2\",\"k1\":{\"a\":\"b\",\"p\":\"r\",\"k21\":{\"xx\":\"yy\"}}}",
+        new String(Utils.toJSON(object, -1)));
     String formatedJson =
-            "{\n" +
-                    "  \"k2\":\"v2\",\n" +
-                    "  \"k1\":{\n"+
-                    "    \"a\":\"b\",\n" +
-                    "    \"p\":\"r\",\n" +
-                    "    \"k21\":{\"xx\":\"yy\"}}}";
+        "{\n"
+            + "  \"k2\":\"v2\",\n"
+            + "  \"k1\":{\n"
+            + "    \"a\":\"b\",\n"
+            + "    \"p\":\"r\",\n"
+            + "    \"k21\":{\"xx\":\"yy\"}}}";
 
-    assertEquals(formatedJson,new String(Utils.toJSON(object)));
+    assertEquals(formatedJson, new String(Utils.toJSON(object)));
   }
 }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
@@ -93,6 +93,12 @@ public class ManagedModelStore extends ManagedResource
     store = new ModelStore();
   }
 
+  @Override
+  protected ManagedResourceStorage createStorage(
+      ManagedResourceStorage.StorageIO storageIO, SolrResourceLoader loader) throws SolrException {
+    return new ManagedResourceStorage.JsonStorage(storageIO, loader, -1);
+  }
+
   public void setManagedFeatureStore(ManagedFeatureStore managedFeatureStore) {
     log.info("INIT model store");
     this.managedFeatureStore = managedFeatureStore;

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -221,6 +221,22 @@ public class Utils {
     return toUTF8(out);
   }
 
+  /**
+   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+   */
+  public static byte[] toJSON(Object o, int indentSize) {
+    if (o == null) return new byte[0];
+    CharArr out = new CharArr();
+    new JSONWriter(out, indentSize).write(o); // indentation by default
+    return toUTF8(out);
+  }
+  
+  /**
+   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+   */
+  public static String toJSONString(Object o, int indentSize) {
+    return new String(toJSON(o, indentSize), StandardCharsets.UTF_8);
+  }
   public static String toJSONString(Object o) {
     return new String(toJSON(o), StandardCharsets.UTF_8);
   }

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -222,7 +222,8 @@ public class Utils {
   }
 
   /**
-   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines
+   *     but no spaces, -1=no indent at all.
    */
   public static byte[] toJSON(Object o, int indentSize) {
     if (o == null) return new byte[0];
@@ -230,13 +231,15 @@ public class Utils {
     new JSONWriter(out, indentSize).write(o); // indentation by default
     return toUTF8(out);
   }
-  
+
   /**
-   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines
+   *     but no spaces, -1=no indent at all.
    */
   public static String toJSONString(Object o, int indentSize) {
     return new String(toJSON(o, indentSize), StandardCharsets.UTF_8);
   }
+
   public static String toJSONString(Object o) {
     return new String(toJSON(o), StandardCharsets.UTF_8);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17050

# Description

Currenly we have a limit for how big a model can be when uploaded to solr. That is because of zookeeper file size limitations. Models are now stored in prettified json with an indent of 2 spaces.

# Solution
Store the model as compacted json. For my use case a model dropped from 27MB to 8.8MB by saving it as compacted json

# Tests

Added test for Utils.toJson 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
