### PR TITLE
SOLR-17201 Make Http2SolrClients not experimental

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -150,6 +150,8 @@ Other Changes
 
 * SOLR-17190: Replace org.apache.solr.util.LongSet with hppc LongHashSet (Michael Gibney)
 
+* SOLR-17201: Http2SolrClient and friends no longer marked as @lucene.experimental (janhoy)
+
 ==================  9.5.0 ==================
 New Features
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -158,7 +158,8 @@ Other Changes
 
 * SOLR-17190: Replace org.apache.solr.util.LongSet with hppc LongHashSet (Michael Gibney)
 
-* SOLR-17201: Http2SolrClient and friends no longer marked as @lucene.experimental (janhoy)
+* SOLR-17201: Http2SolrClient and friends no longer marked as @lucene.experimental.
+  Krb5HttpClientBuilder and PreemptiveBasicAuthClientBuilderFactory no longer deprecated (janhoy)
 
 ==================  9.5.0 ==================
 New Features

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solrj.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solrj.adoc
@@ -97,19 +97,16 @@ Requests are sent in the form of {solr-javadocs}/solrj/org/apache/solr/client/so
 
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/HttpSolrClient.html[`HttpSolrClient`] - geared towards query-centric workloads, though also a good general-purpose client.
 Communicates directly with a single Solr node.
-- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/Http2SolrClient.html[`Http2SolrClient`] - async, non-blocking and general-purpose client that leverage HTTP/2.
-This class is experimental therefore its API's might change or be removed in minor versions of SolrJ.
-- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.html[`HttpJdkSolrClient`] - General-purpose client using the JDK's built-in Http Client.  Supports both Http/2 and Http/1.1.  Targeted for those users wishing to minimize application dependencies.
+- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/Http2SolrClient.html[`Http2SolrClient`] - async, non-blocking and general-purpose client that leverage HTTP/2 using the Jetty Http library.
+- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.html[`HttpJdkSolrClient`] - General-purpose client using the JDK's built-in Http Client. Supports both Http/2 and Http/1.1.  Targeted for those users wishing to minimize application dependencies.
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/LBHttpSolrClient.html[`LBHttpSolrClient`] - balances request load across a list of Solr nodes.
 Adjusts the list of "in-service" nodes based on node health.
-- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.html[`LBHttp2SolrClient`] - just like `LBHttpSolrClient` but using `Http2SolrClient` instead.
-This class is experimental therefore its API's might change or be removed in minor versions of SolrJ.
+- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.html[`LBHttp2SolrClient`] - just like `LBHttpSolrClient` but using `Http2SolrClient` instead, with the Jetty Http library.
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/CloudSolrClient.html[`CloudSolrClient`] - geared towards communicating with SolrCloud deployments.
 Uses already-recorded ZooKeeper state to discover and route requests to healthy Solr nodes.
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.html[`ConcurrentUpdateSolrClient`] - geared towards indexing-centric workloads.
 Buffers documents internally before sending larger batches to Solr.
-- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.html[`ConcurrentUpdateHttp2SolrClient`] - just like `ConcurrentUpdateSolrClient` but using `Http2SolrClient` instead.
-This class is experimental therefore its API's might change or be removed in minor versions of SolrJ.
+- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.html[`ConcurrentUpdateHttp2SolrClient`] - just like `ConcurrentUpdateSolrClient` but using `Http2SolrClient` instead, with the Jetty Http library.
 
 === Common Configuration Options
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -67,6 +67,10 @@ It is always strongly recommended that you fully reindex your documents after a 
 In Solr 8, it was possible to add docValues to a schema without re-indexing via `UninvertDocValuesMergePolicy`, an advanced/expert utility.
 Due to changes in Lucene 9, that isn't possible any more.
 
+== Solr 9.6
+=== SolrJ
+* The suite of `Http2SolrClient`s, powered by the Jetty Http library are no longer marked as experimental.
+
 == Solr 9.5
 === Dependency Upgrades
 <<#solr-8-2,Solr 8.2 recommended using Zookeeper 3.5.5>> and now with Curator 5.5.0 requires https://curator.apache.org/docs/breaking-changes/[Zookeeper 3.5.x or higher]. This primarily affects users of `hadoop-auth`, but usage of Curator could affect other parts of Solr.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -34,7 +34,6 @@ import org.apache.solr.common.SolrException;
  * communicate with Zookeeper to discover Solr endpoints for SolrCloud collections, and then use the
  * {@link LBHttp2SolrClient} to issue requests.
  *
