### PR TITLE
SOLR-17183: Tweak PKI Auth logging

### DIFF
--- a/solr/core/src/test/org/apache/solr/security/TestPKIAuthenticationPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/TestPKIAuthenticationPlugin.java
@@ -64,7 +64,7 @@ public class TestPKIAuthenticationPlugin extends SolrTestCaseJ4 {
     }
 
     @Override
-    PublicKey getRemotePublicKey(String ignored) {
+    PublicKey fetchPublicKeyFromRemote(String ignored) {
       return myKey;
     }
 
@@ -153,7 +153,7 @@ public class TestPKIAuthenticationPlugin extends SolrTestCaseJ4 {
           boolean firstCall = true;
 
           @Override
-          PublicKey getRemotePublicKey(String ignored) {
+          PublicKey fetchPublicKeyFromRemote(String ignored) {
             try {
               return firstCall ? myKey : mock.myKey;
             } finally {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17183

# Description

PKI has some decent logging, but could use a few small tweaks to make it easier to understand what's going on when PKI errors do occur.

# Solution

This commit makes a few minor changes to the logging.  In particular:

- clarifies a few messages which imply use of the v2 header without explicitly checking
- add a new message for the common case of a relevant node being absent from `/live_nodes`

# Tests

Manual testing to ensure the messages appear as appropriate, but not additional unit tests as we don't normally add those to cover logging changes.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
