### PR TITLE
exclude eclipse settings from validation

### DIFF
--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -60,6 +60,7 @@ allprojects {
 
             // Exclude Eclipse
             exclude ".metadata"
+            exclude ".settings"
 
             // Include selected patterns from any source folders. We could make this
             // relative to source sets but it seems to be of little value - all our source sets

--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -82,7 +82,10 @@ allprojects {
       exclude '**/build/**'
       exclude '**/.idea/**'
       exclude '**/.gradle/**'
-      exclude '.metadata/**'
+
+      // Exclude Eclipse
+      exclude ".metadata"
+      exclude ".settings"
 
       if (project == rootProject) {
         // ourselves :-)


### PR DESCRIPTION
# Description

Gradle build fails because of eclipse internal licenses

# Solution

exclude eclipse settings from validation

# Tests

Gradle build runs again.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title. ( minor change, not worth mentioning in release notes )
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
