### PR TITLE
Correct the log.error to include the file name instead of hard coded …

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -130,6 +130,8 @@ Improvements
 
 * SOLR-15960: Unified use of system properties and environment variables (janhoy)
 
+* PR#2183: Include the external file name in the log instead of the hard-coded value in FileFloatSource.java. (Hamzeh Aldmour via Uwe Schindler)
+
 Optimizations
 ---------------------
 * SOLR-17084: LBSolrClient (used by CloudSolrClient) now returns the count of core tracked as not live AKA zombies

--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -307,7 +307,8 @@ public class FileFloatSource extends ValueSource {
         } catch (Exception e) {
           if (++otherErrors <= 10) {
             log.error(
-                "Error loading external value source:" + fname + "{}{}",
+                "Error loading external value source:{}{}{}",
+                fname,
                 e,
                 (otherErrors < 10 ? "" : "\tSkipping future errors for this file."));
           }

--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -307,7 +307,7 @@ public class FileFloatSource extends ValueSource {
         } catch (Exception e) {
           if (++otherErrors <= 10) {
             log.error(
-                "Error loading external value source: {}{}{}",
+                "Error loading external value source: {} {}{}",
                 fname,
                 e,
                 (otherErrors < 10 ? "" : "\tSkipping future errors for this file."));

--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -307,7 +307,7 @@ public class FileFloatSource extends ValueSource {
         } catch (Exception e) {
           if (++otherErrors <= 10) {
             log.error(
-                "Error loading external value source + fileName + {}{}",
+                "Error loading external value source:" + fname + "{}{}",
                 e,
                 (otherErrors < 10 ? "" : "\tSkipping future errors for this file."));
           }

--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -307,7 +307,7 @@ public class FileFloatSource extends ValueSource {
         } catch (Exception e) {
           if (++otherErrors <= 10) {
             log.error(
-                "Error loading external value source:{}{}{}",
+                "Error loading external value source: {}{}{}",
                 fname,
                 e,
                 (otherErrors < 10 ? "" : "\tSkipping future errors for this file."));


### PR DESCRIPTION
Correct the log.error to include the file name instead of the hard-coded value.

`log.error("Error loading external value source + fileName + {}{}", var33, otherErrors < 10 ? "" : "\tSkipping future errors for this file.");`
