### PR TITLE
SOLR-17066: Replace 'data store' term in code and docs

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -125,9 +125,8 @@ Improvements
 * SOLR-17063: Do not retain log param references in LogWatcher (Michael Gibney)
 
 * SOLR-17066: SolrClient builders now allow users to specify a "default" collection or core
-  using the `withDefaultDataStore` method  ("Cloud" client builders retain the more specific
-  `withDefaultCollection`).  Use of the Builder methods is preferable to including the
-  collection in the base URL accepted by certain client implementations. (Jason Gerlowski)
+  using the `withDefaultCollection` method.  Use of the Builder methods is preferable to including
+  the collection in the base URL accepted by certain client implementations. (Jason Gerlowski)
 
 * SOLR-15960: Unified use of system properties and environment variables (janhoy)
 

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/GetSchemaApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/GetSchemaApi.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.client.api.endpoint;
 
-import static org.apache.solr.client.api.util.Constants.STORE_PATH_PREFIX;
+import static org.apache.solr.client.api.util.Constants.INDEX_PATH_PREFIX;
 
 import io.swagger.v3.oas.annotations.Operation;
 import javax.ws.rs.DefaultValue;
@@ -31,7 +31,7 @@ import org.apache.solr.client.api.model.SchemaVersionResponse;
 import org.apache.solr.client.api.model.SchemaZkVersionResponse;
 import org.apache.solr.client.api.util.StoreApiParameters;
 
