### PR TITLE
SOLR-6572: Trim whitespace in XML nodes in solrconfig.xml

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -110,7 +110,7 @@ Bug Fixes
 
 * SOLR-17148: Fixing Config API overlay property enabling or disabling the cache (Sanjay Dutt, hossman, Eric Pugh)
 
-* SOLR-6572: Extra leading or trailing whitespace in XML nodes in solrconfig.xml not supported
+* SOLR-6572: Extra leading or trailing whitespace in XML nodes in solrconfig.xml now ignored
   (Fredrik Rødland, Anurag Sharma via janhoy)
 
 Dependency Upgrades

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -110,6 +110,9 @@ Bug Fixes
 
 * SOLR-17148: Fixing Config API overlay property enabling or disabling the cache (Sanjay Dutt, hossman, Eric Pugh)
 
+* SOLR-6572: Extra leading or trailing whitespace in XML nodes in solrconfig.xml not supported
+  (Fredrik Rødland, Anurag Sharma via janhoy)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/solrj/src/java/org/apache/solr/common/util/DOMUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/DOMUtil.java
@@ -321,7 +321,7 @@ public class DOMUtil {
       case Node.CDATA_SECTION_NODE: /* fall through */
       case Node.COMMENT_NODE: /* fall through */
       case Node.PROCESSING_INSTRUCTION_NODE: /* fall through */
-        buf.append(nd.getNodeValue());
+        buf.append(nd.getNodeValue().strip());
         break;
 
       case Node.DOCUMENT_NODE: /* fall through */

--- a/solr/solrj/src/test/org/apache/solr/common/util/DOMUtilTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/DOMUtilTest.java
@@ -50,25 +50,35 @@ public class DOMUtilTest extends DOMUtilTestBase {
 
   public void testStripWhitespace() throws Exception {
     NamedList<Object> namedList = new SimpleOrderedMap<>();
-    //  SOLR-6572 lineshift in solrconfig.xml is not supported
+    // SOLR-6572 lineshift in solrconfig.xml is not supported
     // space after node value
-    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">no </bool>", "/bool" ), namedList, null );
-    assertTypeAndValue( namedList, "Boolean", false );
+    DOMUtil.addToNamedList(getNode("<bool name=\"Boolean\">no </bool>", "/bool"), namedList, null);
+    assertTypeAndValue(namedList, "Boolean", false);
     // tab after node value
-    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">no\t</bool>", "/bool" ), namedList, null );
-    assertTypeAndValue( namedList, "Boolean", false );
+    DOMUtil.addToNamedList(getNode("<bool name=\"Boolean\">no\t</bool>", "/bool"), namedList, null);
+    assertTypeAndValue(namedList, "Boolean", false);
     // newline after node valueO
-    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">no" + System.getProperty("line.separator") + "</bool>", "/bool" ), namedList, null );
-    assertTypeAndValue( namedList, "Boolean", false );
+    DOMUtil.addToNamedList(
+        getNode(
+            "<bool name=\"Boolean\">no" + System.getProperty("line.separator") + "</bool>",
+            "/bool"),
+        namedList,
+        null);
+    assertTypeAndValue(namedList, "Boolean", false);
     // space before node value
-    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\"> no</bool>", "/bool" ), namedList, null );
-    assertTypeAndValue( namedList, "Boolean", false );
+    DOMUtil.addToNamedList(getNode("<bool name=\"Boolean\"> no</bool>", "/bool"), namedList, null);
+    assertTypeAndValue(namedList, "Boolean", false);
     // tab before node value
-    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">\tno</bool>", "/bool" ), namedList, null );
-    assertTypeAndValue( namedList, "Boolean", false );
+    DOMUtil.addToNamedList(getNode("<bool name=\"Boolean\">\tno</bool>", "/bool"), namedList, null);
+    assertTypeAndValue(namedList, "Boolean", false);
     // newline before node value
-    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">" + System.getProperty("line.separator") + "no</bool>", "/bool" ), namedList, null );
-    assertTypeAndValue( namedList, "Boolean", false );
+    DOMUtil.addToNamedList(
+        getNode(
+            "<bool name=\"Boolean\">" + System.getProperty("line.separator") + "no</bool>",
+            "/bool"),
+        namedList,
+        null);
+    assertTypeAndValue(namedList, "Boolean", false);
   }
 
   private void assertTypeAndValue(NamedList<Object> namedList, String key, Object value) {

--- a/solr/solrj/src/test/org/apache/solr/common/util/DOMUtilTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/DOMUtilTest.java
@@ -48,6 +48,29 @@ public class DOMUtilTest extends DOMUtilTestBase {
     assertTypeAndValue(namedList, "Boolean", false);
   }
 
+  public void testStripWhitespace() throws Exception {
+    NamedList<Object> namedList = new SimpleOrderedMap<>();
+    //  SOLR-6572 lineshift in solrconfig.xml is not supported
+    // space after node value
+    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">no </bool>", "/bool" ), namedList, null );
+    assertTypeAndValue( namedList, "Boolean", false );
+    // tab after node value
+    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">no\t</bool>", "/bool" ), namedList, null );
+    assertTypeAndValue( namedList, "Boolean", false );
+    // newline after node valueO
+    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">no" + System.getProperty("line.separator") + "</bool>", "/bool" ), namedList, null );
+    assertTypeAndValue( namedList, "Boolean", false );
+    // space before node value
+    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\"> no</bool>", "/bool" ), namedList, null );
+    assertTypeAndValue( namedList, "Boolean", false );
+    // tab before node value
+    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">\tno</bool>", "/bool" ), namedList, null );
+    assertTypeAndValue( namedList, "Boolean", false );
+    // newline before node value
+    DOMUtil.addToNamedList( getNode( "<bool name=\"Boolean\">" + System.getProperty("line.separator") + "no</bool>", "/bool" ), namedList, null );
+    assertTypeAndValue( namedList, "Boolean", false );
+  }
+
   private void assertTypeAndValue(NamedList<Object> namedList, String key, Object value) {
     Object v = namedList.get(key);
     assertNotNull(v);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-6572

This PR is based on the patch uploaded to JIRA issue, modified to apply to main.