### PR TITLE
Introduce stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,8 @@ jobs:
 
           stale-pr-message: >
             This PR has not had activity in the past 2 weeks, labeling it as stale.
-            If the PR is waiting for review, notify the dev@solr.apache.org list.
+            Any new activity will remove the stale label. To attract more reviewers, tag
+            someone or notify the dev@solr.apache.org mailing list.
             Thank you for your contribution!
 
           # TODO: Adjust budget and debug after initial testing

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+# This workflow warns of PRs that have had no activity for a specified amount of time.
+#
+# For more information, see https://github.com/actions/stale
+name: Mark stale pull requests
+
+on:
+  # Run every day at 00:00 UTC
+  schedule:
+    - cron: '0 0 * * *'
+  # Or run on demand
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-pr-stale: 14
+          days-before-issue-stale: -1   # we don't use issues
+          days-before-close: -1         # don't close stale PRs/issues
+          exempt-draft-pr: true         # don't mark draft PRs as stale
+
+          stale-pr-message: >
+            This PR has not had activity in the past 2 weeks, labeling it as stale.
+            If the PR is waiting for review, notify the dev@solr.apache.org list.
+            Thank you for your contribution!
+
+          # TODO: Adjust budget and debug after initial testing
+          operations-per-run: 500       # operations budget
+          debug-only: true              # turn on to run the action without applying changes

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,14 +22,14 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-          days-before-pr-stale: 14
+          days-before-pr-stale: 30
           days-before-issue-stale: -1   # we don't use issues
           days-before-close: -1         # don't close stale PRs/issues
           exempt-draft-pr: true         # don't mark draft PRs as stale
           stale-pr-label: "stale"       # label to use when marking as stale
 
           stale-pr-message: >
-            This PR had no visible activity in the past 2 weeks, labeling it as stale.
+            This PR had no visible activity in the past 30 days, labeling it as stale.
             Any new activity will remove the stale label. To attract more reviewers, please tag
             someone or notify the dev@solr.apache.org mailing list.
             Thank you for your contribution!

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,18 +22,17 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-          days-before-pr-stale: 30
+          days-before-pr-stale: 60
           days-before-issue-stale: -1   # we don't use issues
           days-before-close: -1         # don't close stale PRs/issues
           exempt-draft-pr: true         # don't mark draft PRs as stale
           stale-pr-label: "stale"       # label to use when marking as stale
 
           stale-pr-message: >
-            This PR had no visible activity in the past 30 days, labeling it as stale.
+            This PR had no visible activity in the past 60 days, labeling it as stale.
             Any new activity will remove the stale label. To attract more reviewers, please tag
             someone or notify the dev@solr.apache.org mailing list.
             Thank you for your contribution!
 
-          # TODO: Adjust budget and debug after initial testing
-          operations-per-run: 500       # operations budget
-          debug-only: true              # turn on to run the action without applying changes
+          # TODO: Increase budget after initial testing
+          operations-per-run: 10        # operations budget

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
           stale-pr-label: "stale"       # label to use when marking as stale
 
           stale-pr-message: >
-            This PR has not had activity in the past 2 weeks, labeling it as stale.
+            This PR had no visible activity in the past 2 weeks, labeling it as stale.
             Any new activity will remove the stale label. To attract more reviewers, tag
             someone or notify the dev@solr.apache.org mailing list.
             Thank you for your contribution!

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
 
           stale-pr-message: >
             This PR had no visible activity in the past 2 weeks, labeling it as stale.
-            Any new activity will remove the stale label. To attract more reviewers, tag
+            Any new activity will remove the stale label. To attract more reviewers, please tag
             someone or notify the dev@solr.apache.org mailing list.
             Thank you for your contribution!
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,6 +26,7 @@ jobs:
           days-before-issue-stale: -1   # we don't use issues
           days-before-close: -1         # don't close stale PRs/issues
           exempt-draft-pr: true         # don't mark draft PRs as stale
+          stale-pr-label: "stale"       # label to use when marking as stale
 
           stale-pr-message: >
             This PR has not had activity in the past 2 weeks, labeling it as stale.


### PR DESCRIPTION
Following Lucene's lead and adding a stale bot that will label open, non-draft PRs as `Stale` after 60 days of inactivity. It is almost identical fork of Lucene's config: https://github.com/apache/lucene/blob/main/.github/workflows/stale.yml

I re-wrote the stale-message text a bit. I don't think random contributors can tag developers as reviewer, so I encouraged instead tagging people in a comment or emailing the dev-list.