### PR TITLE
update labeler.yml to sync-labels=true

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
+        with:
+          sync-labels: true
       


### PR DESCRIPTION
Building upon  #2180.

Noticed that #2233 had retained the `dependencies` label even after the pull request had been updated.

references:
* https://github.com/actions/labeler?tab=readme-ov-file#create-workflow
* https://github.com/search?q=org%3Aapache%20sync-labels&type=code