### PR TITLE
SOLR-17178: Introduce the "start" command in all the places where it is missing

### DIFF
--- a/solr/core/src/test/org/apache/solr/cli/TestSolrCLIRunExample.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestSolrCLIRunExample.java
@@ -56,7 +56,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Tests the SolrCLI.RunExampleTool implementation that supports bin/solr -e [example] */
+/** Tests the SolrCLI.RunExampleTool implementation that supports bin/solr start -e [example] */
 @SolrTestCaseJ4.SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
 

--- a/solr/example/README.md
+++ b/solr/example/README.md
@@ -22,7 +22,7 @@ This directory contains Solr examples. Each example is contained in a
 separate directory. To run a specific example, do:
 
 ```
-  bin/solr -e <EXAMPLE> where <EXAMPLE> is one of:
+  bin/solr start -e <EXAMPLE> where <EXAMPLE> is one of:
 
     cloud        : SolrCloud example
     schemaless   : Schema-less example (schema is inferred from data during indexing)
@@ -33,7 +33,7 @@ separate directory. To run a specific example, do:
 For instance, if you want to run the SolrCloud example, do:
 
 ```
-  bin/solr -e cloud
+  bin/solr start -e cloud
 ```
 
 To see all the options available when starting Solr:

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
@@ -726,7 +726,7 @@ If a default value is not specified, then the property must be specified at runt
 Any JVM system properties usually specified using the `-D` flag when starting the JVM, can be used as variables in the `solr.xml` file.
 
 For example, in the `solr.xml` file shown below, the `socketTimeout` and `connTimeout` values are each set to "60000".
-However, if you start Solr using `bin/solr -DsocketTimeout=1000`, the `socketTimeout` option of the `HttpShardHandlerFactory` to be overridden using a value of 1000ms, while the `connTimeout` option will continue to use the default property value of "60000".
+However, if you start Solr using `bin/solr start -DsocketTimeout=1000`, the `socketTimeout` option of the `HttpShardHandlerFactory` to be overridden using a value of 1000ms, while the `connTimeout` option will continue to use the default property value of "60000".
 
 [source,xml]
 ----

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/managed-resources.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/managed-resources.adoc
@@ -30,7 +30,7 @@ All of the examples in this section assume you are running the "techproducts" So
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 == Managed Resources Overview

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/package-manager-internals.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/package-manager-internals.adoc
@@ -48,7 +48,7 @@ Start all your nodes with the system property `-Denable.packages=true` to use th
 [source,bash]
 ----
 
-bin/solr -c -Denable.packages=true
+bin/solr start -c -Denable.packages=true
 ----
 
 === Upload Your Keys

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/package-manager.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/package-manager.adoc
@@ -46,7 +46,7 @@ To enable it, start all Solr nodes with the `-Denable.packages=true` parameter.
 
 [source,bash]
 ----
-$ bin/solr -c -Denable.packages=true
+$ bin/solr start -c -Denable.packages=true
 ----
 
 WARNING: There are security consequences to enabling the package manager.

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/realtime-get.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/realtime-get.adoc
@@ -41,7 +41,7 @@ Real Time Get requests can be performed using the `/get` handler which exists im
 </requestHandler>
 ----
 
-For example, if you started Solr using the `bin/solr -e techproducts` example command, you could then index a new document without committing it, like so:
+For example, if you started Solr using the `bin/solr start -e techproducts` example command, you could then index a new document without committing it, like so:
 
 [source,bash]
 ----

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/collection-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/collection-management.adoc
@@ -23,7 +23,7 @@ All of the examples in this section assume you are running the "techproducts" So
 
 [source,bash]
 ----
-bin/solr -c -e techproducts
+bin/solr start -c -e techproducts
 ----
 
 [[create]]

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
@@ -295,7 +295,7 @@ For example:
 
 [source,bash]
 ----
-docker run -it solr bin/solr -f -h myhostname
+docker run -it solr bin/solr start -f -h myhostname
 ----
 
 Finally, the Solr docker image offers several commands that do some work before then invoking the Solr server, like "solr-precreate" and "solr-demo".

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
@@ -278,7 +278,7 @@ Customize the values for the parameters shown as needed and add any used in your
 [.tab-label]**nix Command*
 [source,terminal]
 ----
-$ bin/solr -p 8984
+$ bin/solr start -p 8984
 ----
 ====
 
@@ -308,7 +308,7 @@ If you created the SSL key without all DNS names or IP addresses on which Solr n
 [.tab-label]*\*nix*
 [source,terminal]
 ----
-$ bin/solr -cloud -s cloud/node1 -z server1:2181,server2:2181,server3:2181 -p 8984
+$ bin/solr start -cloud -s cloud/node1 -z server1:2181,server2:2181,server3:2181 -p 8984
 ----
 ====
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/installing-solr.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/installing-solr.adoc
@@ -190,7 +190,7 @@ For instance, to launch the "techproducts" example, you would do:
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 Currently, the available examples you can run are: techproducts, schemaless, and cloud.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/kerberos-authentication-plugin.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/kerberos-authentication-plugin.adoc
@@ -448,7 +448,7 @@ Note you also need to customize the `-z` property as appropriate for the locatio
 
 [source,bash]
 ----
-$ bin/solr -c -z server1:2181,server2:2181,server3:2181/solr
+$ bin/solr start -c -z server1:2181,server2:2181,server3:2181/solr
 ----
 
 NOTE: If you have defined `ZK_HOST` in `solr.in.sh`/`solr.in.cmd` (see xref:zookeeper-ensemble#updating-solr-include-files[Updating Solr Include Files]) you can omit `-z <zk host string>` from the above command.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/replica-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/replica-management.adoc
@@ -25,7 +25,7 @@ All of the examples in this section assume you are running the "techproducts" So
 
 [source,bash]
 ----
-bin/solr -c -e techproducts
+bin/solr start -c -e techproducts
 ----
 
 [[addreplica]]

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/shard-management.adoc
@@ -26,7 +26,7 @@ All of the examples in this section assume you are running the "techproducts" So
 
 [source,bash]
 ----
-bin/solr -c -e techproducts
+bin/solr start -c -e techproducts
 ----
 
 [[splitshard]]

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
@@ -26,13 +26,13 @@ These files are uploaded in either of the following cases:
 
 == Startup Bootstrap
 
-When you try SolrCloud for the first time using the `bin/solr -e cloud`, the related configset gets uploaded to ZooKeeper automatically and is linked with the newly created collection.
+When you try SolrCloud for the first time using the `bin/solr start -e cloud`, the related configset gets uploaded to ZooKeeper automatically and is linked with the newly created collection.
 
 The below command would start SolrCloud with the default collection name (`gettingstarted`) and default configset (`_default`) uploaded and linked to it.
 
 [source,bash]
 ----
-bin/solr -e cloud -noprompt
+bin/solr start -e cloud -noprompt
 ----
 
 You can also explicitly upload a configuration directory when creating a collection using the `bin/solr` script with the `-d` option, such as:

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-utilities.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-utilities.adoc
@@ -97,7 +97,7 @@ The long form parameter options may be specified using either a single dash (e.g
 
 == ZooKeeper CLI Examples
 
-Below are some examples of using the `zkcli.sh` CLI which assume you have already started the SolrCloud example (`bin/solr -e cloud -noprompt`)
+Below are some examples of using the `zkcli.sh` CLI which assume you have already started the SolrCloud example (`bin/solr start -e cloud -noprompt`)
 
 If you are on Windows machine, simply replace `zkcli.sh` with `zkcli.bat` in these examples.
 

--- a/solr/solr-ref-guide/modules/getting-started/pages/about-this-guide.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/about-this-guide.adoc
@@ -55,7 +55,7 @@ Path information is given relative to `solr.home`, which is the location under t
 In many cases, this is in the `server/solr` directory of your installation.
 However, there can be exceptions, particularly if your installation has customized this.
 
-In several cases of this Guide, our examples are built from the "techproducts" example (i.e., you have started Solr with the command `bin/solr -e techproducts`).
+In several cases of this Guide, our examples are built from the "techproducts" example (i.e., you have started Solr with the command `bin/solr start -e techproducts`).
 In this case, `solr.home` will be a sub-directory of the `example/` directory created for you automatically.
 
 See also the section xref:configuration-guide:configuration-files.adoc#solr-home[Solr Home] for further details on what is contained in this directory.

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-five-minutes.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-five-minutes.adoc
@@ -26,7 +26,7 @@ To start another Solr node and have it join the cluster alongside the first node
 
 [,console]
 ----
-$ bin/solr -c -z localhost:9983 -p 8984
+$ bin/solr start -c -z localhost:9983 -p 8984
 ----
 
 

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-solrcloud.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-solrcloud.adoc
@@ -51,7 +51,7 @@ To get started, simply do:
 
 [,console]
 ----
-$ bin/solr -e cloud
+$ bin/solr start -e cloud
 ----
 
 This starts an interactive session to walk you through the steps of setting up a simple SolrCloud cluster with embedded ZooKeeper.
@@ -165,7 +165,7 @@ You can also get SolrCloud started with all the defaults instead of the interact
 
 [,console]
 ----
-$ bin/solr -e cloud -noprompt
+$ bin/solr start -e cloud -noprompt
 ----
 
 === Restarting Nodes
@@ -200,7 +200,7 @@ $ bin/solr start -cloud -s solr.home/solr -p <port num> -z <zk hosts string>
 
 Notice that the above requires you to create a Solr home directory.
 
-Example (with directory structure) that adds a node to an example started with "bin/solr -e cloud":
+Example (with directory structure) that adds a node to an example started with "bin/solr start -e cloud":
 
 [,console]
 ----

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/analysis-screen.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/analysis-screen.adoc
@@ -21,7 +21,7 @@ Once you've xref:field-type-definitions-and-properties.adoc[defined a field type
 Luckily, there is a very handy page in the Solr Admin UI that lets you do just that.
 You can invoke the analyzer for any text field, provide sample input, and display the resulting token stream.
 
-For example, let's look at some of the "Text" field types available in the `bin/solr -e techproducts` example configuration, and use the Analysis Screen (`\http://localhost:8983/solr/#/techproducts/analysis`) to compare how the tokens produced at index time for the sentence "Running an Analyzer" match up with a slightly different query text of "run my analyzer".
+For example, let's look at some of the "Text" field types available in the `bin/solr start -e techproducts` example configuration, and use the Analysis Screen (`\http://localhost:8983/solr/#/techproducts/analysis`) to compare how the tokens produced at index time for the sentence "Running an Analyzer" match up with a slightly different query text of "run my analyzer".
 
 We can begin with `text_ws` - one of the most simplified Text field types available:
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/luke-request-handler.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/luke-request-handler.adoc
@@ -89,7 +89,7 @@ All of the examples in this section assume you are running the "techproducts" So
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 To return summary information about the index:

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/schema-api.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/schema-api.adoc
@@ -62,7 +62,7 @@ All of the examples in this section assume you are running the "techproducts" So
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 == Modify the Schema

