### PR TITLE
RS SOLR-17090: Remove DeleteAlias JAX-RS annotations

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteAlias.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteAlias.java
@@ -26,8 +26,6 @@ import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PER
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import org.apache.solr.client.api.endpoint.DeleteAliasApi;
 import org.apache.solr.client.api.model.AsyncJerseyResponse;
 import org.apache.solr.client.api.model.SolrJerseyResponse;
@@ -51,9 +49,7 @@ public class DeleteAlias extends AdminAPIBase implements DeleteAliasApi {
 
   @Override
   @PermissionName(COLL_EDIT_PERM)
-  public SolrJerseyResponse deleteAlias(
-      @PathParam("aliasName") String aliasName, @QueryParam("async") String asyncId)
-      throws Exception {
+  public SolrJerseyResponse deleteAlias(String aliasName, String asyncId) throws Exception {
     final AsyncJerseyResponse response = instantiateJerseyResponse(AsyncJerseyResponse.class);
     final CoreContainer coreContainer = fetchAndValidateZooKeeperAwareCoreContainer();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17090

# Description

When Jersey reads the annotations on registered APIs, it always chooses annotations from the most-concrete object that has them.  JAX-RS annotations on a sub-class will cause all JAX-RS annotations on its parent to be ignored by Jersey.

This behavior introduced a bug in 9.4 for users attempting to access the v2 "delete alias" API: annotations accidentally left behind on `DeleteAlias.java` were overriding the annotations on `DeleteAliasApi.java`, causing end-users to get a 405 ("method not allowed") when when invoking the API as documented.
 
# Solution

This PR removes the annotations from `DeleteAlias.java` allowing the API to registered correctly.

# Tests

Validated using manual testing.

In the future, we should guard against this type of bug by having forbidden-apis (or something similar) flag any JAX-RS annotations found in 'solr-core'.  (All JAX-RS annotations are expected to live on interfaces and model classes in the 'api' submodule.). We're prevented from doing this currently, because we're still in the process of migrating API definitions from 'core' to 'api.  I've added a note to SOLR-16825 (which exists to track this API migration effort) suggesting this as the final step in closing that ticket out.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
