### PR TITLE
SOLR-17072: CLI package to print problem JSON Path

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -128,6 +128,8 @@ Other Changes
 ---------------------
 * SOLR-17024: Remove support for the long-defunct "collectionDefaults" clusterprops key (Jason Gerlowski)
 
+* SOLR-17072: package CLI tool prints error JSONPath (Mikhail Khludnev)
+
 ==================  9.4.0 ==================
 New Features
 ---------------------

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -859,6 +859,8 @@ public class PackageManager implements Closeable {
   private static String jsonPathResolve(String response, String jsonPath) {
     try {
       return JsonPath.parse(response, PackageUtils.jsonPathConfiguration()).read(jsonPath);
+    } catch (PathNotFoundException pne) {
+      throw pne;
     } catch (InvalidPathException ipe) {
       throw new InvalidPathException("Error in JSON Path:" + jsonPath, ipe);
     }
@@ -1102,7 +1104,7 @@ public class PackageManager implements Closeable {
               new ModifiableSolrParams().add("omitHeader", "true"));
       String version = null;
       try {
-        String jsonPath = "$['response'].['params'].['PKG_VERSIONS'].['" + packageName + "'])";
+        String jsonPath = "$['response'].['params'].['PKG_VERSIONS'].['" + packageName + "']";
         version = jsonPathResolve(paramsJson, jsonPath);
       } catch (PathNotFoundException ex) {
         // Don't worry if PKG_VERSION wasn't found. It just means this collection was never touched

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -773,7 +773,7 @@ public class PackageManager implements Closeable {
               String jsonPath =
                   PackageUtils.resolve(
                       cmd.condition, pkg.parameterDefaults, overridesMap, systemParams);
-              actualValue = jsonPathResolve(response, jsonPath);
+              actualValue = jsonPathRead(response, jsonPath);
             } catch (PathNotFoundException ex) {
               PackageUtils.printRed("Failed to deploy plugin: " + plugin.name);
               success = false;
@@ -826,7 +826,7 @@ public class PackageManager implements Closeable {
                         pkg.parameterDefaults,
                         collectionParameterOverrides,
                         systemParams);
-                actualValue = jsonPathResolve(response, jsonPath);
+                actualValue = jsonPathRead(response, jsonPath);
               } catch (PathNotFoundException ex) {
                 PackageUtils.printRed("Failed to deploy plugin: " + plugin.name);
                 success = false;
@@ -856,7 +856,7 @@ public class PackageManager implements Closeable {
   }
 
   /** just adds problem XPath into {@link InvalidPathException} if occurs */
-  private static String jsonPathResolve(String response, String jsonPath) {
+  private static String jsonPathRead(String response, String jsonPath) {
     try {
       return JsonPath.parse(response, PackageUtils.jsonPathConfiguration()).read(jsonPath);
     } catch (PathNotFoundException pne) {
@@ -1104,8 +1104,9 @@ public class PackageManager implements Closeable {
               new ModifiableSolrParams().add("omitHeader", "true"));
       String version = null;
       try {
-        String jsonPath = "$['response'].['params'].['PKG_VERSIONS'].['" + packageName + "']";
-        version = jsonPathResolve(paramsJson, jsonPath);
+        version =
+            jsonPathRead(
+                paramsJson, "$['response'].['params'].['PKG_VERSIONS'].['" + packageName + "']");
       } catch (PathNotFoundException ex) {
         // Don't worry if PKG_VERSION wasn't found. It just means this collection was never touched
         // by the package manager.

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -770,10 +770,10 @@ public class PackageManager implements Closeable {
             PackageUtils.printGreen(response);
             String actualValue = null;
             try {
-              String jsonPath = PackageUtils.resolve(
+              String jsonPath =
+                  PackageUtils.resolve(
                       cmd.condition, pkg.parameterDefaults, overridesMap, systemParams);
-              actualValue =
-                      jsonPathResolve(response, jsonPath);
+              actualValue = jsonPathResolve(response, jsonPath);
             } catch (PathNotFoundException ex) {
               PackageUtils.printRed("Failed to deploy plugin: " + plugin.name);
               success = false;
@@ -820,13 +820,13 @@ public class PackageManager implements Closeable {
               PackageUtils.printGreen(response);
               String actualValue = null;
               try {
-                String jsonPath = PackageUtils.resolve(
+                String jsonPath =
+                    PackageUtils.resolve(
                         cmd.condition,
                         pkg.parameterDefaults,
                         collectionParameterOverrides,
                         systemParams);
-                actualValue =
-                        jsonPathResolve(response, jsonPath);
+                actualValue = jsonPathResolve(response, jsonPath);
               } catch (PathNotFoundException ex) {
                 PackageUtils.printRed("Failed to deploy plugin: " + plugin.name);
                 success = false;
@@ -855,13 +855,10 @@ public class PackageManager implements Closeable {
     return success;
   }
 
-  /**
-   * just adds problem XPath into {@link InvalidPathException} if occurs
-   * */
+  /** just adds problem XPath into {@link InvalidPathException} if occurs */
   private static String jsonPathResolve(String response, String jsonPath) {
     try {
-      return JsonPath.parse(response, PackageUtils.jsonPathConfiguration())
-              .read(jsonPath);
+      return JsonPath.parse(response, PackageUtils.jsonPathConfiguration()).read(jsonPath);
     } catch (InvalidPathException ipe) {
       throw new InvalidPathException("Error in JSON Path:" + jsonPath, ipe);
     }
@@ -1106,8 +1103,7 @@ public class PackageManager implements Closeable {
       String version = null;
       try {
         String jsonPath = "$['response'].['params'].['PKG_VERSIONS'].['" + packageName + "'])";
-        version =
-                jsonPathResolve(paramsJson, jsonPath);
+        version = jsonPathResolve(paramsJson, jsonPath);
       } catch (PathNotFoundException ex) {
         // Don't worry if PKG_VERSION wasn't found. It just means this collection was never touched
         // by the package manager.

--- a/solr/core/src/test/org/apache/solr/packagemanager/TestPackageManager.java
+++ b/solr/core/src/test/org/apache/solr/packagemanager/TestPackageManager.java
@@ -27,6 +27,7 @@ import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 public class TestPackageManager extends SolrCloudTestCase {
 
@@ -47,6 +48,7 @@ public class TestPackageManager extends SolrCloudTestCase {
     cluster.waitForActiveCollection(COLLECTION_NAME, 1, 1);
   }
 
+  @Test
   public void testWrongVerificationJPathIsThrown() throws IOException {
     SolrZkClient zkClient = cluster.getZkClient();
     URL baseURLV2 = cluster.getJettySolrRunner(0).getBaseURLV2();
@@ -62,18 +64,18 @@ public class TestPackageManager extends SolrCloudTestCase {
         plugin.verifyCommand.path = /*"/api*/
             "/collections/" + COLLECTION_NAME + "/config/requestHandler";
         plugin.verifyCommand.condition = "&[no_quotes_error_jpath]";
-        boolean verify =
-            manager.verify(
-                new SolrPackageInstance(
-                    "",
-                    "",
-                    "1.0",
-                    new SolrPackage.Manifest(),
-                    Collections.singletonList(plugin),
-                    Collections.emptyMap()),
-                Collections.singletonList(COLLECTION_NAME),
-                plugin.type.equals("cluster"),
-                new String[0]);
+        manager.verify(
+            new SolrPackageInstance(
+                "",
+                "",
+                "1.0",
+                new SolrPackage.Manifest(),
+                Collections.singletonList(plugin),
+                Collections.emptyMap()),
+            Collections.singletonList(COLLECTION_NAME),
+            plugin.type.equals("cluster"),
+            new String[0]);
+        fail();
       } catch (InvalidPathException e) {
         assertTrue(e.getMessage().contains("&[no_quotes_error_jpath]"));
       }

--- a/solr/core/src/test/org/apache/solr/packagemanager/TestPackageManager.java
+++ b/solr/core/src/test/org/apache/solr/packagemanager/TestPackageManager.java
@@ -25,7 +25,6 @@ import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.cloud.SolrZkClient;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,12 +36,7 @@ public class TestPackageManager extends SolrCloudTestCase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    System.setProperty("enable.packages", "true");
-    configureCluster(1)
-        .withJettyConfig(jetty -> jetty.enableV2(true))
-        .addConfig("conf", configset("conf3"))
-        .addConfig("conf1", configset("schema-package"))
-        .configure();
+    configureCluster(1).addConfig("conf", configset("conf3")).configure();
     CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 1, 1)
         .process(cluster.getSolrClient());
     cluster.waitForActiveCollection(COLLECTION_NAME, 1, 1);
@@ -80,17 +74,6 @@ public class TestPackageManager extends SolrCloudTestCase {
         assertTrue(e.getMessage().contains("&[no_quotes_error_jpath]"));
       }
     }
-  }
-
-  @After
-  @Override
-  public void tearDown() throws Exception {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-    System.clearProperty("enable.packages");
-
-    super.tearDown();
   }
 
   private static class StubPackageManager extends PackageManager {

--- a/solr/core/src/test/org/apache/solr/packagemanager/TestPackageManager.java
+++ b/solr/core/src/test/org/apache/solr/packagemanager/TestPackageManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.packagemanager;
+
+import com.jayway.jsonpath.InvalidPathException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.junit.After;
+import org.junit.Before;
+
+public class TestPackageManager extends SolrCloudTestCase {
+
+  private static final String COLLECTION_NAME = "collection1";
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    System.setProperty("enable.packages", "true");
+    configureCluster(1)
+        .withJettyConfig(jetty -> jetty.enableV2(true))
+        .addConfig("conf", configset("conf3"))
+        .addConfig("conf1", configset("schema-package"))
+        .configure();
+    CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 1, 1)
+        .process(cluster.getSolrClient());
+    cluster.waitForActiveCollection(COLLECTION_NAME, 1, 1);
+  }
+
+  public void testWrongVerificationJPathIsThrown() throws IOException {
+    SolrZkClient zkClient = cluster.getZkClient();
+    URL baseURLV2 = cluster.getJettySolrRunner(0).getBaseURLV2();
+    try (Http2SolrClient solrClient = new Http2SolrClient.Builder(baseURLV2.toString()).build()) {
+      try (PackageManager manager = new StubPackageManager(solrClient, zkClient)) {
+        SolrPackage.Plugin plugin = new SolrPackage.Plugin();
+        if (random().nextBoolean()) {
+          plugin.type = "cluster";
+        }
+        plugin.name = "foo";
+        plugin.verifyCommand = new SolrPackage.Command();
+        plugin.verifyCommand.method = "GET";
+        plugin.verifyCommand.path = /*"/api*/
+            "/collections/" + COLLECTION_NAME + "/config/requestHandler";
+        plugin.verifyCommand.condition = "&[no_quotes_error_jpath]";
+        boolean verify =
+            manager.verify(
+                new SolrPackageInstance(
+                    "",
+                    "",
+                    "1.0",
+                    new SolrPackage.Manifest(),
+                    Collections.singletonList(plugin),
+                    Collections.emptyMap()),
+                Collections.singletonList(COLLECTION_NAME),
+                plugin.type.equals("cluster"),
+                new String[0]);
+      } catch (InvalidPathException e) {
+        assertTrue(e.getMessage().contains("&[no_quotes_error_jpath]"));
+      }
+    }
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    System.clearProperty("enable.packages");
+
+    super.tearDown();
+  }
+
+  private static class StubPackageManager extends PackageManager {
+    public StubPackageManager(Http2SolrClient solrClient, SolrZkClient zkClient) {
+      super(
+          solrClient,
+          SolrCloudTestCase.cluster.getJettySolrRunners().get(0).getBaseUrl().toString(),
+          zkClient.getZkServerAddress());
+    }
+
+    @Override
+    Map<String, String> getPackageParams(String packageName, String collection) {
+      return Collections.emptyMap();
+    }
+  }
+}

--- a/solr/modules/extraction/src/test/org/apache/solr/handler/extraction/TestXLSXResponseWriter.java
+++ b/solr/modules/extraction/src/test/org/apache/solr/handler/extraction/TestXLSXResponseWriter.java
@@ -38,8 +38,10 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.SolrReturnFields;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class TestXLSXResponseWriter extends SolrTestCaseJ4 {
 
   private static XLSXResponseWriter writerXlsx;

--- a/solr/modules/extraction/src/test/org/apache/solr/handler/extraction/TestXLSXResponseWriter.java
+++ b/solr/modules/extraction/src/test/org/apache/solr/handler/extraction/TestXLSXResponseWriter.java
@@ -38,10 +38,8 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.SolrReturnFields;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class TestXLSXResponseWriter extends SolrTestCaseJ4 {
 
   private static XLSXResponseWriter writerXlsx;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17072

for current repository.json it yields: 

```
com.jayway.jsonpath.InvalidPathException: Error in JSON Path:$[config].[requestHandler].[HANDLER-PATH].[_packageinfo_].[version]
        at org.apache.solr.packagemanager.PackageManager.jsonPathResolve(PackageManager.java:866)
        at org.apache.solr.packagemanager.PackageManager.verify(PackageManager.java:829)
        at org.apache.solr.packagemanager.PackageManager.deployPackage(PackageManager.java:363)
        at org.apache.solr.packagemanager.PackageManager.deploy(PackageManager.java:943)
        at org.apache.solr.cli.PackageTool.runImpl(PackageTool.java:187)
        at org.apache.solr.cli.ToolBase.runTool(ToolBase.java:52)
        at org.apache.solr.cli.SolrCLI.main(SolrCLI.java:153)
Caused by: com.jayway.jsonpath.InvalidPathException: Could not parse token starting at position 1. Expected ?, ', 0-9, *
        at com.jayway.jsonpath.internal.path.PathCompiler.fail(PathCompiler.java:638)
        at com.jayway.jsonpath.internal.path.PathCompiler.readNextToken(PathCompiler.java:139)
        at com.jayway.jsonpath.internal.path.PathCompiler.readContextToken(PathCompiler.java:123)
        at com.jayway.jsonpath.internal.path.PathCompiler.compile(PathCompiler.java:58)
        at com.jayway.jsonpath.internal.path.PathCompiler.compile(PathCompiler.java:75)
        at com.jayway.jsonpath.JsonPath.<init>(JsonPath.java:97)
        at com.jayway.jsonpath.JsonPath.compile(JsonPath.java:515)
        at com.jayway.jsonpath.internal.JsonContext.pathFromCache(JsonContext.java:222)
        at com.jayway.jsonpath.internal.JsonContext.read(JsonContext.java:77)
        at org.apache.solr.packagemanager.PackageManager.jsonPathResolve(PackageManager.java:864)
        ... 6 more

ERROR: Error in JSON Path:$[config].[requestHandler].[HANDLER-PATH].[_packageinfo_].[version]
```