### PR TITLE
ReleaseWizard commands to protect new minor branch

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -415,6 +415,15 @@ groups:
       - !Command
         cmd: git push --set-upstream origin {{ release_branch }}
         tee: true
+      - !Command
+        cmd: "{{ editor }} .asf.yaml"
+        comment: |
+          Add the new branch {{ release_branch }} under `protected_branches` in `.asf.yaml`. An editor will open.
+        stdout: true
+      - !Command
+        cmd: git add .asf.yaml && git commit -m "Add branch protection for {{ release_branch }}" && git push
+        logfile: commit-branch-protection.log
+        tee: true
   - !Todo
     id: update_minor_branch_prerelease_antora
     title: Update Ref Guide Metadata for new Minor Branch

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -389,7 +389,9 @@ groups:
   - !Todo
     id: create_minor_branch
     title: Create a new minor branch off the stable branch
-    description: In our case we'll create {{ release_branch }}
+    description: |
+      In our case we'll create {{ release_branch }}.
+      Also edit `.asf.yaml` to add the new branch under `protected_branches`.
     types:
     - major
     - minor


### PR DESCRIPTION
As a new `branch_X_Y` branch is created, it should be added to list of protected branches.

These commands are not tested, so please do a thorough manual review.