### PR TITLE
SOLR-17084: Don't return full list of zombie in Exception

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -108,7 +108,8 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+* SOLR-17084: LBSolrClient (used by CloudSolrClient) now returns the count of core tracked as not live AKA zombies
+  instead of the full list of cores. This list is potentially VERY long which was causing high CPU and memory usage.
 
 Bug Fixes
 ---------------------

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -358,7 +358,10 @@ public abstract class LBSolrClient extends SolrClient {
       }
     }
     throw new SolrServerException(
-        "No live SolrServers available to handle this request. (Tracking " + zombieServers.size() + " not live)", ex);
+        "No live SolrServers available to handle this request. (Tracking "
+            + zombieServers.size()
+            + " not live)",
+        ex);
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -358,7 +358,7 @@ public abstract class LBSolrClient extends SolrClient {
       }
     }
     throw new SolrServerException(
-        "No live SolrServers available to handle this request:" + zombieServers.keySet(), ex);
+        "No live SolrServers available to handle this request:" + zombieServers.size(), ex);
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -358,7 +358,7 @@ public abstract class LBSolrClient extends SolrClient {
       }
     }
     throw new SolrServerException(
-        "No live SolrServers available to handle this request:" + zombieServers.size(), ex);
+        "No live SolrServers available to handle this request. (Tracking " + zombieServers.size() + " not live)", ex);
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17084

# Description

Exceptions returned by LBSolrClient can become very large. Building and returning them can consume large amount of ressources.

# Solution

Exceptions should not contain the full list of zombie replicas but only its count.

# Tests

No tests added since the change is really simpl

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
