### PR TITLE
SOLR-17017: Reset the collection as part of running the example when starting Solr...

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -264,7 +264,8 @@ public class RunExampleTool extends ToolBase {
 
     String solrUrl = (String) nodeStatus.get("baseUrl");
 
-    // If the example already exists then delete it so we can recreate it.
+    // If the example already exists then let the user know they should delete it or
+    // they may get unusual behaviors.
     boolean alreadyExists = false;
     boolean cloudMode = nodeStatus.get("cloud") != null;
     if (cloudMode) {
@@ -282,24 +283,13 @@ public class RunExampleTool extends ToolBase {
       }
     }
 
-    if (cloudMode && alreadyExists) {
-      String[] deleteArgs =
-          new String[] {"-c", collectionName, "-forceDeleteConfig", "-solrUrl", solrUrl};
-      DeleteTool deleteTool = new DeleteTool(stdout);
-      int deleteCode =
-          deleteTool.runTool(
-              SolrCLI.processCommandLineArgs(
-                  deleteTool.getName(), deleteTool.getOptions(), deleteArgs));
-      if (deleteCode != 0)
-        throw new Exception(
-            "Failed to delete " + collectionName + " using command: " + Arrays.asList(deleteArgs));
+    if (alreadyExists) {
       echo(
-          "\nWARNING: Deleted existing Collection '"
+          "\nWARNING: The Collection '"
               + collectionName
-              + "' and it's Config to create a fresh example setup!");
-      Thread.sleep(5000l);
+              + "' already exists, which may make starting this example not work well!");
+      echo ("You may want to run 'bin/solr delete -c " + collectionName + "' before running the example");
 
-      alreadyExists = false;
     }
 
     if (!alreadyExists) {
@@ -358,7 +348,7 @@ public class RunExampleTool extends ToolBase {
       }
     } else if ("films".equals(exampleName) && !alreadyExists) {
       try (SolrClient solrClient = new Http2SolrClient.Builder(solrUrl).build()) {
-        echo("Adding dense vector field type to films schema \"_default\"");
+        echo("Adding dense vector field type to films schema");
         SolrCLI.postJsonToSolr(
             solrClient,
             "/" + collectionName + "/schema",
@@ -373,7 +363,7 @@ public class RunExampleTool extends ToolBase {
                 + "      }");
 
         echo(
-            "Adding name, initial_release_date, and film_vector fields to films schema \"_default\"");
+            "Adding name, initial_release_date, and film_vector fields to films schema");
         SolrCLI.postJsonToSolr(
             solrClient,
             "/" + collectionName + "/schema",

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -272,22 +272,24 @@ public class RunExampleTool extends ToolBase {
       if (SolrCLI.safeCheckCollectionExists(
           solrUrl, collectionName, cli.getOptionValue(SolrCLI.OPTION_CREDENTIALS.getLongOpt()))) {
         alreadyExists = true;
-        echo("\nWARNING: Collection '" + collectionName + "' already exists!");
+        echo(
+            "\nWARNING: Collection '"
+                + collectionName
+                + "' already exists, which may make starting this example not work well!");
       }
     } else {
       String coreName = collectionName;
       if (SolrCLI.safeCheckCoreExists(
           solrUrl, coreName, cli.getOptionValue(SolrCLI.OPTION_CREDENTIALS.getLongOpt()))) {
         alreadyExists = true;
-        echo("\nWARNING: Core '" + coreName + "' already exists!");
+        echo(
+            "\nWARNING: Core '"
+                + coreName
+                + "' already exists, which may make starting this example not work well!");
       }
     }
 
     if (alreadyExists) {
-      echo(
-          "\nWARNING: The Collection '"
-              + collectionName
-              + "' already exists, which may make starting this example not work well!");
       echo(
           "You may want to run 'bin/solr delete -c "
               + collectionName

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -293,7 +293,7 @@ public class RunExampleTool extends ToolBase {
       echo(
           "You may want to run 'bin/solr delete -c "
               + collectionName
-              + "' before running the example");
+              + "' first before running the example to ensure a fresh state.");
     }
 
     if (!alreadyExists) {

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -288,8 +288,10 @@ public class RunExampleTool extends ToolBase {
           "\nWARNING: The Collection '"
               + collectionName
               + "' already exists, which may make starting this example not work well!");
-      echo ("You may want to run 'bin/solr delete -c " + collectionName + "' before running the example");
-
+      echo(
+          "You may want to run 'bin/solr delete -c "
+              + collectionName
+              + "' before running the example");
     }
 
     if (!alreadyExists) {
@@ -362,8 +364,7 @@ public class RunExampleTool extends ToolBase {
                 + "        }\n"
                 + "      }");
 
-        echo(
-            "Adding name, initial_release_date, and film_vector fields to films schema");
+        echo("Adding name, initial_release_date, and film_vector fields to films schema");
         SolrCLI.postJsonToSolr(
             solrClient,
             "/" + collectionName + "/schema",

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -60,6 +60,9 @@ teardown() {
   refute collection_exists "films"
   
   solr stop -p ${SOLR_PORT}
+  
+  sleep 10
+  
   solr start -e films -c
   solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
   assert collection_exists "films"

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -49,22 +49,3 @@ teardown() {
   solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
 
 }
-
-@test "start, delete,stop and then restarting solr with example" {
-
-  solr start -e films -c
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
-  assert collection_exists "films"
-  
-  solr delete -c films
-  refute collection_exists "films"
-  
-  solr stop -p ${SOLR_PORT}
-  
-  sleep 10
-  
-  solr start -e films -c
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
-  assert collection_exists "films"
-  
-}

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -49,3 +49,19 @@ teardown() {
   solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
 
 }
+
+@test "start, delete,stop and then restarting solr with example" {
+
+  solr start -e films -c
+  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  assert collection_exists "films"
+  
+  solr delete -c films
+  refute collection_exists "films"
+  
+  solr stop -p ${SOLR_PORT}
+  solr start -e films -c
+  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  assert collection_exists "films"
+  
+}


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-17017



# Description

Providing a message to a user when an example collection already exists.

# Solution

I tried to use `DeleteTool` but it woudn't run properly, i would get werid errors around core unload/load and maybe file locking. So gave up and went with less ambitious option.

# Tests

bats and manually

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
