### PR TITLE
SOLR-17026: Fix releaseBuild without signing

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -128,7 +128,7 @@ def prepare(root, version, pause_before_sign, mf_username, gpg_key_id, gpg_passw
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'
   if gpg_key_id is None:
-    cmd += ' -Psign=false -x signJarsPublication'  # Disable signing if no key provided to script
+    cmd += ' -Psign=false'  # Disable signing if no key provided to script
   else:
     cmd += ' -Psign --max-workers 2'
     if sign_gradle:

--- a/gradle/maven/defaults-maven.gradle
+++ b/gradle/maven/defaults-maven.gradle
@@ -177,7 +177,7 @@ configure(subprojects.findAll { it.path in rootProject.published }) { prj ->
         if (project(":solr:distribution").ext.useGpgForSigning) {
           useGpgCmd()
         }
-        required { !version.endsWith("SNAPSHOT") }
+        required { project(":solr:distribution").ext.withSignedArtifacts }
         sign publishing.publications.jars
       }
     }


### PR DESCRIPTION
Tested this out a bit locally with and without signing. Love that we can get rid of the “-x signJarsPublication” requirement for non signed builds.

Need to make sure that the artifacts are still teated to make sure that the signatures exist in the full smoke tester.