### PR TITLE
SOLR-17181: Using apache commons implementation for wildcard matching for glob patterns

### DIFF
--- a/solr/solrj/build.gradle
+++ b/solr/solrj/build.gradle
@@ -49,6 +49,7 @@ dependencies {
   })
   implementation 'org.apache.httpcomponents:httpclient'
   implementation 'org.apache.httpcomponents:httpcore'
+  implementation 'commons-io:commons-io'
 
   compileOnly 'com.github.stephenc.jcip:jcip-annotations'
 

--- a/solr/solrj/build.gradle
+++ b/solr/solrj/build.gradle
@@ -49,7 +49,6 @@ dependencies {
   })
   implementation 'org.apache.httpcomponents:httpclient'
   implementation 'org.apache.httpcomponents:httpcore'
-  implementation 'commons-io:commons-io'
 
   compileOnly 'com.github.stephenc.jcip:jcip-annotations'
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
@@ -24,9 +24,9 @@ import java.util.Deque;
 public class GlobPatternUtil {
 
   /**
-   * Matches an input string against a provided glob patterns. This uses Java NIO FileSystems
-   * PathMatcher to match glob patterns in the same way to how glob patterns are matches for file
-   * paths, rather than implementing our own glob pattern matching.
+   * Matches an input string against a provided glob patterns. This uses the implementation from
+   * Apache Commons IO FilenameUtils. We are just redoing the implementation here instead of
+   * bringing in commons-io as a dependency.
    *
    * @see <a
    *     href="https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,java.lang.String)">This

--- a/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
@@ -16,8 +16,7 @@
  */
 package org.apache.solr.common.util;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Paths;
+import org.apache.commons.io.FilenameUtils;
 
 /** Provides methods for matching glob patterns against input strings. */
 public class GlobPatternUtil {
@@ -32,6 +31,6 @@ public class GlobPatternUtil {
    * @return true if the input string matches the glob pattern, false otherwise
    */
   public static boolean matches(String pattern, String input) {
-    return FileSystems.getDefault().getPathMatcher("glob:" + pattern).matches(Paths.get(input));
+    return FilenameUtils.wildcardMatch(input, pattern);
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
@@ -16,7 +16,9 @@
  */
 package org.apache.solr.common.util;
 
-import org.apache.commons.io.FilenameUtils;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 
 /** Provides methods for matching glob patterns against input strings. */
 public class GlobPatternUtil {
@@ -26,11 +28,158 @@ public class GlobPatternUtil {
    * PathMatcher to match glob patterns in the same way to how glob patterns are matches for file
    * paths, rather than implementing our own glob pattern matching.
    *
+   * <p>This uses code from Apache Commons IO {@see
+   * org.apache.commons.io.FilenameUtils#wildcardMatch}
+   *
    * @param pattern the glob pattern to match against
    * @param input the input string to match against a glob pattern
    * @return true if the input string matches the glob pattern, false otherwise
    */
   public static boolean matches(String pattern, String input) {
-    return FilenameUtils.wildcardMatch(input, pattern);
+    if (input == null && pattern == null) {
+      return true;
+    }
+    if (input == null || pattern == null) {
+      return false;
+    }
+    final String[] wcs = splitOnTokens(pattern);
+    boolean anyChars = false;
+    int textIdx = 0;
+    int wcsIdx = 0;
+    final Deque<int[]> backtrack = new ArrayDeque<>(wcs.length);
+
+    // loop around a backtrack stack, to handle complex * matching
+    do {
+      if (!backtrack.isEmpty()) {
+        final int[] array = backtrack.pop();
+        wcsIdx = array[0];
+        textIdx = array[1];
+        anyChars = true;
+      }
+
+      // loop whilst tokens and text left to process
+      while (wcsIdx < wcs.length) {
+
+        if (wcs[wcsIdx].equals("?")) {
+          // ? so move to next text char
+          textIdx++;
+          if (textIdx > input.length()) {
+            break;
+          }
+          anyChars = false;
+
+        } else if (wcs[wcsIdx].equals("*")) {
+          // set any chars status
+          anyChars = true;
+          if (wcsIdx == wcs.length - 1) {
+            textIdx = input.length();
+          }
+
+        } else {
+          // matching text token
+          if (anyChars) {
+            // any chars then try to locate text token
+            textIdx = checkIndexOf(input, textIdx, wcs[wcsIdx]);
+            if (textIdx == -1) {
+              // token not found
+              break;
+            }
+            final int repeat = checkIndexOf(input, textIdx + 1, wcs[wcsIdx]);
+            if (repeat >= 0) {
+              backtrack.push(new int[] {wcsIdx, repeat});
+            }
+          } else if (!input.regionMatches(false, textIdx, wcs[wcsIdx], 0, wcs[wcsIdx].length())) {
+            // matching from current position
+            // couldn't match token
+            break;
+          }
+
+          // matched text token, move text index to end of matched token
+          textIdx += wcs[wcsIdx].length();
+          anyChars = false;
+        }
+
+        wcsIdx++;
+      }
+
+      // full match
+      if (wcsIdx == wcs.length && textIdx == input.length()) {
+        return true;
+      }
+
+    } while (!backtrack.isEmpty());
+
+    return false;
+  }
+
+  /**
+   * Splits a string into a number of tokens. The text is split by '?' and '*'. Where multiple '*'
+   * occur consecutively they are collapsed into a single '*'.
+   *
+   * <p>This is code from Apache Commons IO {@see org.apache.commons.io.FilenameUtils#splitOnTokens}
+   *
+   * @param text the text to split
+   * @return the array of tokens, never null
+   */
+  private static String[] splitOnTokens(final String text) {
+    // used by wildcardMatch
+    // package level so a unit test may run on this
+
+    if (text.indexOf('?') == -1 && text.indexOf('*') == -1) {
+      return new String[] {text};
+    }
+
+    final char[] array = text.toCharArray();
+    final ArrayList<String> list = new ArrayList<>();
+    final StringBuilder buffer = new StringBuilder();
+    char prevChar = 0;
+    for (final char ch : array) {
+      if (ch == '?' || ch == '*') {
+        if (buffer.length() != 0) {
+          list.add(buffer.toString());
+          buffer.setLength(0);
+        }
+        if (ch == '?') {
+          list.add("?");
+        } else if (prevChar != '*') { // ch == '*' here; check if previous char was '*'
+          list.add("*");
+        }
+      } else {
+        buffer.append(ch);
+      }
+      prevChar = ch;
+    }
+    if (buffer.length() != 0) {
+      list.add(buffer.toString());
+    }
+
+    return list.toArray(new String[] {});
+  }
+
+  /**
+   * Checks if one string contains another starting at a specific index using the case-sensitivity
+   * rule.
+   *
+   * <p>This method mimics parts of {@link String#indexOf(String, int)} but takes case-sensitivity
+   * into account. This is code from Apache Commons IO {@see
+   * org.apache.commons.io.FilenameUtils#checkIndexOf}
+   *
+   * @param str the string to check, not null
+   * @param strStartIndex the index to start at in str
+   * @param search the start to search for, not null
+   * @return the first index of the search String, -1 if no match or {@code null} string input
+   * @throws NullPointerException if either string is null
+   * @since 2.0
+   */
+  private static int checkIndexOf(final String str, final int strStartIndex, final String search) {
+    final int endIndex = str.length() - search.length();
+    if (endIndex >= strStartIndex) {
+      for (int i = strStartIndex; i <= endIndex; i++) {
+        if (str.regionMatches(false, i, search, 0, search.length())) {
+          return i;
+        }
+      }
+    }
+    return -1;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
@@ -28,10 +28,9 @@ public class GlobPatternUtil {
    * PathMatcher to match glob patterns in the same way to how glob patterns are matches for file
    * paths, rather than implementing our own glob pattern matching.
    *
-   * <p>This uses code from Apache Commons IO
-   *
-   * @link
-   *     https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,java.lang.String)
+   * @see <a
+   *     href="https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,java.lang.String)">This
+   *     uses code from Apache Commons IO</a>
    * @param pattern the glob pattern to match against
    * @param input the input string to match against a glob pattern
    * @return true if the input string matches the glob pattern, false otherwise
@@ -117,10 +116,9 @@ public class GlobPatternUtil {
    * Splits a string into a number of tokens. The text is split by '?' and '*'. Where multiple '*'
    * occur consecutively they are collapsed into a single '*'.
    *
-   * <p>This is code from Apache Commons IO
-   *
-   * @link
-   *     https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html
+   * @see <a
+   *     href="https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html">This
+   *     uses code from Apache Commons IO</a>
    * @param text the text to split
    * @return the array of tokens, never null
    */
@@ -164,10 +162,11 @@ public class GlobPatternUtil {
    * rule.
    *
    * <p>This method mimics parts of {@link String#indexOf(String, int)} but takes case-sensitivity
-   * into account. This is code from Apache Commons IO.
+   * into account.
    *
-   * @link
-   *     https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html
+   * @see <a
+   *     href="https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html">This
+   *     uses code from Apache Commons IO</a>
    * @param str the string to check, not null
    * @param strStartIndex the index to start at in str
    * @param search the start to search for, not null

--- a/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/GlobPatternUtil.java
@@ -28,9 +28,10 @@ public class GlobPatternUtil {
    * PathMatcher to match glob patterns in the same way to how glob patterns are matches for file
    * paths, rather than implementing our own glob pattern matching.
    *
-   * <p>This uses code from Apache Commons IO {@see
-   * org.apache.commons.io.FilenameUtils#wildcardMatch}
+   * <p>This uses code from Apache Commons IO
    *
+   * @link
+   *     https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,java.lang.String)
    * @param pattern the glob pattern to match against
    * @param input the input string to match against a glob pattern
    * @return true if the input string matches the glob pattern, false otherwise
@@ -116,8 +117,10 @@ public class GlobPatternUtil {
    * Splits a string into a number of tokens. The text is split by '?' and '*'. Where multiple '*'
    * occur consecutively they are collapsed into a single '*'.
    *
-   * <p>This is code from Apache Commons IO {@see org.apache.commons.io.FilenameUtils#splitOnTokens}
+   * <p>This is code from Apache Commons IO
    *
+   * @link
+   *     https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html
    * @param text the text to split
    * @return the array of tokens, never null
    */
@@ -161,9 +164,10 @@ public class GlobPatternUtil {
    * rule.
    *
    * <p>This method mimics parts of {@link String#indexOf(String, int)} but takes case-sensitivity
-   * into account. This is code from Apache Commons IO {@see
-   * org.apache.commons.io.FilenameUtils#checkIndexOf}
+   * into account. This is code from Apache Commons IO.
    *
+   * @link
+   *     https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html
    * @param str the string to check, not null
    * @param strStartIndex the index to start at in str
    * @param search the start to search for, not null


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17181

# Description

This is intended to fix a bug raised where glob pattern matching suffered a performance degradation after https://github.com/apache/solr/pull/1996.

# Solution

This reverts back to using the Apache Commons IO FilenameUtils.wildcardMatch method to do glob pattern matching. This is the original implementation used prior to 9.5 and thus should match performance. This does introduce commons-io as a new library for solrj since glob pattern matching is needed in solrj as well to be available for all use cases.

# Tests

Using existing tests to validate functionality.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
