### PR TITLE
Add option for specifying a imageTagSuffix in gradle

### DIFF
--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -29,11 +29,12 @@ def isDistSlim = {String dist -> dist.toLowerCase(Locale.ROOT) == "slim"}
 def isImageSlim = { -> isDistSlim(dockerImageSolrDist) }
 def distToSuffix = {String dist -> isDistSlim(dist) ? "-slim" : ""}
 def dockerImageDistSuffix = "${ -> distToSuffix(dockerImageSolrDist)}"
+def dockerImageTagSuffix = "${ -> propertyOrEnvOrDefault("solr.docker.imageTagSuffix", "SOLR_DOCKER_IMAGE_TAG_SUFFIX", '')}"
 def dockerImageRepo = "${ -> propertyOrEnvOrDefault("solr.docker.imageRepo", "SOLR_DOCKER_IMAGE_REPO", "apache/solr") }"
 def dockerImageTag = "${ -> propertyOrEnvOrDefault("solr.docker.imageTag", "SOLR_DOCKER_IMAGE_TAG", project.version + dockerImageDistSuffix) }"
-def dockerImageName = "${ -> propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}:${dockerImageTag}") }"
+def dockerImageName = "${ -> propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}:${dockerImageTag}${dockerImageTagSuffix}") }"
 def baseDockerImage = "${ -> propertyOrEnvOrDefault("solr.docker.baseImage", "SOLR_DOCKER_BASE_IMAGE", 'eclipse-temurin:17-jre-jammy') }"
-def officialDockerImageName = {String dist -> "${ -> propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}-official:${dockerImageTag}${distToSuffix(dist)}") }" }
+def officialDockerImageName = {String dist -> "${ -> propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}-official:${dockerImageTag}${distToSuffix(dist)}${dockerImageTagSuffix}") }" }
 
 def releaseGpgFingerprint = "${ -> propertyOrDefault('signing.gnupg.keyName',propertyOrDefault('signing.keyId','')) }"
 
@@ -182,7 +183,7 @@ task dockerBuild() {
     project.logger.lifecycle("\tID: \t${ -> dockerImageId }")
     project.logger.lifecycle("\tBase Image: \t${ -> baseDockerImage }")
     project.logger.lifecycle("\tSolr Version: \t${ -> project.version }")
-    project.logger.lifecycle("\tSolr Distribution: \t${dockerImageDistSuffix.isEmpty() ? "Full" : "Slim"}")
+    project.logger.lifecycle("\tSolr Distribution: \t${isImageSlim() ? "Slim" : "Full"}")
   }
 
   outputs.files(imageIdFile)

--- a/solr/docker/gradle-help.txt
+++ b/solr/docker/gradle-help.txt
@@ -47,12 +47,17 @@ Docker Image Repository:
    Gradle Property: -Psolr.docker.imageRepo
 
 Docker Image Tag:
-   Default: the Solr version, e.g. "9.0.0-SNAPSHOT"
+   Default: the Solr version and distribution (if applicable), e.g. "9.0.0-SNAPSHOT" or "9.5.0-SNAPSHOT-slim"
    EnvVar: SOLR_DOCKER_IMAGE_TAG
    Gradle Property: -Psolr.docker.imageTag
 
+Docker Image Tag Suffix:
+   Default: None. Example: "-java21"
+   EnvVar: SOLR_DOCKER_IMAGE_TAG_SUFFIX
+   Gradle Property: -Psolr.docker.imageTagSuffix
+
 Docker Image Name: (Use this to explicitly set a whole image name. If given, the image repo and image version options above are ignored.)
-   Default: {image_repo}/{image_tag} (both options provided above, with defaults)
+   Default: {image_repo}/{image_tag}{image_tag_suffix} (all options provided above, with defaults)
    EnvVar: SOLR_DOCKER_IMAGE_NAME
    Gradle Property: -Psolr.docker.imageName
 


### PR DESCRIPTION
Small change, so I don't think there needs to be a JIRA.

Example:

```bash
$ gradle dockerTag -Psolr.docker.imageTagSuffix=-java21 -Psolr.docker.baseImage=eclipse-temurin:21-jre-jammy

...

Solr Docker Image Created
        ID:     sha256:2fc272cd564635f1b60f75d216d8f3d794fa2f7f79ed432bbb5ff806ffe86c50
        Base Image:     eclipse-temurin:21-jre-jammy
        Solr Version:   10.0.0-SNAPSHOT
        Solr Distribution:      Full

Solr Docker Image Tagged
        ID:     sha256:2fc272cd564635f1b60f75d216d8f3d794fa2f7f79ed432bbb5ff806ffe86c50
        Tag:    apache/solr:10.0.0-SNAPSHOT-java21
```