### PR TITLE
remove unused local variable in SolrIndexSearcher.sortDocSet

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -2253,9 +2253,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       return;
     }
 
-    // bit of a hack to tell if a set is sorted - do it better in the future.
-    boolean inOrder = set instanceof BitDocSet || set instanceof SortedIntDocSet;
-
     TopDocsCollector<? extends ScoreDoc> topCollector = buildTopDocsCollector(nDocs, cmd);
 
     DocIterator iter = set.iterator();


### PR DESCRIPTION
unusedness spotted by @chatman in #2248 -- splitting out removal here for clarity (though that's subjective of course).