--- a/solr/solr-ref-guide/modules/query-guide/pages/dismax-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/dismax-query-parser.adoc
@@ -219,7 +219,7 @@ All of the sample URLs in this section assume you are running Solr's "techproduc
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 Results for the word "video" using the standard query parser, and we assume "df" is pointing to a field to search:

--- a/solr/solr-ref-guide/modules/query-guide/pages/edismax-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/edismax-query-parser.adoc
@@ -134,7 +134,7 @@ All of the sample URLs in this section assume you are running Solr's "techproduc
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 Boost the result of the query term "hello" based on the document's popularity:

--- a/solr/solr-ref-guide/modules/query-guide/pages/faceting.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/faceting.adoc
@@ -470,7 +470,7 @@ Separate each list of fields with a comma.
 +
 The `facet.pivot.mincount` parameter defines the minimum number of documents that need to match in order for the facet to be included in results.
 +
-Using the "`bin/solr -e techproducts`" example, A query URL like this one will return the data below, with the pivot faceting results found in the section "facet_pivot":
+Using the "`bin/solr start -e techproducts`" example, A query URL like this one will return the data below, with the pivot faceting results found in the section "facet_pivot":
 +
 [source,text]
 ----

--- a/solr/solr-ref-guide/modules/query-guide/pages/query-elevation-component.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/query-elevation-component.adoc
@@ -28,7 +28,7 @@ All of the sample configuration and queries used in this section assume you are 
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 == Configuring the Query Elevation Component

