### PR TITLE
Suppress two `gradle dependencyCheckAggregate` false positives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ import java.time.format.DateTimeFormatter
 plugins {
   id 'base'
   id 'com.palantir.consistent-versions' version '2.16.0'
-  id 'org.owasp.dependencycheck' version '8.4.0'
+  id 'org.owasp.dependencycheck' version '9.0.8'
   id 'ca.cutterslade.analyze' version '1.9.1'
   id 'de.thetaphi.forbiddenapis' version '3.6' apply false
   id 'de.undercouch.download' version '5.5.0' apply false

--- a/gradle/validation/owasp-dependency-check/exclusions.xml
+++ b/gradle/validation/owasp-dependency-check/exclusions.xml
@@ -22,6 +22,20 @@
  -->
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress base="true">
+     <notes><![CDATA[
+     This CVE only affects the Kerby backend-ldap component, which Solr
+     does not include.
+     ]]></notes>
+     <cve>CVE-2023-25613</cve>
+  </suppress>
+  <suppress base="true">
+     <notes><![CDATA[
+     FP per issue #6388
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.apache\.rat/apache-rat@.*$</packageUrl>
+     <cpe>cpe:/a:line:line</cpe>
+  </suppress>
   <suppress>
     <notes><![CDATA[simple-xml-safe is a safe xml-safe fork]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.carrotsearch\.thirdparty/simple\-xml\-safe@.*$</packageUrl>


### PR DESCRIPTION
line is incorrectly matched

the kerby CVE is specific to a subcomponent that is not used in Solr