### PR TITLE
Tests: avoid NPE in JettySolrRunner lifeCycleStopped

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
+++ b/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
@@ -383,7 +383,9 @@ public class JettySolrRunner {
 
             @Override
             public synchronized void lifeCycleStopped(LifeCycle arg0) {
-              coreContainerProvider.close();
+              if (coreContainerProvider != null) {
+                coreContainerProvider.close();
+              }
             }
 
             @Override


### PR DESCRIPTION
Very simple little check.  I saw in a failure here: https://github.com/apache/solr/actions/runs/8180447387/job/22376604762?pr=2335 for TestLBHttp2SolrClient.