### PR TITLE
GH Labeler action: Category labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -224,6 +224,9 @@ cat:index:
       - any-glob-to-any-file:
           - '**/org/apache/solr/index/**'
           - '**/org/apache/solr/hdfs/index/**'
+          - '**/org/apache/solr/update/**'
+          - '**/org/apache/solr/hdfs/update/**'
+          - '**/org/apache/solr/scripting/update/**'
 
 cat:logging:
   - changed-files:
@@ -267,10 +270,3 @@ cat:servlet:
   - changed-files:
       - any-glob-to-any-file:
           - '**/org/apache/solr/servlet/**'
-
-cat:update:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/update/**'
-          - '**/org/apache/solr/hdfs/update/**'
-          - '**/org/apache/solr/scripting/update/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -181,8 +181,7 @@ tests:
           - '**/src/test/**'
           - '**/src/test-files/**'
 
-# Add category labels based on java pacakges
-# In essence, for a package org.apache.solr.foo[.xxx], assign label cat:foo
+# Add category labels loosely based on java packages
 cat:analysis:
   - changed-files:
       - any-glob-to-any-file:
@@ -197,10 +196,6 @@ cat:cloud:
   - changed-files:
       - any-glob-to-any-file:
           - '**/org/apache/solr/cloud/**'
-
-cat:cluster:
-  - changed-files:
-      - any-glob-to-any-file:
           - '**/org/apache/solr/cluster/**'
 
 cat:backup:
@@ -224,11 +219,6 @@ cat:handler:
       - any-glob-to-any-file:
           - '**/org/apache/solr/handler/**'
 
