### PR TITLE
SOLR-16911: Purge last hostContext references

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -447,14 +447,12 @@ public class MiniSolrCloudCluster {
   /**
    * Start a new Solr instance
    *
-   * @param hostContext context path of Solr servers used by Jetty
    * @param extraServlets Extra servlets to be started by Jetty
    * @param extraRequestFilters extra filters to be started by Jetty
    * @return new Solr instance
    */
   public JettySolrRunner startJettySolrRunner(
       String name,
-      String hostContext,
       SortedMap<ServletHolder, String> extraServlets,
       SortedMap<Class<? extends Filter>, String> extraRequestFilters)
       throws Exception {

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -449,21 +449,6 @@ public class MiniSolrCloudCluster {
    *
    * @param extraServlets Extra servlets to be started by Jetty
    * @param extraRequestFilters extra filters to be started by Jetty
-   * @return new Solr instance
-   */
-  public JettySolrRunner startJettySolrRunner(
-      String name,
-      SortedMap<ServletHolder, String> extraServlets,
-      SortedMap<Class<? extends Filter>, String> extraRequestFilters)
-      throws Exception {
-    return startJettySolrRunner(name, extraServlets, extraRequestFilters, null);
-  }
-
-  /**
-   * Start a new Solr instance
-   *
-   * @param extraServlets Extra servlets to be started by Jetty
-   * @param extraRequestFilters extra filters to be started by Jetty
    * @param sslConfig SSL configuration
    * @return new Solr instance
    */


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16911


# Description

SOLR-16911 removed almost all of the references to a variable called 'hostContext' used by Jetty to set a base path for v1 requests.  However, one reference remained.

# Solution

This PR removes the last removable hostContext reference from 'main': an unused parameter to a MiniSolrCloudCluster method.

# Tests

N/A - small refactor. Existing tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
