### PR TITLE
SOLR-17121: Fix SchemaCodecFactory to get PostingsFormat and DocValues from field.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -164,6 +164,8 @@ Bug Fixes
 
 * SOLR-17090: The v2 "delete alias" API no longer errantly returns a 405 status code (Jason Gerlowski)
 
+* SOLR-17121: Fix SchemaCodecFactory to get PostingsFormat and DocValues from field. (Bruno Roustant, David Smiley)
+
 Dependency Upgrades
 ---------------------
 * SOLR-17012: Update Apache Hadoop to 3.3.6 and Apache Curator to 5.5.0 (Kevin Risden)

--- a/solr/core/src/java/org/apache/solr/core/SchemaCodecFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/SchemaCodecFactory.java
@@ -102,7 +102,7 @@ public class SchemaCodecFactory extends CodecFactory implements SolrCoreAware {
           public PostingsFormat getPostingsFormatForField(String field) {
             final SchemaField schemaField = core.getLatestSchema().getFieldOrNull(field);
             if (schemaField != null) {
-              String postingsFormatName = schemaField.getType().getPostingsFormat();
+              String postingsFormatName = schemaField.getPostingsFormat();
               if (postingsFormatName != null) {
                 return PostingsFormat.forName(postingsFormatName);
               }
@@ -114,7 +114,7 @@ public class SchemaCodecFactory extends CodecFactory implements SolrCoreAware {
           public DocValuesFormat getDocValuesFormatForField(String field) {
             final SchemaField schemaField = core.getLatestSchema().getFieldOrNull(field);
             if (schemaField != null) {
-              String docValuesFormatName = schemaField.getType().getDocValuesFormat();
+              String docValuesFormatName = schemaField.getDocValuesFormat();
               if (docValuesFormatName != null) {
                 return DocValuesFormat.forName(docValuesFormatName);
               }

--- a/solr/core/src/test-files/solr/collection1/conf/schema_postingsformat.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema_postingsformat.xml
@@ -19,14 +19,14 @@
 
   <fieldType name="str_none" class="solr.StrField"/>
   <fieldType name="str_direct_asserting" class="solr.StrField" postingsFormat="Direct" docValuesFormat="Asserting"/>
-  <fieldType name="str_standard_simple" class="solr.StrField" postingsFormat="Lucene84" docValuesFormat="SimpleTextDocValuesFormat"/>
+  <fieldType name="str_standard_simple" class="solr.StrField" postingsFormat="Lucene84" docValuesFormat="Lucene80"/>
 
   <field name="str_none_f" type="str_none"/>
   <field name="str_direct_asserting_f" type="str_direct_asserting"/>
   <field name="str_standard_simple_f" type="str_standard_simple"/>
 
   <field name="str_none_lucene80_f" type="str_none" postingsFormat="Lucene80"/>
-  <field name="str_standard_lucene80_f" type="str_standard_simple" postingsFormat="Lucene80"/>
+  <field name="str_standard_lucene90_f" type="str_standard_simple" postingsFormat="Lucene90"/>
 
   <field name="str_none_asserting_f" type="str_none" docValuesFormat="Asserting"/>
   <field name="str_standard_asserting_f" type="str_standard_simple" docValuesFormat="Asserting"/>
@@ -36,6 +36,6 @@
   <dynamicField name="*_lucene70" type="str_none" postingsFormat="Lucene70"/>
 
   <dynamicField name="*_asserting" type="str_none" docValuesFormat="Asserting"/>
-  <dynamicField name="*_simple" type="str_direct_asserting" docValuesFormat="SimpleTextDocValuesFormat"/>
+  <dynamicField name="*_simple" type="str_direct_asserting" docValuesFormat="Lucene80"/>
 
 </schema>


### PR DESCRIPTION
This fixes [SOLR-13968](https://issues.apache.org/jira/browse/SOLR-13968) and adds a test case.
Thanks @dsmiley for spotting this!