### PR TITLE
Update core param in STATUS doc

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/coreadmin-api.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/coreadmin-api.adoc
@@ -92,7 +92,7 @@ curl -X GET http://localhost:8983/api/cores?indexInfo=false
 |===
 +
 The name of a core, as listed in the "name" attribute of a `<core>` element in `solr.xml`.
-This parameter is required in v1, and part of the url in the v2 API.
+If this parameter is omitted, status of all the running cores is returned.
 
 `indexInfo`::
 +


### PR DESCRIPTION
This is a trivial fix in doc. I did not fill a Jira for it.

Parameter `core` for `STATUS` admin request is (wrongly) required in the full description, but (correctly) optional just before.



# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