-cat:highlight:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/highlight/**'
-
 cat:index:
   - changed-files:
       - any-glob-to-any-file:
@@ -251,22 +241,6 @@ cat:packagemanager:
           - '**/org/apache/solr/packagemanager/**'
           - '**/org/apache/solr/pkg/**'
 
-cat:query:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/parser/**'
-          - '**/org/apache/solr/query/**'
-
-cat:request:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/request/**'
-
-cat:response:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/response/**'
-
 cat:schema:
   - changed-files:
       - any-glob-to-any-file:
@@ -277,6 +251,12 @@ cat:search:
   - changed-files:
       - any-glob-to-any-file:
           - '**/org/apache/solr/search/**'
+          - '**/org/apache/solr/highlight/**'
+          - '**/org/apache/solr/request/**'
+          - '**/org/apache/solr/response/**'
+          - '**/org/apache/solr/parser/**'
+          - '**/org/apache/solr/query/**'
+          - '**/org/apache/solr/spelling/**'
 
 cat:security:
   - changed-files:
@@ -288,20 +268,9 @@ cat:servlet:
       - any-glob-to-any-file:
           - '**/org/apache/solr/servlet/**'
 
-cat:spelling:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/spelling/**'
-
 cat:update:
   - changed-files:
       - any-glob-to-any-file:
           - '**/org/apache/solr/update/**'
           - '**/org/apache/solr/hdfs/update/**'
           - '**/org/apache/solr/scripting/update/**'
-
-cat:util:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/util/**'
-          - '**/org/apache/solr/hdfs/util/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,7 +47,7 @@ tool:build:
           - buildSrc/**
 
 # Add 'tools' label for changes to dev tools
-tool:scripts:
+scripts:
   - changed-files:
       - any-glob-to-any-file:
           - dev-tools/**
@@ -61,6 +61,8 @@ jetty-server:
           - solr/server/contexts/**
           - solr/server/resources/**
           - solr/server/modules/**
+          - '**/org/apache/solr/servlet/**'
+          - '**/org/apache/solr/logging/**'
 
 # Add 'start-scripts' label for changes to start scripts
 start-scripts:
@@ -73,15 +75,6 @@ configs:
   - changed-files:
       - any-glob-to-any-file:
           - solr/server/solr/**
-
-# Add 'api' label
-api:
-  - changed-files:
-      - any-glob-to-any-file:
-          - solr/api/**
-          - solr/core/src/java/org/apache/solr/api/**
-          - solr/core/src/java/org/apache/solr/cloud/api/**
-          - solr/core/src/java/org/apache/solr/jersey/**
 
 # Add 'client:solrj' labels
 client:solrj:
@@ -182,10 +175,14 @@ tests:
           - '**/src/test-files/**'
 
 # Add category labels loosely based on java packages
-cat:analysis:
+# Add 'api' label
+cat:api:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/org/apache/solr/analysis/**'
+          - solr/api/**
+          - solr/core/src/java/org/apache/solr/api/**
+          - solr/core/src/java/org/apache/solr/cloud/api/**
+          - solr/core/src/java/org/apache/solr/jersey/**
 
 cat:cli:
   - changed-files:
@@ -198,27 +195,6 @@ cat:cloud:
           - '**/org/apache/solr/cloud/**'
           - '**/org/apache/solr/cluster/**'
 
-cat:backup:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/core/backup/**'
-          - '**/org/apache/solr/hdfs/backup/**'
-
-cat:core:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/core/**'
-
-cat:filestore:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/filestore/**'
-
-cat:handler:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/handler/**'
-
 cat:index:
   - changed-files:
       - any-glob-to-any-file:
@@ -227,11 +203,7 @@ cat:index:
           - '**/org/apache/solr/update/**'
           - '**/org/apache/solr/hdfs/update/**'
           - '**/org/apache/solr/scripting/update/**'
-
-cat:logging:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/logging/**'
+          - '**/org/apache/solr/handler/loader/**'
 
 cat:metrics:
   - changed-files:
@@ -243,6 +215,7 @@ cat:packagemanager:
       - any-glob-to-any-file:
           - '**/org/apache/solr/packagemanager/**'
           - '**/org/apache/solr/pkg/**'
+          - '**/org/apache/solr/filestore/**'
 
 cat:schema:
   - changed-files:
@@ -260,13 +233,10 @@ cat:search:
           - '**/org/apache/solr/parser/**'
           - '**/org/apache/solr/query/**'
           - '**/org/apache/solr/spelling/**'
+          - '**/org/apache/solr/analysis/**'
+          - '**/org/apache/solr/handler/component/**'
 
 cat:security:
   - changed-files:
       - any-glob-to-any-file:
           - '**/org/apache/solr/security/**'
-
-cat:servlet:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/org/apache/solr/servlet/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -79,6 +79,9 @@ api:
   - changed-files:
       - any-glob-to-any-file:
           - solr/api/**
+          - solr/core/src/java/org/apache/solr/api/**
+          - solr/core/src/java/org/apache/solr/cloud/api/**
+          - solr/core/src/java/org/apache/solr/jersey/**
 
 # Add 'client:solrj' labels
 client:solrj:
@@ -170,3 +173,135 @@ module:sql:
   - changed-files:
       - any-glob-to-any-file:
           - solr/modules/sql/**
+
+# Any test source files
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/src/test/**'
+          - '**/src/test-files/**'
+
+# Add category labels based on java pacakges
+# In essence, for a package org.apache.solr.foo[.xxx], assign label cat:foo
+cat:analysis:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/analysis/**'
+
+cat:cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/cli/**'
+
+cat:cloud:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/cloud/**'
+
+cat:cluster:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/cluster/**'
+
+cat:backup:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/core/backup/**'
+          - '**/org/apache/solr/hdfs/backup/**'
+
+cat:core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/core/**'
+
+cat:filestore:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/filestore/**'
+
+cat:handler:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/handler/**'
+
+cat:highlight:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/highlight/**'
+
+cat:index:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/index/**'
+          - '**/org/apache/solr/hdfs/index/**'
+
+cat:logging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/logging/**'
+
+cat:metrics:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/metrics/**'
+
+cat:packagemanager:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/packagemanager/**'
+          - '**/org/apache/solr/pkg/**'
+
+cat:query:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/parser/**'
+          - '**/org/apache/solr/query/**'
+
+cat:request:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/request/**'
+
+cat:response:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/response/**'
+
+cat:schema:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/rest/**'
+          - '**/org/apache/solr/schema/**'
+
+cat:search:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/search/**'
+
+cat:security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/security/**'
+
+cat:servlet:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/servlet/**'
+
+cat:spelling:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/spelling/**'
+
+cat:update:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/update/**'
+          - '**/org/apache/solr/hdfs/update/**'
+          - '**/org/apache/solr/scripting/update/**'
+
+cat:util:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/org/apache/solr/util/**'
+          - '**/org/apache/solr/hdfs/util/**'


### PR DESCRIPTION
Followup from #2180 

Add GH labels based on java packages, e.g. for a package `org.apache.solr.foo[.xxx]`, assign label `cat:foo`. There are 23 new cat labels defined in total.

Also added label `tests` when any test is touched.

Most PRs will get two more labels due to this. Large refactor PRs or e.g. changing `javax.` to `jakarta.` would touch large parts of the code base and may thus get a large number of labels assigned.

This is still just a proposal. I'm open to suggestions for how to group some packages together into larger topics to obtain fewer categories. I also contemplated using different naming than the package name, e.g. "requesthandler" instead of "handler", but then there is something simplistic about that 1:1 relation too... 

As long as we're using this tool, we are constrained to the capabilities, i.e. looking at file paths. No fancy java-knowhow here...