### PR TITLE
tests-via-crave.yml - switch to the correct branch for the PR

### DIFF
--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -18,8 +18,9 @@ jobs:
     - name: Crave clone sources
       run: crave clone create --projectID 39 /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
     - name: Checkout the correct branch
-      run: git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr checkout ${GITHUB_HEAD_REF} || echo "${GITHUB_HEAD_REF} not present on solr repo, staying at main"
-      continue-on-error: true
+      run: |
+        git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr fetch ${GITHUB_REF}:${GITHUB_REF}
+        git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr checkout ${GITHUB_REF}
     - name: Initialize, build, test
       run: |
         cd /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr

--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -19,7 +19,7 @@ jobs:
       run: crave clone create --projectID 39 /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
     - name: Checkout the correct branch
       run: |
-        git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr fetch ${GITHUB_REF}:${GITHUB_REF}
+        git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr fetch origin ${GITHUB_REF}:${GITHUB_REF}
         git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}/solr checkout ${GITHUB_REF}
     - name: Initialize, build, test
       run: |


### PR DESCRIPTION
# Description

PRs have remote refs.
That remote ref will not be automatically fetched when we fetch origin. 

# Solution

So how do we fetch it?
1. first fetch the actual remote reference and map it to a "local ref". This is done using `git fetch origin <remote-ref>:<name for local ref>`
2. Then we switch to the ref: `git checkout <name for local ref>`

This sets the state of the local clone to what the PR expects it to be

# Tests

I've run this on a private repository with Crave's internal self-hosted Actions.

Needs to run against the solr GHA to test

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
