### PR TITLE
SOLR-17074 - Not correctly escaped quote in bin/solr script

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -30,6 +30,8 @@ Optimizations
 Bug Fixes
 ---------------------
 
+* SOLR-17074: Fixed not correctly escaped quote in bin/solr script
+
 Deprecation Removals
 ----------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -30,8 +30,6 @@ Optimizations
 Bug Fixes
 ---------------------
 
-* SOLR-17074: Fixed not correctly escaped quote in bin/solr script
-
 Deprecation Removals
 ----------------------
 
@@ -175,6 +173,8 @@ Bug Fixes
   They will only be used when sent to the default ZK Host. (Houston Putman, Jan Høydahl, David Smiley, Gus Heck, Qing Xu)
 
 * SOLR-16203: Properly initialize schema plugins loaded by SPI name (janhoy, hossman, Uwe Schindler)
+
+* SOLR-17074: Fixed not correctly escaped quote in bin/solr script (Dominique Béjean, Vincenzo D'Amore)
 
 Dependency Upgrades
 ---------------------

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -422,7 +422,7 @@ function print_usage() {
     echo ""
     echo "  -noprompt             Don't prompt for input; accept all defaults when running examples that accept user input"
     echo ""
-    echo "  -force                If attempting to start Solr as the root user, the script will exit with a warning that running Solr as "root" can cause problems."
+    echo "  -force                If attempting to start Solr as the root user, the script will exit with a warning that running Solr as \"root\" can cause problems."
     echo "                          It is possible to override this warning with the `-force` parameter."
     echo ""
     echo "  -v and -q             Verbose (-v) or quiet (-q) logging. Sets default log level of Solr to DEBUG or WARN instead of INFO"

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -423,7 +423,7 @@ function print_usage() {
     echo "  -noprompt             Don't prompt for input; accept all defaults when running examples that accept user input"
     echo ""
     echo "  -force                If attempting to start Solr as the root user, the script will exit with a warning that running Solr as \"root\" can cause problems."
-    echo "                          It is possible to override this warning with the `-force` parameter."
+    echo "                          It is possible to override this warning with the '-force' parameter."
     echo ""
     echo "  -v and -q             Verbose (-v) or quiet (-q) logging. Sets default log level of Solr to DEBUG or WARN instead of INFO"
     echo ""


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17074

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

fixed the script `solr/bin/solr` 

# Solution

Added the missing quotes 

# Tests

Tried to run the script locally, now the output is correct. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
