### PR TITLE
Tests: JettyConfig.Builder.setContext("/solr")

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestSolrCoreProperties.java
+++ b/solr/core/src/test/org/apache/solr/TestSolrCoreProperties.java
@@ -74,8 +74,7 @@ public class TestSolrCoreProperties extends SolrJettyTestBase {
       nodeProperties.setProperty("solr.data.dir", createTempDir().toFile().getCanonicalPath());
     }
 
-    solrClientTestRule.startSolr(
-        homeDir, nodeProperties, JettyConfig.builder().setContext("/solr").build());
+    solrClientTestRule.startSolr(homeDir, nodeProperties, JettyConfig.builder().build());
 
     // createJetty(homeDir.getAbsolutePath(), null, null);
   }

--- a/solr/core/src/test/org/apache/solr/cli/TestSolrCLIRunExample.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestSolrCLIRunExample.java
@@ -123,7 +123,7 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
                   Files.readAllBytes(Paths.get(solrHomeDir).resolve("solr.xml")),
                   Charset.defaultCharset());
 
-          JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").setPort(port).build();
+          JettyConfig jettyConfig = JettyConfig.builder().setPort(port).build();
           try {
             if (solrCloudCluster == null) {
               Path logDir = createTempDir("solr_logs");

--- a/solr/core/src/test/org/apache/solr/cloud/ConcurrentCreateRoutedAliasTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ConcurrentCreateRoutedAliasTest.java
@@ -45,9 +45,7 @@ public class ConcurrentCreateRoutedAliasTest extends SolrTestCaseJ4 {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    solrCluster =
-        new MiniSolrCloudCluster(
-            4, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+    solrCluster = new MiniSolrCloudCluster(4, createTempDir(), JettyConfig.builder().build());
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIExclusivity.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIExclusivity.java
@@ -50,9 +50,7 @@ public class TestConfigSetsAPIExclusivity extends SolrTestCaseJ4 {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    solrCluster =
-        new MiniSolrCloudCluster(
-            1, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+    solrCluster = new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIZkFailure.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestConfigSetsAPIZkFailure.java
@@ -87,7 +87,7 @@ public class TestConfigSetsAPIZkFailure extends SolrTestCaseJ4 {
             1,
             testDir,
             MiniSolrCloudCluster.DEFAULT_CLOUD_SOLR_XML,
-            JettyConfig.builder().setContext("/solr").build(),
+            JettyConfig.builder().build(),
             zkTestServer,
             true);
   }

--- a/solr/core/src/test/org/apache/solr/cloud/TestRequestForwarding.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRequestForwarding.java
@@ -35,9 +35,7 @@ public class TestRequestForwarding extends SolrTestCaseJ4 {
     super.setUp();
     System.setProperty("solr.test.sys.prop1", "propone");
     System.setProperty("solr.test.sys.prop2", "proptwo");
-    solrCluster =
-        new MiniSolrCloudCluster(
-            3, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+    solrCluster = new MiniSolrCloudCluster(3, createTempDir(), JettyConfig.builder().build());
     solrCluster.uploadConfigSet(TEST_PATH().resolve("collection1/conf"), "conf1");
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestWaitForStateWithJettyShutdowns.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestWaitForStateWithJettyShutdowns.java
@@ -43,8 +43,7 @@ public class TestWaitForStateWithJettyShutdowns extends SolrTestCaseJ4 {
   public void testWaitForStateAfterShutDown() throws Exception {
     final String col_name = "test_col";
     final MiniSolrCloudCluster cluster =
-        new MiniSolrCloudCluster(
-            1, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
     try {
       log.info("Create our collection");
       CollectionAdminRequest.createCollection(col_name, "_default", 1, 1)
@@ -78,8 +77,7 @@ public class TestWaitForStateWithJettyShutdowns extends SolrTestCaseJ4 {
         ExecutorUtil.newMDCAwareFixedThreadPool(
             1, new SolrNamedThreadFactory("background_executor"));
     final MiniSolrCloudCluster cluster =
-        new MiniSolrCloudCluster(
-            1, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
     try {
       log.info("Create our collection");
       CollectionAdminRequest.createCollection(col_name, "_default", 1, 1)

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ConcurrentDeleteAndCreateCollectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ConcurrentDeleteAndCreateCollectionTest.java
@@ -47,9 +47,7 @@ public class ConcurrentDeleteAndCreateCollectionTest extends SolrTestCaseJ4 {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    solrCluster =
-        new MiniSolrCloudCluster(
-            1, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+    solrCluster = new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/handler/PingRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/PingRequestHandlerTest.java
@@ -170,8 +170,7 @@ public class PingRequestHandlerTest extends SolrTestCaseJ4 {
   public void testPingInClusterWithNoHealthCheck() throws Exception {
 
     MiniSolrCloudCluster miniCluster =
-        new MiniSolrCloudCluster(
-            NUM_SERVERS, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(NUM_SERVERS, createTempDir(), JettyConfig.builder().build());
 
     final CloudSolrClient cloudSolrClient = miniCluster.getSolrClient();
 

--- a/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
+++ b/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
@@ -58,7 +58,7 @@ public final class ReplicationTestHelper {
         new File(instance.getHomeDir(), "solr.xml"));
     Properties nodeProperties = new Properties();
     nodeProperties.setProperty("solr.data.dir", instance.getDataDir());
-    JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").setPort(0).build();
+    JettyConfig jettyConfig = JettyConfig.builder().setPort(0).build();
     JettySolrRunner jetty = new JettySolrRunner(instance.getHomeDir(), nodeProperties, jettyConfig);
     jetty.start();
     return jetty;

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandlerBackup.java
@@ -78,7 +78,7 @@ public class TestReplicationHandlerBackup extends SolrJettyTestBase {
         new File(instance.getHomeDir(), "solr.xml"));
     Properties nodeProperties = new Properties();
     nodeProperties.setProperty("solr.data.dir", instance.getDataDir());
-    JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").setPort(0).build();
+    JettyConfig jettyConfig = JettyConfig.builder().setPort(0).build();
     JettySolrRunner jetty = new JettySolrRunner(instance.getHomeDir(), nodeProperties, jettyConfig);
     jetty.start();
     return jetty;

--- a/solr/core/src/test/org/apache/solr/handler/TestRestoreCore.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestRestoreCore.java
@@ -63,7 +63,7 @@ public class TestRestoreCore extends SolrJettyTestBase {
         new File(instance.getHomeDir(), "solr.xml"));
     Properties nodeProperties = new Properties();
     nodeProperties.setProperty("solr.data.dir", instance.getDataDir());
-    JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").setPort(0).build();
+    JettyConfig jettyConfig = JettyConfig.builder().setPort(0).build();
     JettySolrRunner jetty = new JettySolrRunner(instance.getHomeDir(), nodeProperties, jettyConfig);
     jetty.start();
     return jetty;

--- a/solr/core/src/test/org/apache/solr/handler/V2StandaloneTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/V2StandaloneTest.java
@@ -38,9 +38,7 @@ public class V2StandaloneTest extends SolrTestCaseJ4 {
     Files.copy(Path.of(TEST_HOME(), "solr.xml"), solrHomeTmp.resolve("solr.xml"));
 
     JettySolrRunner jetty =
-        new JettySolrRunner(
-            solrHomeTmp.toAbsolutePath().toString(),
-            JettyConfig.builder().setContext("/solr").build());
+        new JettySolrRunner(solrHomeTmp.toAbsolutePath().toString(), JettyConfig.builder().build());
     jetty.start();
 
     try (SolrClient client = getHttpSolrClient(buildUrl(jetty.getLocalPort(), "/solr/"))) {

--- a/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminHandlerTest.java
@@ -303,8 +303,7 @@ public class CoreAdminHandlerTest extends SolrTestCaseJ4 {
 
     JettySolrRunner runner =
         new JettySolrRunner(
-            solrHomeDirectory.toAbsolutePath().toString(),
-            JettyConfig.builder().setContext("/solr").build());
+            solrHomeDirectory.toAbsolutePath().toString(), JettyConfig.builder().build());
     runner.start();
 
     try (SolrClient client =
@@ -378,8 +377,7 @@ public class CoreAdminHandlerTest extends SolrTestCaseJ4 {
     Files.writeString(corex.resolve("core.properties"), "", StandardCharsets.UTF_8);
     JettySolrRunner runner =
         new JettySolrRunner(
-            solrHomeDirectory.toAbsolutePath().toString(),
-            JettyConfig.builder().setContext("/solr").build());
+            solrHomeDirectory.toAbsolutePath().toString(), JettyConfig.builder().build());
     runner.start();
 
     try (SolrClient client =
@@ -444,8 +442,7 @@ public class CoreAdminHandlerTest extends SolrTestCaseJ4 {
     Files.writeString(corex.resolve("core.properties"), "", StandardCharsets.UTF_8);
     JettySolrRunner runner =
         new JettySolrRunner(
-            solrHomeDirectory.toAbsolutePath().toString(),
-            JettyConfig.builder().setContext("/solr").build());
+            solrHomeDirectory.toAbsolutePath().toString(), JettyConfig.builder().build());
     runner.start();
 
     try (SolrClient client =

--- a/solr/core/src/test/org/apache/solr/handler/admin/DaemonStreamApiTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/DaemonStreamApiTest.java
@@ -66,9 +66,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    cluster =
-        new MiniSolrCloudCluster(
-            1, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+    cluster = new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
 
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + CHECKPOINT_COLL;
 

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -126,8 +126,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
   @Test
   public void testZkConnected() throws Exception {
     MiniSolrCloudCluster miniCluster =
-        new MiniSolrCloudCluster(
-            5, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(5, createTempDir(), JettyConfig.builder().build());
 
     final CloudSolrClient cloudSolrClient = miniCluster.getSolrClient();
 
@@ -175,8 +174,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
   @Test
   public void testRequireZkConnected() throws Exception {
     MiniSolrCloudCluster miniCluster =
-        new MiniSolrCloudCluster(
-            5, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(5, createTempDir(), JettyConfig.builder().build());
 
     final CloudSolrClient cloudSolrClient = miniCluster.getSolrClient();
 
@@ -230,8 +228,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
   @Test
   public void testRequireZkConnectedDistrib() throws Exception {
     MiniSolrCloudCluster miniCluster =
-        new MiniSolrCloudCluster(
-            2, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(2, createTempDir(), JettyConfig.builder().build());
 
     final CloudSolrClient cloudSolrClient = miniCluster.getSolrClient();
 

--- a/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
@@ -94,9 +94,7 @@ public class TestRawTransformer extends SolrCloudTestCase {
     nodeProperties.setProperty("solr.data.dir", h.getCore().getDataDir());
     JSR =
         new JettySolrRunner(
-            homeDir.toAbsolutePath().toString(),
-            nodeProperties,
-            JettyConfig.builder().setContext("/solr").build());
+            homeDir.toAbsolutePath().toString(), nodeProperties, JettyConfig.builder().build());
   }
 
   private static void initCloud() throws Exception {

--- a/solr/core/src/test/org/apache/solr/search/stats/TestDistribIDF.java
+++ b/solr/core/src/test/org/apache/solr/search/stats/TestDistribIDF.java
@@ -54,9 +54,7 @@ public class TestDistribIDF extends SolrTestCaseJ4 {
     }
 
     super.setUp();
-    solrCluster =
-        new MiniSolrCloudCluster(
-            3, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+    solrCluster = new MiniSolrCloudCluster(3, createTempDir(), JettyConfig.builder().build());
     // set some system properties for use by tests
     System.setProperty("solr.test.sys.prop1", "propone");
     System.setProperty("solr.test.sys.prop2", "proptwo");

--- a/solr/core/src/test/org/apache/solr/security/BasicAuthStandaloneTest.java
+++ b/solr/core/src/test/org/apache/solr/security/BasicAuthStandaloneTest.java
@@ -203,9 +203,7 @@ public class BasicAuthStandaloneTest extends SolrTestCaseJ4 {
     nodeProperties.setProperty("solr.data.dir", instance.getDataDir().toString());
     JettySolrRunner jetty =
         new JettySolrRunner(
-            instance.getHomeDir().toString(),
-            nodeProperties,
-            JettyConfig.builder().setContext("/solr").build());
+            instance.getHomeDir().toString(), nodeProperties, JettyConfig.builder().build());
     jetty.start();
     return jetty;
   }

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithDelegationTokens.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithDelegationTokens.java
@@ -69,8 +69,7 @@ public class TestSolrCloudWithDelegationTokens extends SolrTestCaseJ4 {
     System.setProperty("solr.kerberos.cookie.domain", "127.0.0.1");
 
     miniCluster =
-        new MiniSolrCloudCluster(
-            NUM_SERVERS, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(NUM_SERVERS, createTempDir(), JettyConfig.builder().build());
     JettySolrRunner runnerPrimary = miniCluster.getJettySolrRunners().get(0);
     solrClientPrimary = new HttpSolrClient.Builder(runnerPrimary.getBaseUrl().toString()).build();
     JettySolrRunner runnerSecondary = miniCluster.getJettySolrRunners().get(1);

--- a/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithSecureImpersonation.java
+++ b/solr/modules/hadoop-auth/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithSecureImpersonation.java
@@ -115,8 +115,7 @@ public class TestSolrCloudWithSecureImpersonation extends SolrTestCaseJ4 {
     System.setProperty("collectionsHandler", ImpersonatorCollectionsHandler.class.getName());
 
     miniCluster =
-        new MiniSolrCloudCluster(
-            NUM_SERVERS, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(NUM_SERVERS, createTempDir(), JettyConfig.builder().build());
     JettySolrRunner runner = miniCluster.getJettySolrRunners().get(0);
     solrClient = new HttpSolrClient.Builder(runner.getBaseUrl().toString()).build();
   }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTROnSolrCloud.java
@@ -323,9 +323,7 @@ public class TestLTROnSolrCloud extends TestRerankBase {
   }
 
   private void setupSolrCluster(int numShards, int numReplicas, int numServers) throws Exception {
-    solrCluster =
-        new MiniSolrCloudCluster(
-            numServers, tmpSolrHome, JettyConfig.builder().setContext("/solr").build());
+    solrCluster = new MiniSolrCloudCluster(numServers, tmpSolrHome, JettyConfig.builder().build());
     Path configDir = tmpSolrHome.resolve("collection1/conf");
     solrCluster.uploadConfigSet(configDir, "conf1");
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttp2SolrClient.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttp2SolrClient.java
@@ -329,7 +329,7 @@ public class TestLBHttp2SolrClient extends SolrTestCaseJ4 {
       props.setProperty("solrconfig", "bad_solrconfig.xml");
       props.setProperty("solr.data.dir", getDataDir());
 
-      JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").setPort(port).build();
+      JettyConfig jettyConfig = JettyConfig.builder().setPort(port).build();
 
       jetty = new JettySolrRunner(getHomeDir(), props, jettyConfig);
       jetty.start();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttpSolrClient.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/TestLBHttpSolrClient.java
@@ -334,7 +334,7 @@ public class TestLBHttpSolrClient extends SolrTestCaseJ4 {
       props.setProperty("solrconfig", "bad_solrconfig.xml");
       props.setProperty("solr.data.dir", getDataDir());
 
-      JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").setPort(port).build();
+      JettyConfig jettyConfig = JettyConfig.builder().setPort(port).build();
 
       jetty = new JettySolrRunner(getHomeDir(), props, jettyConfig);
       jetty.start();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/TestCloudSolrClientConnections.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/TestCloudSolrClientConnections.java
@@ -34,8 +34,7 @@ public class TestCloudSolrClientConnections extends SolrTestCaseJ4 {
 
     // Start by creating a cluster with no jetties
     MiniSolrCloudCluster cluster =
-        new MiniSolrCloudCluster(
-            0, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(0, createTempDir(), JettyConfig.builder().build());
     try {
 
       CloudSolrClient client = cluster.getSolrClient();
@@ -64,8 +63,7 @@ public class TestCloudSolrClientConnections extends SolrTestCaseJ4 {
     Path configPath = getFile("solrj").toPath().resolve("solr/configsets/configset-2/conf");
 
     MiniSolrCloudCluster cluster =
-        new MiniSolrCloudCluster(
-            0, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(0, createTempDir(), JettyConfig.builder().build());
     try {
       CloudSolrClient client = cluster.getSolrClient();
       SolrException e =
@@ -97,8 +95,7 @@ public class TestCloudSolrClientConnections extends SolrTestCaseJ4 {
   public void testAlreadyClosedClusterStateProvider() throws Exception {
 
     final MiniSolrCloudCluster cluster =
-        new MiniSolrCloudCluster(
-            1, createTempDir(), JettyConfig.builder().setContext("/solr").build());
+        new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
     // from a client perspective the behavior of ZkClientClusterStateProvider should be
     // consistent regardless of wether it's constructed with a zkhost or an existing ZkStateReader
     try {

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
@@ -503,8 +503,7 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
       }
 
       if (jetty == null) {
-        JettyConfig jettyConfig =
-            JettyConfig.builder().stopAtShutdown(true).setContext("/solr").setPort(port).build();
+        JettyConfig jettyConfig = JettyConfig.builder().stopAtShutdown(true).setPort(port).build();
         Properties nodeProperties = new Properties();
         nodeProperties.setProperty("solrconfig", solrconfigFile);
         nodeProperties.setProperty(CoreDescriptor.CORE_SCHEMA, schemaFile);

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -1124,7 +1124,7 @@ public class MiniSolrCloudCluster {
       this.nodeCount = nodeCount;
       this.baseDir = baseDir;
 
-      jettyConfigBuilder = JettyConfig.builder().setContext("/solr");
+      jettyConfigBuilder = JettyConfig.builder();
     }
 
     /** Use a JettyConfig.Builder to configure the cluster's jetty servers */

--- a/solr/test-framework/src/test/org/apache/solr/embedded/TestJettySolrRunner.java
+++ b/solr/test-framework/src/test/org/apache/solr/embedded/TestJettySolrRunner.java
@@ -48,7 +48,7 @@ public class TestJettySolrRunner extends SolrTestCaseJ4 {
             .replace("COREROOT", coresDir.toString());
     Files.write(solrHome.resolve("solr.xml"), solrxml.getBytes(StandardCharsets.UTF_8));
 
-    JettyConfig jettyConfig = JettyConfig.builder().setContext("/solr").build();
+    JettyConfig jettyConfig = JettyConfig.builder().build();
 
     JettySolrRunner runner =
         new JettySolrRunner(solrHome.toString(), new Properties(), jettyConfig);


### PR DESCRIPTION
Isn't needed because it's the default

Note this is on branch_9x.  Main already has this; was done some time ago I guess.