### PR TITLE
Auto-label PRs with labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,166 @@
+# Add 'dependencies' label to any PR updating dependencies
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+        - versions.props
+        - versions.lock
+        - solr/licenses/**
+
+# Add 'documentation' label to any changes within ref-guide or dev-docs
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+        - dev-docs/**
+        - solr/solr-ref-guide/**
+        - solr/documentation/**
+        - help/**
+        - solr/README.adoc
+        - CONTRIBUTING.md
+        - README.md
+
+# Add 'example' label to examples
+example:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/example/**
+
+# Add 'bats-tests' label
+bats-tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/packaging/tests/**
+
+# Add 'tool:docker' label for changes to docker
+tool:docker:
+  - changed-files:
+      - any-glob-to-any-file:
+        - solr/docker/**
+
+# Add 'tool:build' label for changes to gradle build files
+tool:build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.gradle'
+          - settings.gradle
+          - build.gradle
+          - gradle/**
+          - buildSrc/**
+
+# Add 'start-scripts' label for changes to start scripts
+start-scripts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/bin/**
+
+# Add 'tools' label for changes to dev tools
+tool:scripts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - dev-tools/**
+          - solr/server/scripts/cloud-scripts/**
+
+# Add jetty related labels
+jetty-server:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/server/etc/**
+          - solr/server/contexts/**
+          - solr/server/resources/**
+          - solr/server/modules/**
+
+# Add 'config-sets' label
+configs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/server/solr/**
+
+# Add 'solrj' labels
+solrj:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/solrj/**
+          - solr/solrj-*/**
+
+# Add 'test-framework' label
+test-framework:
+    - changed-files:
+        - any-glob-to-any-file:
+            - solr/test-framework/**
+
+# Add 'admin-ui' label
+admin-ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/webapp/**
+
+# Add 'prometheus-exporter' label
+prometheus-exporter:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/prometheus-exporter/**
+
+# Add labels for changes to solr modules
+module:analysis-extras:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/analytics-extras/**
+
+module:clustering:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/clustering/**
+
+module:extraction:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/extraction/**
+
+module:gcs-repository:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/gcs-repository/**
+
+module:hadoop-auth:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/hadoop-auth/**
+
+module:hdfs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/hdfs/**
+
+module:jwt-auth:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/jwt-auth/**
+
+module:langid:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/langid/**
+
+module:ltr:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/ltr/**
+
+module:opentelemetry:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/opentelemetry/**
+
+module:s3-repository:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/s3-repository/**
+
+module:scripting:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/scripting/**
+
+module:sql:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/modules/sql/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,8 +18,8 @@ documentation:
         - CONTRIBUTING.md
         - README.md
 
-# Add 'example' label to examples
-example:
+# Add 'examples' label to examples
+examples:
   - changed-files:
       - any-glob-to-any-file:
           - solr/example/**
@@ -30,8 +30,8 @@ bats-tests:
       - any-glob-to-any-file:
           - solr/packaging/tests/**
 
-# Add 'tool:docker' label for changes to docker
-tool:docker:
+# Add 'docker' label for changes to docker
+docker:
   - changed-files:
       - any-glob-to-any-file:
         - solr/docker/**
@@ -45,12 +45,6 @@ tool:build:
           - build.gradle
           - gradle/**
           - buildSrc/**
-
-# Add 'start-scripts' label for changes to start scripts
-start-scripts:
-  - changed-files:
-      - any-glob-to-any-file:
-          - solr/bin/**
 
 # Add 'tools' label for changes to dev tools
 tool:scripts:
@@ -68,14 +62,26 @@ jetty-server:
           - solr/server/resources/**
           - solr/server/modules/**
 
-# Add 'config-sets' label
+# Add 'start-scripts' label for changes to start scripts
+start-scripts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/bin/**
+
+# Add 'configs' label
 configs:
   - changed-files:
       - any-glob-to-any-file:
           - solr/server/solr/**
 
-# Add 'solrj' labels
-solrj:
+# Add 'api' label
+api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - solr/api/**
+
+# Add 'client:solrj' labels
+client:solrj:
   - changed-files:
       - any-glob-to-any-file:
           - solr/solrj/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
+      


### PR DESCRIPTION
The project has some PR labels defined, but we don't use them because it is boring to manually label things, see https://github.com/apache/solr/pulls

This PR implements https://github.com/actions/labeler github action. It will make it easier to quickly discern the PRs and filter on area of interest.

The configuration will assign labels based on what paths have modifications. See `.github/labeler.yml` for labels and rules.

I borrowed some label names from lucene, e.g. `tool:build` and `module:XXX`.
Other labels are not prefixed such as `bats-tests`, `example`, `admin-ui`, `solrj`. I feel those should be prefixed in some way too, ideas welcome.

See screenshot below for a test I did in a fork:
<img width="539" alt="Skjermbilde 2024-01-06 kl  00 37 27" src="https://github.com/apache/solr/assets/409128/b9eaf204-2ac1-4b50-ad61-df214276bb97">
