### PR TITLE
SOLR-17066: Add deprecation warnings to 9x methods

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -287,7 +287,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
             .withMaxConnectionsPerHost(maxConnectionsPerHost)
             .build();
     this.defaultClient.addListenerFactory(this.httpListenerFactory);
-    this.loadbalancer = new LBHttp2SolrClient.Builder(defaultClient).build();
+    this.loadbalancer = new LBHttp2SolrClient.Builder(defaultClient, new String[0]).build();
 
     initReplicaListTransformers(getParameter(args, "replicaRouting", null, sb));
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -83,7 +83,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     // locks.
     this.locks = objectList(builder.parallelCacheRefreshesLocks);
 
-    this.lbClient = new LBHttp2SolrClient.Builder(myClient).build();
+    this.lbClient = new LBHttp2SolrClient.Builder(myClient, new String[0]).build();
   }
 
   @Override

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -101,8 +101,17 @@ public class LBHttp2SolrClient extends LBSolrClient {
     this.defaultCollection = builder.defaultCollection;
   }
 
+  /**
+   * @deprecated Use {@link #getClient(Endpoint)} instead.
+   */
+  @Deprecated
   @Override
   protected SolrClient getClient(String baseUrl) {
+    return solrClient;
+  }
+
+  @Override
+  protected SolrClient getClient(Endpoint endpoint) {
     return solrClient;
   }
 