--- a/solr/solr-ref-guide/modules/query-guide/pages/result-grouping.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/result-grouping.adoc
@@ -232,7 +232,7 @@ Any number of group commands (e.g., `group.field`, `group.func`, `group.query`, 
 
 == Grouping Examples
 
-All of the following sample queries work with Solr's "`bin/solr -e techproducts`" example.
+All of the following sample queries work with Solr's "`bin/solr start -e techproducts`" example.
 
 === Grouping Results by Field
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/spell-checking.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/spell-checking.adoc
@@ -450,7 +450,7 @@ For example, given a dictionary called `foo`, `spellcheck.foo.myKey=myValue` wou
 
 === Spell Check Example
 
-Using Solr's `bin/solr -e techproducts` example, this query shows the results of a simple request that defines a query using the `spellcheck.q` parameter, and forces the collations to require all input terms must match:
+Using Solr's `bin/solr start -e techproducts` example, this query shows the results of a simple request that defines a query using the `spellcheck.q` parameter, and forces the collations to require all input terms must match:
 
 `\http://localhost:8983/solr/techproducts/spell?df=text&spellcheck.q=delll+ultra+sharp&spellcheck=true&spellcheck.collateParam.q.op=AND&wt=xml`
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/stats-component.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/stats-component.adoc
@@ -22,7 +22,7 @@ The sample queries in this section assume you are running the "techproducts" exa
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 == Stats Component Parameters

--- a/solr/solr-ref-guide/modules/query-guide/pages/term-vector-component.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/term-vector-component.adoc
@@ -27,7 +27,7 @@ The examples on this page show how it is configured in Solr's "techproducts" exa
 
 [source,bash]
 ----
-bin/solr -e techproducts
+bin/solr start -e techproducts
 ----
 
 To enable this component, you need to configure it using a `searchComponent` element:

--- a/solr/solr-ref-guide/modules/query-guide/pages/terms-component.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/terms-component.adoc
@@ -322,7 +322,7 @@ You may also be interested in the {solr-javadocs}/core/org/apache/solr/handler/c
 
 == Terms Component Examples
 
-All of the following sample queries work with Solr's "`bin/solr -e techproducts`" example.
+All of the following sample queries work with Solr's "`bin/solr start -e techproducts`" example.
 
 === Get Top 10 Terms
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17178



# Description

back in the day `bin/solr` implicitly called the `start` command, but now we make it explicit.   However the docs have NOT kept up.

# Solution
update docs.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
