### PR TITLE
SOLR-17163: Only load the films.json file when running the bin/solr start -e films

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -338,7 +338,9 @@ public class PostTool extends ToolBase {
       info("Entering auto mode. File endings considered are " + fileTypes);
     }
     if (recursive > 0) {
-      info("Entering recursive mode, max depth=" + recursive + ", delay=" + delay + "s");
+      if (recursionPossible(args)) {
+        info("Entering recursive mode, max depth=" + recursive + ", delay=" + delay + "s");
+      }
     }
     fileFilter = getFileFilterFromFileTypes(fileTypes);
     int numFilesPosted = postFiles(args, 0, out, type);
@@ -415,6 +417,24 @@ public class PostTool extends ToolBase {
 
   private boolean checkIsValidPath(File srcFile) {
     return Files.exists(srcFile.toPath());
+  }
+
+  /**
+   * Check all the arguments looking to see if any are directories, and if so then we can recurse
+   * into them.
+   *
+   * @param args array of file names
+   * @return if we have a directory to recurse into
+   */
+  boolean recursionPossible(String[] args) {
+    boolean recursionPossible = false;
+    for (String arg : args) {
+      File f = new File(arg);
+      if (f.isDirectory()) {
+        recursionPossible = true;
+      }
+    }
+    return recursionPossible;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -420,9 +420,7 @@ public class RunExampleTool extends ToolBase {
               updateUrl,
               "-type",
               "application/json",
-              "-filetypes",
-              "json",
-              exampleDir.toString()
+              filmsJsonFile.getAbsolutePath()
             };
         PostTool postTool = new PostTool();
         CommandLine postToolCli =

--- a/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
@@ -44,6 +44,8 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.Utils;
@@ -106,7 +108,8 @@ public class PostToolTest extends SolrCloudTestCase {
     File jsonDoc = File.createTempFile("temp", ".json");
 
     FileWriter fw = new FileWriter(jsonDoc, StandardCharsets.UTF_8);
-    Utils.writeJson(Utils.toJSONString(Map.of("id", "1", "title", "mytitle")), fw, true);
+    Utils.writeJson(Map.of("id", "1", "title_s", "mytitle"), fw, true);
+    fw.flush();
 
     String[] args = {
       "post",
@@ -117,6 +120,21 @@ public class PostToolTest extends SolrCloudTestCase {
       jsonDoc.getAbsolutePath()
     };
     assertEquals(0, runTool(args));
+
+    int numFound = 0;
+    int expectedDocCount = 1;
+
+    for (int idx = 0; idx < 100; ++idx) {
+      QueryRequest req = withBasicAuth(new QueryRequest(params("q", "*:*")));
+      QueryResponse rsp = req.process(cluster.getSolrClient(), collection);
+
+      numFound = (int) rsp.getResults().getNumFound();
+      if (numFound == expectedDocCount) {
+        break;
+      }
+      Thread.sleep(100);
+    }
+    assertEquals("*:* found unexpected number of documents", expectedDocCount, numFound);
   }
 
   @Test
@@ -129,15 +147,31 @@ public class PostToolTest extends SolrCloudTestCase {
     withBasicAuth(CollectionAdminRequest.createCollection(collection, "conf1", 1, 1, 0, 0))
         .processAndWait(cluster.getSolrClient(), 10);
 
-    File jsonDoc = File.createTempFile("temp", "json");
+    File jsonDoc = File.createTempFile("temp", ".json");
 
     FileWriter fw = new FileWriter(jsonDoc, StandardCharsets.UTF_8);
-    Utils.writeJson(Utils.toJSONString(Map.of("id", "1", "title", "mytitle")), fw, true);
+    Utils.writeJson(Map.of("id", "1", "title_s", "mytitle"), fw, true);
+    fw.flush();
 
     String[] args = {
       "post", "-c", collection, "-credentials", USER + ":" + PASS, jsonDoc.getAbsolutePath()
     };
     assertEquals(0, runTool(args));
+
+    int numFound = 0;
+    int expectedDocCount = 1;
+
+    for (int idx = 0; idx < 100; ++idx) {
+      QueryRequest req = withBasicAuth(new QueryRequest(params("q", "*:*")));
+      QueryResponse rsp = req.process(cluster.getSolrClient(), collection);
+
+      numFound = (int) rsp.getResults().getNumFound();
+      if (numFound == expectedDocCount) {
+        break;
+      }
+      Thread.sleep(100);
+    }
+    assertEquals("*:* found unexpected number of documents", expectedDocCount, numFound);
   }
 
   private int runTool(String[] args) throws Exception {
@@ -223,6 +257,28 @@ public class PostToolTest extends SolrCloudTestCase {
   public void testDoFilesMode() throws MalformedURLException {
     PostTool postTool = new PostTool();
     postTool.recursive = 0;
+    postTool.dryRun = true;
+    postTool.solrUpdateUrl = new URL("http://localhost:8983/solr/fake/update");
+    File dir = getFile("exampledocs");
+    int num = postTool.postFiles(new String[] {dir.toString()}, 0, null, null);
+    assertEquals(2, num);
+  }
+
+  @Test
+  public void testDetectingIfRecursionPossibleInFilesMode() throws IOException {
+    PostTool postTool = new PostTool();
+    postTool.recursive = 1; // This is the default
+    File dir = getFile("exampledocs");
+    File doc = File.createTempFile("temp", ".json");
+    assertTrue(postTool.recursionPossible(new String[] {dir.toString()}));
+    assertFalse(postTool.recursionPossible(new String[] {doc.toString()}));
+    assertTrue(postTool.recursionPossible(new String[] {doc.toString(), dir.toString()}));
+  }
+
+  @Test
+  public void testRecursionAppliesToFilesMode() throws MalformedURLException {
+    PostTool postTool = new PostTool();
+    postTool.recursive = 1; // This is the default
     postTool.dryRun = true;
     postTool.solrUpdateUrl = new URL("http://localhost:8983/solr/fake/update");
     File dir = getFile("exampledocs");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17163



# Description
Make sure not to load other non films.json files that are json formatted

# Solution

Explicit path to the file, plus fix some informaiton message around recursion when you don't have directories to index.

# Tests

Added a test for the detection of recursing into directories.   Also made two existing tests that run the PostTool actually run the full lifecycle.
