### PR TITLE
Update required JTS version

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/spatial-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/spatial-search.adoc
@@ -480,7 +480,7 @@ The https://github.com/locationtech/jts[JTS Topology Suite] is a popular computa
 It supports a variety of shapes including polygons, buffering shapes, and some invalid polygon repair fall-backs.
 With the help of Spatial4j, included with Solr, the polygons support dateline (anti-meridian) crossing.
 You must download it (a JAR file) and put that in a special location internal to Solr:  `SOLR_INSTALL/server/solr-webapp/webapp/WEB-INF/lib/`.
-You can readily download it here: https://mvnrepository.com/artifact/org.locationtech.jts/jts-core/1.15.0.
+You can readily download it here: https://mvnrepository.com/artifact/org.locationtech.jts/jts-core/1.17.1.
 _It will not work if placed in other more typical Solr lib directories, unfortunately._
 
 Set the `spatialContextFactory` attribute on the field type to `JTS`.


### PR DESCRIPTION
Due to API changes a JTS 1.17.x version is currently required.

The appropriate JTS version may be determined based on the JTS version used for tests in Lucene, referenced in https://github.com/apache/lucene/blob/main/versions.props

Strictly speaking, the appropriate JTS version for the version of spatial4j used by the Lucene version used in Solr should always be referenced - either this needs to be kept manually updated here (or somehow automatically in the build process?) or the process of finding the correct JTS version should be described here in a clear and concise way rather than just pointing to a specific version.