### PR TITLE
SOLR-17186: Streaming query breaks if token contains backtick

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -27,7 +27,7 @@ Optimizations
 
 Bug Fixes
 ---------------------
-
+SOLR-17186: Streaming query breaks if token contains backtick (Rahul Goswami)
 
 Deprecation Removals
 ----------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -27,7 +27,7 @@ Optimizations
 
 Bug Fixes
 ---------------------
-SOLR-17186: Streaming query breaks if token contains backtick (Rahul Goswami)
+(No changes)
 
 Deprecation Removals
 ----------------------
@@ -125,6 +125,8 @@ Bug Fixes
 * SOLR-17152: Better alignment of Admin UI graph (janhoy)
 
 * SOLR-17148: Fixing Config API overlay property enabling or disabling the cache (Sanjay Dutt, hossman, Eric Pugh)
+
+* SOLR-17186: Streaming query breaks if token contains backtick (Rahul Goswami via Eric Pugh)
 
 Dependency Upgrades
 ---------------------

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -132,8 +132,9 @@ public class StreamExpressionParser {
         }
       }
 
-      // If contains ` replace with ". Preserves ` which are escaped.
+      // If contains ` replace with ", except when ` is escaped in the query as (\`)
       // This allows ` to be used as a quote character
+      //Below replacement regex does a negative lookbehind and replaces ` with " only when NOT preceded by \
       parameter = parameter.replaceAll("(?<!\\\\)`", "\"");
       if (0 == parameter.length()) {
         throw new IllegalArgumentException(

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -132,15 +132,12 @@ public class StreamExpressionParser {
         }
       }
 
-      // If contains ` replace with "
+      // If contains ` replace with ". Preserves ` which are escaped.
       // This allows ` to be used as a quote character
-
-      if (parameter.contains("`")) {
-        parameter = parameter.replace('`', '"');
-        if (0 == parameter.length()) {
-          throw new IllegalArgumentException(
-              String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
-        }
+      parameter = parameter.replaceAll("(?<!\\\\)`", "\"");
+      if (0 == parameter.length()) {
+        throw new IllegalArgumentException(
+            String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
       }
 
       namedParameter.setParameter(new StreamExpressionValue(parameter));

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -134,14 +134,15 @@ public class StreamExpressionParser {
 
       // If contains ` replace with ", except when ` is escaped in the query as (\`)
       // This allows ` to be used as a quote character
-      // Below replacement regex does a negative lookbehind and replaces ` with " only when NOT
-      // preceded by \
-      parameter = parameter.replaceAll("(?<!\\\\)`", "\"");
-      if (0 == parameter.length()) {
-        throw new IllegalArgumentException(
-            String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
+      if (parameter.contains("`")) {
+        // Below replacement regex does a negative lookbehind and replaces ` with " only when NOT
+        // preceded by \
+        parameter = parameter.replaceAll("(?<!\\\\)`", "\"");
+        if (0 == parameter.length()) {
+          throw new IllegalArgumentException(
+              String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
+        }
       }
-
       namedParameter.setParameter(new StreamExpressionValue(parameter));
     }
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -134,7 +134,8 @@ public class StreamExpressionParser {
 
       // If contains ` replace with ", except when ` is escaped in the query as (\`)
       // This allows ` to be used as a quote character
-      //Below replacement regex does a negative lookbehind and replaces ` with " only when NOT preceded by \
+      // Below replacement regex does a negative lookbehind and replaces ` with " only when NOT
+      // preceded by \
       parameter = parameter.replaceAll("(?<!\\\\)`", "\"");
       if (0 == parameter.length()) {
         throw new IllegalArgumentException(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17186

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

StreamExpressionParser today replaces ` with " indiscriminately which can break queries where the tokens themselves contain backtick. 

# Solution

Allow for backticks to be escaped in the streaming query and only replace non-escaped backticks with "

# Checklist

Please review the following and check all that apply:

- [+ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ +] I have created a Jira issue and added the issue ID to my pull request title.
- [ +] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ +] I have developed this patch against the `main` branch.
- [ +] I have run `./gradlew check`.
- [ +] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
