### PR TITLE
SOLR-17018: add QueryLimits support to Learning To Rank rescoring

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -152,6 +152,9 @@ Bug Fixes
 
 * SOLR-17198: AffinityPlacementFactory can fail if Shard leadership changes occur while it is collecting metrics.
   (Paul McArthur)
+  
+* SOLR-17018: Add QueryLimits support to Learning To Rank rescoring.
+    (Alessandro Benedetti)
 
 * SOLR-14892: Queries with shards.info and shards.tolerant can yield multiple null keys in place of shard names
   (Mathieu Marie, David Smiley)

--- a/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
+++ b/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
@@ -18,7 +18,7 @@ package org.apache.solr.search;
 
 public class IncompleteRerankingException extends RuntimeException {
 
-  public IncompleteRerankingException(String msg) {
-    super(msg);
+  public IncompleteRerankingException() {
+    super();
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
+++ b/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+public class IncompleteRerankingException extends RuntimeException {
+
+  public IncompleteRerankingException(String msg) {
+    super(msg);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -128,8 +128,8 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
       }
 
       ScoreDoc[] mainScoreDocs = mainDocs.scoreDocs;
-      ScoreDoc[] mainScoreDocsClone =
-          deepClone(mainScoreDocs, reRankScaler != null && reRankScaler.scaleScores());
+      boolean zeroOutScores = reRankScaler != null && reRankScaler.scaleScores();
+      ScoreDoc[] mainScoreDocsClone = deepClone(mainScoreDocs, zeroOutScores);
       ScoreDoc[] reRankScoreDocs = new ScoreDoc[Math.min(mainScoreDocs.length, reRankDocs)];
       System.arraycopy(mainScoreDocs, 0, reRankScoreDocs, 0, reRankScoreDocs.length);
 

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -144,7 +144,7 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
                     .getReplaceRescorer()
                     .rescore(searcher, mainDocs, mainDocs.scoreDocs.length)
                 : reRankQueryRescorer.rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
-      } catch (QueryLimitsExceededException ex) {
+      } catch (IncompleteRerankingException ex) {
         mainDocs.scoreDocs = mainScoreDocsClone;
         rescoredDocs = mainDocs;
       }

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -139,7 +139,7 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
       TopDocs rescoredDocs;
       try {
         rescoredDocs =
-            reRankScaler != null && reRankScaler.scaleScores()
+            zeroOutScores // previously zero-ed out scores are to be replaced
                 ? reRankScaler
                     .getReplaceRescorer()
                     .rescore(searcher, mainDocs, mainDocs.scoreDocs.length)

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -31,8 +31,8 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.solr.ltr.interleaving.OriginalRankingLTRScoringQuery;
+import org.apache.solr.search.IncompleteRerankingException;
 import org.apache.solr.search.QueryLimits;
-import org.apache.solr.search.QueryLimitsExceededException;
 import org.apache.solr.search.SolrIndexSearcher;
 
 /**
@@ -239,9 +239,9 @@ public class LTRRescorer extends Rescorer {
     if (QueryLimits.getCurrentLimits()
         .maybeExitWithPartialResults(
             "Learning To Rank rescoring -"
-                + " The full reranking didn't complete and got reverted."
-                + " All documents preserved their original score and ranking.")) {
-      throw new QueryLimitsExceededException("A query limit has been exceeded when rescoring");
+                + " The full reranking didn't complete."
+                + " If partial results are tolerated the reranking got reverted and all documents preserved their original score and ranking.")) {
+      throw new IncompleteRerankingException("A query limit has been exceeded when rescoring");
     }
     if (hitUpto < topN) {
       reranked[hitUpto] = hit;

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -235,13 +235,13 @@ public class LTRRescorer extends Rescorer {
     boolean logHit = false;
 
     scorer.getDocInfo().setOriginalDocScore(hit.score);
-    QueryLimits queryLimits = QueryLimits.getCurrentLimits();
     hit.score = scorer.score();
-    if (queryLimits.maybeExitWithPartialResults(
-        "Learning To Rank rescoring -"
-            + " The full reranking didn't complete and got reverted."
-            + " All documents preserved their original score and ranking.")) {
-      throw new QueryLimitsExceededException("The Time Allowed has been exceeded when rescoring");
+    if (QueryLimits.getCurrentLimits()
+        .maybeExitWithPartialResults(
+            "Learning To Rank rescoring -"
+                + " The full reranking didn't complete and got reverted."
+                + " All documents preserved their original score and ranking.")) {
+      throw new QueryLimitsExceededException("A query limit has been exceeded when rescoring");
     }
     if (hitUpto < topN) {
       reranked[hitUpto] = hit;

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -241,7 +241,7 @@ public class LTRRescorer extends Rescorer {
             "Learning To Rank rescoring -"
                 + " The full reranking didn't complete."
                 + " If partial results are tolerated the reranking got reverted and all documents preserved their original score and ranking.")) {
-      throw new IncompleteRerankingException("A query limit has been exceeded when rescoring");
+      throw new IncompleteRerankingException();
     }
     if (hitUpto < topN) {
       reranked[hitUpto] = hit;

--- a/solr/modules/ltr/src/test-files/featureExamples/features-slow.json
+++ b/solr/modules/ltr/src/test-files/featureExamples/features-slow.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name" : "slow",
+    "class" : "org.apache.solr.ltr.feature.SolrFeature",
+    "params" : { "q" : "{!func}sleep(1000,999)" }
+  }
+]

--- a/solr/modules/ltr/src/test-files/modelExamples/linear-slow-model.json
+++ b/solr/modules/ltr/src/test-files/modelExamples/linear-slow-model.json
@@ -1,0 +1,14 @@
+{
+  "class": "org.apache.solr.ltr.model.LinearModel",
+  "name": "slowModel",
+  "features": [
+    {
+      "name": "slow"
+    }
+  ],
+  "params": {
+    "weights": {
+      "expensive": 1
+    }
+  }
+}

--- a/solr/modules/ltr/src/test-files/modelExamples/linear-slow-model.json
+++ b/solr/modules/ltr/src/test-files/modelExamples/linear-slow-model.json
@@ -8,7 +8,7 @@
   ],
   "params": {
     "weights": {
-      "expensive": 1
+      "slow": 1
     }
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -151,7 +151,7 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     final String solrQuery = "_query_:{!edismax qf='id' v='8^=10 9^=5 7^=3 6^=1'}";
     final SolrQuery query = new SolrQuery();
     query.setQuery(solrQuery);
-    query.setFields("*", "score");
+    query.setFields("id", "score");
     query.setRows(4);
     query.setTimeAllowed(300);
     query.add("fv", "true");

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -153,7 +153,7 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     query.add("fl", "*, score");
     query.add("rows", "4");
     query.add("fv", "true");
-    query.add("rq", "{!ltr model=expensiveModel reRankDocs=3}");
+    query.add("rq", "{!ltr model=slowModel reRankDocs=3}");
     query.add("timeAllowed", "300");
 
     assertJQ(

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -225,7 +225,8 @@ public class TestLTRQParserPlugin extends TestRerankBase {
         "/response/docs/[1]/score==999.0",
         "/response/docs/[2]/id=='9'",
         "/response/docs/[2]/score==999.0",
-        "/response/docs/[3]/id=='6'", // original score for the 4th document due to reRankDocs=3 limit
+        "/response/docs/[3]/id=='6'",
+        // original score for the 4th document due to reRankDocs=3 limit
         "/response/docs/[3]/score==1.0");
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -185,7 +185,7 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     final String solrQuery = "_query_:{!edismax qf='id' v='8^=10 9^=5 7^=3 6^=1'}";
     final SolrQuery query = new SolrQuery();
     query.setQuery(solrQuery);
-    query.setFields("*", "score");
+    query.setFields("id", "score");
     query.setRows(4);
     query.setTimeAllowed(300);
     query.add("partialResults", "false");
@@ -210,7 +210,7 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     final String solrQuery = "_query_:{!edismax qf='id' v='8^=10 9^=5 7^=3 6^=1'}";
     final SolrQuery query = new SolrQuery();
     query.setQuery(solrQuery);
-    query.setFields("*", "score");
+    query.setFields("id", "score");
     query.setRows(4);
     query.setTimeAllowed(5000);
     query.add("fv", "true");
@@ -225,7 +225,7 @@ public class TestLTRQParserPlugin extends TestRerankBase {
         "/response/docs/[1]/score==999.0",
         "/response/docs/[2]/id=='9'",
         "/response/docs/[2]/score==999.0",
-        "/response/docs/[3]/id=='6'",
+        "/response/docs/[3]/id=='6'", // original score for the 4th document due to reRankDocs=3 limit
         "/response/docs/[3]/score==1.0");
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -137,4 +137,40 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     query.add("rq", "{!ltr reRankDocs=3 model=6029760550880411648}");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==0");
   }
+
+  @Test
+  public void ltr_expensiveFeatureRescoring_shouldTimeOutAndReturnPartialResults()
+      throws Exception {
+    /* One SolrFeature is defined: {!func}sleep(1000,999)
+     *  It simulates a slow feature extraction, sleeping for 1000ms and returning 999 as a score when finished
+     * */
+    loadFeatures("features-slow.json");
+    loadModels("linear-slow-model.json"); // just a linear model with one feature
+
+    final String solrQuery = "_query_:{!edismax qf='id' v='8^=10 9^=5 7^=3 6^=1'}";
+    final SolrQuery query = new SolrQuery();
+    query.setQuery(solrQuery);
+    query.add("fl", "*, score");
+    query.add("rows", "4");
+    query.add("fv", "true");
+    query.add("rq", "{!ltr model=expensiveModel reRankDocs=3}");
+    query.add("timeAllowed", "300");
+
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/response/numFound/==4",
+        "/responseHeader/partialResults/==true",
+        "/responseHeader/partialResultsDetails/=='Limits exceeded! (Learning To Rank rescoring - "
+            + "The full reranking didn\\'t complete and got reverted. "
+            + "All documents preserved their original score and ranking.)"
+            + ": Query limits: [TimeAllowedLimit:LIMIT EXCEEDED]'",
+        "/response/docs/[0]/id=='8'",
+        "/response/docs/[0]/score==10.0",
+        "/response/docs/[1]/id=='9'",
+        "/response/docs/[1]/score==5.0",
+        "/response/docs/[2]/id=='7'",
+        "/response/docs/[2]/score==3.0",
+        "/response/docs/[3]/id=='6'",
+        "/response/docs/[3]/score==1.0");
+  }
 }

--- a/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/learning-to-rank.adoc
@@ -499,6 +499,17 @@ The output will include feature values as a comma-separated list, resembling the
   }}
 ----
 
