### PR TITLE
githubPRs script: Exclude solrbot and draft PRs

### DIFF
--- a/dev-tools/scripts/githubPRs.py
+++ b/dev-tools/scripts/githubPRs.py
@@ -92,14 +92,16 @@ def main():
   out("============================")
   out("Number of open Pull Requests: %s" % open_prs.totalCount)
   result['open_count'] = open_prs.totalCount
+  active_prs = list(filter(lambda x: not x.draft and not x.user.login == 'solrbot', open_prs))
+  out("Number of active non-draft, non-solrbot Pull Requests: %s" % len(active_prs))
 
-  lack_jira = list(filter(lambda x: not re.match(r'.*\b(SOLR)-\d{3,6}\b', x.title), open_prs))
+  lack_jira = list(filter(lambda x: not re.match(r'.*\b(SOLR)-\d{3,6}\b', x.title), active_prs))
   result['no_jira_count'] = len(lack_jira)
   lack_jira_list = []
   for pr in lack_jira:
     lack_jira_list.append({'title': pr.title, 'number': pr.number, 'user': pr.user.login, 'created': pr.created_at.strftime("%Y-%m-%d")})
   result['no_jira'] = lack_jira_list
-  out("\nPRs lacking JIRA reference in title")
+  out("\nActive PRs lacking JIRA reference in title")
   for pr in lack_jira_list:
     out("  #%s: %s %s (%s)" % (pr['number'], pr['created'], pr['title'], pr['user'] ))
 

--- a/dev-tools/scripts/requirements.txt
+++ b/dev-tools/scripts/requirements.txt
@@ -4,5 +4,5 @@ PyYAML~=6.0
 holidays~=0.16
 ics~=0.7.2
 console-menu~=0.7.1
-PyGithub~=1.56
+PyGithub~=2.1.1
 jira~=3.4.1


### PR DESCRIPTION
When listing PRs that lack JIRA in title, we must exclude "solrbot" user and also DRAFT PRs