### PR TITLE
SOLR-17184: Fixing sorting order of documents for comparison in PeerSyncTest to avoid random failures

### DIFF
--- a/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
+++ b/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
@@ -413,7 +413,9 @@ public class PeerSyncTest extends BaseDistributedSearchTestCase {
     QueryResponse qacResponse;
     qacResponse =
         queryAndCompare(
-            params("q", "*:*", "rows", "10000", "sort", "_version_ desc,id desc"), client0, client1);
+            params("q", "*:*", "rows", "10000", "sort", "_version_ desc,id desc"),
+            client0,
+            client1);
     validateQACResponse(docsAdded, qacResponse);
   }
 

--- a/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
+++ b/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
@@ -413,7 +413,7 @@ public class PeerSyncTest extends BaseDistributedSearchTestCase {
     QueryResponse qacResponse;
     qacResponse =
         queryAndCompare(
-            params("q", "*:*", "rows", "10000", "sort", "_version_ desc"), client0, client1);
+            params("q", "*:*", "rows", "10000", "sort", "_version_ desc,id desc"), client0, client1);
     validateQACResponse(docsAdded, qacResponse);
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17184

# Description

This is a small fix for an issue with PeerSyncTest where it would randomly fail due to the order of documents returned.

# Solution

Added a secondary sort on id for the queries to ensure consistent ordering.

# Tests

Using existing tests.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
