### PR TITLE
Add a note that tells cosine similarities are normalized

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
@@ -97,6 +97,9 @@ this similarity is intended as an optimized way to perform cosine similarity. In
 * `cosine`: https://en.wikipedia.org/wiki/Cosine_similarity[Cosine similarity]
 
 [NOTE]
+the cosine similarity scores returned by Solr are normalized like this : `(1 + cosine_similarity) / 2`.
+
+[NOTE]
 the preferred way to perform cosine similarity is to normalize all vectors to unit length, and instead use DOT_PRODUCT. You should only use this function if you need to preserve the original vectors and cannot normalize them in advance.
 
 To use the following advanced parameters that customise the codec format


### PR DESCRIPTION
Minor change to dense vector search documentation (added a note) in relation to this [stackoverflow question](https://stackoverflow.com/questions/77522104/dense-vector-search-with-solr-9-4-incorrect-dot-product-and-cosine-values-retu)


# Description

Added a note to dense vector search to tell that cosine similarity scores returned by the knn search for dense vector are normalized.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