@@ -352,10 +361,53 @@ public class LBHttp2SolrClient extends LBSolrClient {
      * In this case the client is more flexible and can be used to send requests to any cores. Users
      * can still provide a "default" collection if desired through use of {@link
      * #withDefaultCollection(String)}.
+     *
+     * @deprecated use {@link #Builder(Http2SolrClient, Endpoint...)} instead
      */
+    @Deprecated
     public Builder(Http2SolrClient http2Client, String... baseSolrUrls) {
       this.http2SolrClient = http2Client;
       this.baseSolrUrls = baseSolrUrls;
+    }
+
+    /**
+     * Create a Builder object, based on the provided solrClient and endpoint objects.
+     *
+     * <p>Endpoint instances come in two main flavors:
+     *
+     * <p>1) Endpoints representing a particular core or collection
+     *
+     * <pre>
+     *   SolrClient client = new LBHttp2SolrClient.Builder(
+     *           client, new LBSolrClient.Endpoint("http://my-solr-server:8983/solr", "core1"))
+     *       .build();
+     *   QueryResponse resp = client.query(new SolrQuery("*:*"));
+     * </pre>
+     *
+     * Note that when a core is provided in the endpoint, queries and other requests can be made
+     * without mentioning the core explicitly. However, the client can only send requests to that
+     * core. Attempts to make core-agnostic requests, or requests for other cores will fail.
+     *
+     * <p>2) Endpoints representing the root Solr path (i.e. "/solr")
+     *
+     * <pre>
+     *   SolrClient client = new LBHttp2SolrClient.Builder(
+     *           client, new LBSolrClient.Endpoint("http://my-solr-server:8983/solr"))
+     *       .build();
+     *   QueryResponse resp = client.query("core1", new SolrQuery("*:*"));
+     * </pre>
+     *
+     * In this case the client is more flexible and can be used to send requests to any cores. Users
+     * can still provide a "default" collection if desired through use of {@link
+     * #withDefaultCollection(String)}.
+     */
+    public Builder(Http2SolrClient http2Client, Endpoint... endpoints) {
+      this.http2SolrClient = http2Client;
+
+      this.baseSolrUrls = new String[endpoints.length];
+      for (int i = 0; i < endpoints.length; i++) {
+        this.baseSolrUrls[i] = endpoints[i].getUrl();
+      }
     }
 
     /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -325,7 +325,7 @@ public abstract class LBSolrClient extends SolrClient {
     private final Integer numServersToTry;
 
     /**
-     * @deprecated use {@link #Req(SolrRequest, Collection<Endpoint>)} instead
+     * @deprecated use {@link #Req(SolrRequest, Collection)} instead
      */
     @Deprecated
     public Req(SolrRequest<?> request, List<String> servers) {
@@ -339,7 +339,7 @@ public abstract class LBSolrClient extends SolrClient {
     }
 
     /**
-     * @deprecated use {@link #Req(SolrRequest, Collection<Endpoint>, Integer)} instead
+     * @deprecated use {@link #Req(SolrRequest, Collection, Integer)} instead
      */
     @Deprecated
     public Req(SolrRequest<?> request, List<String> servers, Integer numServersToTry) {
@@ -540,6 +540,8 @@ public abstract class LBSolrClient extends SolrClient {
 
   protected abstract SolrClient getClient(String baseUrl);
 
+  protected abstract SolrClient getClient(Endpoint endpoint);
+
   protected Exception addZombie(String serverStr, Exception e) {
     ServerWrapper wrapper = createServerWrapper(serverStr);
     wrapper.standard = false;
@@ -689,7 +691,7 @@ public abstract class LBSolrClient extends SolrClient {
   }
 
   /**
-   * @deprecated use {@link #removeSolrServer(Endpoint)} instead
+   * @deprecated use {@link #removeSolrEndpoint(Endpoint)} instead
    */
   @Deprecated
   public String removeSolrServer(String server) {
@@ -709,7 +711,7 @@ public abstract class LBSolrClient extends SolrClient {
     return null;
   }
 
-  public String removeSolrServer(Endpoint endpoint) {
+  public String removeSolrEndpoint(Endpoint endpoint) {
     return removeSolrServer(endpoint.getUrl());
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -28,18 +28,21 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -98,6 +101,82 @@ public abstract class LBSolrClient extends SolrClient {
     // not a top-level request, we are interested only in the server being sent to i.e. it need not
     // distribute our request to further servers
     solrQuery.setDistrib(false);
+  }
+
+  /**
+   * A Solr endpoint for {@link LBSolrClient} to include in its load-balancing
+   *
+   * <p>Used in many places instead of the more common String URL to allow {@link LBSolrClient} to
+   * more easily determine whether a URL is a "base" or "core-aware" URL.
+   */
+  public static class Endpoint {
+    private final String baseUrl;
+    private final String core;
+
+    /**
+     * Creates an {@link Endpoint} representing a "base" URL of a Solr node
+     *
+     * @param baseUrl a base Solr URL, in the form "http[s]://host:port/solr"
+     */
+    public Endpoint(String baseUrl) {
+      this(baseUrl, null);
+    }
+
+    /**
+     * Create an {@link Endpoint} representing a Solr core or collection
+     *
+     * @param baseUrl a base Solr URL, in the form "http[s]://host:port/solr"
+     * @param core the name of a Solr core or collection
+     */
+    public Endpoint(String baseUrl, String core) {
+      this.baseUrl = normalize(baseUrl);
+      this.core = core;
+    }
+
+    /**
+     * Return the base URL of the Solr node this endpoint represents
+     *
+     * @return a base Solr URL, in the form "http[s]://host:port/solr"
+     */
+    public String getBaseUrl() {
+      return baseUrl;
+    }
+
+    /**
+     * The core or collection this endpoint represents
+     *
+     * @return a core/collection name, or null if this endpoint doesn't represent a particular core.
+     */
+    public String getCore() {
+      return core;
+    }
+
+    /** Get the full URL, possibly including the collection/core if one was provided */
+    public String getUrl() {
+      if (core == null) {
+        return baseUrl;
+      }
+      return baseUrl + "/" + core;
+    }
+
+    @Override
+    public String toString() {
+      return getUrl();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(baseUrl, core);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (!(obj instanceof Endpoint)) return false;
+      final Endpoint rhs = (Endpoint) obj;
+
+      return Objects.equals(baseUrl, rhs.baseUrl) && Objects.equals(core, rhs.core);
+    }
   }
 
   protected static class ServerWrapper {
@@ -245,10 +324,24 @@ public abstract class LBSolrClient extends SolrClient {
     protected int numDeadServersToTry;
     private final Integer numServersToTry;
 
+    /**
+     * @deprecated use {@link #Req(SolrRequest, Collection<Endpoint>)} instead
+     */
+    @Deprecated
     public Req(SolrRequest<?> request, List<String> servers) {
       this(request, servers, null);
     }
 
+    public Req(SolrRequest<?> request, Collection<Endpoint> servers) {
+      this(
+          request,
+          servers.stream().map(endpoint -> endpoint.getUrl()).collect(Collectors.toList()));
+    }
+
+    /**
+     * @deprecated use {@link #Req(SolrRequest, Collection<Endpoint>, Integer)} instead
+     */
+    @Deprecated
     public Req(SolrRequest<?> request, List<String> servers, Integer numServersToTry) {
       this.request = request;
       this.servers = servers;
@@ -256,10 +349,22 @@ public abstract class LBSolrClient extends SolrClient {
       this.numServersToTry = numServersToTry;
     }
 
+    public Req(SolrRequest<?> request, Collection<Endpoint> servers, Integer numServersToTry) {
+      this(
+          request,
+          servers.stream().map(endpoint -> endpoint.getUrl()).collect(Collectors.toList()),
+          numServersToTry);
+    }
+
     public SolrRequest<?> getRequest() {
       return request;
     }
 
+    /**
+     * @deprecated will be replaced with a similar method in 10.0 that returns {@link Endpoint}
+     *     instances instead.
+     */
+    @Deprecated
     public List<String> getServers() {
       return servers;
     }
@@ -571,10 +676,22 @@ public abstract class LBSolrClient extends SolrClient {
     }
   }
 
+  /**
+   * @deprecated use {@link #addSolrServer(Endpoint)} instead
+   */
+  @Deprecated
   public void addSolrServer(String server) throws MalformedURLException {
     addToAlive(createServerWrapper(server));
   }
 
+  public void addSolrServer(Endpoint server) throws MalformedURLException {
+    addSolrServer(server.getUrl());
+  }
+
+  /**
+   * @deprecated use {@link #removeSolrServer(Endpoint)} instead
+   */
+  @Deprecated
   public String removeSolrServer(String server) {
     try {
       server = new URL(server).toExternalForm();
@@ -590,6 +707,10 @@ public abstract class LBSolrClient extends SolrClient {
     removeFromAlive(server);
     zombieServers.remove(server);
     return null;
+  }
+
+  public String removeSolrServer(Endpoint endpoint) {
+    return removeSolrServer(endpoint.getUrl());
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17066

# Description

In PR #2283, SOLR-17066 introduced the `LBSolrClient.Endpoint` class, and modified several "LB" client methods to use it on "main".  Users who take advantage of these methods in Solr 9 should be given proper notice that they'll be changing (or going away entirely) in Solr 10.

# Solution

This commit adds the corresponding deprecation notices to branch_9x, so that users can be notified of these changes and start to upgrade their apps where appropriate/required.

# Tests

N/A - doc change only.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] **I have developed this patch against `branch_9x` branch.**
- [x] I have run `./gradlew check`.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
