### PR TITLE
SOLR-17147: Make committing documents after posting them the default behavior for bin/solr post

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -55,8 +55,8 @@ public class PostTool extends ToolBase {
             .required(false)
             .desc("Name of the collection.")
             .build(),
-        Option.builder("commit").required(false).desc("Issue a commit at end of post").build(),
-        Option.builder("optimize").required(false).desc("Issue an optimize at end of post").build(),
+        Option.builder("nocommit").required(false).desc("Disable commiting newly posted documents").build(),
+        Option.builder("optimize").required(false).desc("Issue an optimize at end of posting documents").build(),
         Option.builder("mode")
             .argName("mode")
             .hasArg(true)
@@ -146,7 +146,7 @@ public class PostTool extends ToolBase {
     int recursive = Integer.parseInt(cli.getOptionValue("recursive", "1"));
 
     OutputStream out = cli.hasOption("out") ? CLIO.getOutStream() : null;
-    boolean commit = cli.hasOption("commit");
+    boolean commit = cli.hasOption("nocommit") ? false : true;
     boolean optimize = cli.hasOption("optimize");
 
     String credentials = cli.getOptionValue(SolrCLI.OPTION_CREDENTIALS.getLongOpt());

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -55,8 +55,14 @@ public class PostTool extends ToolBase {
             .required(false)
             .desc("Name of the collection.")
             .build(),
-        Option.builder("nocommit").required(false).desc("Disable commiting newly posted documents").build(),
-        Option.builder("optimize").required(false).desc("Issue an optimize at end of posting documents").build(),
+        Option.builder("nocommit")
+            .required(false)
+            .desc("Disable commiting newly posted documents")
+            .build(),
+        Option.builder("optimize")
+            .required(false)
+            .desc("Issue an optimize at end of posting documents")
+            .build(),
         Option.builder("mode")
             .argName("mode")
             .hasArg(true)

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -409,7 +409,6 @@ public class RunExampleTool extends ToolBase {
         String[] args =
             new String[] {
               "post",
-              "-commit",
               "-url",
               updateUrl,
               "-type",

--- a/solr/docker/scripts/solr-demo
+++ b/solr/docker/scripts/solr-demo
@@ -37,9 +37,9 @@ else
   /opt/solr/bin/solr create -c "$CORE"
   echo "Created $CORE"
   echo "Loading example data"
-  /opt/solr/bin/solr post -c $CORE -commit no example/exampledocs/*.xml
-  /opt/solr/bin/solr post -c $CORE -commit no example/exampledocs/books.json
-  /opt/solr/bin/solr post -c $CORE -commit yes example/exampledocs/books.csv
+  /opt/solr/bin/solr post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/solr post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/solr post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
 

--- a/solr/docker/tests/cases/create_core/test.sh
+++ b/solr/docker/tests/cases/create_core/test.sh
@@ -25,7 +25,7 @@ docker run --name "$container_name" -d "$tag" solr-create -c gettingstarted
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/create_core_exec/test.sh
+++ b/solr/docker/tests/cases/create_core_exec/test.sh
@@ -27,7 +27,7 @@ wait_for_container_and_solr "$container_name"
 echo "Creating core"
 docker exec --user=solr "$container_name" bin/solr create -c gettingstarted
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/create_core_randomuser_rootgroup/test.sh
+++ b/solr/docker/tests/cases/create_core_randomuser_rootgroup/test.sh
@@ -27,7 +27,7 @@ docker run --user 7777:0 --name "$container_name" -d "$tag" solr-create -c getti
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
@@ -32,7 +32,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-dir-solr/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-dir-solr/test.sh
@@ -31,7 +31,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-dir-user/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-dir-user/test.sh
@@ -32,7 +32,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
@@ -36,7 +36,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-vol-solr-nocopy/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-vol-solr-nocopy/test.sh
@@ -42,7 +42,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-vol-solr/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-vol-solr/test.sh
@@ -35,7 +35,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/empty-varsolr-vol-user/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-vol-user/test.sh
@@ -44,7 +44,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c getting-started -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c getting-started example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')

--- a/solr/docker/tests/cases/gosu/test.sh
+++ b/solr/docker/tests/cases/gosu/test.sh
@@ -38,7 +38,7 @@ docker run --user 0:0 --name "$container_name" -d -e VERBOSE=yes \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/precreate_core/test.sh
+++ b/solr/docker/tests/cases/precreate_core/test.sh
@@ -25,7 +25,7 @@ docker run --name "$container_name" -d -e VERBOSE=yes "$tag" solr-precreate gett
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/precreate_core_randomuser_rootgroup/test.sh
+++ b/solr/docker/tests/cases/precreate_core_randomuser_rootgroup/test.sh
@@ -30,7 +30,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/test_log4j/test.sh
+++ b/solr/docker/tests/cases/test_log4j/test.sh
@@ -29,7 +29,7 @@ docker run --name "$container_name" -d -e VERBOSE=yes \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c gettingstarted -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c gettingstarted example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')

--- a/solr/docker/tests/cases/user_volume/test.sh
+++ b/solr/docker/tests/cases/user_volume/test.sh
@@ -67,7 +67,7 @@ docker run \
 wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
-docker exec --user=solr "$container_name" bin/solr post -c mycore -commit example/exampledocs/manufacturers.xml
+docker exec --user=solr "$container_name" bin/solr post -c mycore example/exampledocs/manufacturers.xml
 sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/mycore/select?q=id%3Adell')

--- a/solr/packaging/test/test_extraction.bats
+++ b/solr/packaging/test/test_extraction.bats
@@ -73,7 +73,7 @@ teardown() {
   }' "http://localhost:${SOLR_PORT}/solr/content_extraction/config"
   
   # We filter to pdf to invoke the Extract handler.
-  run solr post -filetypes pdf -commit -url http://localhost:${SOLR_PORT}/solr/content_extraction/update ${SOLR_TIP}/example/exampledocs
+  run solr post -filetypes pdf -url http://localhost:${SOLR_PORT}/solr/content_extraction/update ${SOLR_TIP}/example/exampledocs
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'
@@ -100,7 +100,7 @@ teardown() {
   }' "http://localhost:${SOLR_PORT}/solr/website_extraction/config"
   
   # Change to -recursive 1 to crawl multiple pages, but may be too slow.
-  run solr post -mode web -commit -url http://localhost:${SOLR_PORT}/solr/website_extraction/update -recursive 0 -delay 1 https://solr.apache.org/
+  run solr post -mode web -url http://localhost:${SOLR_PORT}/solr/website_extraction/update -recursive 0 -delay 1 https://solr.apache.org/
 
   assert_output --partial 'POSTed web resource https://solr.apache.org (depth: 0)'
   refute_output --partial 'ERROR'

--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -63,7 +63,7 @@ teardown() {
   refute_output --partial 'ERROR'
 }
 
-@test "basic post with c parameter instead of url parameter" {
+@test "basic post with collection instead of url parameter" {
   
   run solr create -c monitors_c_param -d _default
   assert_output --partial "Created collection 'monitors_c_param'"

--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -133,15 +133,15 @@ teardown() {
   assert_output --partial 'Entering crawl at level 0'
 }
 
-@test "commit and optimize and delete" {
+@test "nocommit and optimize and delete" {
   
   run solr create -c monitors2 -d _default
   assert_output --partial "Created collection 'monitors2'"
   
-  run solr post -url http://localhost:${SOLR_PORT}/solr/monitors2/update -type application/xml -commit -optimize ${SOLR_TIP}/example/exampledocs/monitor.xml
+  run solr post -url http://localhost:${SOLR_PORT}/solr/monitors2/update -type application/xml -nocommit -optimize ${SOLR_TIP}/example/exampledocs/monitor.xml
 
   assert_output --partial '1 files indexed.'
-  assert_output --partial 'COMMITting Solr index'
+  refute_output --partial 'COMMITting Solr index'
   assert_output --partial 'Performing an OPTIMIZE'
   refute_output --partial 'ERROR'
 
@@ -156,14 +156,14 @@ teardown() {
   assert_output --partial '<int name="status">0</int>'
   
   # confirm default type
-  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -out -commit "{'delete': {'query': '*:*'}}"
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -out "{'delete': {'query': '*:*'}}"
   assert_output --partial '"status":0'
   
   # confirm we don't get back output without -out
-  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -commit "{'delete': {'query': '*:*'}}"
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args "{'delete': {'query': '*:*'}}"
   refute_output --partial '"status":0'
   
-  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -commit -type text/csv -out $'id,value\nROW1,0.47'
+  run solr post -url http://localhost:${SOLR_PORT}/solr/test_args/update -mode args -type text/csv -out $'id,value\nROW1,0.47'
   assert_output --partial '"status":0'
   run curl "http://localhost:${SOLR_PORT}/solr/test_args/select?q=id:ROW1"
   assert_output --partial '"numFound":1'

--- a/solr/packaging/test/test_ssl.bats
+++ b/solr/packaging/test/test_ssl.bats
@@ -604,7 +604,7 @@ teardown() {
   run solr api -get "https://localhost:${SOLR2_PORT}/solr/test-single-shard/select?q=query4"
   assert_output --partial '"numFound":0'
 
-  run solr post -url https://localhost:${SOLR_PORT}/solr/test/update -commit ${SOLR_TIP}/example/exampledocs/books.csv
+  run solr post -url https://localhost:${SOLR_PORT}/solr/test/update ${SOLR_TIP}/example/exampledocs/books.csv
 
   run solr api -get "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*"
   assert_output --partial '"numFound":10'

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
@@ -44,50 +44,58 @@ The basic usage of `bin/solr post` is:
 
 [source,plain]
 ----
-$ bin/solr post -h
-Usage: post -url http://localhost:8983/gettingstarted/update [OPTIONS] <files|directories|urls|-d ["...",...]>
-    or post -help
-
-OPTIONS
-=======
-  Solr options:
-    -url <base Solr update URL>
-    -commit issue a commit
-    -u or -credentials <user:pass> (sets BasicAuth credentials)
-
-  Web crawl options:
-    -recursive <depth> (default: 1)
-    -delay <seconds> (default: 10)
-
-  Directory crawl options:
-    -delay <seconds> (default: 0)
-
-  stdin/args options:
-    -type <content/type> (default: application/json)
-
-
-  Other options:
-    -filetypes <type>[,<type>,...] (default: xml,json,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,ots,rtf,htm,html,txt,log)
-    -params "<key>=<value>[&<key>=<value>...]" (values must be URL-encoded; these pass through to Solr update request)
-    -out output the Solr responses to console
-    -format solr (sends application/json content as Solr commands to /update instead of /update/json/docs
-    
-Examples:
-
-* JSON file: bin/solr post -url http://localhost:8983/wizbang/update events.json
-* XML files: bin/solr post -url http://localhost:8983/records/update article*.xml
-* CSV file: bin/solr post -url http://localhost:8983/signals/update LATEST-signals.csv
-* Directory of files: bin/solr post -filetypes xml,json,csv -url http://localhost:8983/myfiles/update ~/Documents
-* Web crawl: bin/solr post -mode web -url http://localhost:8983/gettingstarted/update -recursive 1 -delay 1 https://solr.apache.org/ 
-* Standard input (stdin): echo '{commit: {}}' | bin/solr post -mode stdin -url http://localhost:8983/my_collection/update -out
-* Data as string: bin/solr post -url http://localhost:8983/signals/update -mode args -type text/csv -out $'id,value\n1,0.47' 
-
+usage: post
+ -c,--name <NAME>                             Name of the collection.
+ -delay <delay>                               If recursive then delay will
+                                              be the wait time between
+                                              posts.  default: 10 for web,
+                                              0 for files
+ -filetypes <<type>[,<type>,...]>             default:
+                                              xml,json,jsonl,csv,pdf,doc,d
+                                              ocx,ppt,pptx,xls,xlsx,odt,od
+                                              p,ods,ott,otp,ots,rtf,htm,ht
+                                              ml,txt,log
+ -format                                      sends application/json
+                                              content as Solr commands to
+                                              /update instead of
+                                              /update/json/docs
+ -help                                        Print this message
+ -mode <mode>                                 Files crawls files, web
+                                              crawls website. default:
+                                              files.
+ -nocommit                                    Disable commiting newly
+                                              posted documents
+ -optimize                                    Issue an optimize at end of
+                                              posting documents
+ -out                                         sends Solr response outputs
+                                              to console
+ -params <<key>=<value>[&<key>=<value>...]>   values must be URL-encoded;
+                                              these pass through to Solr
+                                              update request
+ -recursive <recursive>                       For web crawl, how deep to
+                                              go. default: 1
+ -type <content-type>                         default: application/json
+ -u,--credentials <credentials>               Credentials in the format
+                                              username:password. Example:
+                                              --credentials solr:SolrRocks
+ -url <url>                                   <base Solr update URL>
+ -verbose                                     Enable more verbose command
+                                              output.
 ----
 
 == Examples Using bin/solr post
 
 There are several ways to use `bin/solr post`.
 This section presents several examples.
+
+=== Indexing JSON
+
+Index all JSON files into `gettingstarted`.
+
+[source,bash]
+----
+bin/solr post -url http://localhost:8983/solr/gettingstarted/update *.json
+----
 
 === Indexing XML
 
@@ -98,11 +106,11 @@ Add all documents with file extension `.xml` to the collection named `gettingsta
 bin/solr post -url http://localhost:8983/solr/gettingstarted/update *.xml
 ----
 
-Add all documents with file extension `.xml` to the `gettingstarted` collection on Solr running on port `8984`.
+Add all documents starting with `article` with file extension `.xml` to the `gettingstarted` collection on Solr running on port `8984`.
 
 [source,bash]
 ----
-bin/solr post -url http://localhost:8984/solr/gettingstarted/update *.xml
+bin/solr post -url http://localhost:8984/solr/gettingstarted/update article*.xml
 ----
 
 Send XML arguments to delete a document from `gettingstarted`.
@@ -130,15 +138,6 @@ bin/solr post -url http://localhost:8984/solr/signals/update -params "separator=
 
 The content type (`-type`) parameter is required to treat the file as the proper type, otherwise it will be ignored and a WARNING logged as it does not know what type of content a .tsv file is.
 The xref:indexing-with-update-handlers.adoc#csv-formatted-index-updates[CSV handler] supports the `separator` parameter, and is passed through using the `-params` setting.
-
-=== Indexing JSON
-
-Index all JSON files into `gettingstarted`.
-
-[source,bash]
-----
-bin/solr post -url http://localhost:8983/solr/gettingstarted/update *.json
-----
 
 === Indexing Rich Documents (PDF, Word, HTML, etc.)
 
@@ -170,4 +169,15 @@ Index a PDF as the user "solr" with password "SolrRocks":
 [source,bash]
 ----
 bin/solr post -u solr:SolrRocks -url http://localhost:8983/solr/gettingstarted/update a.pdf
+----
+
+=== Web Crawl and Index Documents 
+
+Crawl the Apache Solr website going one layer deep and indexing the pages into Solr.   
+
+See xref:indexing-with-tika.adoc#trying-out-solr-cell[Trying Out Solr Cell] to learn more about setting up Solr for extracting content from web pages.
+
+[source,bash]
+----
+bin/solr post -mode web -c gettingstarted -recursive 1 -delay 1 https://solr.apache.org/ 
 ----

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
@@ -171,7 +171,7 @@ Index a PDF as the user "solr" with password "SolrRocks":
 bin/solr post -u solr:SolrRocks -url http://localhost:8983/solr/gettingstarted/update a.pdf
 ----
 
-=== Web Crawl and Index Documents 
+=== Crawling a Website to Index Documents 
 
 Crawl the Apache Solr website going one layer deep and indexing the pages into Solr.   
 
@@ -180,4 +180,23 @@ See xref:indexing-with-tika.adoc#trying-out-solr-cell[Trying Out Solr Cell] to l
 [source,bash]
 ----
 bin/solr post -mode web -c gettingstarted -recursive 1 -delay 1 https://solr.apache.org/ 
+----
+
+=== Standard Input as Source for Indexing
+
+You can use the standard input as your source for data to index.  
+Notice the `-out` providing raw responses from Solr.
+
+[source,bash]
+----
+echo '{commit: {}}' | bin/solr post -mode stdin -url http://localhost:8983/my_collection/update -out
+----
+
+=== Raw Data as Source for Indexing
+
+Provide the raw document as a string for indexing.
+
+[source,bash]
+----
+bin/solr post -url http://localhost:8983/signals/update -mode args -type text/csv -out $'id,value\n1,0.47' 
 ----


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17147

# Description

The `bin/post` command by default committed documents, you have to pass a seperate `-commit=false` to disable that behavior.  However `bin/solr post` required you to pass in a `-commit` flag.

Since the core users are poeple playing with Solr, we want to make it simpler, so that after you post your documents you can search them.

For folks who care about commit times, there is not a `-nocommit` option.

# Solution

change default options.

# Tests
updated

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `main` branch.
- [ X] I have run `./gradlew check`.
- [ X] I have added tests for my changes.
- [ X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
