### PR TITLE
SOLR-17130: edismax-matchalldocs-optimization

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -199,6 +199,18 @@ public class ExtendedDismaxQParser extends QParser {
       topQuery = FunctionScoreQuery.boostByValue(topQuery, boosts.get(0).asDoubleValuesSource());
     }
 
+    // If topQuery is a boolean query, unwrap the boolean query to check if it is just
+    // a MatchAllDocsQuery. Using MatchAllDocsQuery by itself enables later optimizations
+    if (topQuery instanceof BooleanQuery) {
+      BooleanQuery topQueryBoolean = (BooleanQuery) topQuery;
+      if (topQueryBoolean.clauses().size() == 1) {
+        Query onlyQuery = topQueryBoolean.clauses().get(0).getQuery();
+        if (onlyQuery instanceof MatchAllDocsQuery) {
+          return onlyQuery;
+        }
+      }
+    }
+
     return topQuery;
   }
 

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -25,6 +25,7 @@ import static org.apache.solr.util.QueryMatchers.termQuery;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isA;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -41,6 +42,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.solr.SolrTestCaseJ4;
@@ -141,6 +143,18 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
           req("defType", "edismax", "q", "doesnotexist_s:( * * * )", "sow", sow),
           "/response/numFound==0" // nothing should be found
           );
+    }
+  }
+
+  @Test
+  public void testMatchAllDocs() throws Exception {
+    for (String sow : Arrays.asList("true", "false")) {
+      for (String q : Arrays.asList("*:*", "*")) {
+        try (SolrQueryRequest req = req("sow", sow, "qf", "id")) {
+          QParser qParser = QParser.getParser(q, "edismax", req);
+          MatcherAssert.assertThat(qParser.getQuery(), isA(MatchAllDocsQuery.class));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17130

# Description

This unwraps the case of using edismax query parser and `q=*:*`. Prior to this change, `*:*` was being changed to `+*:*` which wraps the `MatchAllDocsQuery` with a boolean query. We can unwrap the boolean query since its not necessary if the `MatchAllDocsQuery` is the only clause.

I found this by looking at https://issues.apache.org/jira/browse/SOLR-14765 and wondering why when using `edismax` the optimizations were skipped even though the query was `*:*`. The boolean wrapped `MatchAllDocsQuery` means that some of the optimization logic is skipped - https://github.com/apache/solr/blob/main/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java#L1623

# Tests

Added tests to confirm that if `*` or `*:*` is the query then Solr returns just a `MatchAllDocsQuery` instead of a boolean wrapped `MatchAllDocsQuery`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
