### PR TITLE
Fix test failure on J9: do not mock jre class

### DIFF
--- a/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
+++ b/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
@@ -71,7 +71,8 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
     super.setUp();
     blobFetched = false;
     blobKey = "";
-    reset(mocks);
+    reset(mockContainer);
+    mapMock = new ConcurrentHashMap<>();
     repository =
         new BlobRepository(mockContainer) {
           @Override
@@ -117,8 +118,7 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
     assertNotNull(ref.blob);
     assertEquals(blobData, ref.blob.get());
     verify(mockContainer).isZooKeeperAware();
-    verify(mapMock).get("foo!");
-    verify(mapMock).put(eq("foo!"), any(BlobRepository.BlobContent.class));
+    assertTrue(mapMock.get("foo!") instanceof  BlobRepository.BlobContent);
   }
 
   @Test
@@ -151,15 +151,14 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
   @Test
   public void testCachedAlready() {
     when(mockContainer.isZooKeeperAware()).thenReturn(true);
-    when(mapMock.get("foo!"))
-        .thenReturn(new BlobRepository.BlobContent<BlobRepository>("foo!", blobData));
+    mapMock.put("foo!", new BlobRepository.BlobContent<BlobRepository>("foo!", blobData));
     BlobRepository.BlobContentRef<ByteBuffer> ref = repository.getBlobIncRef("foo!");
     assertEquals("", blobKey);
     assertFalse(blobFetched);
     assertNotNull(ref.blob);
     assertEquals(blobData, ref.blob.get());
     verify(mockContainer).isZooKeeperAware();
-    verify(mapMock).get("foo!");
+    assertTrue(mapMock.get("foo!") instanceof  BlobRepository.BlobContent);
   }
 
   @Test
@@ -191,8 +190,6 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
     assertTrue(blobFetched);
     assertNotNull(ref.blob);
     assertEquals(PARSED, ref.blob.get());
-    verify(mockContainer).isZooKeeperAware();
-    verify(mapMock).get("foo!mocked");
-    verify(mapMock).put(eq("foo!mocked"), any(BlobRepository.BlobContent.class));
+    verify(mockContainer).isZooKeeperAware();assertTrue(mapMock.get("foo!mocked") instanceof  BlobRepository.BlobContent);
   }
 }

--- a/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
+++ b/solr/core/src/test/org/apache/solr/core/BlobRepositoryMockingTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.solr.core;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -33,6 +31,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.junit.Before;
@@ -50,8 +49,6 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
   @SuppressWarnings({"unchecked", "rawtypes"})
   private ConcurrentHashMap<String, BlobRepository.BlobContent> mapMock =
       mock(ConcurrentHashMap.class);
-
-  private Object[] mocks = new Object[] {mockContainer, mapMock};
 
   BlobRepository repository;
   ByteBuffer blobData = ByteBuffer.wrap(BLOBSTR.getBytes(UTF8));
@@ -102,7 +99,7 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
   public void testCloudOnly() {
     when(mockContainer.isZooKeeperAware()).thenReturn(false);
     try {
-      BlobRepository.BlobContentRef<ByteBuffer> ref = repository.getBlobIncRef("foo!");
+      repository.getBlobIncRef("foo!");
     } catch (SolrException e) {
       verify(mockContainer).isZooKeeperAware();
       throw e;
@@ -158,7 +155,7 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
     assertNotNull(ref.blob);
     assertEquals(blobData, ref.blob.get());
     verify(mockContainer).isZooKeeperAware();
-    assertTrue(mapMock.get("foo!") instanceof  BlobRepository.BlobContent);
+    assertTrue("Key was not mapped to a BlobContent instance.", mapMock.get("foo!") instanceof BlobRepository.BlobContent);
   }
 
   @Test
@@ -190,6 +187,7 @@ public class BlobRepositoryMockingTest extends SolrTestCaseJ4 {
     assertTrue(blobFetched);
     assertNotNull(ref.blob);
     assertEquals(PARSED, ref.blob.get());
-    verify(mockContainer).isZooKeeperAware();assertTrue(mapMock.get("foo!mocked") instanceof  BlobRepository.BlobContent);
+    verify(mockContainer).isZooKeeperAware();
+    assertTrue(mapMock.get("foo!mocked") instanceof  BlobRepository.BlobContent);
   }
 }


### PR DESCRIPTION
[No JIRA Issue]
- Fix test failure on J9: do not mock jre class

