### PR TITLE
SOLR-17067 SolrCloudTestCase activeClusterShape() should only consider active shards

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SplitShardTest.java
@@ -99,7 +99,7 @@ public class SplitShardTest extends SolrCloudTestCase {
                 .getActiveSlices()
                 .size(),
         COLLECTION_NAME,
-        activeClusterShape(6, 7));
+        activeClusterShape(6, 6));
 
     try {
       splitShard =
@@ -163,7 +163,7 @@ public class SplitShardTest extends SolrCloudTestCase {
                 .getActiveSlices()
                 .size(),
         collectionName,
-        activeClusterShape(3, 4));
+        activeClusterShape(3, 3));
     DocCollection coll = cluster.getSolrClient().getClusterState().getCollection(collectionName);
     Slice s1_0 = coll.getSlice("shard1_0");
     Slice s1_1 = coll.getSlice("shard1_1");
@@ -277,8 +277,7 @@ public class SplitShardTest extends SolrCloudTestCase {
           "Timed out waiting for sub shards to be active.",
           collectionName,
           activeClusterShape(
-              2,
-              3 * repFactor)); // 2 repFactor for the new split shards, 1 repFactor for old replicas
+              2, 2 * repFactor)); // parent shard replicas are ignored by activeClusterShape
 
       // make sure that docs were indexed during the split
       assertTrue(model.size() > docCount);

--- a/solr/core/src/test/org/apache/solr/cloud/SplitShardWithNodeRoleTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SplitShardWithNodeRoleTest.java
@@ -84,9 +84,13 @@ public class SplitShardWithNodeRoleTest extends SolrCloudTestCase {
 
     ur.commit(client, collName);
 
+    final int numSubShards = 2;
     CollectionAdminRequest.SplitShard splitShard =
-        CollectionAdminRequest.splitShard(collName).setShardName("shard1");
+        CollectionAdminRequest.splitShard(collName)
+            .setShardName("shard1")
+            .setNumSubShards(numSubShards);
     splitShard.process(cluster.getSolrClient());
+    int totalShards = shard + (numSubShards - 1);
     waitForState(
         "Timed out waiting for sub shards to be active. Number of active shards="
             + cluster
@@ -96,6 +100,6 @@ public class SplitShardWithNodeRoleTest extends SolrCloudTestCase {
                 .getActiveSlices()
                 .size(),
         collName,
-        activeClusterShape(shard + 1, 3 * (nrtReplica + pullReplica)));
+        activeClusterShape(totalShards, totalShards * (nrtReplica + pullReplica)));
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SplitByPrefixTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SplitByPrefixTest.java
@@ -164,11 +164,12 @@ public class SplitByPrefixTest extends SolrCloudTestCase {
       splitShard.setAsyncId("SPLIT1");
     }
     splitShard.process(client);
-    // expectedReplicas==3 because original replica still exists (just inactive)
+    // expectedReplicas==2 because original replica still exists and active but its shard is
+    // inactive
     waitForState(
         "Timed out waiting for sub shards to be active.",
         COLLECTION_NAME,
-        activeClusterShape(2, 3));
+        activeClusterShape(2, 2));
 
     List<Prefix> prefixes = findPrefixes(20, 0, 0x00ffffff);
     List<Prefix> uniquePrefixes = removeDups(prefixes);
@@ -195,7 +196,7 @@ public class SplitByPrefixTest extends SolrCloudTestCase {
     waitForState(
         "Timed out waiting for sub shards to be active.",
         COLLECTION_NAME,
-        activeClusterShape(3, 5));
+        activeClusterShape(3, 3));
 
     // OK, now let's check that the correct split point was chosen
     // We can use the router to find the shards for the middle prefixes, and they should be
@@ -238,7 +239,7 @@ public class SplitByPrefixTest extends SolrCloudTestCase {
     waitForState(
         "Timed out waiting for sub shards to be active.",
         COLLECTION_NAME,
-        activeClusterShape(4, 7));
+        activeClusterShape(4, 4));
 
     collection = client.getClusterState().getCollection(COLLECTION_NAME);
     slices1 =
@@ -266,7 +267,7 @@ public class SplitByPrefixTest extends SolrCloudTestCase {
     waitForState(
         "Timed out waiting for sub shards to be active.",
         COLLECTION_NAME,
-        activeClusterShape(5, 9));
+        activeClusterShape(5, 5));
 
     collection = client.getClusterState().getCollection(COLLECTION_NAME);
     slices1 =
@@ -289,7 +290,7 @@ public class SplitByPrefixTest extends SolrCloudTestCase {
     waitForState(
         "Timed out waiting for sub shards to be active.",
         COLLECTION_NAME,
-        activeClusterShape(6, 11));
+        activeClusterShape(6, 6));
 
     collection = client.getClusterState().getCollection(COLLECTION_NAME);
     slices1 =


### PR DESCRIPTION
Given the low and test only impact of this change, absent any feedback I plan to merge in about 2 days from now.