### PR TITLE
SOLR-17093: Collection restore API returns requestid when executed asynchronously

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -130,6 +130,9 @@ Bug Fixes
 * SOLR-10653: When there's a UUIDField in the schema and atomic update touches another field
   the error occurs when leader updates replica (Mikhail Khludnev)
 
+* SOLR-17093: Collection restore API command now returns "requestid" when executed asynchronously like other APIs
+  (Tomás Fernández Löbbe)
+
 Dependency Upgrades
 ---------------------
 * SOLR-17012: Update Apache Hadoop to 3.3.6 and Apache Curator to 5.5.0 (Kevin Risden)

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RestoreCollectionAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RestoreCollectionAPI.java
@@ -144,10 +144,14 @@ public class RestoreCollectionAPI extends BackupAPIBase {
       throw remoteResponse.getException();
     }
 
+    if (requestBody.async != null) {
+      response.requestId = requestBody.async;
+      return response;
+    }
+
     // Values fetched from remoteResponse may be null
     response.successfulSubResponsesByNodeName = remoteResponse.getResponse().get("success");
     response.failedSubResponsesByNodeName = remoteResponse.getResponse().get("failure");
-
     return response;
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractCloudBackupRestoreTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractCloudBackupRestoreTestCase.java
@@ -172,7 +172,7 @@ public abstract class AbstractCloudBackupRestoreTestCase extends SolrCloudTestCa
       solrClient.commit(getCollectionName());
     }
 
-    testBackupAndRestore(getCollectionName(), backupReplFactor);
+    testBackupAndRestore(getCollectionName());
     testConfigBackupOnly("conf1", getCollectionName());
     testInvalidPath(getCollectionName());
   }
@@ -326,7 +326,7 @@ public abstract class AbstractCloudBackupRestoreTestCase extends SolrCloudTestCa
     return numDocs;
   }
 
-  private void testBackupAndRestore(String collectionName, int backupReplFactor) throws Exception {
+  private void testBackupAndRestore(String collectionName) throws Exception {
     String backupLocation = getBackupLocation();
     String backupName = BACKUPNAME_PREFIX + testSuffix;
 
@@ -347,7 +347,9 @@ public abstract class AbstractCloudBackupRestoreTestCase extends SolrCloudTestCa
       if (random().nextBoolean()) {
         assertEquals(0, backup.process(client).getStatus());
       } else {
-        assertEquals(RequestStatusState.COMPLETED, backup.processAndWait(client, 30)); // async
+        String asyncId = backup.processAsync(client);
+        assertNotNull(asyncId);
+        CollectionAdminRequest.waitForAsyncRequest(asyncId, client, 30);
       }
     }
 
@@ -395,10 +397,13 @@ public abstract class AbstractCloudBackupRestoreTestCase extends SolrCloudTestCa
     if (sameConfig == false) {
       restore.setConfigName("customConfigName");
     }
+
     if (random().nextBoolean()) {
       assertEquals(0, restore.process(client).getStatus());
     } else {
-      assertEquals(RequestStatusState.COMPLETED, restore.processAndWait(client, 60)); // async
+      String asyncId = restore.processAsync(client);
+      assertNotNull(asyncId);
+      CollectionAdminRequest.waitForAsyncRequest(asyncId, client, 60);
     }
     AbstractDistribZkTestBase.waitForRecoveriesToFinish(
         restoreCollectionName, ZkStateReader.from(client), log.isDebugEnabled(), true, 30);


### PR DESCRIPTION
Most APIs return a "requestid" field with the request id when executed asynchronously. [SolrJ even relies on this field to return](https://github.com/apache/solr/blob/7eceece76771bdcd71245bcdfd5c0ae99ec980ee/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java#L218), but now this is returning null for the restore API.
This API adds this field to the response when present.