### PR TITLE
SOLR-17082 Disable TestGlobalCircuitBreaker on windows (9x)

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
@@ -29,6 +29,9 @@ import org.slf4j.LoggerFactory;
  * <p>This circuit breaker gets the load average (length of the run queue) over the last minute and
  * uses that data to take a decision. We depend on OperatingSystemMXBean which does not allow a
  * configurable interval of collection of data.
+ *
+ * <p>This Circuit breaker is dependent on the operating system, and may typically not work on
+ * Microsoft Windows.
  */
 public class LoadAverageCircuitBreaker extends CircuitBreaker {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/test/org/apache/solr/util/TestGlobalCircuitBreaker.java
+++ b/solr/core/src/test/org/apache/solr/util/TestGlobalCircuitBreaker.java
@@ -17,10 +17,12 @@
 
 package org.apache.solr.util;
 
+import org.apache.commons.exec.OS;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,12 +48,18 @@ public class TestGlobalCircuitBreaker extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testGloalCbRegistered() {
+  public void testGlobalCbRegistered() {
     assertEquals(1, CircuitBreakerRegistry.listGlobal().size());
   }
 
+  /**
+   * Index some docs and see that load avg is tripped. This test will not run on Windows, as it does
+   * not support load average. See <a
+   * href="https://issues.apache.org/jira/browse/SOLR-17082">SOLR-17082</a>.
+   */
   @Test
-  public void testIndexingTripsCpuCb() {
+  public void testIndexingTripsLoadavgCb() {
+    Assume.assumeFalse(OS.isFamilyWindows());
     try {
       for (int i = 0; i < 100; i++) {
         assertU(adoc("name", "john smith", "id", "1"));

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/circuit-breakers.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/circuit-breakers.adoc
@@ -133,7 +133,7 @@ usually averaged over one minute. Some systems include processes waiting on IO i
 documentation for your system and JVM to understand this metric. For more information, see the
 https://en.wikipedia.org/wiki/Load_(computing)[Wikipedia page for Load],
 
-To enable and configure the CPU utilization based circuit breaker:
+To enable and configure the Load average circuit breaker:
 
 .Per collection in `solrconfig.xml`
 [source,xml]
@@ -151,6 +151,11 @@ SOLR_CIRCUITBREAKER_QUERY_LOADAVG=8.0
 
 The triggering threshold is a floating point number matching load average.
 The example circuit breaker above will trip when the load average is equal to or greater than 8.0.
+
+[NOTE]
+====
+The System Load Average Circuit breaker behavior is dependent on the operating system, and may not work on some operating systems like Microsoft Windows. See https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage()[JavaDoc] for more.
+====
 
 == Advanced example
 


### PR DESCRIPTION
(cherry picked from commit a96eca6c1d88aff1d5f0b617e8c7dd768e51434b)

https://issues.apache.org/jira/browse/SOLR-17082
