### PR TITLE
SOLR-16825: Migrate v2 definitions to 'api' module, pt 7

### DIFF
--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/BalanceShardUniqueApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/BalanceShardUniqueApi.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.endpoint;
+
+import io.swagger.v3.oas.annotations.Operation;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.BalanceShardUniqueRequestBody;
+import org.apache.solr.client.api.model.SubResponseAccumulatingJerseyResponse;
+
+/**
+ * V2 API definition for insuring that a specified per-shard property is distributed evenly amongst
+ * the physical nodes comprising a collection.
+ *
+ * <p>The new API (POST /v2/collections/collectionName/balance-shard-unique {...} ) is analogous to
+ * the v1 /admin/collections?action=BALANCESHARDUNIQUE command.
+ */
+@Path("/collections/{collectionName}/balance-shard-unique")
+public interface BalanceShardUniqueApi {
+  @POST
+  @Operation(
+      summary =
+          "Ensure a specified per-shard property is distributed evenly amongst physical nodes comprising a collection",
+      tags = {"collections"})
+  SubResponseAccumulatingJerseyResponse balanceShardUnique(
+      @PathParam("collectionName") String collectionName, BalanceShardUniqueRequestBody requestBody)
+      throws Exception;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CreateCollectionBackupApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CreateCollectionBackupApi.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.endpoint;
+
+import io.swagger.v3.oas.annotations.Operation;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.CreateCollectionBackupRequestBody;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
+/**
+ * V2 API definition for creating a new "backup" of a specified collection
+ *
+ * <p>This API is analogous to the v1 /admin/collections?action=BACKUP command.
+ */
+@Path("/collections/{collectionName}/backups/{backupName}/versions")
+public interface CreateCollectionBackupApi {
+
+  @POST
+  @Operation(
+      summary = "Creates a new backup point for a collection",
+      tags = {"collection-backups"})
+  SolrJerseyResponse createCollectionBackup(
+      @PathParam("collectionName") String collectionName,
+      @PathParam("backupName") String backupName,
+      CreateCollectionBackupRequestBody requestBody)
+      throws Exception;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CreateCollectionSnapshotApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CreateCollectionSnapshotApi.java
@@ -14,37 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.solr.client.api.endpoint;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.DeleteCollectionSnapshotResponse;
+import org.apache.solr.client.api.model.CreateCollectionSnapshotRequestBody;
+import org.apache.solr.client.api.model.CreateCollectionSnapshotResponse;
 
-@Path("/collections/{collName}/snapshots/{snapshotName}")
-public interface DeleteCollectionSnapshotApi {
-
-  /** This API is analogous to V1's (POST /solr/admin/collections?action=DELETESNAPSHOT) */
-  @DELETE
+/** V2 API definition for creating a collection-level snapshot. */
+@Path("/collections/{collName}/snapshots")
+public interface CreateCollectionSnapshotApi {
+  @POST
+  @Path("/{snapshotName}")
   @Operation(
-      summary = "Delete an existing collection-snapshot by name.",
+      summary = "Creates a new snapshot of the specified collection.",
       tags = {"collection-snapshots"})
-  DeleteCollectionSnapshotResponse deleteCollectionSnapshot(
+  CreateCollectionSnapshotResponse createCollectionSnapshot(
       @Parameter(description = "The name of the collection.", required = true)
           @PathParam("collName")
           String collName,
-      @Parameter(description = "The name of the snapshot to be deleted.", required = true)
+      @Parameter(description = "The name of the snapshot to be created.", required = true)
           @PathParam("snapshotName")
           String snapshotName,
-      @Parameter(description = "A flag that treats the collName parameter as a collection alias.")
-          @DefaultValue("false")
-          @QueryParam("followAliases")
-          boolean followAliases,
-      @QueryParam("async") String asyncId)
+      @RequestBody(description = "Contains user provided parameters", required = true)
+          CreateCollectionSnapshotRequestBody requestBody)
       throws Exception;
 }

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CreateCoreBackupApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CreateCoreBackupApi.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.endpoint;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import org.apache.solr.client.api.model.CreateCoreBackupRequestBody;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
+@Path("/cores/{coreName}/backups")
+public interface CreateCoreBackupApi {
+
+  @POST
+  @Operation(
+      summary = "Creates a core-level backup",
+      tags = {"core-backups"})
+  SolrJerseyResponse createBackup(
+      @Parameter(description = "The name of the core.") @PathParam("coreName") String coreName,
+      @Schema(description = "Additional backup params")
+          CreateCoreBackupRequestBody backupCoreRequestBody)
+      throws Exception;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/BalanceShardUniqueRequestBody.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/BalanceShardUniqueRequestBody.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BalanceShardUniqueRequestBody {
+  @JsonProperty(required = true)
+  public String property;
+
+  public Boolean onlyActiveNodes;
+
+  public Boolean shardUnique;
+
+  public String async;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionBackupDetails.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionBackupDetails.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public class CreateCollectionBackupDetails {
+  @JsonProperty public String collection;
+  @JsonProperty public Integer numShards;
+  @JsonProperty public Integer backupId;
+  @JsonProperty public String indexVersion;
+  @JsonProperty public String startTime;
+  @JsonProperty public String endTime;
+  @JsonProperty public Integer indexFileCount;
+  @JsonProperty public Integer uploadedIndexFileCount;
+  @JsonProperty public Double indexSizeMB;
+  @JsonProperty public Map<String, String> extraProperties;
+
+  @JsonProperty("uploadedIndexFileMB")
+  public Double uploadedIndexSizeMB;
+
+  @JsonProperty public List<String> shardBackupIds;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionBackupRequestBody.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionBackupRequestBody.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public class CreateCollectionBackupRequestBody {
+  @JsonProperty public String location;
+  @JsonProperty public String repository;
+  @JsonProperty public Boolean followAliases;
+  @JsonProperty public String backupStrategy;
+  @JsonProperty public String snapshotName;
+  @JsonProperty public Boolean incremental;
+  @JsonProperty public Boolean backupConfigset;
+  @JsonProperty public Integer maxNumBackupPoints;
+  @JsonProperty public String async;
+  @JsonProperty public Map<String, String> extraProperties;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionBackupResponseBody.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionBackupResponseBody.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class CreateCollectionBackupResponseBody extends SubResponseAccumulatingJerseyResponse {
+  @JsonProperty("response")
+  public CreateCollectionBackupDetails backupDataResponse;
+
+  @JsonProperty("deleted")
+  public List<BackupDeletionData> deleted;
+
+  @JsonProperty public String collection;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionSnapshotRequestBody.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionSnapshotRequestBody.java
@@ -14,29 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.solr.client.api.model;
 
-import static org.apache.solr.client.api.model.Constants.COLLECTION;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
-import org.apache.solr.client.api.endpoint.DeleteCollectionSnapshotApi;
 
-/**
- * The Response for {@link DeleteCollectionSnapshotApi#deleteCollectionSnapshot(String, String,
- * boolean, String)}
- */
-public class DeleteCollectionSnapshotResponse extends AsyncJerseyResponse {
-  @Schema(description = "The name of the collection.")
-  @JsonProperty(COLLECTION)
-  public String collection;
-
-  @Schema(description = "The name of the snapshot to be deleted.")
-  @JsonProperty("snapshot")
-  public String snapshotName;
-
-  @Schema(description = "A flag that treats the collName parameter as a collection alias.")
-  @JsonProperty("followAliases")
+public class CreateCollectionSnapshotRequestBody {
+  @JsonProperty(value = "followAliases", defaultValue = "false")
   public boolean followAliases;
+
+  public String async;
 }

--- a/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionSnapshotResponse.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CreateCollectionSnapshotResponse.java
@@ -14,29 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.solr.client.api.model;
-
-import static org.apache.solr.client.api.model.Constants.COLLECTION;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.apache.solr.client.api.endpoint.DeleteCollectionSnapshotApi;
 
-/**
- * The Response for {@link DeleteCollectionSnapshotApi#deleteCollectionSnapshot(String, String,
- * boolean, String)}
- */
-public class DeleteCollectionSnapshotResponse extends AsyncJerseyResponse {
+public class CreateCollectionSnapshotResponse extends AsyncJerseyResponse {
   @Schema(description = "The name of the collection.")
-  @JsonProperty(COLLECTION)
   public String collection;
 
-  @Schema(description = "The name of the snapshot to be deleted.")
+  @Schema(description = "The name of the snapshot to be created.")
   @JsonProperty("snapshot")
   public String snapshotName;
 
   @Schema(description = "A flag that treats the collName parameter as a collection alias.")
-  @JsonProperty("followAliases")
   public boolean followAliases;
 }

--- a/solr/api/src/java/org/apache/solr/client/api/model/CreateCoreBackupRequestBody.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CreateCoreBackupRequestBody.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class CreateCoreBackupRequestBody {
+
+  @Schema(description = "The name of the repository to be used for backup.")
+  public String repository;
+
+  @Schema(description = "The path where the backup will be created")
+  public String location;
+
+  public String shardBackupId;
+
+  public String prevShardBackupId;
+
+  @Schema(
+      description = "A descriptive name for the backup.  Only used by non-incremental backups.",
+      name = "backupName")
+  @JsonProperty("name")
+  public String backupName;
+
+  @Schema(
+      description =
+          "The name of the commit which was used while taking a snapshot using the CREATESNAPSHOT command.")
+  public String commitName;
+
+  @Schema(description = "To turn on incremental backup feature")
+  public Boolean incremental;
+
+  @Schema(description = "Request ID to track this action which will be processed asynchronously.")
+  public String async;
+}

--- a/solr/core/src/java/org/apache/solr/handler/admin/BackupCoreOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/BackupCoreOp.java
@@ -17,13 +17,14 @@
 
 package org.apache.solr.handler.admin;
 
+import org.apache.solr.client.api.model.CreateCoreBackupRequestBody;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.backup.ShardBackupId;
-import org.apache.solr.handler.admin.api.BackupCoreAPI;
+import org.apache.solr.handler.admin.api.CreateCoreBackup;
 import org.apache.solr.handler.api.V2ApiUtils;
 
 class BackupCoreOp implements CoreAdminHandler.CoreAdminOp {
@@ -36,8 +37,7 @@ class BackupCoreOp implements CoreAdminHandler.CoreAdminOp {
   @Override
   public void execute(CoreAdminHandler.CallInfo it) throws Exception {
     final SolrParams params = it.req.getParams();
-    BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody =
-        new BackupCoreAPI.BackupCoreRequestBody();
+    CreateCoreBackupRequestBody backupCoreRequestBody = new CreateCoreBackupRequestBody();
     backupCoreRequestBody.repository = params.get(CoreAdminParams.BACKUP_REPOSITORY);
     backupCoreRequestBody.location = params.get(CoreAdminParams.BACKUP_LOCATION);
     // An optional parameter to describe the snapshot to be backed-up. If this
@@ -53,8 +53,8 @@ class BackupCoreOp implements CoreAdminHandler.CoreAdminOp {
           params.get(CoreAdminParams.PREV_SHARD_BACKUP_ID, null);
       backupCoreRequestBody.incremental = true;
     }
-    BackupCoreAPI backupCoreAPI =
-        new BackupCoreAPI(
+    CreateCoreBackup backupCoreAPI =
+        new CreateCoreBackup(
             it.handler.coreContainer, it.req, it.rsp, it.handler.coreAdminAsyncTracker);
     try {
       final var response = backupCoreAPI.createBackup(cname, backupCoreRequestBody);

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -172,7 +172,7 @@ import org.apache.solr.handler.admin.api.AddReplicaProperty;
 import org.apache.solr.handler.admin.api.AdminAPIBase;
 import org.apache.solr.handler.admin.api.AliasProperty;
 import org.apache.solr.handler.admin.api.BalanceReplicas;
-import org.apache.solr.handler.admin.api.BalanceShardUniqueAPI;
+import org.apache.solr.handler.admin.api.BalanceShardUnique;
 import org.apache.solr.handler.admin.api.CollectionProperty;
 import org.apache.solr.handler.admin.api.CollectionStatusAPI;
 import org.apache.solr.handler.admin.api.CreateAliasAPI;
@@ -1024,7 +1024,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     BALANCESHARDUNIQUE_OP(
         BALANCESHARDUNIQUE,
         (req, rsp, h) -> {
-          BalanceShardUniqueAPI.invokeFromV1Params(h.coreContainer, req, rsp);
+          BalanceShardUnique.invokeFromV1Params(h.coreContainer, req, rsp);
           return null;
         }),
     REBALANCELEADERS_OP(
@@ -1363,7 +1363,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     return List.of(
         CreateReplica.class,
         AddReplicaProperty.class,
-        BalanceShardUniqueAPI.class,
+        BalanceShardUnique.class,
         CreateAliasAPI.class,
         CreateCollection.class,
         CreateCollectionBackup.class,

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -123,6 +123,8 @@ import org.apache.solr.api.AnnotatedApi;
 import org.apache.solr.api.Api;
 import org.apache.solr.api.JerseyResource;
 import org.apache.solr.client.api.model.AddReplicaPropertyRequestBody;
+import org.apache.solr.client.api.model.CreateCollectionSnapshotRequestBody;
+import org.apache.solr.client.api.model.CreateCollectionSnapshotResponse;
 import org.apache.solr.client.api.model.InstallShardDataRequestBody;
 import org.apache.solr.client.api.model.ReplaceNodeRequestBody;
 import org.apache.solr.client.api.model.SolrJerseyResponse;
@@ -176,7 +178,7 @@ import org.apache.solr.handler.admin.api.CollectionStatusAPI;
 import org.apache.solr.handler.admin.api.CreateAliasAPI;
 import org.apache.solr.handler.admin.api.CreateCollection;
 import org.apache.solr.handler.admin.api.CreateCollectionBackupAPI;
-import org.apache.solr.handler.admin.api.CreateCollectionSnapshotAPI;
+import org.apache.solr.handler.admin.api.CreateCollectionSnapshot;
 import org.apache.solr.handler.admin.api.CreateReplica;
 import org.apache.solr.handler.admin.api.CreateShard;
 import org.apache.solr.handler.admin.api.DeleteAlias;
@@ -1114,16 +1116,16 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
           final String commitName = req.getParams().get(CoreAdminParams.COMMIT_NAME);
           final String asyncId = req.getParams().get(ASYNC);
 
-          final CreateCollectionSnapshotAPI createCollectionSnapshotAPI =
-              new CreateCollectionSnapshotAPI(h.coreContainer, req, rsp);
+          final CreateCollectionSnapshot createCollectionSnapshotAPI =
+              new CreateCollectionSnapshot(h.coreContainer, req, rsp);
 
-          final CreateCollectionSnapshotAPI.CreateSnapshotRequestBody requestBody =
-              new CreateCollectionSnapshotAPI.CreateSnapshotRequestBody();
+          final CreateCollectionSnapshotRequestBody requestBody =
+              new CreateCollectionSnapshotRequestBody();
           requestBody.followAliases = followAliases;
-          requestBody.asyncId = asyncId;
+          requestBody.async = asyncId;
 
-          final CreateCollectionSnapshotAPI.CreateSnapshotResponse createSnapshotResponse =
-              createCollectionSnapshotAPI.createSnapshot(
+          final CreateCollectionSnapshotResponse createSnapshotResponse =
+              createCollectionSnapshotAPI.createCollectionSnapshot(
                   extCollectionName, commitName, requestBody);
 
           V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, createSnapshotResponse);
@@ -1144,7 +1146,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
               new DeleteCollectionSnapshot(h.coreContainer, req, rsp);
 
           final var deleteSnapshotResponse =
-              deleteCollectionSnapshotAPI.deleteSnapshot(
+              deleteCollectionSnapshotAPI.deleteCollectionSnapshot(
                   extCollectionName, commitName, followAliases, asyncId);
 
           V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, deleteSnapshotResponse);
@@ -1389,7 +1391,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         ListAliases.class,
         AliasProperty.class,
         ListCollectionSnapshotsAPI.class,
-        CreateCollectionSnapshotAPI.class,
+        CreateCollectionSnapshot.class,
         DeleteCollectionSnapshot.class);
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -177,7 +177,7 @@ import org.apache.solr.handler.admin.api.CollectionProperty;
 import org.apache.solr.handler.admin.api.CollectionStatusAPI;
 import org.apache.solr.handler.admin.api.CreateAliasAPI;
 import org.apache.solr.handler.admin.api.CreateCollection;
-import org.apache.solr.handler.admin.api.CreateCollectionBackupAPI;
+import org.apache.solr.handler.admin.api.CreateCollectionBackup;
 import org.apache.solr.handler.admin.api.CreateCollectionSnapshot;
 import org.apache.solr.handler.admin.api.CreateReplica;
 import org.apache.solr.handler.admin.api.CreateShard;
@@ -1065,7 +1065,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         BACKUP,
         (req, rsp, h) -> {
           final var response =
-              CreateCollectionBackupAPI.invokeFromV1Params(req, rsp, h.coreContainer);
+              CreateCollectionBackup.invokeFromV1Params(req, rsp, h.coreContainer);
           V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
           return null;
         }),
@@ -1367,7 +1367,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         BalanceShardUniqueAPI.class,
         CreateAliasAPI.class,
         CreateCollection.class,
-        CreateCollectionBackupAPI.class,
+        CreateCollectionBackup.class,
         CreateShard.class,
         DeleteAlias.class,
         DeleteCollectionBackup.class,

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -1064,8 +1064,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     BACKUP_OP(
         BACKUP,
         (req, rsp, h) -> {
-          final var response =
-              CreateCollectionBackup.invokeFromV1Params(req, rsp, h.coreContainer);
+          final var response = CreateCollectionBackup.invokeFromV1Params(req, rsp, h.coreContainer);
           V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
           return null;
         }),

--- a/solr/core/src/java/org/apache/solr/handler/admin/CoreAdminHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CoreAdminHandler.java
@@ -55,9 +55,9 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.handler.admin.api.AllCoresStatusAPI;
-import org.apache.solr.handler.admin.api.BackupCoreAPI;
 import org.apache.solr.handler.admin.api.CoreSnapshot;
 import org.apache.solr.handler.admin.api.CreateCoreAPI;
+import org.apache.solr.handler.admin.api.CreateCoreBackup;
 import org.apache.solr.handler.admin.api.InstallCoreData;
 import org.apache.solr.handler.admin.api.MergeIndexesAPI;
 import org.apache.solr.handler.admin.api.OverseerOperationAPI;
@@ -401,7 +401,7 @@ public class CoreAdminHandler extends RequestHandlerBase implements PermissionNa
     return List.of(
         CoreSnapshot.class,
         InstallCoreData.class,
-        BackupCoreAPI.class,
+        CreateCoreBackup.class,
         RestoreCore.class,
         ReloadCore.class,
         UnloadCore.class,

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CreateCollection.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CreateCollection.java
@@ -369,9 +369,7 @@ public class CreateCollection extends AdminAPIBase implements CreateCollectionAp
         case ROUTER_KEY:
           final var routerProperties =
               (CreateCollectionRouterProperties) v2MapVals.remove(ROUTER_KEY);
-          final Map<String, Object> routerPropertiesAsMap =
-              ((Utils.DelegateReflectWriter) Utils.getReflectWriter(routerProperties))
-                  .toMap(new HashMap<>());
+          final Map<String, Object> routerPropertiesAsMap = Utils.reflectToMap(routerProperties);
           flattenMapWithPrefix(
               routerPropertiesAsMap, v2MapVals, CollectionAdminParams.ROUTER_PREFIX);
           break;
@@ -406,8 +404,7 @@ public class CreateCollection extends AdminAPIBase implements CreateCollectionAp
 
   public static void addToRemoteMessageWithPrefix(
       CreateCollectionRequestBody requestBody, Map<String, Object> remoteMessage, String prefix) {
-    final Map<String, Object> v1Params =
-        ((Utils.DelegateReflectWriter) Utils.getReflectWriter(requestBody)).toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.reflectToMap(requestBody);
     convertV2CreateCollectionMapToV1ParamMap(v1Params);
     for (Map.Entry<String, Object> v1Param : v1Params.entrySet()) {
       remoteMessage.put(prefix + v1Param.getKey(), v1Param.getValue());

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CreateCoreBackup.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CreateCoreBackup.java
@@ -16,21 +16,14 @@
  */
 package org.apache.solr.handler.admin.api;
 
-import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONTENT_TYPE_V2;
 import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Optional;
 import javax.inject.Inject;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import org.apache.solr.client.api.endpoint.CreateCoreBackupApi;
+import org.apache.solr.client.api.model.CreateCoreBackupRequestBody;
 import org.apache.solr.client.api.model.SolrJerseyResponse;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.core.CoreContainer;
@@ -45,10 +38,9 @@ import org.apache.solr.jersey.PermissionName;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 
-@Path("/cores/{coreName}/backups")
-public class BackupCoreAPI extends CoreAdminAPIBase {
+public class CreateCoreBackup extends CoreAdminAPIBase implements CreateCoreBackupApi {
   @Inject
-  public BackupCoreAPI(
+  public CreateCoreBackup(
       CoreContainer coreContainer,
       SolrQueryRequest solrQueryRequest,
       SolrQueryResponse solrQueryResponse,
@@ -61,14 +53,10 @@ public class BackupCoreAPI extends CoreAdminAPIBase {
     return true;
   }
 
-  @POST
-  @Produces({"application/json", "application/xml", BINARY_CONTENT_TYPE_V2})
+  @Override
   @PermissionName(COLL_EDIT_PERM)
   public SolrJerseyResponse createBackup(
-      @Parameter(description = "The name of the core.") @PathParam("coreName") String coreName,
-      @Schema(description = "The POJO for representing additional backup params.") @RequestBody
-          BackupCoreRequestBody backupCoreRequestBody)
-      throws Exception {
+      String coreName, CreateCoreBackupRequestBody backupCoreRequestBody) throws Exception {
     ensureRequiredParameterProvided("coreName", coreName);
     return handlePotentiallyAsynchronousTask(
         null,
@@ -142,41 +130,5 @@ public class BackupCoreAPI extends CoreAdminAPIBase {
                 exp);
           }
         });
-  }
-
-  public static class BackupCoreRequestBody extends SolrJerseyResponse {
-
-    @Schema(description = "The name of the repository to be used for backup.")
-    @JsonProperty("repository")
-    public String repository;
-
-    @Schema(description = "The path where the backup will be created")
-    @JsonProperty("location")
-    public String location;
-
-    @JsonProperty("shardBackupId")
-    public String shardBackupId;
-
-    @JsonProperty("prevShardBackupId")
-    public String prevShardBackupId;
-
-    @Schema(
-        description = "A descriptive name for the backup.  Only used by non-incremental backups.")
-    @JsonProperty("name")
-    public String backupName;
-
-    @Schema(
-        description =
-            "The name of the commit which was used while taking a snapshot using the CREATESNAPSHOT command.")
-    @JsonProperty("commitName")
-    public String commitName;
-
-    @Schema(description = "To turn on incremental backup feature")
-    @JsonProperty("incremental")
-    public Boolean incremental;
-
-    @Schema(description = "Request ID to track this action which will be processed asynchronously.")
-    @JsonProperty("async")
-    public String async;
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteCollectionSnapshot.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/DeleteCollectionSnapshot.java
@@ -51,7 +51,7 @@ public class DeleteCollectionSnapshot extends AdminAPIBase implements DeleteColl
 
   @Override
   @PermissionName(COLL_EDIT_PERM)
-  public DeleteCollectionSnapshotResponse deleteSnapshot(
+  public DeleteCollectionSnapshotResponse deleteCollectionSnapshot(
       String collName, String snapshotName, boolean followAliases, String asyncId)
       throws Exception {
     final var response = instantiateJerseyResponse(DeleteCollectionSnapshotResponse.class);

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/BackupCoreAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/BackupCoreAPITest.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.api.model.CreateCoreBackupRequestBody;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.backup.BackupFilePaths;
@@ -38,7 +39,7 @@ import org.junit.Test;
 
 public class BackupCoreAPITest extends SolrTestCaseJ4 {
 
-  private BackupCoreAPI backupCoreAPI;
+  private CreateCoreBackup backupCoreAPI;
   private static final String backupName = "my-new-backup";
 
   @BeforeClass
@@ -58,13 +59,13 @@ public class BackupCoreAPITest extends SolrTestCaseJ4 {
     CoreAdminHandler.CoreAdminAsyncTracker coreAdminAsyncTracker =
         new CoreAdminHandler.CoreAdminAsyncTracker();
     backupCoreAPI =
-        new BackupCoreAPI(
+        new CreateCoreBackup(
             coreContainer, solrQueryRequest, solrQueryResponse, coreAdminAsyncTracker);
   }
 
   @Test
   public void testCreateNonIncrementalBackupReturnsValidResponse() throws Exception {
-    BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
+    CreateCoreBackupRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
     backupCoreRequestBody.incremental = false;
     backupCoreRequestBody.backupName = backupName;
     SnapShooter.CoreSnapshotResponse response =
@@ -79,7 +80,7 @@ public class BackupCoreAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testMissingLocationParameter() throws Exception {
-    BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
+    CreateCoreBackupRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
     backupCoreRequestBody.location = null;
     backupCoreRequestBody.incremental = false;
     backupCoreRequestBody.backupName = backupName;
@@ -99,7 +100,7 @@ public class BackupCoreAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testMissingCoreNameParameter() throws Exception {
-    BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
+    CreateCoreBackupRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
     backupCoreRequestBody.location = null;
     backupCoreRequestBody.incremental = false;
     backupCoreRequestBody.backupName = backupName;
@@ -118,7 +119,7 @@ public class BackupCoreAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testNonIncrementalBackupForNonExistentCore() throws Exception {
-    BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
+    CreateCoreBackupRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
     backupCoreRequestBody.location = null;
     backupCoreRequestBody.incremental = false;
     backupCoreRequestBody.backupName = backupName;
@@ -133,7 +134,7 @@ public class BackupCoreAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testCreateIncrementalBackupReturnsValidResponse() throws Exception {
-    BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
+    CreateCoreBackupRequestBody backupCoreRequestBody = createBackupCoreRequestBody();
     backupCoreRequestBody.incremental = true;
     backupCoreRequestBody.shardBackupId = "md_shard1_0";
     IncrementalShardBackup.IncrementalShardSnapshotResponse response =
@@ -165,13 +166,12 @@ public class BackupCoreAPITest extends SolrTestCaseJ4 {
     }
   }
 
-  private BackupCoreAPI.BackupCoreRequestBody createBackupCoreRequestBody() throws Exception {
+  private CreateCoreBackupRequestBody createBackupCoreRequestBody() throws Exception {
     final Path locationPath = createBackupLocation();
     final URI locationUri = bootstrapBackupLocation(locationPath);
     final CoreContainer cores = h.getCoreContainer();
     cores.getAllowPaths().add(Paths.get(locationUri));
-    final BackupCoreAPI.BackupCoreRequestBody backupCoreRequestBody =
-        new BackupCoreAPI.BackupCoreRequestBody();
+    final CreateCoreBackupRequestBody backupCoreRequestBody = new CreateCoreBackupRequestBody();
     backupCoreRequestBody.location = locationPath.toString();
     return backupCoreRequestBody;
   }

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/BalanceShardUniqueAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/BalanceShardUniqueAPITest.java
@@ -25,10 +25,11 @@ import static org.apache.solr.common.params.CollectionAdminParams.COLLECTION;
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.api.model.BalanceShardUniqueRequestBody;
 import org.apache.solr.common.SolrException;
 import org.junit.Test;
 
-/** Unit tests for {@link BalanceShardUniqueAPI} */
+/** Unit tests for {@link BalanceShardUnique} */
 public class BalanceShardUniqueAPITest extends SolrTestCaseJ4 {
 
   @Test
@@ -37,7 +38,7 @@ public class BalanceShardUniqueAPITest extends SolrTestCaseJ4 {
         expectThrows(
             SolrException.class,
             () -> {
-              final var api = new BalanceShardUniqueAPI(null, null, null);
+              final var api = new BalanceShardUnique(null, null, null);
               api.balanceShardUnique("someCollectionName", null);
             });
 
@@ -47,13 +48,13 @@ public class BalanceShardUniqueAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testReportsErrorIfCollectionNameMissing() {
-    final var requestBody = new BalanceShardUniqueAPI.BalanceShardUniqueRequestBody();
+    final var requestBody = new BalanceShardUniqueRequestBody();
     requestBody.property = "preferredLeader";
     final SolrException thrown =
         expectThrows(
             SolrException.class,
             () -> {
-              final var api = new BalanceShardUniqueAPI(null, null, null);
+              final var api = new BalanceShardUnique(null, null, null);
               api.balanceShardUnique(null, requestBody);
             });
 
@@ -64,12 +65,12 @@ public class BalanceShardUniqueAPITest extends SolrTestCaseJ4 {
   @Test
   public void testReportsErrorIfPropertyToBalanceIsMissing() {
     // Note, 'property' param on reqBody not set
-    final var requestBody = new BalanceShardUniqueAPI.BalanceShardUniqueRequestBody();
+    final var requestBody = new BalanceShardUniqueRequestBody();
     final SolrException thrown =
         expectThrows(
             SolrException.class,
             () -> {
-              final var api = new BalanceShardUniqueAPI(null, null, null);
+              final var api = new BalanceShardUnique(null, null, null);
               api.balanceShardUnique("someCollName", requestBody);
             });
 
@@ -79,13 +80,13 @@ public class BalanceShardUniqueAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testCreateRemoteMessageAllProperties() {
-    final var requestBody = new BalanceShardUniqueAPI.BalanceShardUniqueRequestBody();
+    final var requestBody = new BalanceShardUniqueRequestBody();
     requestBody.property = "someProperty";
     requestBody.shardUnique = Boolean.TRUE;
     requestBody.onlyActiveNodes = Boolean.TRUE;
-    requestBody.asyncId = "someAsyncId";
+    requestBody.async = "someAsyncId";
     final var remoteMessage =
-        BalanceShardUniqueAPI.createRemoteMessage("someCollName", requestBody).getProperties();
+        BalanceShardUnique.createRemoteMessage("someCollName", requestBody).getProperties();
 
     assertEquals(6, remoteMessage.size());
     assertEquals("balanceshardunique", remoteMessage.get(QUEUE_OPERATION));

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/CreateCollectionSnapshotAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/CreateCollectionSnapshotAPITest.java
@@ -34,8 +34,7 @@ public class CreateCollectionSnapshotAPITest extends SolrTestCaseJ4 {
   @Test
   public void testConstructsValidOverseerMessage() {
     final ZkNodeProps messageOne =
-        CreateCollectionSnapshotAPI.createRemoteMessage(
-            "myCollName", false, "mySnapshotName", null);
+        CreateCollectionSnapshot.createRemoteMessage("myCollName", false, "mySnapshotName", null);
     final Map<String, Object> rawMessageOne = messageOne.getProperties();
     assertEquals(4, rawMessageOne.size());
     MatcherAssert.assertThat(
@@ -48,7 +47,7 @@ public class CreateCollectionSnapshotAPITest extends SolrTestCaseJ4 {
     assertEquals(false, rawMessageOne.get(FOLLOW_ALIASES));
 
     final ZkNodeProps messageTwo =
-        CreateCollectionSnapshotAPI.createRemoteMessage(
+        CreateCollectionSnapshot.createRemoteMessage(
             "myCollName", true, "mySnapshotName", "myAsyncId");
     final Map<String, Object> rawMessageTwo = messageTwo.getProperties();
     assertEquals(5, rawMessageTwo.size());

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/V2CollectionBackupApiTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/V2CollectionBackupApiTest.java
@@ -20,14 +20,15 @@ import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
 import static org.apache.solr.common.params.CollectionAdminParams.COPY_FILES_STRATEGY;
 
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.api.model.CreateCollectionBackupRequestBody;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.junit.Test;
 
-/** Unit tests for {@link CreateCollectionBackupAPI} */
+/** Unit tests for {@link CreateCollectionBackup} */
 public class V2CollectionBackupApiTest extends SolrTestCaseJ4 {
   @Test
   public void testCreateRemoteMessageWithAllProperties() {
-    final var requestBody = new CreateCollectionBackupAPI.CreateCollectionBackupRequestBody();
+    final var requestBody = new CreateCollectionBackupRequestBody();
     requestBody.location = "/some/location";
     requestBody.repository = "someRepoName";
     requestBody.followAliases = true;
@@ -38,7 +39,7 @@ public class V2CollectionBackupApiTest extends SolrTestCaseJ4 {
     requestBody.async = "someId";
 
     var message =
-        CreateCollectionBackupAPI.createRemoteMessage(
+        CreateCollectionBackup.createRemoteMessage(
             "someCollectionName", "someBackupName", requestBody);
     var messageProps = message.getProperties();
 
@@ -58,11 +59,11 @@ public class V2CollectionBackupApiTest extends SolrTestCaseJ4 {
 
   @Test
   public void testCreateRemoteMessageOmitsNullValues() {
-    final var requestBody = new CreateCollectionBackupAPI.CreateCollectionBackupRequestBody();
+    final var requestBody = new CreateCollectionBackupRequestBody();
     requestBody.location = "/some/location";
 
     var message =
-        CreateCollectionBackupAPI.createRemoteMessage(
+        CreateCollectionBackup.createRemoteMessage(
             "someCollectionName", "someBackupName", requestBody);
     var messageProps = message.getProperties();
 
@@ -86,7 +87,7 @@ public class V2CollectionBackupApiTest extends SolrTestCaseJ4 {
     params.set("maxNumBackupPoints", "123");
     params.set("async", "someId");
 
-    final var requestBody = CreateCollectionBackupAPI.createRequestBodyFromV1Params(params);
+    final var requestBody = CreateCollectionBackup.createRequestBodyFromV1Params(params);
 
     assertEquals("/some/location", requestBody.location);
     assertEquals("someRepoName", requestBody.repository);

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -1033,6 +1033,16 @@ public class Utils {
     }
   }
 
+  /**
+   * Produce a Map representation of the provided object using reflection to identify annotated
+   * fields.
+   *
+   * <p>The provided object is not required to be a {@link MapWriter}.
+   */
+  public static Map<String, Object> reflectToMap(Object toReflect) {
+    return ((Utils.DelegateReflectWriter) Utils.getReflectWriter(toReflect)).toMap(new HashMap<>());
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static Map<String, Object> convertToMap(MapWriter m, Map<String, Object> map) {
     try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16825


# Description

[SOLR-16825](https://issues.apache.org/jira/browse/SOLR-16825) added a new gradle module, 'api', which holds v2 API definitions as interfaces. This allows us to generate an OAS (and SolrRequest implementations from that) as a part of the solrj build.

But these artifacts (the OAS and generated Java code), only cover the v2 APIs that have interfaces in the 'api' module. We need to extract interfaces to live in 'api' for each v2 API in 'core' that doesn't already have one.

# Solution

This PR creates 'api' interfaces for a number of v2 APIs, allowing them to be included in Solr's generated clients. The following APIs are covered in this PR:

- create collection backup
- create core backup
- balance shard unique
- create collection snapshot

# Tests

PR is a refactor, so doesn't add any additional tests. But manual testing has been done to make sure the affected v2 APIs continue to work, and existing tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