-@Path(STORE_PATH_PREFIX + "/schema")
+@Path(INDEX_PATH_PREFIX + "/schema")
 public interface GetSchemaApi {
 
   @GET

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/SelectApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/SelectApi.java
@@ -17,7 +17,7 @@
 package org.apache.solr.client.api.endpoint;
 
 import static org.apache.solr.client.api.util.Constants.GENERIC_ENTITY_PROPERTY;
-import static org.apache.solr.client.api.util.Constants.STORE_PATH_PREFIX;
+import static org.apache.solr.client.api.util.Constants.INDEX_PATH_PREFIX;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,7 +42,7 @@ import org.apache.solr.client.api.util.StoreApiParameters;
  * Solr's OAS (and the clients generated from that) an approximate view of the endpoint until its
  * inputs and outputs can be understood more fully.
  */
-@Path(STORE_PATH_PREFIX + "/select")
+@Path(INDEX_PATH_PREFIX + "/select")
 public interface SelectApi {
   @GET
   @StoreApiParameters

--- a/solr/api/src/java/org/apache/solr/client/api/model/IndexType.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/IndexType.java
@@ -16,13 +16,13 @@
  */
 package org.apache.solr.client.api.model;
 
-public enum StoreType {
+public enum IndexType {
   COLLECTION("collections"),
   CORE("cores");
 
   private final String pathString;
 
-  StoreType(String pathString) {
+  IndexType(String pathString) {
     this.pathString = pathString;
   }
 

--- a/solr/api/src/java/org/apache/solr/client/api/util/Constants.java
+++ b/solr/api/src/java/org/apache/solr/client/api/util/Constants.java
@@ -22,10 +22,10 @@ public class Constants {
     /* Private ctor prevents instantiation */
   }
 
-  public static final String STORE_TYPE_PATH_PARAMETER = "storeType";
-  public static final String STORE_NAME_PATH_PARAMETER = "storeName";
-  public static final String STORE_PATH_PREFIX =
-      "/{" + STORE_TYPE_PATH_PARAMETER + ":cores|collections}/{" + STORE_NAME_PATH_PARAMETER + "}";
+  public static final String INDEX_TYPE_PATH_PARAMETER = "indexType";
+  public static final String INDEX_NAME_PATH_PARAMETER = "indexName";
+  public static final String INDEX_PATH_PREFIX =
+      "/{" + INDEX_TYPE_PATH_PARAMETER + ":cores|collections}/{" + INDEX_NAME_PATH_PARAMETER + "}";
 
   public static final String GENERIC_ENTITY_PROPERTY = "genericEntity";
 

--- a/solr/api/src/java/org/apache/solr/client/api/util/StoreApiParameters.java
+++ b/solr/api/src/java/org/apache/solr/client/api/util/StoreApiParameters.java
@@ -16,8 +16,8 @@
  */
 package org.apache.solr.client.api.util;
 
-import static org.apache.solr.client.api.util.Constants.STORE_NAME_PATH_PARAMETER;
-import static org.apache.solr.client.api.util.Constants.STORE_TYPE_PATH_PARAMETER;
+import static org.apache.solr.client.api.util.Constants.INDEX_NAME_PATH_PARAMETER;
+import static org.apache.solr.client.api.util.Constants.INDEX_TYPE_PATH_PARAMETER;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -26,7 +26,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.apache.solr.client.api.model.StoreType;
+import org.apache.solr.client.api.model.IndexType;
 
 /**
  * Concisely collects the parameters shared by APIs that interact with contents of a specific
@@ -38,8 +38,8 @@ import org.apache.solr.client.api.model.StoreType;
 @Target({ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(
-    name = STORE_TYPE_PATH_PARAMETER,
+    name = INDEX_TYPE_PATH_PARAMETER,
     in = ParameterIn.PATH,
-    schema = @Schema(implementation = StoreType.class, enumAsRef = true))
-@Parameter(name = STORE_NAME_PATH_PARAMETER, in = ParameterIn.PATH)
+    schema = @Schema(implementation = IndexType.class, enumAsRef = true))
+@Parameter(name = INDEX_NAME_PATH_PARAMETER, in = ParameterIn.PATH)
 public @interface StoreApiParameters {}

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -181,7 +181,7 @@ public class RecoveryStrategy implements Runnable, Closeable {
     // (even though getRecoveryOnlyHttpClient() already has them set)
     final UpdateShardHandlerConfig cfg = cc.getConfig().getUpdateShardHandlerConfig();
     return (new HttpSolrClient.Builder(baseUrl)
-        .withDefaultDataStore(leaderCoreName)
+        .withDefaultCollection(leaderCoreName)
         .withConnectionTimeout(cfg.getDistributedConnectionTimeout(), TimeUnit.MILLISECONDS)
         .withSocketTimeout(cfg.getDistributedSocketTimeout(), TimeUnit.MILLISECONDS)
         .withHttpClient(cc.getUpdateShardHandler().getRecoveryOnlyHttpClient()));

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CollectionHandlingUtils.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CollectionHandlingUtils.java
@@ -260,7 +260,7 @@ public class CollectionHandlingUtils {
 
     try (SolrClient client =
         new HttpSolrClient.Builder(baseUrl)
-            .withDefaultDataStore(coreName)
+            .withDefaultCollection(coreName)
             .withConnectionTimeout(30000, TimeUnit.MILLISECONDS)
             .withSocketTimeout(120000, TimeUnit.MILLISECONDS)
             .build()) {

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/ReindexCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/ReindexCollectionCmd.java
@@ -796,7 +796,7 @@ public class ReindexCollectionCmd implements CollApiCmds.CollectionApiCommand {
     try (SolrClient solrClient =
         new HttpSolrClient.Builder()
             .withHttpClient(client)
-            .withDefaultDataStore(daemonReplica.getCoreName())
+            .withDefaultCollection(daemonReplica.getCoreName())
             .withBaseSolrUrl(daemonReplica.getBaseUrl())
             .build()) {
       ModifiableSolrParams q = new ModifiableSolrParams();

--- a/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
@@ -59,7 +59,7 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.io.stream.expr.Expressible;
-import org.apache.solr.client.solrj.request.DataStoreSolrRequest;
+import org.apache.solr.client.solrj.request.CollectionRequiringSolrRequest;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.cloud.ZkSolrResourceLoader;
 import org.apache.solr.common.MapSerializable;
@@ -959,7 +959,7 @@ public class SolrConfigHandler extends RequestHandlerBase
     }
   }
 
-  private static class PerReplicaCallable extends DataStoreSolrRequest<SolrResponse>
+  private static class PerReplicaCallable extends CollectionRequiringSolrRequest<SolrResponse>
       implements Callable<Boolean> {
     Replica replica;
     String prop;
@@ -988,7 +988,7 @@ public class SolrConfigHandler extends RequestHandlerBase
       int attempts = 0;
       try (HttpSolrClient solr =
           new HttpSolrClient.Builder(replica.getBaseUrl())
-              .withDefaultDataStore(replica.getCoreName())
+              .withDefaultCollection(replica.getCoreName())
               .build()) {
         // eventually, this loop will get killed by the ExecutorService's timeout
         while (true) {

--- a/solr/core/src/java/org/apache/solr/handler/component/IterativeMergeStrategy.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/IterativeMergeStrategy.java
@@ -96,7 +96,7 @@ public abstract class IterativeMergeStrategy implements MergeStrategy {
           URLUtil.extractCoreFromCoreUrl(originalShardResponse.getShardAddress());
       this.solrClient =
           new Builder(shardBaseUrl)
-              .withDefaultDataStore(shardCoreName)
+              .withDefaultCollection(shardCoreName)
               .withHttpClient(httpClient)
               .build();
       this.req = req;

--- a/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
@@ -44,7 +44,7 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.request.DataStoreSolrRequest;
+import org.apache.solr.client.solrj.request.CollectionRequiringSolrRequest;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.cloud.ZkSolrResourceLoader;
 import org.apache.solr.common.SolrException;
@@ -347,8 +347,8 @@ public final class ManagedIndexSchema extends IndexSchema {
     return activeReplicas;
   }
 
-  private static class GetZkSchemaVersionCallable extends DataStoreSolrRequest<SolrResponse>
-      implements Callable<Integer> {
+  private static class GetZkSchemaVersionCallable
+      extends CollectionRequiringSolrRequest<SolrResponse> implements Callable<Integer> {
 
     private final ZkController zkController;
     private String baseUrl;
@@ -375,7 +375,7 @@ public final class ManagedIndexSchema extends IndexSchema {
     public Integer call() throws Exception {
       int remoteVersion = -1;
       try (HttpSolrClient solr =
-          new HttpSolrClient.Builder(baseUrl).withDefaultDataStore(coreName).build()) {
+          new HttpSolrClient.Builder(baseUrl).withDefaultCollection(coreName).build()) {
         // eventually, this loop will get killed by the ExecutorService's timeout
         while (remoteVersion == -1
             || (remoteVersion < expectedZkVersion

--- a/solr/core/src/java/org/apache/solr/update/PeerSyncWithLeader.java
+++ b/solr/core/src/java/org/apache/solr/update/PeerSyncWithLeader.java
@@ -85,7 +85,7 @@ public class PeerSyncWithLeader implements SolrMetricProducer {
     final var coreName = URLUtil.extractCoreFromCoreUrl(leaderUrl);
     this.clientToLeader =
         new HttpSolrClient.Builder(leaderBaseUrl)
-            .withDefaultDataStore(coreName)
+            .withDefaultCollection(coreName)
             .withHttpClient(httpClient)
             .build();
 

--- a/solr/core/src/java/org/apache/solr/update/StreamingSolrClients.java
+++ b/solr/core/src/java/org/apache/solr/update/StreamingSolrClients.java
@@ -76,7 +76,7 @@ public class StreamingSolrClients {
       client =
           new ErrorReportingConcurrentUpdateSolrClient.Builder(
                   req.node.getBaseUrl(), httpClient, req, errors)
-              .withDefaultDataStore(defaultCore)
+              .withDefaultCollection(defaultCore)
               .withQueueSize(100)
               .withThreadCount(runnerCount)
               .withExecutorService(updateExecutor)

--- a/solr/solr-ref-guide/modules/getting-started/pages/solr-glossary.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/solr-glossary.adoc
@@ -55,7 +55,8 @@ In Solr, one or more <<document,Documents>> grouped together in a single logical
 In <<solrclouddef,SolrCloud>> a collection may be divided up into multiple logical shards, which may in turn be distributed across many nodes.
 +
 Single-node installations and user-managed clusters use instead the concept of a <<core,Core>>.
-
+"Collection" is most frequently used in the SolrCloud context, but as it represents a "logical index", the term may be used to refer to individual cores in a user-managed cluster as well.
++
 [[defcommit]]Commit::
 To make document changes permanent in the index.
 In the case of added documents, they would be searchable after a _commit_.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -176,15 +176,15 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
   public abstract SolrParams getParams();
 
   /**
-   * Determines whether this request should use or ignore any specified data stores (esp. {@link
+   * Determines whether this request should use or ignore any specified collections (esp. {@link
    * SolrClient#defaultCollection})
    *
-   * <p>Many Solr requests target a particular data store (i.e. core or collection). But not all of
-   * them - many Solr APIs (e.g. security or other admin APIs) are agnostic of data stores entirely.
-   * This method gives these requests a way to opt out of using {@link SolrClient#defaultCollection}
-   * or other specified data stores.
+   * <p>Many Solr requests target a particular core or collection. But not all of them - many Solr
+   * APIs (e.g. security or other admin APIs) are agnostic of collections entirely. This method
+   * gives these requests a way to opt out of using {@link SolrClient#defaultCollection} or other
+   * specified collections.
    */
-  public boolean requiresDataStore() {
+  public boolean requiresCollection() {
     return false;
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
@@ -64,7 +64,7 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     super(builder.shardLeadersOnly, builder.parallelUpdates, builder.directUpdatesToLeadersOnly);
     this.stateProvider = builder.stateProvider;
     this.retryExpiryTimeNano = builder.retryExpiryTimeNano;
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
     this.collectionStateCache.timeToLiveMs =
         TimeUnit.MILLISECONDS.convert(builder.timeToLiveSeconds, TimeUnit.SECONDS);
     this.clientIsInternal = builder.httpClient == null;
@@ -235,16 +235,6 @@ public class CloudLegacySolrClient extends CloudSolrClient {
     /** Whether or not to use the default ZK ACLs when building a ZK Client. */
     public Builder canUseZkACLs(boolean canUseZkACLs) {
       this.canUseZkACLs = canUseZkACLs;
-      return this;
-    }
-
-    /**
-     * Sets a default collection for all collection-based requests.
-     *
-     * <p>Identical to {@link #withDefaultDataStore(String)} for this builder
-     */
-    public Builder withDefaultCollection(String defaultCollection) {
-      this.defaultDataStore = defaultCollection;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
@@ -792,7 +792,7 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
       return this;
     }
 
-    /** Sets a default for core- or collection-based requests. */
+    /** Sets a default for core or collection based requests. */
     public Builder withDefaultCollection(String defaultCoreOrCollection) {
       this.defaultCollection = defaultCoreOrCollection;
       return this;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
@@ -150,7 +150,7 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
     this.runners = new ArrayDeque<>();
     this.streamDeletes = builder.streamDeletes;
     this.basePath = builder.baseSolrUrl;
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
     this.pollQueueTimeMillis = builder.pollQueueTimeMillis;
     this.stallTimeMillis = Integer.getInteger("solr.cloud.client.stallTime", 15000);
 
@@ -361,7 +361,7 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
   @Override
   public NamedList<Object> request(final SolrRequest<?> request, String collection)
       throws SolrServerException, IOException {
-    if (ClientUtils.shouldApplyDefaultDataStore(collection, request))
+    if (ClientUtils.shouldApplyDefaultCollection(collection, request))
       collection = defaultCollection;
     if (!(request instanceof UpdateRequest)) {
       request.setBasePath(basePath);
@@ -701,7 +701,7 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
   public static class Builder {
     protected Http2SolrClient client;
     protected String baseSolrUrl;
-    protected String defaultDataStore;
+    protected String defaultCollection;
     protected int queueSize = 10;
     protected int threadCount;
     protected ExecutorService executorService;
@@ -792,9 +792,9 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
       return this;
     }
 
-    /** Sets a default data store for core- or collection-based requests. */
-    public Builder withDefaultDataStore(String defaultCoreOrCollection) {
-      this.defaultDataStore = defaultCoreOrCollection;
+    /** Sets a default for core- or collection-based requests. */
+    public Builder withDefaultCollection(String defaultCoreOrCollection) {
+      this.defaultCollection = defaultCoreOrCollection;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -116,7 +116,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
     this.soTimeout = builder.socketTimeoutMillis;
     this.pollQueueTimeMillis = builder.pollQueueTime;
     this.stallTimeMillis = Integer.getInteger("solr.cloud.client.stallTime", 15000);
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
 
     // make sure the stall time is larger than the polling time
     // to give a chance for the queue to change
@@ -476,7 +476,7 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
   @Override
   public NamedList<Object> request(final SolrRequest<?> request, String collection)
       throws SolrServerException, IOException {
-    if (ClientUtils.shouldApplyDefaultDataStore(collection, request))
+    if (ClientUtils.shouldApplyDefaultCollection(collection, request))
       collection = defaultCollection;
     if (!(request instanceof UpdateRequest)) {
       return client.request(request, collection);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -1197,7 +1197,7 @@ public class Http2SolrClient extends SolrClient {
       return this;
     }
 
-    /** Sets a default for core- or collection-based requests. */
+    /** Sets a default for core or collection based requests. */
     public Builder withDefaultCollection(String defaultCoreOrCollection) {
       this.defaultCollection = defaultCoreOrCollection;
       return this;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -191,7 +191,7 @@ public class Http2SolrClient extends SolrClient {
       this.parser = builder.responseParser;
     }
     updateDefaultMimeTypeForParser();
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
     if (builder.requestTimeoutMillis != null) {
       this.requestTimeoutMillis = builder.requestTimeoutMillis;
     } else {
@@ -555,7 +555,7 @@ public class Http2SolrClient extends SolrClient {
   @Override
   public NamedList<Object> request(SolrRequest<?> solrRequest, String collection)
       throws SolrServerException, IOException {
-    if (ClientUtils.shouldApplyDefaultDataStore(collection, solrRequest))
+    if (ClientUtils.shouldApplyDefaultCollection(collection, solrRequest))
       collection = defaultCollection;
     String url = getRequestPath(solrRequest, collection);
     Throwable abortCause = null;
@@ -1072,7 +1072,7 @@ public class Http2SolrClient extends SolrClient {
     private ExecutorService executor;
     protected RequestWriter requestWriter;
     protected ResponseParser responseParser;
-    protected String defaultDataStore;
+    protected String defaultCollection;
     private Set<String> urlParamNames;
     private CookieStore cookieStore = getDefaultCookieStore();
     private String proxyHost;
@@ -1197,9 +1197,9 @@ public class Http2SolrClient extends SolrClient {
       return this;
     }
 
-    /** Sets a default data store for core- or collection-based requests. */
-    public Builder withDefaultDataStore(String defaultCoreOrCollection) {
-      this.defaultDataStore = defaultCoreOrCollection;
+    /** Sets a default for core- or collection-based requests. */
+    public Builder withDefaultCollection(String defaultCoreOrCollection) {
+      this.defaultCollection = defaultCoreOrCollection;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -189,7 +189,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
     this.soTimeout = builder.socketTimeoutMillis;
     this.useMultiPartPost = builder.useMultiPartPost;
     this.urlParamNames = builder.urlParamNames;
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
   }
 
   public Set<String> getUrlParamNames() {
@@ -244,7 +244,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
   public NamedList<Object> request(
       final SolrRequest<?> request, final ResponseParser processor, String collection)
       throws SolrServerException, IOException {
-    if (ClientUtils.shouldApplyDefaultDataStore(collection, request))
+    if (ClientUtils.shouldApplyDefaultCollection(collection, request))
       collection = defaultCollection;
     HttpRequestBase method = createMethod(request, collection);
     setBasicAuthHeader(request, method);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -89,7 +89,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
     super(Arrays.asList(builder.baseSolrUrls));
     this.solrClient = builder.http2SolrClient;
     this.aliveCheckIntervalMillis = builder.aliveCheckIntervalMillis;
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
   }
 
   @Override
@@ -259,7 +259,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
     private final String[] baseSolrUrls;
     private long aliveCheckIntervalMillis =
         TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS); // 1 minute between checks
-    protected String defaultDataStore;
+    protected String defaultCollection;
 
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
       this.http2SolrClient = http2Client;
@@ -281,9 +281,9 @@ public class LBHttp2SolrClient extends LBSolrClient {
       return this;
     }
 
-    /** Sets a default data store for core- or collection-based requests. */
-    public LBHttp2SolrClient.Builder withDefaultDataStore(String defaultCoreOrCollection) {
-      this.defaultDataStore = defaultCoreOrCollection;
+    /** Sets a default for core- or collection-based requests. */
+    public LBHttp2SolrClient.Builder withDefaultCollection(String defaultCoreOrCollection) {
+      this.defaultCollection = defaultCoreOrCollection;
       return this;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -281,7 +281,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
       return this;
     }
 
-    /** Sets a default for core- or collection-based requests. */
+    /** Sets a default for core or collection based requests. */
     public LBHttp2SolrClient.Builder withDefaultCollection(String defaultCoreOrCollection) {
       this.defaultCollection = defaultCoreOrCollection;
       return this;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttpSolrClient.java
@@ -93,9 +93,9 @@ public class LBHttpSolrClient extends LBSolrClient {
         builder.httpClient == null
             ? constructClient(builder.baseSolrUrls.toArray(new String[0]))
             : builder.httpClient;
-    this.defaultCollection = builder.defaultDataStore;
+    this.defaultCollection = builder.defaultCollection;
     if (httpSolrClientBuilder != null && this.defaultCollection != null) {
-      httpSolrClientBuilder.defaultDataStore = this.defaultCollection;
+      httpSolrClientBuilder.defaultCollection = this.defaultCollection;
     }
     this.connectionTimeoutMillis = builder.connectionTimeoutMillis;
     this.soTimeoutMillis = builder.socketTimeoutMillis;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -575,7 +575,7 @@ public abstract class LBSolrClient extends SolrClient {
     final int maxTries = (numServersToTry == null ? serverList.length : numServersToTry.intValue());
     int numServersTried = 0;
     Map<String, ServerWrapper> justFailed = null;
-    if (ClientUtils.shouldApplyDefaultDataStore(collection, request))
+    if (ClientUtils.shouldApplyDefaultCollection(collection, request))
       collection = defaultCollection;
 
     boolean timeAllowedExceeded = false;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -41,7 +41,7 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
   protected int socketTimeoutMillis = 120000; // 120 seconds
   private boolean socketTimeoutMillisUpdate = false;
   protected boolean followRedirects = false;
-  protected String defaultDataStore;
+  protected String defaultCollection;
   protected Set<String> urlParamNames;
 
   /** The solution for the unchecked cast warning. */
@@ -98,9 +98,9 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
     return getThis();
   }
 
-  /** Sets a default data store for core- or collection-based requests. */
-  public B withDefaultDataStore(String defaultCoreOrCollection) {
-    this.defaultDataStore = defaultCoreOrCollection;
+  /** Sets a default for core- or collection-based requests. */
+  public B withDefaultCollection(String defaultCoreOrCollection) {
+    this.defaultCollection = defaultCoreOrCollection;
     return getThis();
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/SolrClientBuilder.java
@@ -98,7 +98,7 @@ public abstract class SolrClientBuilder<B extends SolrClientBuilder<B>> {
     return getThis();
   }
 
-  /** Sets a default for core- or collection-based requests. */
+  /** Sets a default for core or collection based requests. */
   public B withDefaultCollection(String defaultCoreOrCollection) {
     this.defaultCollection = defaultCoreOrCollection;
     return getThis();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/AbstractUpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/AbstractUpdateRequest.java
@@ -22,7 +22,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.UpdateParams;
 
 /** */
-public abstract class AbstractUpdateRequest extends DataStoreSolrRequest<UpdateResponse>
+public abstract class AbstractUpdateRequest extends CollectionRequiringSolrRequest<UpdateResponse>
     implements IsUpdateRequest {
   protected ModifiableSolrParams params;
   protected int commitWithin = -1;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionRequiringSolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionRequiringSolrRequest.java
@@ -19,7 +19,7 @@ package org.apache.solr.client.solrj.request;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 
-/** Parent {@link SolrRequest} class that requires a (target) collection or core. */
+/** Parent {@link SolrRequest} class that requires a target collection or core. */
 public abstract class CollectionRequiringSolrRequest<T extends SolrResponse>
     extends SolrRequest<T> {
   public CollectionRequiringSolrRequest(METHOD m, String path) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionRequiringSolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionRequiringSolrRequest.java
@@ -19,13 +19,15 @@ package org.apache.solr.client.solrj.request;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 
-public abstract class DataStoreSolrRequest<T extends SolrResponse> extends SolrRequest<T> {
-  public DataStoreSolrRequest(METHOD m, String path) {
+/** Parent {@link SolrRequest} class that requires a (target) collection or core. */
+public abstract class CollectionRequiringSolrRequest<T extends SolrResponse>
+    extends SolrRequest<T> {
+  public CollectionRequiringSolrRequest(METHOD m, String path) {
     super(m, path);
   }
 
   @Override
-  public boolean requiresDataStore() {
+  public boolean requiresCollection() {
     return true;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/DirectXmlRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/DirectXmlRequest.java
@@ -27,7 +27,7 @@ import org.apache.solr.common.params.SolrParams;
  *
  * @since solr 1.3
  */
-public class DirectXmlRequest extends DataStoreSolrRequest<UpdateResponse>
+public class DirectXmlRequest extends CollectionRequiringSolrRequest<UpdateResponse>
     implements IsUpdateRequest {
 
   final String xml;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/DocumentAnalysisRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/DocumentAnalysisRequest.java
@@ -37,7 +37,8 @@ import org.apache.solr.common.params.ModifiableSolrParams;
  *
  * @since solr 1.4
  */
-public class DocumentAnalysisRequest extends DataStoreSolrRequest<DocumentAnalysisResponse> {
+public class DocumentAnalysisRequest
+    extends CollectionRequiringSolrRequest<DocumentAnalysisResponse> {
 
   private List<SolrInputDocument> documents = new ArrayList<>();
   private String query;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/FieldAnalysisRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/FieldAnalysisRequest.java
@@ -29,7 +29,7 @@ import org.apache.solr.common.params.SolrParams;
  *
  * @since solr.14
  */
-public class FieldAnalysisRequest extends DataStoreSolrRequest<FieldAnalysisResponse> {
+public class FieldAnalysisRequest extends CollectionRequiringSolrRequest<FieldAnalysisResponse> {
 
   private String fieldValue;
   private String query;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/LukeRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/LukeRequest.java
@@ -27,7 +27,7 @@ import org.apache.solr.common.params.SolrParams;
 /**
  * @since solr 1.3
  */
-public class LukeRequest extends DataStoreSolrRequest<LukeResponse> {
+public class LukeRequest extends CollectionRequiringSolrRequest<LukeResponse> {
 
   private List<String> fields;
   private int numTerms = -1;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/QueryRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/QueryRequest.java
@@ -24,7 +24,7 @@ import org.apache.solr.common.params.SolrParams;
 /**
  * @since solr 1.3
  */
-public class QueryRequest extends DataStoreSolrRequest<QueryResponse> {
+public class QueryRequest extends CollectionRequiringSolrRequest<QueryResponse> {
 
   private SolrParams query;
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/SolrPing.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/SolrPing.java
@@ -28,7 +28,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
  *
  * @since solr 1.3
  */
-public class SolrPing extends DataStoreSolrRequest<SolrPingResponse> {
+public class SolrPing extends CollectionRequiringSolrRequest<SolrPingResponse> {
 
   /** serialVersionUID. */
   private static final long serialVersionUID = 5828246236669090017L;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/schema/AbstractSchemaRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/schema/AbstractSchemaRequest.java
@@ -17,11 +17,11 @@
 package org.apache.solr.client.solrj.request.schema;
 
 import org.apache.solr.client.solrj.SolrResponse;
-import org.apache.solr.client.solrj.request.DataStoreSolrRequest;
+import org.apache.solr.client.solrj.request.CollectionRequiringSolrRequest;
 import org.apache.solr.common.params.SolrParams;
 
 public abstract class AbstractSchemaRequest<T extends SolrResponse>
-    extends DataStoreSolrRequest<T> {
+    extends CollectionRequiringSolrRequest<T> {
   private SolrParams params = null;
 
   public AbstractSchemaRequest(METHOD m, String path) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
@@ -249,8 +249,8 @@ public class ClientUtils {
    *     through {@link org.apache.solr.client.solrj.SolrClient#request(SolrRequest, String)}
    * @param request the {@link SolrRequest} being executed
    */
-  public static boolean shouldApplyDefaultDataStore(
+  public static boolean shouldApplyDefaultCollection(
       String providedCollection, SolrRequest<? extends SolrResponse> request) {
-    return providedCollection == null && request.requiresDataStore();
+    return providedCollection == null && request.requiresCollection();
   }
 }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClientBuilderTest.java
@@ -77,7 +77,7 @@ public class ConcurrentUpdateSolrClientBuilderTest extends SolrTestCase {
   public void testDefaultCollectionPassedFromBuilderToClient() throws IOException {
     try (SolrClient createdClient =
         new ConcurrentUpdateSolrClient.Builder("someurl")
-            .withDefaultDataStore("aCollection")
+            .withDefaultCollection("aCollection")
             .build()) {
       assertEquals("aCollection", createdClient.getDefaultCollection());
     }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderTest.java
@@ -88,7 +88,7 @@ public class HttpSolrClientBuilderTest extends SolrTestCase {
   @Test
   public void testDefaultCollectionPassedFromBuilderToClient() throws IOException {
     try (final SolrClient createdClient =
-        new Builder(ANY_BASE_SOLR_URL).withDefaultDataStore("aCollection").build()) {
+        new Builder(ANY_BASE_SOLR_URL).withDefaultCollection("aCollection").build()) {
       assertEquals("aCollection", createdClient.getDefaultCollection());
     }
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttpSolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttpSolrClientBuilderTest.java
@@ -83,7 +83,7 @@ public class LBHttpSolrClientBuilderTest extends SolrTestCase {
     try (LBHttpSolrClient createdClient =
         new LBHttpSolrClient.Builder()
             .withBaseSolrUrl(ANY_BASE_SOLR_URL)
-            .withDefaultDataStore("aCollection")
+            .withDefaultCollection("aCollection")
             .build()) {
       assertEquals("aCollection", createdClient.getDefaultCollection());
     }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestSuggesterResponse.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestSuggesterResponse.java
@@ -144,7 +144,7 @@ public class TestSuggesterResponse extends SolrJettyTestBase {
         random().nextBoolean() ? new BinaryResponseParser() : new XMLResponseParser();
     return new HttpSolrClient.Builder()
         .withBaseSolrUrl(getBaseUrl())
-        .withDefaultDataStore(DEFAULT_TEST_CORENAME)
+        .withDefaultCollection(DEFAULT_TEST_CORENAME)
         .withResponseParser(randomParser)
         .build();
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/util/ClientUtilsTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/util/ClientUtilsTest.java
@@ -35,18 +35,18 @@ public class ClientUtilsTest extends SolrTestCase {
   }
 
   @Test
-  public void testDeterminesWhenToUseDefaultDataStore() {
+  public void testDeterminesWhenToUseDefaultCollection() {
     final var noDefaultNeededRequest = new CollectionAdminRequest.List();
     final var defaultNeededRequest = new UpdateRequest();
 
     assertFalse(
         "Expected default-coll to be skipped for collection-agnostic request",
-        ClientUtils.shouldApplyDefaultDataStore(null, noDefaultNeededRequest));
+        ClientUtils.shouldApplyDefaultCollection(null, noDefaultNeededRequest));
     assertTrue(
         "Expected default-coll to be used for collection-based request",
-        ClientUtils.shouldApplyDefaultDataStore(null, defaultNeededRequest));
+        ClientUtils.shouldApplyDefaultCollection(null, defaultNeededRequest));
     assertFalse(
         "Expected default-coll to be skipped when a collection is explicitly provided",
-        ClientUtils.shouldApplyDefaultDataStore("someCollection", defaultNeededRequest));
+        ClientUtils.shouldApplyDefaultCollection("someCollection", defaultNeededRequest));
   }
 }

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -2665,7 +2665,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    * should use the {@link org.apache.solr.client.solrj.impl.Http2SolrClient.Builder} class directly
    */
   public static HttpSolrClient getHttpSolrClient(String url, String defaultCoreName) {
-    return new HttpSolrClient.Builder(url).withDefaultDataStore(defaultCoreName).build();
+    return new HttpSolrClient.Builder(url).withDefaultCollection(defaultCoreName).build();
   }
 
   /**

--- a/solr/test-framework/src/java/org/apache/solr/cloud/ConfigRequest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/ConfigRequest.java
@@ -19,7 +19,7 @@ package org.apache.solr.cloud;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
-import org.apache.solr.client.solrj.request.DataStoreSolrRequest;
+import org.apache.solr.client.solrj.request.CollectionRequiringSolrRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
 import org.apache.solr.client.solrj.response.SolrResponseBase;
 import org.apache.solr.common.params.CommonParams;
@@ -30,7 +30,7 @@ import org.apache.solr.common.params.SolrParams;
  * components, handlers, parsers, etc. to an otherwise generic configset.
  */
 @SuppressWarnings({"rawtypes"})
-public class ConfigRequest extends DataStoreSolrRequest {
+public class ConfigRequest extends CollectionRequiringSolrRequest {
 
   protected final String message;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17066


# Description

"Data store" as a term, was introduced a few weeks back as a way to refer generically to something that could be either a collection or a core.  As its use expanded though, it turned out to not be very well liked in practice.  @dsmiley and @epugh in particular suggested we start using "collection" in a more generic sense to refer to any sort of "logical index" (regardless of whether it's a single core or a distributed collection in actuality).

# Solution

This PR replaces "data store" and the related term "store type", with "collection" and "index type" respectively.

The "Glossary" in our ref-guide has been updated to clarify that "collection" can be used to refer to both cores and collections.
 
# Tests

N/A - existing tests continue to pass, but otherwise this is an IDE refactor/rename that doesn't add or remove any functionality.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
