### PR TITLE
GitHub: tests-via-crave.yml should use self-hosted runner

### DIFF
--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: Run Solr Tests using Crave.io resources
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
We now have self-hosted runners by Crave.io.  Only Crave based GHA actions should use it.  More improvements to come later.