### PR TITLE
Prevent odd error from occasionally showing up.

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/SolrCloudExampleTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCloudExampleTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.cli.CommandLine;
+import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.cli.CreateTool;
 import org.apache.solr.cli.DeleteTool;
 import org.apache.solr.cli.HealthcheckTool;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * docs in collections that use data driven functionality and managed schema features of the default
  * configset (configsets/_default).
  */
+@SolrTestCaseJ4.SuppressSSL
 public class SolrCloudExampleTest extends AbstractFullDistribZkTestBase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());


### PR DESCRIPTION


# Description

Occasionally get a "PKIX" error in the test runs. 

# Solution

Suppress SSL, like we do in many other unit tests.   For a while I thought bin/solr post didnt' support SSL, but I did a bats test as part of `test_ssl.bats` and it worked just fine.

Not user facing, so no JIRA.

# Tests

n/a

# Checklist
