### PR TITLE
SOLR-17131: Optimize rows=0 since score/sort isn't necessary

### DIFF
--- a/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
@@ -159,6 +159,9 @@ public class MiniClusterState {
 
       IOUtils.closeQuietly(client);
       cluster.shutdown();
+      if (useHttp1) {
+        System.clearProperty("solr.http1");
+      }
       logClusterDirectorySize();
     }
 
@@ -265,6 +268,9 @@ public class MiniClusterState {
       }
 
       try {
+        if (useHttp1) {
+          System.setProperty("solr.http1", "true");
+        }
         cluster =
             new MiniSolrCloudCluster.Builder(nodeCount, miniClusterBaseDir)
                 .formatZkServer(false)

--- a/solr/benchmark/src/java/org/apache/solr/bench/search/SearchOptimizations.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/search/SearchOptimizations.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.bench.search;
+
+import static org.apache.solr.bench.Docs.docs;
+import static org.apache.solr.bench.generators.SourceDSL.integers;
+import static org.apache.solr.bench.generators.SourceDSL.strings;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.solr.bench.BaseBenchState;
+import org.apache.solr.bench.Docs;
+import org.apache.solr.bench.MiniClusterState;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.common.params.CommonParams;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(value = 1)
+@Warmup(time = 5, iterations = 9)
+@Measurement(time = 5, iterations = 9)
+@Threads(value = 16)
+public class SearchOptimizations {
+
+  static final String COLLECTION = "c1";
+
+  @State(Scope.Benchmark)
+  public static class BenchState {
+    @Param({"false", "true"})
+    boolean singleShard;
+
+    @Param({"false", "true"})
+    boolean matchAllDocs;
+
+    @Param({"false", "true"})
+    boolean noRowsQuery;
+
+    @Param({"false", "true"})
+    boolean flScore;
+
+    @Param({"false", "true"})
+    boolean sortScore;
+
+    int numDocs = 10000;
+
+    AtomicLong total = new AtomicLong();
+    AtomicLong err = new AtomicLong();
+
+    QueryRequest q;
+
+    @Setup(Level.Trial)
+    public void setupTrial(MiniClusterState.MiniClusterBenchState miniClusterState)
+        throws Exception {
+      miniClusterState.setUseHttp1(true);
+      miniClusterState.startMiniCluster(1);
+      miniClusterState.createCollection(COLLECTION, singleShard ? 1 : 2, 1);
+      Docs docGen =
+          docs()
+              .field("id", integers().incrementing())
+              .field("text2_ts", strings().alpha().multi(10).ofLengthBetween(5, 10));
+      miniClusterState.index(COLLECTION, docGen, numDocs);
+      miniClusterState.forceMerge(COLLECTION, 1);
+      String base = miniClusterState.nodes.get(0);
+
+      q = new QueryRequest(getSolrQuery());
+      q.setBasePath(base);
+    }
+
+    private SolrQuery getSolrQuery() {
+      final String qstr;
+      if (matchAllDocs) {
+        qstr = "*:*";
+      } else {
+        qstr =
+            "id:10 OR id:20 OR id:30 OR id:40 OR id:50 OR id:60 OR id:70 OR id:80 OR id:90 OR id:100";
+      }
+      SolrQuery solrQuery = new SolrQuery("q", qstr);
+      if (noRowsQuery) {
+        solrQuery.set(CommonParams.ROWS, 0);
+      } else {
+        solrQuery.set(CommonParams.ROWS, CommonParams.ROWS_DEFAULT);
+      }
+      if (flScore) {
+        solrQuery.set(CommonParams.FL, "id,score");
+      } else {
+        solrQuery.set(CommonParams.FL, "id");
+      }
+      if (sortScore) {
+        solrQuery.set(CommonParams.SORT, "score desc,id asc");
+      } else {
+        solrQuery.set(CommonParams.SORT, "id asc");
+      }
+      return solrQuery;
+    }
+
+    @Setup(Level.Iteration)
+    public void setupIteration(MiniClusterState.MiniClusterBenchState miniClusterState)
+        throws SolrServerException, IOException {
+      // Reload the collection/core to drop existing caches
+      CollectionAdminRequest.Reload reload = CollectionAdminRequest.reloadCollection(COLLECTION);
+      reload.setBasePath(miniClusterState.nodes.get(0));
+      miniClusterState.client.request(reload);
+
+      total = new AtomicLong();
+      err = new AtomicLong();
+    }
+
+    @TearDown(Level.Iteration)
+    public void teardownIt() {
+      if (err.get() > 0) {
+        BaseBenchState.log(
+            "Completed Iteration with " + total.get() + " queries and " + err.get() + " errors");
+      }
+    }
+  }
+
+  @Benchmark
+  public Object query(
+      BenchState benchState, MiniClusterState.MiniClusterBenchState miniClusterState, Blackhole bh)
+      throws IOException {
+    try {
+      return miniClusterState.client.request(benchState.q, COLLECTION);
+    } catch (SolrServerException e) {
+      bh.consume(e);
+      benchState.err.getAndIncrement();
+      return null;
+    } finally {
+      benchState.total.getAndIncrement();
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -147,6 +147,14 @@ public class QueryComponent extends SearchComponent {
       }
     }
 
+    ReturnFields returnFields = new SolrReturnFields(req);
+    rsp.setReturnFields(returnFields);
+    int flags = 0;
+    if (returnFields.wantsScore()) {
+      flags |= SolrIndexSearcher.GET_SCORES;
+    }
+    rb.setFieldFlags(flags);
+
     String defType = params.get(QueryParsing.DEFTYPE, QParserPlugin.DEFAULT_QTYPE);
 
     // get it from the response builder to give a different component a chance
@@ -160,18 +168,6 @@ public class QueryComponent extends SearchComponent {
 
     try {
       QParser parser = QParser.getParser(rb.getQueryString(), defType, req);
-
-      SortSpec sortSpec = parser.getSortSpec(true);
-      rb.setSortSpec(sortSpec);
-
-      ReturnFields returnFields = new SolrReturnFields(req, sortSpec);
-      rsp.setReturnFields(returnFields);
-      int flags = 0;
-      if (returnFields.wantsScore()) {
-        flags |= SolrIndexSearcher.GET_SCORES;
-      }
-      rb.setFieldFlags(flags);
-
       Query q = parser.getQuery();
       if (q == null) {
         // normalize a null query to a query that matches nothing
@@ -200,6 +196,7 @@ public class QueryComponent extends SearchComponent {
         }
       }
 
+      rb.setSortSpec(parser.getSortSpec(true));
       rb.setQparser(parser);
 
       String[] fqs = req.getParams().getParams(CommonParams.FQ);

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -163,13 +163,12 @@ public class QueryComponent extends SearchComponent {
 
       SortSpec sortSpec = parser.getSortSpec(true);
       rb.setSortSpec(sortSpec);
-      boolean someDocs = sortSpec == null || sortSpec.getCount() != 0;
 
       // Set field flags
-      ReturnFields returnFields = new SolrReturnFields(req);
+      ReturnFields returnFields = new SolrReturnFields(req, sortSpec);
       rsp.setReturnFields(returnFields);
       int flags = 0;
-      if (returnFields.wantsScore() && someDocs) {
+      if (returnFields.wantsScore()) {
         flags |= SolrIndexSearcher.GET_SCORES;
       }
       rb.setFieldFlags(flags);

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -164,7 +164,6 @@ public class QueryComponent extends SearchComponent {
       SortSpec sortSpec = parser.getSortSpec(true);
       rb.setSortSpec(sortSpec);
 
-      // Set field flags
       ReturnFields returnFields = new SolrReturnFields(req, sortSpec);
       rsp.setReturnFields(returnFields);
       int flags = 0;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1666,7 +1666,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       // the filters instead of anding them first...
       // perhaps there should be a multi-docset-iterator
       if (needSort) {
-        fullSortCount.increment();
         sortDocSet(qr, cmd);
       } else {
         skipSortCount.increment();
@@ -1775,6 +1774,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    */
   private TopDocsCollector<? extends ScoreDoc> buildTopDocsCollector(int len, QueryCommand cmd)
       throws IOException {
+    fullSortCount.increment();
     int minNumFound = cmd.getMinExactCount();
     Query q = cmd.getQuery();
     if (q instanceof RankQuery) {
@@ -1868,7 +1868,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       qr.setNextCursorMark(cmd.getCursorMark());
       hitsRelation = Relation.EQUAL_TO;
     } else {
-      fullSortCount.increment();
       final TopDocsCollector<?> topCollector = buildTopDocsCollector(len, cmd);
       MaxScoreCollector maxScoreCollector = null;
       Collector collector = topCollector;
@@ -1981,7 +1980,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       // no docs on this page, so cursor doesn't change
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
-      fullSortCount.increment();
       final TopDocsCollector<? extends ScoreDoc> topCollector = buildTopDocsCollector(len, cmd);
       DocSetCollector setCollector = new DocSetCollector(maxDoc);
       MaxScoreCollector maxScoreCollector = null;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1868,6 +1868,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       qr.setNextCursorMark(cmd.getCursorMark());
       hitsRelation = Relation.EQUAL_TO;
     } else {
+      fullSortCount.increment();
       final TopDocsCollector<?> topCollector = buildTopDocsCollector(len, cmd);
       MaxScoreCollector maxScoreCollector = null;
       Collector collector = topCollector;
@@ -1980,6 +1981,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       // no docs on this page, so cursor doesn't change
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
+      fullSortCount.increment();
       final TopDocsCollector<? extends ScoreDoc> topCollector = buildTopDocsCollector(len, cmd);
       DocSetCollector setCollector = new DocSetCollector(maxDoc);
       MaxScoreCollector maxScoreCollector = null;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1617,9 +1617,16 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     // check if we should try and use the filter cache
     final boolean needSort;
     final boolean useFilterCache;
-    if ((flags & (GET_SCORES | NO_CHECK_FILTERCACHE)) != 0 || filterCache == null) {
+    final boolean useFilterCacheForQuery;
+    if (cmd.getLen() == 0) {
+      // No rows are being returned so no need to sort and can use the filterCache
+      needSort = false;
+      useFilterCache = true;
+      useFilterCacheForQuery = false;
+    } else if ((flags & (GET_SCORES | NO_CHECK_FILTERCACHE)) != 0 || filterCache == null) {
       needSort = true; // this value should be irrelevant when `useFilterCache=false`
       useFilterCache = false;
+      useFilterCacheForQuery = useFilterCache;
     } else if (q instanceof MatchAllDocsQuery
         || (useFilterForSortedQuery && QueryUtils.isConstantScoreQuery(q))) {
       // special-case MatchAllDocsQuery: implicit default useFilterForSortedQuery=true;
@@ -1643,10 +1650,12 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         useFilterCache =
             Arrays.stream(sort.getSort()).noneMatch((sf) -> sf.getType() == SortField.Type.SCORE);
       }
+      useFilterCacheForQuery = useFilterCache;
     } else {
       // for non-constant-score queries, must sort unless no docs requested
       needSort = cmd.getLen() > 0;
       useFilterCache = useFilterCacheForDynamicScoreQuery(needSort, cmd);
+      useFilterCacheForQuery = useFilterCache;
     }
 
     if (useFilterCache) {
@@ -1654,7 +1663,11 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       // for large filters that match few documents, this may be
       // slower than simply re-executing the query.
       if (out.docSet == null) {
-        out.docSet = getDocSet(cmd.getQuery());
+        if (useFilterCacheForQuery) {
+          out.docSet = getDocSet(cmd.getQuery());
+        } else {
+          out.docSet = getDocSetNC(QueryUtils.makeQueryable(cmd.getQuery()), null);
+        }
         List<Query> filterList = cmd.getFilterList();
         if (filterList != null && !filterList.isEmpty()) {
           out.docSet = DocSetUtil.getDocSet(out.docSet.intersection(getDocSet(filterList)), this);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1594,7 +1594,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
       if ((flags & NO_SET_QCACHE) == 0) {
         // handle 0 special case as well as avoid idiv in the common case.
-        if (maxDocRequested < queryResultWindowSize) {
+        if (cmd.getLen() == 0) {
+          supersetMaxDoc = 0;
+        } else if (maxDocRequested < queryResultWindowSize) {
           supersetMaxDoc = queryResultWindowSize;
         } else {
           supersetMaxDoc =
@@ -1818,7 +1820,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     int[] ids;
     float[] scores;
 
-    boolean needScores = (cmd.getFlags() & GET_SCORES) != 0;
+    boolean needScores = ((cmd.getFlags() & GET_SCORES) != 0) && (cmd.getLen() != 0);
 
     ProcessedFilter pf = getProcessedFilter(cmd.getFilterList());
     final Query query =
@@ -1937,7 +1939,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     float[] scores;
     DocSet set;
 
-    boolean needScores = (cmd.getFlags() & GET_SCORES) != 0;
+    boolean needScores = ((cmd.getFlags() & GET_SCORES) != 0) && (cmd.getLen() != 0);
     int maxDoc = maxDoc();
     cmd.setMinExactCount(Integer.MAX_VALUE); // We need the full DocSet
 

--- a/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
@@ -57,6 +57,8 @@ public class SolrReturnFields extends ReturnFields {
   // This *may* include fields that will not be in the final response
   private final Set<String> fields = new HashSet<>();
 
+  private SortSpec _sortSpec = null;
+
   // Field names that are OK to include in the response.
   // This will include pseudo fields, lucene fields, and matching globs
   private Set<String> okFieldNames = new HashSet<>();
@@ -99,7 +101,11 @@ public class SolrReturnFields extends ReturnFields {
   }
 
   public SolrReturnFields(SolrQueryRequest req) {
-    this(req.getParams().getParams(CommonParams.FL), req);
+    this(req, null);
+  }
+
+  public SolrReturnFields(SolrQueryRequest req, SortSpec sortSpec) {
+    this(req.getParams().getParams(CommonParams.FL), req, sortSpec);
   }
 
   public SolrReturnFields(String fl, SolrQueryRequest req) {
@@ -121,6 +127,11 @@ public class SolrReturnFields extends ReturnFields {
   }
 
   public SolrReturnFields(String[] fl, SolrQueryRequest req) {
+    this(fl, req, null);
+  }
+
+  public SolrReturnFields(String[] fl, SolrQueryRequest req, SortSpec sortSpec) {
+    _sortSpec = sortSpec;
     parseFieldList(fl, req);
   }
 
@@ -531,7 +542,7 @@ public class SolrReturnFields extends ReturnFields {
     okFieldNames.add(field);
     okFieldNames.add(key);
     // a valid field name
-    if (SCORE.equals(field)) {
+    if (SCORE.equals(field) && (_sortSpec == null || _sortSpec.getCount() != 0)) {
       _wantsScore = true;
 
       String disp = (key == null) ? field : key;

--- a/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
@@ -542,11 +542,19 @@ public class SolrReturnFields extends ReturnFields {
     okFieldNames.add(field);
     okFieldNames.add(key);
     // a valid field name
-    if (SCORE.equals(field) && (_sortSpec == null || _sortSpec.getCount() != 0)) {
-      _wantsScore = true;
+    if (SCORE.equals(field)) {
+      if (_sortSpec == null || _sortSpec.getCount() != 0) {
+        _wantsScore = true;
 
-      String disp = (key == null) ? field : key;
-      augmenters.addTransformer(new ScoreAugmenter(disp));
+        String disp = (key == null) ? field : key;
+        augmenters.addTransformer(new ScoreAugmenter(disp));
+      } else {
+        reqFieldNames.remove(field);
+        reqFieldNames.remove(key);
+        fields.remove(field);
+        okFieldNames.remove(field);
+        okFieldNames.remove(key);
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SortSpec.java
+++ b/solr/core/src/java/org/apache/solr/search/SortSpec.java
@@ -62,16 +62,13 @@ public class SortSpec {
     this.fields = Collections.unmodifiableList(fields);
   }
 
-  public static boolean includesScore(Sort sort) {
+  public boolean includesScore() {
+    if (num == 0) return false;
     if (sort == null) return true;
     for (SortField sf : sort.getSort()) {
       if (sf.getType() == SortField.Type.SCORE) return true;
     }
     return false;
-  }
-
-  public boolean includesScore() {
-    return includesScore(sort);
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
+++ b/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
@@ -866,7 +866,7 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
     args.put("fl", "*,score");
     args.put("sort", "id desc");
     req = new LocalSolrQueryRequest(h.getCore(), "id:44", "/select", 0, 0, args);
-    assertQ(req, "//result[@maxScore>0]");
+    assertQ(req, "//result[count(@maxScore)=0]");
 
     //  test schema field attribute inheritance and overriding
 

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -1637,6 +1637,27 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
         CommonParams.TIME_ALLOWED,
         1);
 
+    // Check rows=0 ngroups still work
+    rsp =
+        query(
+            "q",
+            "*:*",
+            "fq",
+            s1 + ":a",
+            "rows",
+            0,
+            "group",
+            "true",
+            "group.field",
+            i1,
+            "group.ngroups",
+            "true");
+    nl = (NamedList<?>) rsp.getResponse().get("grouped");
+    nl = (NamedList<?>) nl.get(i1);
+    assertEquals(rsp.toString(), 200, nl.get("matches"));
+    assertEquals(rsp.toString(), 2, nl.get("ngroups"));
+    assertEquals(rsp.toString(), 0, ((List<NamedList<?>>) nl.get("groups")).size());
+
     // Debug
     simpleQuery(
         "q",

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -1548,6 +1548,33 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void testGroupingNoRows() throws Exception {
+    assertU(add(doc("id", "1", "date_dt", "2012-11-20T00:00:00Z")));
+    assertU(add(doc("id", "2", "date_dt", "2012-11-21T00:00:00Z")));
+    assertU(commit());
+
+    assertU(add(doc("id", "3", "date_dt", "2012-11-20T00:00:00Z")));
+    assertU(add(doc("id", "4", "date_dt", "2013-01-15T00:00:00Z")));
+    assertU(add(doc("id", "5")));
+    assertU(commit());
+
+    assertJQ(
+        req(
+            params(
+                "q",
+                "*:*",
+                "rows",
+                "0",
+                "group",
+                "true",
+                "group.ngroups",
+                "true",
+                "group.field",
+                "date_dt")),
+        "/grouped=={'date_dt':{'matches':5,'ngroups':4, 'groups':[ ]}}");
+  }
+
+  @Test
   public void testGroupingOnDateField() throws Exception {
     assertU(add(doc("id", "1", "date_dt", "2012-11-20T00:00:00Z")));
     assertU(add(doc("id", "2", "date_dt", "2012-11-21T00:00:00Z")));

--- a/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
@@ -21,7 +21,6 @@ import static org.apache.solr.response.DocsStreamer.convertLuceneDocToSolrDoc;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -398,8 +397,7 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
 
   @Test
   public void testRowsZeroNoScore() {
-    SortSpec sortSpec = new SortSpec(null, Collections.emptyList(), 0, 0);
-    ReturnFields rf = new SolrReturnFields(req("fl", "id,score"), sortSpec);
+    ReturnFields rf = new SolrReturnFields(req("fl", "id,score", "rows", "0"));
     assertFalse(rf.wantsScore());
     assertFalse(rf.wantsField("score"));
     assertTrue(rf.wantsField("id"));

--- a/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
@@ -21,6 +21,7 @@ import static org.apache.solr.response.DocsStreamer.convertLuceneDocToSolrDoc;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -393,6 +394,17 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
         "//*[@numFound='1'] ",
         "//str[@name='id'][.='1']",
         "//arr[@name='#foo_s']/str[.='how now brown cow']");
+  }
+
+  @Test
+  public void testRowsZeroNoScore() {
+    SortSpec sortSpec = new SortSpec(null, Collections.emptyList(), 0, 0);
+    ReturnFields rf = new SolrReturnFields(req("fl", "id,score"), sortSpec);
+    assertFalse(rf.wantsScore());
+    assertFalse(rf.wantsField("score"));
+    assertTrue(rf.wantsField("id"));
+    assertFalse(rf.wantsField("xxx"));
+    assertFalse(rf.wantsAllFields());
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
@@ -256,6 +256,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
         .withSearcher(
             searcher -> {
               final QueryCommand cmd = new QueryCommand();
+              cmd.setLen(1); // make sure we get at least one doc to check later
               cmd.setFlags(SolrIndexSearcher.GET_SCORES | getDocSetFlag);
 
               if (doSort) {

--- a/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
@@ -141,7 +141,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
   public void testScoringQuery() throws Exception {
     // plain request should have no caching or sorting optimization
     String response = JQ(req("q", SCORING_QUERY, "indent", "true"));
-    assertMetricCounts(response, false, 0, 0, 0);
+    assertMetricCounts(response, false, 0, 1, 0);
   }
 
   @Test
@@ -173,12 +173,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
   public void testScoringQueryNonScoreSort() throws Exception {
     // plain request with no score in sort should consult filterCache, but need full sorting
     String response = JQ(req("q", SCORING_QUERY, "indent", "true", "sort", "id asc"));
-    assertMetricCounts(
-        response,
-        false,
-        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
-        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
-        0);
+    assertMetricCounts(response, false, USE_FILTER_FOR_SORTED_QUERY ? 1 : 0, 1, 0);
   }
 
   @Test
@@ -204,19 +199,19 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
     // hit cache and skip sort because constant score query
     String response = JQ(req("q", CONSTANT_SCORE_QUERY, "indent", "true"));
     final int insertAndSkipCount = USE_FILTER_FOR_SORTED_QUERY ? 1 : 0;
-    assertMetricCounts(response, false, insertAndSkipCount, 0, insertAndSkipCount);
+    assertMetricCounts(
+        response,
+        false,
+        insertAndSkipCount,
+        USE_FILTER_FOR_SORTED_QUERY ? 0 : 1,
+        insertAndSkipCount);
   }
 
   @Test
   public void testConstantScoreNonScoreSort() throws Exception {
     // consult filterCache because constant score query, but no skip sort (because sort-by-id)
     String response = JQ(req("q", CONSTANT_SCORE_QUERY, "indent", "true", "sort", "id asc"));
-    assertMetricCounts(
-        response,
-        false,
-        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
-        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
-        0);
+    assertMetricCounts(response, false, USE_FILTER_FOR_SORTED_QUERY ? 1 : 0, 1, 0);
   }
 
   /**
@@ -241,12 +236,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
                 "sort",
                 "id asc"));
     assertMetricCounts(
-        response,
-        USE_FILTER_FOR_SORTED_QUERY,
-        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
-        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
-        0,
-        ALL_DOCS);
+        response, USE_FILTER_FOR_SORTED_QUERY, USE_FILTER_FOR_SORTED_QUERY ? 1 : 0, 1, 0, ALL_DOCS);
   }
 
   @Test
@@ -341,23 +331,15 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
     if (includeScoreInSort) {
       consultMatchAllDocs = false;
       insertFilterCache = false;
-      fullSort = false;
     } else if (MATCH_ALL_DOCS_QUERY.equals(q)) {
       consultMatchAllDocs = true;
       insertFilterCache = false;
-      fullSort = true;
     } else {
       consultMatchAllDocs = false;
       insertFilterCache = USE_FILTER_FOR_SORTED_QUERY;
-      fullSort = USE_FILTER_FOR_SORTED_QUERY;
     }
     assertMetricCounts(
-        response,
-        consultMatchAllDocs,
-        insertFilterCache ? 1 : 0,
-        fullSort ? 1 : 0,
-        0,
-        expectNumFound);
+        response, consultMatchAllDocs, insertFilterCache ? 1 : 0, 1, 0, expectNumFound);
   }
 
   @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17131

# Description

If a query has `rows=0` Solr does not need to sort the results or even compute the score. This means the filterCache can be more efficient to compute the result and Solr doesn't spend time on unnecessarily sorting and scoring large result sets for it to be thrown away. 

There is one subtle difference from this change - `maxScore` is no longer returned if `rows=0` which seems like a reasonable tradeoff. If `maxScore` is needed then set `rows=1`. `maxScore` can't reliably be compared across searches anyway so no reason to have it when `rows=0`.

This was found while looking at https://issues.apache.org/jira/browse/SOLR-14765 and trying to reason through the case of `rows=0` that are sometimes used to just determine count of matching results. This change adds the check for `rows=0` before other checks to ensure that we can short circuit scoring even if there is a scoring query. We also don't add the query to the filter cache since that could result in filter cache thrashing. 

In some tests, we found that queries with `rows=0` p99 improved by 50% and CPU dropped by 5%.

# Tests

Updated tests in TestMainQueryCaching to account for this optimization.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
