### PR TITLE
[SOLR-10059] Handle appended fq params with macros in distributed requests

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -227,8 +227,9 @@ public abstract class RequestHandlerBase
     Timer.Context timer = metrics.requestTimes.time();
     try {
       TestInjection.injectLeaderTragedy(req.getCore());
-      if (pluginInfo != null && pluginInfo.attributes.containsKey(USEPARAM))
+      if (pluginInfo != null && pluginInfo.attributes.containsKey(USEPARAM)) {
         req.getContext().put(USEPARAM, pluginInfo.attributes.get(USEPARAM));
+      }
       SolrPluginUtils.setDefaults(this, req, defaults, appends, invariants);
       req.getContext().remove(USEPARAM);
       rsp.setHttpCaching(httpCaching);

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.params.SolrParams;
@@ -33,6 +34,7 @@ import org.apache.solr.handler.component.SearchHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.macro.MacroExpander;
+import org.apache.solr.request.macro.MacroSanitizer;
 import org.apache.solr.search.QueryParsing;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
@@ -164,7 +166,11 @@ public class RequestUtil {
       newMap.putAll(MultiMapSolrParams.asMultiMap(invariants));
     }
 
-    if (!isShard) { // Don't expand macros in shard requests
+    if (isShard) {
+      // sanitize all macros from fq parameters as they
+      // might corrupt handler local params
+      newMap = MacroSanitizer.sanitize(CommonParams.FQ, newMap);
+    } else { // Don't expand macros in shard requests
       String[] doMacrosStr = newMap.get("expandMacros");
       boolean doMacros = true;
       if (doMacrosStr != null) {

--- a/solr/core/src/java/org/apache/solr/request/macro/MacroSanitizer.java
+++ b/solr/core/src/java/org/apache/solr/request/macro/MacroSanitizer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.request.macro;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class MacroSanitizer {
+
+  /**
+   * Sanitizes macros for the given parameter in the given params set if present
+   *
+   * @param param the parameter whose values we should sanitzize
+   * @param params the parameter set
+   * @return the sanitized parameter set
+   */
+  public static Map<String, String[]> sanitize(String param, Map<String, String[]> params) {
+    // quick peek into the values to check for macros
+    final boolean needsSanitizing =
+        params.containsKey(param)
+            && Arrays.stream(params.get(param))
+                .anyMatch(s -> s.contains(MacroExpander.MACRO_START));
+
+    if (needsSanitizing) {
+      final String[] fqs = params.get(param);
+      final List<String> sanitizedFqs = new ArrayList<>(fqs.length);
+
+      for (int i = 0; i < fqs.length; i++) {
+        if (!fqs[i].contains(MacroExpander.MACRO_START)) {
+          sanitizedFqs.add(fqs[i]);
+        }
+      }
+
+      params.put(param, sanitizedFqs.toArray(new String[] {}));
+    }
+
+    return params;
+  }
+}

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerAppendsWithMacrosCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerAppendsWithMacrosCloudTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.component;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.cloud.AbstractDistribZkTestBase;
+import org.apache.solr.cloud.ConfigRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CommonParams;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SearchHandlerAppendsWithMacrosCloudTest extends SolrCloudTestCase {
+
+  private static String COLLECTION;
+  private static int NUM_SHARDS;
+  private static int NUM_REPLICAS;
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+
+    // decide collection name ...
+    COLLECTION = "collection" + (1 + random().nextInt(100));
+    // ... and shard/replica/node numbers
+    NUM_SHARDS = (2 + random().nextInt(2)); // 0..2
+    NUM_REPLICAS = (1 + random().nextInt(2)); // 0..2
+
+    // create and configure cluster
+    configureCluster(NUM_SHARDS * NUM_REPLICAS /* nodeCount */)
+        .addConfig("conf", configset("cloud-dynamic"))
+        .configure();
+
+    // create an empty collection
+    CollectionAdminRequest.createCollection(COLLECTION, "conf", NUM_SHARDS, NUM_REPLICAS)
+        .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
+    AbstractDistribZkTestBase.waitForRecoveriesToFinish(
+        COLLECTION, ZkStateReader.from(cluster.getSolrClient()), false, true, DEFAULT_TIMEOUT);
+  }
+
+  @Test
+  public void test() throws Exception {
+
+    // field names
+    final String id = "id";
+    final String bee_si = "bee_sI";
+    final String forage_t = "forage_t";
+    final String handlerName = "/custom-select";
+
+    // add custom handlers (the exact custom handler names should not matter)
+    cluster
+        .getSolrClient()
+        .request(
+            new ConfigRequest(
+                "{\n"
+                    + "  'add-requesthandler': {\n"
+                    + "    'name' : '"
+                    + handlerName
+                    + "',\n"
+                    + "    'class' : 'org.apache.solr.handler.component.SearchHandler',\n"
+                    + "    'appends' : { 'fq' : '{!collapse tag=collapsing field="
+                    + bee_si
+                    + " sort=\"${collapseSort}\" }' }, \n"
+                    + "  }\n"
+                    + "}"),
+            COLLECTION);
+
+    // add some documents
+    {
+      new UpdateRequest()
+          .add(sdoc(id, 1, bee_si, "bumble bee", forage_t, "nectar"))
+          .add(sdoc(id, 2, bee_si, "honey bee", forage_t, "propolis"))
+          .add(sdoc(id, 3, bee_si, "solitary bee", forage_t, "pollen"))
+          .commit(cluster.getSolrClient(), COLLECTION);
+    }
+
+    // compose the query
+    final SolrQuery solrQuery = new SolrQuery(bee_si + ":bee");
+    solrQuery.setParam(CommonParams.QT, handlerName);
+    solrQuery.setParam(CommonParams.SORT, "id desc");
+    solrQuery.setParam("collapseSort", "id asc");
+
+    // make the query
+    // the query wouold break with macros in shard response
+    final QueryResponse queryResponse =
+        new QueryRequest(solrQuery).process(cluster.getSolrClient(), COLLECTION);
+    assertNotNull(queryResponse);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/request/macro/MacroSanitizerTest.java
+++ b/solr/core/src/test/org/apache/solr/request/macro/MacroSanitizerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.request.macro;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.solr.common.params.CommonParams;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class MacroSanitizerTest {
+
+  @Test
+  public void shouldReturnSameInstanceWhenNotSanitizing() {
+    // given
+    Map<String, String[]> params = new HashMap<>();
+
+    // when
+    Map<String, String[]> sanitized = MacroSanitizer.sanitize(CommonParams.FQ, params);
+
+    // then
+    assertSame(params, sanitized);
+  }
+
+  @Test
+  public void shouldNotSanitizeNonMacros() {
+    // given
+    Map<String, String[]> params = new HashMap<>();
+    params.put(
+        CommonParams.FQ,
+        new String[] {
+          "bee:up", "look:left", "{!collapse tag=collapsing field=bee sort=${collapseSort}}"
+        });
+    params.put("q", new String[] {"bee:honey"});
+
+    // when
+    Map<String, String[]> sanitized = MacroSanitizer.sanitize(CommonParams.FQ, params);
+
+    // then
+    assertEquals(2, sanitized.size());
+    assertEquals(2, sanitized.get("fq").length);
+    MatcherAssert.assertThat(sanitized.get("fq"), Matchers.arrayContaining("bee:up", "look:left"));
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-10059

# Description

In distributed requests, the appends section of a `RequestHandler` is evaluated not only on the coordinator but also on the shard nodes of the distributed request. This leads to parameters being attached multiple times. This is usually not a problem but if a `fq` parameter that contains a macro is appended on the shard, the request will crash. This is due to the fact that macros are not evaluated during shard requests.

```xml
<requestHandler name="/myHandler" class="solr.SearchHandler">
    <lst name="appends">
        <str name="fq">{!collapse tag=collapsing field=bee_sI sort="${collapseSort}"}</str>
    </lst>
</requestHandler>
```

# Solution

This fix will remove all `fq` parameters in shard requests that contain unexpanded macros. Macros should have been expanded on the coordinator. If macros are present in an `fq` parameter they must have been injected in an `appends` block.

# Tests

This fix contains a Cloud Test that will fail without the proposed fix and unit tests for the `MacroSanitizer`.

# Checklist

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