- * @lucene.experimental
  * @since solr 8.0
  */
 @SuppressWarnings("serial")

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 /**
- * @lucene.experimental
+ * A Solr client using {@link Http2SolrClient} to send concurrent updates to Solr.
  */
 public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
   private static final long serialVersionUID = 1L;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
@@ -48,9 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-/**
- * A Solr client using {@link Http2SolrClient} to send concurrent updates to Solr.
- */
+/** A Solr client using {@link Http2SolrClient} to send concurrent updates to Solr. */
 public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
   private static final long serialVersionUID = 1L;
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -104,8 +104,6 @@ import org.slf4j.MDC;
  *       HttpSolrClient#getHttpClient()}, sharing connection pools should be done by {@link
  *       Http2SolrClient.Builder#withHttpClient(Http2SolrClient)}
  * </ul>
- *
- * @lucene.experimental
  */
 public class Http2SolrClient extends HttpSolrClientBase {
   public static final String REQ_PRINCIPAL_KEY = "solr-req-principal";

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
@@ -18,7 +18,12 @@ package org.apache.solr.client.solrj.impl;
 
 import java.io.Closeable;
 
-/** Factory interface for configuring {@linkplain SolrHttpClientBuilder}. */
+/**
+ * Factory interface for configuring {@linkplain SolrHttpClientBuilder}. This relies on the internal
+ * HttpClient implementation and is subject to change.
+ *
+ * @lucene.experimental
+ */
 public interface HttpClientBuilderFactory extends Closeable {
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
@@ -19,10 +19,7 @@ package org.apache.solr.client.solrj.impl;
 import java.io.Closeable;
 
 /**
- * Factory interface for configuring {@linkplain SolrHttpClientBuilder}. This relies on the internal
- * HttpClient implementation and is subject to change.
- *
- * @lucene.experimental
+ * Factory interface for configuring {@linkplain SolrHttpClientBuilder}.
  */
 public interface HttpClientBuilderFactory extends Closeable {
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
@@ -18,9 +18,7 @@ package org.apache.solr.client.solrj.impl;
 
 import java.io.Closeable;
 
-/**
- * Factory interface for configuring {@linkplain SolrHttpClientBuilder}.
- */
+/** Factory interface for configuring {@linkplain SolrHttpClientBuilder}. */
 public interface HttpClientBuilderFactory extends Closeable {
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
@@ -47,9 +47,7 @@ import org.eclipse.jetty.client.util.SPNEGOAuthentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Kerberos-enabled SolrHttpClientBuilder
- */
+/** Kerberos-enabled SolrHttpClientBuilder */
 public class Krb5HttpClientBuilder implements HttpClientBuilderFactory {
 
   public static final String LOGIN_CONFIG_PROP = "java.security.auth.login.config";

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
@@ -49,10 +49,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Kerberos-enabled SolrHttpClientBuilder
- *
- * @deprecated Please consider alternatives involving the new Solr Http2Client
  */
-@Deprecated(since = "9.0")
 public class Krb5HttpClientBuilder implements HttpClientBuilderFactory {
 
   public static final String LOGIN_CONFIG_PROP = "java.security.auth.login.config";

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -95,7 +95,6 @@ import org.slf4j.MDC;
  * httpd with mod_proxy_balancer as a load balancer. See <a
  * href="http://en.wikipedia.org/wiki/Load_balancing_(computing)">Load balancing on Wikipedia</a>
  *
- * @lucene.experimental
  * @since solr 8.0
  */
 public class LBHttp2SolrClient extends LBSolrClient {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/PreemptiveBasicAuthClientBuilderFactory.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/PreemptiveBasicAuthClientBuilderFactory.java
@@ -42,10 +42,7 @@ import org.eclipse.jetty.client.WWWAuthenticationProtocolHandler;
 /**
  * HttpClientConfigurer implementation providing support for preemptive Http Basic authentication
  * scheme.
- *
- * @deprecated Please look into using Solr's new Http2 clients
  */
-@Deprecated(since = "9.0")
 public class PreemptiveBasicAuthClientBuilderFactory implements HttpClientBuilderFactory {
   /**
    * A system property used to specify a properties file containing default parameters used for


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17201

Also, undeprecate `Krb5HttpClientBuilder` and `PreemptiveBasicAuthClientBuilderFactory`.