### PR TITLE
SOLR-6853: Allow '/' characters in the text managed by Managed Resources API (branch_9_4)

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -10,6 +10,8 @@ Bug Fixes
 ---------------------
 * SOLR-17039: Entropy calculation in bin/solr script fails in Docker due to missing 'bc' cmd (janhoy)
 
+* SOLR-6853: Allow '/' characters in the text managed by Managed Resources API. (Nikita Rusetskii via Eric Pugh)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/core/src/test/org/apache/solr/rest/schema/analysis/TestManagedStopFilterFactory.java
+++ b/solr/core/src/test/org/apache/solr/rest/schema/analysis/TestManagedStopFilterFactory.java
@@ -191,6 +191,18 @@ public class TestManagedStopFilterFactory extends RestTestBase {
 
     // should fail with 404 as foo doesn't exist
     assertJDelete(endpoint + "/foo", "/error/code==404");
+
+    // test for SOLR-6853 - should be able to delete stopwords with slash
+    assertJPut(
+        endpoint,
+        Utils.toJSONString(Arrays.asList("cheerful/joyful", "sleepy/tired")),
+        "/responseHeader/status==0");
+
+    // verify delete works
+    assertJDelete(endpoint + "/cheerful/joyful", "/responseHeader/status==0");
+
+    // should fail with 404 as some/thing doesn't exist
+    assertJDelete(endpoint + "/cheerful/joyful", "/error/code==404");
   }
 
   /** Can we add and remove stopwords with umlauts */

--- a/solr/core/src/test/org/apache/solr/rest/schema/analysis/TestManagedSynonymGraphFilterFactory.java
+++ b/solr/core/src/test/org/apache/solr/rest/schema/analysis/TestManagedSynonymGraphFilterFactory.java
@@ -249,6 +249,17 @@ public class TestManagedSynonymGraphFilterFactory extends RestTestBase {
         "/entertaining==['entertaining','funny','jocular','whimsical']");
     assertJQ(endpoint + "/jocular", "/jocular==['entertaining','funny','jocular','whimsical']");
     assertJQ(endpoint + "/whimsical", "/whimsical==['entertaining','funny','jocular','whimsical']");
+
+    // test for SOLR-6853 - should be able to delete synonyms with slash
+    Map<String, List<String>> slashSyns = new HashMap<>();
+    slashSyns.put("cheerful/joyful", List.of("sleepy/tired"));
+    assertJPut(endpoint, toJSONString(slashSyns), "/responseHeader/status==0");
+
+    // verify delete works
+    assertJDelete(endpoint + "/cheerful/joyful", "/responseHeader/status==0");
+
+    // should fail with 404 as some/thing doesn't exist
+    assertJDelete(endpoint + "/cheerful/joyful", "/error/code==404");
   }
 
   /** Can we add and remove stopwords with umlauts */


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-6853

Backport to 9.4.1