### PR TITLE
SOLR-17066: Switch Http2SolrClient away from coreURLs

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
@@ -42,6 +42,7 @@ import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.handler.component.ShardRequest;
 
 /** A command line tool for indexing Solr logs in the out-of-the-box log format. */
@@ -89,9 +90,16 @@ public class PostLogsTool extends ToolBase {
   }
 
   public void runCommand(String baseUrl, String root, String credentials) throws IOException {
+    if (URLUtil.isBaseUrl(baseUrl)) {
+      throw new IllegalArgumentException(
+          "'url' parameter ["
+              + baseUrl
+              + "] must point to a particular collection but appears to be a Solr base URL");
+    }
 
     Http2SolrClient.Builder builder =
-        new Http2SolrClient.Builder(baseUrl)
+        new Http2SolrClient.Builder(URLUtil.extractBaseUrl(baseUrl))
+            .withDefaultCollection(URLUtil.extractCoreFromCoreUrl(baseUrl))
             .withKeyStoreReloadInterval(-1, TimeUnit.SECONDS)
             .withOptionalBasicAuthCredentials(credentials);
     try (SolrClient client = builder.build()) {

--- a/solr/core/src/test/org/apache/solr/core/snapshots/TestSolrCoreSnapshots.java
+++ b/solr/core/src/test/org/apache/solr/core/snapshots/TestSolrCoreSnapshots.java
@@ -109,7 +109,10 @@ public class TestSolrCoreSnapshots extends SolrCloudTestCase {
 
     try (SolrClient adminClient =
             getHttpSolrClient(cluster.getJettySolrRunners().get(0).getBaseUrl().toString());
-        SolrClient leaderClient = new Http2SolrClient.Builder(replica.getCoreUrl()).build()) {
+        SolrClient leaderClient =
+            new Http2SolrClient.Builder(replica.getBaseUrl())
+                .withDefaultCollection(replica.getCoreName())
+                .build()) {
 
       SnapshotMetaData metaData = createSnapshot(adminClient, coreName, commitName);
       // Create another snapshot referring to the same index commit to verify the
@@ -200,7 +203,10 @@ public class TestSolrCoreSnapshots extends SolrCloudTestCase {
 
     try (SolrClient adminClient =
             getHttpSolrClient(cluster.getJettySolrRunners().get(0).getBaseUrl().toString());
-        SolrClient leaderClient = new Http2SolrClient.Builder(replica.getCoreUrl()).build()) {
+        SolrClient leaderClient =
+            new Http2SolrClient.Builder(replica.getBaseUrl())
+                .withDefaultCollection(replica.getCoreName())
+                .build()) {
 
       SnapshotMetaData metaData = createSnapshot(adminClient, coreName, commitName);
 

--- a/solr/core/src/test/org/apache/solr/handler/TestHttpRequestId.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestHttpRequestId.java
@@ -105,7 +105,8 @@ public class TestHttpRequestId extends SolrJettyTestBase {
               new SolrNamedThreadFactory("httpShardExecutor"),
               false);
       try (Http2SolrClient client =
-          new Http2SolrClient.Builder(getBaseUrl() + collection)
+          new Http2SolrClient.Builder(getBaseUrl())
+              .withDefaultCollection(collection)
               .withExecutor(commExecutor)
               .build()) {
         MDC.put(key, value);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleBinaryHttp2Test.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleBinaryHttp2Test.java
@@ -38,7 +38,8 @@ public class SolrExampleBinaryHttp2Test extends SolrExampleTests {
 
   @Override
   public SolrClient createNewSolrClient() {
-    return new Http2SolrClient.Builder(getCoreUrl())
+    return new Http2SolrClient.Builder(getBaseUrl())
+        .withDefaultCollection(DEFAULT_TEST_CORENAME)
         .withConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
         .withRequestWriter(new BinaryRequestWriter())
         // where the magic happens

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/embedded/SolrExampleXMLHttp2Test.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/embedded/SolrExampleXMLHttp2Test.java
@@ -39,7 +39,8 @@ public class SolrExampleXMLHttp2Test extends SolrExampleTests {
   public SolrClient createNewSolrClient() {
 
     Http2SolrClient client =
-        new Http2SolrClient.Builder(getCoreUrl())
+        new Http2SolrClient.Builder(getBaseUrl())
+            .withDefaultCollection(DEFAULT_TEST_CORENAME)
             .withConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
             .withRequestWriter(new RequestWriter())
             .withResponseParser(new XMLResponseParser())

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -66,6 +66,14 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   private static final String EXPECTED_USER_AGENT =
       "Solr[" + Http2SolrClient.class.getName() + "] 2.0";
 
+  private static final String DEFAULT_CORE = "foo";
+  private static final String SLOW_SERVLET_PATH = "/slow";
+  private static final String SLOW_SERVLET_REGEX = SLOW_SERVLET_PATH + "/*";
+  private static final String DEBUG_SERVLET_PATH = "/debug";
+  private static final String DEBUG_SERVLET_REGEX = DEBUG_SERVLET_PATH + "/*";
+  private static final String REDIRECT_SERVLET_PATH = "/redirect";
+  private static final String REDIRECT_SERVLET_REGEX = REDIRECT_SERVLET_PATH + "/*";
+
   public static class DebugServlet extends HttpServlet {
     public static void clear() {
       lastMethod = null;
@@ -179,9 +187,11 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     JettyConfig jettyConfig =
         JettyConfig.builder()
             .withServlet(
-                new ServletHolder(BasicHttpSolrClientTest.RedirectServlet.class), "/redirect/*")
-            .withServlet(new ServletHolder(BasicHttpSolrClientTest.SlowServlet.class), "/slow/*")
-            .withServlet(new ServletHolder(DebugServlet.class), "/debug/*")
+                new ServletHolder(BasicHttpSolrClientTest.RedirectServlet.class),
+                REDIRECT_SERVLET_REGEX)
+            .withServlet(
+                new ServletHolder(BasicHttpSolrClientTest.SlowServlet.class), SLOW_SERVLET_REGEX)
+            .withServlet(new ServletHolder(DebugServlet.class), DEBUG_SERVLET_REGEX)
             .withSSLConfig(sslConfig.buildServerSSLConfig())
             .build();
     createAndStartJetty(legacyExampleCollection1SolrHome(), jettyConfig);
@@ -206,7 +216,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testTimeout() throws Exception {
     SolrQuery q = new SolrQuery("*:*");
     try (Http2SolrClient client =
-        getHttp2SolrClientBuilder(getBaseUrl() + "/slow/foo", DEFAULT_CONNECTION_TIMEOUT, 2000)
+        getHttp2SolrClientBuilder(
+                getBaseUrl() + SLOW_SERVLET_PATH, DEFAULT_CONNECTION_TIMEOUT, 2000)
+            .withDefaultCollection(DEFAULT_CORE)
             .build()) {
       client.query(q, SolrRequest.METHOD.GET);
       fail("No exception thrown.");
@@ -219,7 +231,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void test0IdleTimeout() throws Exception {
     SolrQuery q = new SolrQuery("*:*");
     try (Http2SolrClient client =
-        getHttp2SolrClientBuilder(getBaseUrl() + "/debug/foo", DEFAULT_CONNECTION_TIMEOUT, 0)
+        getHttp2SolrClientBuilder(getBaseUrl() + DEBUG_SERVLET_PATH, DEFAULT_CONNECTION_TIMEOUT, 0)
+            .withDefaultCollection(DEFAULT_CORE)
             .build()) {
       try {
         client.query(q, SolrRequest.METHOD.GET);
@@ -232,7 +245,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testRequestTimeout() throws Exception {
     SolrQuery q = new SolrQuery("*:*");
     try (Http2SolrClient client =
-        getHttp2SolrClientBuilder(getBaseUrl() + "/slow/foo", DEFAULT_CONNECTION_TIMEOUT, 0)
+        getHttp2SolrClientBuilder(getBaseUrl() + SLOW_SERVLET_PATH, DEFAULT_CONNECTION_TIMEOUT, 0)
+            .withDefaultCollection(DEFAULT_CORE)
             .withRequestTimeout(500, TimeUnit.MILLISECONDS)
             .build()) {
       client.query(q, SolrRequest.METHOD.GET);
@@ -256,7 +270,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
         SolrException.ErrorCode.getErrorCode(status));
 
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo").build()) {
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
+            .build()) {
       DebugServlet.setErrorCode(status);
       try {
         SolrQuery q = new SolrQuery("foo");
@@ -288,8 +304,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
       try {
         // if client base url is null, request url will be used in exception message
         SolrPing ping = new SolrPing();
-        ping.setBasePath(getBaseUrl() + "/debug/foo");
-        client.request(ping);
+        ping.setBasePath(getBaseUrl() + DEBUG_SERVLET_PATH);
+        client.request(ping, DEFAULT_CORE);
 
         fail("Didn't get excepted exception from oversided request");
       } catch (SolrException e) {
@@ -304,10 +320,11 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testQuery() throws Exception {
     DebugServlet.clear();
-    String url = getBaseUrl() + "/debug/foo";
+    String url = getBaseUrl() + DEBUG_SERVLET_PATH;
     SolrQuery q = new SolrQuery("foo");
     q.setParam("a", "\u1234");
-    try (Http2SolrClient client = new Http2SolrClient.Builder(url).build()) {
+    try (Http2SolrClient client =
+        new Http2SolrClient.Builder(url).withDefaultCollection(DEFAULT_CORE).build()) {
 
       try {
         client.query(q, SolrRequest.METHOD.GET);
@@ -434,8 +451,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testDelete() throws Exception {
     DebugServlet.clear();
-    String url = getBaseUrl() + "/debug/foo";
-    try (Http2SolrClient client = new Http2SolrClient.Builder(url).build()) {
+    String url = getBaseUrl() + DEBUG_SERVLET_PATH;
+    try (Http2SolrClient client =
+        new Http2SolrClient.Builder(url).withDefaultCollection(DEFAULT_CORE).build()) {
       try {
         client.deleteById("id");
       } catch (BaseHttpSolrClient.RemoteSolrException ignored) {
@@ -457,7 +475,10 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     // XML
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(url).withResponseParser(new XMLResponseParser()).build()) {
+        new Http2SolrClient.Builder(url)
+            .withDefaultCollection(DEFAULT_CORE)
+            .withResponseParser(new XMLResponseParser())
+            .build()) {
 
       try {
         client.deleteByQuery("*:*");
@@ -479,7 +500,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testGetById() throws Exception {
     DebugServlet.clear();
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo").build()) {
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
+            .build()) {
       Collection<String> ids = Collections.singletonList("a");
       try {
         client.getById("a");
@@ -506,11 +529,12 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testUpdate() throws Exception {
     DebugServlet.clear();
-    String url = getBaseUrl() + "/debug/foo";
+    String url = getBaseUrl() + DEBUG_SERVLET_PATH;
     UpdateRequest req = new UpdateRequest();
     req.add(new SolrInputDocument());
     req.setParam("a", "\u1234");
-    try (Http2SolrClient client = new Http2SolrClient.Builder(url).build()) {
+    try (Http2SolrClient client =
+        new Http2SolrClient.Builder(url).withDefaultCollection(DEFAULT_CORE).build()) {
 
       try {
         client.request(req);
@@ -536,6 +560,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     }
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(url)
+            .withDefaultCollection(DEFAULT_CORE)
             .withRequestWriter(new RequestWriter())
             .withResponseParser(new XMLResponseParser())
             .build()) {
@@ -561,6 +586,7 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     // javabin request
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(url)
+            .withDefaultCollection(DEFAULT_CORE)
             .withRequestWriter(new BinaryRequestWriter())
             .withResponseParser(new BinaryResponseParser())
             .build()) {
@@ -586,9 +612,12 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
 
   @Test
   public void testFollowRedirect() throws Exception {
-    final String clientUrl = getBaseUrl() + "/redirect/foo";
+    final String clientUrl = getBaseUrl() + REDIRECT_SERVLET_PATH;
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withFollowRedirects(true).build()) {
+        new Http2SolrClient.Builder(clientUrl)
+            .withDefaultCollection(DEFAULT_CORE)
+            .withFollowRedirects(true)
+            .build()) {
       SolrQuery q = new SolrQuery("*:*");
       client.query(q);
     }
@@ -596,9 +625,12 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
 
   @Test
   public void testDoNotFollowRedirect() throws Exception {
-    final String clientUrl = getBaseUrl() + "/redirect/foo";
+    final String clientUrl = getBaseUrl() + REDIRECT_SERVLET_PATH;
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withFollowRedirects(false).build()) {
+        new Http2SolrClient.Builder(clientUrl)
+            .withDefaultCollection(DEFAULT_CORE)
+            .withFollowRedirects(false)
+            .build()) {
       SolrQuery q = new SolrQuery("*:*");
 
       SolrServerException thrown = assertThrows(SolrServerException.class, () -> client.query(q));
@@ -608,25 +640,32 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
 
   @Test
   public void testRedirectSwapping() throws Exception {
-    final String clientUrl = getBaseUrl() + "/redirect/foo";
+    final String clientUrl = getBaseUrl() + REDIRECT_SERVLET_PATH;
     SolrQuery q = new SolrQuery("*:*");
 
     // default for follow redirects is false
-    try (Http2SolrClient client = new Http2SolrClient.Builder(clientUrl).build()) {
+    try (Http2SolrClient client =
+        new Http2SolrClient.Builder(clientUrl).withDefaultCollection(DEFAULT_CORE).build()) {
 
       SolrServerException e = expectThrows(SolrServerException.class, () -> client.query(q));
       assertTrue(e.getMessage().contains("redirect"));
     }
 
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withFollowRedirects(true).build()) {
+        new Http2SolrClient.Builder(clientUrl)
+            .withDefaultCollection(DEFAULT_CORE)
+            .withFollowRedirects(true)
+            .build()) {
       // shouldn't throw an exception
       client.query(q);
     }
 
     // set explicit false for following redirects
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(clientUrl).withFollowRedirects(false).build()) {
+        new Http2SolrClient.Builder(clientUrl)
+            .withDefaultCollection(DEFAULT_CORE)
+            .withFollowRedirects(false)
+            .build()) {
 
       SolrServerException e = expectThrows(SolrServerException.class, () -> client.query(q));
       assertTrue(e.getMessage().contains("redirect"));
@@ -686,11 +725,12 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testQueryString() throws Exception {
 
-    final String clientUrl = getBaseUrl() + "/debug/foo";
+    final String clientUrl = getBaseUrl() + DEBUG_SERVLET_PATH;
     UpdateRequest req = new UpdateRequest();
 
     try (Http2SolrClient client =
         new Http2SolrClient.Builder(clientUrl)
+            .withDefaultCollection(DEFAULT_CORE)
             .withTheseParamNamesInTheUrl(Set.of("serverOnly"))
             .build()) {
       // test without request query params
@@ -819,7 +859,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testSetCredentialsExplicitly() {
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo")
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
             .withBasicAuthCredentials("foo", "explicit")
             .build(); ) {
       QueryRequest r = new QueryRequest(new SolrQuery("quick brown fox"));
@@ -853,7 +894,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     PreemptiveBasicAuthClientBuilderFactory.setDefaultSolrParams(
         new PreemptiveBasicAuthClientBuilderFactory.CredentialsResolver().defaultParams);
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo").build(); ) {
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
+            .build()) {
       QueryRequest r = new QueryRequest(new SolrQuery("quick brown fox"));
       DebugServlet.addResponseHeader(
           WWWAuthenticationProtocolHandler.NAME, "Basic realm=\"Debug Servlet\"");
@@ -882,7 +925,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testPerRequestCredentialsWin() {
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo")
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
             .withBasicAuthCredentials("foo2", "explicit")
             .build(); ) {
       QueryRequest r = new QueryRequest(new SolrQuery("quick brown fox"));
@@ -912,7 +956,9 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   @Test
   public void testNoCredentials() {
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo").build(); ) {
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
+            .build()) {
       QueryRequest r = new QueryRequest(new SolrQuery("quick brown fox"));
       try {
         ignoreException("Error from server");
@@ -931,7 +977,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testUseOptionalCredentials() {
     // username foo, password with embedded colon separator is "expli:cit".
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo")
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
             .withOptionalBasicAuthCredentials("foo:expli:cit")
             .build(); ) {
       QueryRequest r = new QueryRequest(new SolrQuery("quick brown fox"));
@@ -959,7 +1006,8 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testUseOptionalCredentialsWithNull() {
     // username foo, password with embedded colon separator is "expli:cit".
     try (Http2SolrClient client =
-        new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo")
+        new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+            .withDefaultCollection(DEFAULT_CORE)
             .withOptionalBasicAuthCredentials(null)
             .build(); ) {
       QueryRequest r = new QueryRequest(new SolrQuery("quick brown fox"));
@@ -996,7 +1044,10 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
   public void testBadHttpFactory() {
     System.setProperty(HttpClientUtil.SYS_PROP_HTTP_CLIENT_BUILDER_FACTORY, "FakeClassName");
     try {
-      SolrClient client = new Http2SolrClient.Builder(getBaseUrl() + "/debug/foo").build();
+      SolrClient client =
+          new Http2SolrClient.Builder(getBaseUrl() + DEBUG_SERVLET_PATH)
+              .withDefaultCollection(DEFAULT_CORE)
+              .build();
       fail("Expecting exception");
     } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains("Unable to instantiate"));
@@ -1008,7 +1059,10 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     DebugServlet.clear();
     try (Http2SolrClient client =
         getHttp2SolrClientBuilder(
-                getBaseUrl() + "/debug/foo", DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT)
+                getBaseUrl() + DEBUG_SERVLET_PATH,
+                DEFAULT_CONNECTION_TIMEOUT,
+                DEFAULT_CONNECTION_TIMEOUT)
+            .withDefaultCollection(DEFAULT_CORE)
             .build()) {
       final var req = new QueryRequest(params("q", "*:*"));
       req.setResponseParser(new InputStreamResponseParser("xml"));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17066


# Description

SOLR-17066 introduced a `withDefaultCollection` builder method that can be used in lieu of providing a core URL as a "base".  (Core URLs are not ideal as they prevent clients from making core-agnostic requests.)

However, Solr's own client usage still needs modified to use this new builder method.

# Solution

This commit migrates Http2SolrClient away from core URLs and towards using `withDefaultCollection`.  This (along with #2254) are the last vestiges of core URLs in Solr!

# Tests

Tests continue to pass.  No additional tests as this is "just" a refactor.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
