### PR TITLE
SOLR-17126 Changes entry for 9.6 and new JIRA number

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -99,7 +99,7 @@ Dependency Upgrades
 
 Other Changes
 ---------------------
-(No changes)
+* SOLR-17126: Cut over System.getProperty to EnvUtils.getProperty (janhoy)
 
 ==================  9.5.0 ==================
 New Features


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17126

Targeting 9.6 for this since 9.5 release is already rolling. Therefore also using a separate JIRA number