+=== Running a Rerank Query and Query Limits
+
+Apache Solr allows to define Query Limits to interrupt particularly expensive queries (xref:query-guide:common-query-parameters.adoc#timeallowed-parameter[Time Allowed], xref:query-guide:common-query-parameters.adoc#cpuallowed-parameter[Cpu Allowed]).
+
+If a query limit is exceeded while reranking, the rescoring is aborted and fully reverted.
+
+The original ranked list is returned and the response marked with the responseHeader 'partialResults'.
+The details of what limit was exceeded is returned in the responseHeader 'partialResultsDetails'.
+
+See xref:query-guide:common-query-parameters.adoc#partialresults-parameter[Partial Results Parameter] for more details on how to handle partial results.
+
 === Running a Rerank Query Interleaving Two Models
 
 To rerank the results of a query, interleaving two models (myModelA, myModelB) add the `rq` parameter to your search, passing two models in input, for example:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17018

# Description

Learning To Rank was ignoring any queryLimit parameter (such as timeAllowed) during the reranking phase.
This means that a particularly expensive feature to extract may cause extremely slow responses and failures out of control.

# Solution

The idea is to check the query limits after the rescore of each search result (Learning To Rank rescore topK results).
If the query limit is exhausted before the completion of the rescoring, the reranking is aborted and reverted (all or nothing approach).
The response is marked as a partialResult and the original score and ranking are returned.

# Tests

A test has been added with a simple Learning To Rank model that uses just one single slow feature (implemented with a sleep function query).
This feature simulates a slow feature extraction.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
