### PR TITLE
[SOLR-17185] Open ValueAugmenter in ValueAugmenterFactory for extension

### DIFF
--- a/solr/core/src/java/org/apache/solr/response/transform/ValueAugmenterFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ValueAugmenterFactory.java
@@ -73,8 +73,8 @@ public class ValueAugmenterFactory extends TransformerFactory {
   }
 
   public static class ValueAugmenter extends DocTransformer {
-    final String name;
-    final Object value;
+    private final String name;
+    protected final Object value;
 
     public ValueAugmenter(String name, Object value) {
       this.name = name;

--- a/solr/core/src/java/org/apache/solr/response/transform/ValueAugmenterFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ValueAugmenterFactory.java
@@ -72,7 +72,7 @@ public class ValueAugmenterFactory extends TransformerFactory {
     return new ValueAugmenter(field, val);
   }
 
-  static class ValueAugmenter extends DocTransformer {
+  public static class ValueAugmenter extends DocTransformer {
     final String name;
     final Object value;
 

--- a/solr/core/src/test/org/apache/solr/pkg/ValueAugmenterPublicTest.java
+++ b/solr/core/src/test/org/apache/solr/pkg/ValueAugmenterPublicTest.java
@@ -1,0 +1,14 @@
+package org.apache.solr.pkg;
+
+import org.apache.solr.response.transform.ValueAugmenterFactory;
+import org.junit.Test;
+
+public class ValueAugmenterPublicTest {
+
+    @Test
+    public void testValueAugmenterIsOpenForExtension() {
+        // this should compile from this package
+        new ValueAugmenterFactory.ValueAugmenter("bee_sI", new Object());
+    }
+
+}

--- a/solr/core/src/test/org/apache/solr/pkg/ValueAugmenterPublicTest.java
+++ b/solr/core/src/test/org/apache/solr/pkg/ValueAugmenterPublicTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.pkg;
 
 import org.apache.solr.response.transform.ValueAugmenterFactory;
@@ -5,10 +21,9 @@ import org.junit.Test;
 
 public class ValueAugmenterPublicTest {
 
-    @Test
-    public void testValueAugmenterIsOpenForExtension() {
-        // this should compile from this package
-        new ValueAugmenterFactory.ValueAugmenter("bee_sI", new Object());
-    }
-
+  @Test
+  public void testValueAugmenterIsOpenForExtension() {
+    // this should compile from this package
+    new ValueAugmenterFactory.ValueAugmenter("bee_sI", new Object());
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17185

# Description

Opening up the class `ValueAugmenter` in the `ValueAugmenterFactory` to `public` access level eases the creation of custom document transformers.

Currently, we have to place our custom document transformers in the `org.apache.solr.response.transform` package to be able to access the package private `ValueAugmenter`. Changing the visibility to `public` enables building custom document transformers very slim and quick like the following one in any package:

```java
public class CollectionAugmenterFactory extends TransformerFactory {

@Override
public DocTransformer create(String field, SolrParams params, SolrQueryRequest req) { 
  String v = ComponentUtils.getCollectionNameFrom(req.getCore()).orElse("[unknown]"); 
  return new ValueAugmenterFactory.ValueAugmenter(field, v); }
}
```

# Solution

Change the visibility of `ValueAugmenter` from package private to `public`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
