### PR TITLE
NO JIRA: termVectors[NL] local variable rename in TermVectorComponent.process

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java
@@ -130,8 +130,8 @@ public class TermVectorComponent extends SearchComponent {
       return;
     }
 
-    NamedList<Object> termVectors = new NamedList<>();
-    rb.rsp.add(TERM_VECTORS, termVectors);
+    NamedList<Object> termVectorsNL = new NamedList<>();
+    rb.rsp.add(TERM_VECTORS, termVectorsNL);
 
     IndexSchema schema = rb.req.getSchema();
     SchemaField keyField = schema.getUniqueKeyField();
@@ -236,7 +236,7 @@ public class TermVectorComponent extends SearchComponent {
       warnings.add("noPayloads", noPay);
     }
     if (warnings.size() > 0) {
-      termVectors.add(TV_KEY_WARNINGS, warnings);
+      termVectorsNL.add(TV_KEY_WARNINGS, warnings);
     }
 
     DocListAndSet listAndSet = rb.getResults();
@@ -268,10 +268,10 @@ public class TermVectorComponent extends SearchComponent {
         String uKey = schema.printableUniqueKey(solrDoc);
         assert null != uKey;
         docNL.add("uniqueKey", uKey);
-        termVectors.add(uKey, docNL);
+        termVectorsNL.add(uKey, docNL);
       } else {
         // support for schemas w/o a unique key,
-        termVectors.add("doc-" + docId, docNL);
+        termVectorsNL.add("doc-" + docId, docNL);
       }
 
       if (null != fields) {


### PR DESCRIPTION
* There's already a `termVectorsNL` name used elsewhere in the component: https://github.com/apache/solr/blob/releases/solr/9.4.1/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java#L419
* To make `termVectors` available for use as per the the https://github.com/apache/solr/pull/1557/files#r1192193725 comments.