### PR TITLE
exclude eclipse settings from license check

### DIFF
--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -38,6 +38,9 @@ allprojects {
             // Don't check under the project's build folder.
             exclude project.buildDir.name
 
+            // Exclude eclipse settings.
+            exclude ".settings"
+
             // Exclude any generated stuff.
             exclude "src/generated"
 

--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -63,6 +63,7 @@ allprojects {
 
             // Exclude Eclipse
             exclude ".metadata"
+            exclude ".settings"
 
             // Include selected patterns from any source folders. We could make this
             // relative to source sets but it seems to be of little value - all our source sets

--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -77,12 +77,16 @@ allprojects {
         exclude "${it}/**"
       }
 
+
       // default excludes.
       exclude '/lucene/**'
       exclude '**/build/**'
       exclude '**/.idea/**'
       exclude '**/.gradle/**'
+
+      // Exclude Eclipse
       exclude '.metadata/**'
+      exclude '.settings/**'
 
       if (project == rootProject) {
         // ourselves :-)


### PR DESCRIPTION

# Description

Gradle build fails because of eclipse internal licenses.

# Solution

Exclude eclipse settings folder from checks

# Tests

Gradle build runs again.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title. ( it's minor, not worth mentioning in the release notes)
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
