### PR TITLE
SOLR-17176: Log history V2 API doesn't serialize properly

### DIFF
--- a/solr/core/src/test/org/apache/solr/logging/TestLogWatcher.java
+++ b/solr/core/src/test/org/apache/solr/logging/TestLogWatcher.java
@@ -16,17 +16,31 @@
  */
 package org.apache.solr.logging;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequestBase;
+import org.apache.solr.response.BinaryQueryResponseWriter;
+import org.apache.solr.response.JSONResponseWriter;
+import org.apache.solr.response.JacksonJsonWriter;
+import org.apache.solr.response.QueryResponseWriter;
+import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.TimeOut;
 import org.junit.Before;
 import org.junit.Test;
+import org.noggit.CharArr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +59,7 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
   //       All we really care about is that new watchers get the new messages, so test for that
   //       explicitly. See SOLR-12732.
   @Test
-  public void testLog4jWatcher() throws InterruptedException {
+  public void testLog4jWatcher() throws InterruptedException, IOException {
     LogWatcher<?> watcher = null;
     int lim = random().nextInt(3) + 2;
     // Every time through this loop, ensure that, of all the test messages that have been logged,
@@ -65,9 +79,12 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
       boolean foundNewMsg = false;
       boolean foundOldMessage = false;
       // In local testing this loop usually succeeds 1-2 tries, so it's not very expensive to loop.
+      QueryResponseWriter responseWriter =
+          random().nextBoolean() ? new JacksonJsonWriter() : new JSONResponseWriter();
       do {
         // Returns an empty (but non-null) list even if there are no messages yet.
         SolrDocumentList events = watcher.getHistory(-1, null);
+        validateWrite(responseWriter, events, msg);
         for (SolrDocument doc : events) {
           String oneMsg = (String) doc.get("message");
           if (oneMsg.equals(msg)) {
@@ -103,5 +120,57 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
       }
       oldMessages.add(msg);
     }
+  }
+
+  /**
+   * Here we validate that serialization works as expected for several different methods. Ideally we
+   * would use actual serialization from Jersey/Jackson, since this is what really happens in V2
+   * APIs. But this is simpler, and should give us roughly equivalent assurances.
+   */
+  private static void validateWrite(
+      QueryResponseWriter responseWriter, SolrDocumentList docs, String expectMsg)
+      throws IOException {
+    SolrQueryRequest req = new SolrQueryRequestBase(null, new ModifiableSolrParams()) {};
+    SolrQueryResponse rsp = new SolrQueryResponse();
+    rsp.addResponse(docs);
+    String output;
+    if (responseWriter instanceof BinaryQueryResponseWriter) {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ((BinaryQueryResponseWriter) responseWriter).write(baos, req, rsp);
+      baos.close();
+      output = baos.toString(StandardCharsets.UTF_8);
+    } else {
+      StringWriter writer = new StringWriter();
+      responseWriter.write(writer, req, rsp);
+      writer.close();
+      output = writer.toString();
+    }
+    assertTrue("found: " + output, output.contains(expectMsg));
+    validateWrite(docs, expectMsg);
+  }
+
+  private static void validateWrite(SolrDocumentList docs, String expectMsg) throws IOException {
+    CharArr arr = new CharArr();
+    org.noggit.JSONWriter w = new org.noggit.JSONWriter(arr, 2);
+    docs.writeMap(
+        new MapWriter.EntryWriter() {
+          boolean first = true;
+
+          @Override
+          public MapWriter.EntryWriter put(CharSequence k, Object v) {
+            if (first) {
+              first = false;
+            } else {
+              w.writeValueSeparator();
+            }
+            w.indent();
+            w.writeString(k.toString());
+            w.writeNameSeparator();
+            w.write(v);
+            return this;
+          }
+        });
+    String output = arr.toString();
+    assertTrue("found: " + output, output.contains(expectMsg));
   }
 }


### PR DESCRIPTION
fix `LogWatcher.unmodifiable()` to be backed by a full-featured Map

`SolrDocument.getFieldValuesMap()` provides a feature-poor Map instance that also does undesired extra manipulations on values.

https://issues.apache.org/jira/browse/SOLR-17176