### PR TITLE
SOLR-16780: Prevent ZK subcommands from being run without the bin/solr zk prefix

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -873,6 +873,12 @@ if [[ "$SCRIPT_CMD" == "delete" ]]; then
   exit $?
 fi
 
+# Prevent any zk subcommands from going through with out invoking zk command
+if [[ "$SCRIPT_CMD" == "upconfig" || $SCRIPT_CMD == "downconfig" || $SCRIPT_CMD == "cp" || $SCRIPT_CMD == "rm" || $SCRIPT_CMD == "mv" || $SCRIPT_CMD == "ls" || $SCRIPT_CMD == "mkroot" ]]; then
+  print_short_zk_usage "You must invoke this subcommand using the zk command.   bin/solr zk $SCRIPT_CMD."
+  exit $?
+fi
+
 ZK_RECURSE=false
 # Zookeeper file maintenance (upconfig, downconfig, files up/down etc.)
 # It's a little clumsy to have the parsing go round and round for upconfig and downconfig, but that's

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -298,7 +298,7 @@ IF "%SCRIPT_CMD%"=="stop" goto stop_usage
 IF "%SCRIPT_CMD%"=="healthcheck" goto run_solrcli
 IF "%SCRIPT_CMD%"=="create" goto run_solrcli
 IF "%SCRIPT_CMD%"=="delete" goto run_solrcli
-IF  "%SCRIPT_CMD%"=="zk" goto zk_usage
+IF "%SCRIPT_CMD%"=="zk" goto zk_usage
 IF "%SCRIPT_CMD%"=="auth" goto auth_usage
 IF "%SCRIPT_CMD%"=="status" goto run_solrcli
 IF "%SCRIPT_CMD%"=="postlogs" goto run_solrcli

--- a/solr/packaging/test/test_zk.bats
+++ b/solr/packaging/test/test_zk.bats
@@ -36,6 +36,11 @@ teardown() {
   save_home_on_failure
 }
 
+@test "running subcommands with zk is prevented" {
+ run solr ls / -z localhost:${ZK_PORT}
+ assert_output --partial "You must invoke this subcommand using the zk command"
+}
+
 @test "listing out files" {
   sleep 1
   run solr zk ls / -z localhost:${ZK_PORT}
@@ -44,8 +49,9 @@ teardown() {
 
 @test "copying files around" {
   touch myfile.txt
-  # Umm, what is solr cp?  It's like bin/solr zk cp but not?
-  run solr cp -src myfile.txt -dst zk:/myfile.txt -z localhost:${ZK_PORT}
+
+  #run solr zk cp -src myfile.txt -dst zk:/myfile.txt -z localhost:${ZK_PORT}
+  run solr zk cp myfile.txt zk:/myfile.txt -z localhost:${ZK_PORT}
   assert_output --partial "Copying from 'myfile.txt' to 'zk:/myfile.txt'. ZooKeeper at localhost:${ZK_PORT}"
   sleep 1
   run solr zk ls / -z localhost:${ZK_PORT}

--- a/solr/packaging/test/test_zk.bats
+++ b/solr/packaging/test/test_zk.bats
@@ -50,7 +50,6 @@ teardown() {
 @test "copying files around" {
   touch myfile.txt
 
-  #run solr zk cp -src myfile.txt -dst zk:/myfile.txt -z localhost:${ZK_PORT}
   run solr zk cp myfile.txt zk:/myfile.txt -z localhost:${ZK_PORT}
   assert_output --partial "Copying from 'myfile.txt' to 'zk:/myfile.txt'. ZooKeeper at localhost:${ZK_PORT}"
   sleep 1


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16780


# Description

bin/solr cp would run, but the params wouldn't be properly formatted and you get an error.

# Solution

Trap the use of the zk subcommands and give user appropriate message.

# Tests

Bats
