### PR TITLE
SOLR-17058: fix TestDistribIDF.testDisableDistribStats failure on LRU…

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/stats/TestDistribIDF.java
+++ b/solr/core/src/test/org/apache/solr/search/stats/TestDistribIDF.java
@@ -31,7 +31,6 @@ import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.CompositeIdRouter;
 import org.apache.solr.common.cloud.ImplicitDocRouter;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.embedded.JettySolrRunner;
@@ -300,8 +299,8 @@ public class TestDistribIDF extends SolrTestCaseJ4 {
     assertNotNull("stats cache hit", track.get("PARSE_QUERY"));
 
     // distributed stats explicitly disabled
-    query.set(CommonParams.DISTRIB_STATS_CACHE, "false");
-    query.set(CommonParams.Q, "{!terms f=id}1,2");
+    query.set("distrib.statsCache", "false");
+    query.set("q", "{!terms f=id}1,2");
     rsp = client.query(COLLECTION, query);
     track = (NamedList<Object>) rsp.getDebugMap().get("track");
     assertNotNull(track);
@@ -309,11 +308,11 @@ public class TestDistribIDF extends SolrTestCaseJ4 {
     assertNotNull("just search", track.get("EXECUTE_QUERY"));
 
     // distributed stats explicitly enabled
-    query.set(CommonParams.DISTRIB_STATS_CACHE, "true");
-    query.set(CommonParams.Q, "cat:electronics");
+    query.set("distrib.statsCache", "true");
+    query.set("q", "name:ipad"); // trick around LRUStatsCache
     rsp = client.query(COLLECTION, query);
     track = (NamedList<Object>) rsp.getDebugMap().get("track");
     assertNotNull(track);
-    assertNotNull("stats cache hit", track.get("PARSE_QUERY"));
+    assertNotNull("stats cache hit:" + track, track.get("PARSE_QUERY"));
   }
 }


### PR DESCRIPTION
…StatsCache (#2299)

 - use another field to penetrate LRUStatsCache
