### PR TITLE
Backport SOLR-17203 to 9x

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CpuAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/CpuAllowedLimit.java
@@ -17,25 +17,29 @@
 package org.apache.solr.search;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.util.ThreadCpuTimer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Enforces a CPU-time based timeout on a given SolrQueryRequest, as specified by the {@code
  * cpuAllowed} query parameter.
+ *
+ * <p>Since this class uses {@link ThreadCpuTimer} it is irrevocably lock-hostile and can never be
+ * exposed to multiple threads, even if guarded by synchronization. Normally this is attached to
+ * objects ultimately held by a ThreadLocal in {@link SolrRequestInfo} to provide safe usage on the
+ * assumption that such objects are not shared to other threads.
+ *
+ * @see ThreadCpuTimer
  */
+@NotThreadSafe
 public class CpuAllowedLimit implements QueryTimeout {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  private final long limitAtNs;
   private final ThreadCpuTimer threadCpuTimer;
+  private final long requestedTimeoutNs;
 
   /**
    * Create an object to represent a CPU time limit for the current request. NOTE: this
@@ -49,6 +53,8 @@ public class CpuAllowedLimit implements QueryTimeout {
       throw new IllegalArgumentException("Thread CPU time monitoring is not available.");
     }
     SolrRequestInfo solrRequestInfo = SolrRequestInfo.getRequestInfo();
+    // get existing timer if available to ensure sub-queries can't reset/exceed the intended time
+    // constraint.
     threadCpuTimer =
         solrRequestInfo != null ? solrRequestInfo.getThreadCpuTimer() : new ThreadCpuTimer();
     long reqCpuLimit = req.getParams().getLong(CommonParams.CPU_ALLOWED, -1L);
@@ -57,18 +63,14 @@ public class CpuAllowedLimit implements QueryTimeout {
       throw new IllegalArgumentException(
           "Check for limit with hasCpuLimit(req) before creating a CpuAllowedLimit");
     }
-    // calculate when the time limit is reached, account for the time already spent
-    limitAtNs =
-        threadCpuTimer.getStartCpuTimeNs()
-            + TimeUnit.NANOSECONDS.convert(reqCpuLimit, TimeUnit.MILLISECONDS);
+    // calculate the time when the limit is reached, e.g. account for the time already spent
+    requestedTimeoutNs = TimeUnit.NANOSECONDS.convert(reqCpuLimit, TimeUnit.MILLISECONDS);
   }
 
   @VisibleForTesting
   CpuAllowedLimit(long limitMs) {
     this.threadCpuTimer = new ThreadCpuTimer();
-    limitAtNs =
-        threadCpuTimer.getCurrentCpuTimeNs()
-            + TimeUnit.NANOSECONDS.convert(limitMs, TimeUnit.MILLISECONDS);
+    requestedTimeoutNs = TimeUnit.NANOSECONDS.convert(limitMs, TimeUnit.MILLISECONDS);
   }
 
   /** Return true if the current request has a parameter with a valid value of the limit. */
@@ -76,9 +78,9 @@ public class CpuAllowedLimit implements QueryTimeout {
     return req.getParams().getLong(CommonParams.CPU_ALLOWED, -1L) > 0L;
   }
 
-  /** Return true if a max limit value is set and the current usage has exceeded the limit. */
+  /** Return true if usage has exceeded the limit. */
   @Override
   public boolean shouldExit() {
-    return limitAtNs - threadCpuTimer.getCurrentCpuTimeNs() < 0L;
+    return threadCpuTimer.getElapsedCpuNs() > requestedTimeoutNs;
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestCpuAllowedLimit.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCpuAllowedLimit.java
@@ -208,4 +208,11 @@ public class TestCpuAllowedLimit extends SolrCloudTestCase {
     // System.err.println("rsp=" + rsp.jsonStr());
     assertNotNull("should have partial results", rsp.getHeader().get("partialResults"));
   }
+
+  @Test
+  public void testDistribLimit2() throws Exception {
+    // This looks silly, but it actually guards against:
+    // https://issues.apache.org/jira/browse/SOLR-17203
+    testDistribLimit();
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17203

SOLR-16986 is not back-ported, so changes to RequestHandlerBase were omitted, but it's just a method name change and a couple IDE nits so that should be obvious and easy if SOLR-16896 is subsequently back-ported.