### PR TITLE
Clarify split parameter usage

### DIFF
--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-with-update-handlers.adoc
@@ -666,7 +666,7 @@ Example: `map=left:right` or `f.subject.map=history:bunk`
 |===
 +
 If `true`, split a field into multiple values by a separate parser.
-This parameter is used on a per-field basis.
+This parameter is used on a per-field basis, for example `f.FIELD_NAME_GOES_HERE.split=true`.
 
 `overwrite`::
 +


### PR DESCRIPTION
It's a minor change that we tested (if you just do `split=true` it seems to apply to all fields, which is rarely what you want).