### PR TITLE
solr.xml: honor plugin enable=true|false

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -679,6 +679,7 @@ public class SolrXmlConfig {
     List<PluginInfo> plugins =
         nodes.stream()
             .map(n -> new PluginInfo(n, n.name(), true, true))
+            .filter(PluginInfo::isEnabled)
             .collect(Collectors.toList());
 
     // Cluster plugin names must be unique
@@ -781,6 +782,9 @@ public class SolrXmlConfig {
     boolean hasJmxReporter = false;
     for (ConfigNode node : metrics.getAll("reporter")) {
       PluginInfo info = getPluginInfo(node);
+      if (info == null) {
+        continue;
+      }
       String clazz = info.className;
       if (clazz != null && clazz.equals(SolrJmxReporter.class.getName())) {
         hasJmxReporter = true;
@@ -825,6 +829,7 @@ public class SolrXmlConfig {
 
   private static PluginInfo getPluginInfo(ConfigNode cfg) {
     if (cfg == null || !cfg.exists()) return null;
-    return new PluginInfo(cfg, cfg.name(), false, true);
+    final var pluginInfo = new PluginInfo(cfg, cfg.name(), false, true);
+    return pluginInfo.isEnabled() ? pluginInfo : null;
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -636,17 +636,10 @@ public class SolrXmlConfig {
   }
 
   private static PluginInfo[] getBackupRepositoryPluginInfos(List<ConfigNode> cfg) {
-    if (cfg.isEmpty()) {
-      return new PluginInfo[0];
-    }
-
-    PluginInfo[] configs = new PluginInfo[cfg.size()];
-    for (int i = 0; i < cfg.size(); i++) {
-      ConfigNode c = cfg.get(i);
-      configs[i] = new PluginInfo(c, "BackupRepositoryFactory", true, true);
-    }
-
-    return configs;
+    return cfg.stream()
+        .map(c -> new PluginInfo(c, "BackupRepositoryFactory", true, true))
+        .filter(PluginInfo::isEnabled)
+        .toArray(PluginInfo[]::new);
   }
 
   private static PluginInfo[] getClusterPlugins(SolrResourceLoader loader, ConfigNode root) {


### PR DESCRIPTION
Plugins can be disabled via `enable="false"` but unfortunately it's up to the caller of creating a PluginInfo to remember to consult this flag.  This PR addresses plugin disablement in solr.xml stuff.  No test, I know... it's not like every possible other case is tested :-).  Nonetheless I will manually test one of these soon that I have an interest in disabling via config before merging the PR.  Seems so minor, maybe no CHANGES.txt.