### PR TITLE
Various asf.yaml updates

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,18 @@ github:
     merge:  false
     rebase: false
 
+  protected_branches:
+    main: {}
+
+  protected_tags:
+    - "releases/*"
+
+  autolink_jira:
+    - SOLR
+
+  collaborators:
+    - solrbot
+
 notifications:
   commits:      commits@solr.apache.org
   issues:       issues@solr.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,8 +18,15 @@ github:
     merge:  false
     rebase: false
 
+  # TODO: Add to this list for each new minor release
   protected_branches:
     main: {}
+    branch_9_0: {}
+    branch_9_1: {}
+    branch_9_2: {}
+    branch_9_3: {}
+    branch_9_4: {}
+    branch_9x: {}
 
   protected_tags:
     - "releases/*"


### PR DESCRIPTION
I browsed the [asf.yaml docs](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=git+-+.asf.yaml+features), and found several new capabilities related to GitHub that I believe we should add:

* `protected_branches` - our main branch should at least be protected from force-push
* `protected_tags` - prevent deletion of `release*` tags
* `autolink_jira` - make references to short-form SOLR JIRA issues in PRs clickable
* `collaborators` - list of github user names to allow full PR edit karma