### PR TITLE
Fix/solr 17018 branch 9 1

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
+++ b/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
@@ -18,7 +18,7 @@ package org.apache.solr.search;
 
 public class IncompleteRerankingException extends RuntimeException {
 
-  public IncompleteRerankingException(String msg) {
-    super(msg);
+  public IncompleteRerankingException() {
+    super();
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
+++ b/solr/core/src/java/org/apache/solr/search/IncompleteRerankingException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+public class IncompleteRerankingException extends RuntimeException {
+
+  public IncompleteRerankingException(String msg) {
+    super(msg);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -39,6 +39,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.handler.component.QueryElevationComponent;
 import org.apache.solr.request.SolrRequestInfo;
+import org.apache.solr.response.SolrQueryResponse;
 
 /* A TopDocsCollector used by reranking queries. */
 public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
@@ -117,10 +118,15 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
 
       TopDocs rescoredDocs;
       try {
-        rescoredDocs =reRankQueryRescorer.rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
+        rescoredDocs = reRankQueryRescorer.rescore(searcher, mainDocs, mainDocs.scoreDocs.length);
       } catch (IncompleteRerankingException ex) {
         mainDocs.scoreDocs = mainScoreDocsClone;
         rescoredDocs = mainDocs;
+        SolrRequestInfo.getRequestInfo()
+            .getRsp()
+            .getResponseHeader()
+            .asShallowMap()
+            .put(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY, Boolean.TRUE);
       }
 
       // Lower howMany to return if we've collected fewer documents.

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -33,6 +33,9 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.solr.ltr.interleaving.OriginalRankingLTRScoringQuery;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrRequestInfo;
+import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.IncompleteRerankingException;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SolrQueryTimeoutImpl;
@@ -269,6 +272,10 @@ public class LTRRescorer extends Rescorer {
   }
 
   private static boolean maybeExitWithPartialResults(String label) {
+    SolrQueryRequest req = SolrRequestInfo.getRequestInfo().getReq();
+    SolrQueryResponse rsp = SolrRequestInfo.getRequestInfo().getRsp();
+    boolean allowPartialResults =
+            req != null ? req.getParams().getBool(CommonParams.PARTIAL_RESULTS, true) : true;
     if (SolrQueryTimeoutImpl.getInstance().isTimeoutEnabled() && SolrQueryTimeoutImpl.getInstance().shouldExit()) {
       /*
       if (allowPartialResults) {

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRRescorer.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.solr.ltr.interleaving.OriginalRankingLTRScoringQuery;
+import org.apache.solr.search.IncompleteRerankingException;
 import org.apache.solr.search.SolrIndexSearcher;
 
 /**
@@ -234,6 +235,13 @@ public class LTRRescorer extends Rescorer {
 
     scorer.getDocInfo().setOriginalDocScore(hit.score);
     hit.score = scorer.score();
+    if (QueryLimits.getCurrentLimits()
+        .maybeExitWithPartialResults(
+            "Learning To Rank rescoring -"
+                + " The full reranking didn't complete."
+                + " If partial results are tolerated the reranking got reverted and all documents preserved their original score and ranking.")) {
+      throw new IncompleteRerankingException("A query limit has been exceeded when rescoring");
+    }
     if (hitUpto < topN) {
       reranked[hitUpto] = hit;
       // if the heap is not full, maybe I want to log the features for this

--- a/solr/modules/ltr/src/test-files/featureExamples/features-slow.json
+++ b/solr/modules/ltr/src/test-files/featureExamples/features-slow.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name" : "slow",
+    "class" : "org.apache.solr.ltr.feature.SolrFeature",
+    "params" : { "q" : "{!func}sleep(1000,999)" }
+  }
+]

--- a/solr/modules/ltr/src/test-files/modelExamples/linear-slow-model.json
+++ b/solr/modules/ltr/src/test-files/modelExamples/linear-slow-model.json
@@ -1,0 +1,14 @@
+{
+  "class": "org.apache.solr.ltr.model.LinearModel",
+  "name": "slowModel",
+  "features": [
+    {
+      "name": "slow"
+    }
+  ],
+  "params": {
+    "weights": {
+      "slow": 1
+    }
+  }
+}

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -29,6 +29,9 @@ public class TestLTRQParserPlugin extends TestRerankBase {
 
     loadFeatures("features-linear.json");
     loadModels("linear-model.json");
+
+    loadFeatures("features-slow.json");
+    loadModels("linear-slow-model.json"); // just a linear model with one feature
   }
 
   @AfterClass
@@ -136,5 +139,64 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     query.add("debugQuery", "on");
     query.add("rq", "{!ltr reRankDocs=3 model=6029760550880411648}");
     assertJQ("/query" + query.toQueryString(), "/response/numFound/==0");
+  }
+
+  @Test
+  public void ltr_expensiveFeatureRescoring_shouldTimeOutAndReturnPartialResults()
+      throws Exception {
+    /* One SolrFeature is defined: {!func}sleep(1000,999)
+     * It simulates a slow feature extraction, sleeping for 1000ms and returning 999 as a score when finished
+     * */
+
+    final String solrQuery = "_query_:{!edismax qf='id' v='8^=10 9^=5 7^=3 6^=1'}";
+    final SolrQuery query = new SolrQuery();
+    query.setQuery(solrQuery);
+    query.add("fl", "*, score");
+    query.add("rows", "4");
+    query.add("fv", "true");
+    query.add("rq", "{!ltr model=slowModel reRankDocs=3}");
+    query.add("timeAllowed", "300");
+
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/response/numFound/==4",
+        "/responseHeader/partialResults/==true",
+        "/responseHeader/partialResultsDetails/=='Limits exceeded! (Learning To Rank rescoring - "
+            + "The full reranking didn\\'t complete. "
+            + "If partial results are tolerated the reranking got reverted and "
+            + "all documents preserved their original score and ranking.)"
+            + ": Query limits: [TimeAllowedLimit:LIMIT EXCEEDED]'",
+        "/response/docs/[0]/id=='8'",
+        "/response/docs/[0]/score==10.0",
+        "/response/docs/[1]/id=='9'",
+        "/response/docs/[1]/score==5.0",
+        "/response/docs/[2]/id=='7'",
+        "/response/docs/[2]/score==3.0",
+        "/response/docs/[3]/id=='6'",
+        "/response/docs/[3]/score==1.0");
+  }
+
+  @Test
+  public void ltr_expensiveFeatureRescoringAndPartialResultsNotTolerated_shouldRaiseException()
+      throws Exception {
+    /* One SolrFeature is defined: {!func}sleep(1000,999)
+     * It simulates a slow feature extraction, sleeping for 1000ms and returning 999 as a score when finished
+     * */
+    final String solrQuery = "_query_:{!edismax qf='id' v='8^=10 9^=5 7^=3 6^=1'}";
+    final SolrQuery query = new SolrQuery();
+    query.setQuery(solrQuery);
+    query.add("fl", "*, score");
+    query.add("rows", "4");
+    query.add("fv", "true");
+    query.add("rq", "{!ltr model=slowModel reRankDocs=3}");
+    query.add("timeAllowed", "300");
+    query.add("partialResults", "false");
+
+    assertJQ(
+        "/query" + query.toQueryString(),
+        "/error/msg=='org.apache.solr.search.QueryLimitsExceededException: Limits exceeded! (Learning To Rank rescoring - "
+            + "The full reranking didn\\'t complete. "
+            + "If partial results are tolerated the reranking got reverted and all documents preserved their original score and ranking.)"
+            + ": Query limits: [TimeAllowedLimit:LIMIT EXCEEDED]'");
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserPlugin.java
@@ -155,7 +155,7 @@ public class TestLTRQParserPlugin extends TestRerankBase {
     query.add("rows", "4");
     query.add("fv", "true");
     query.add("rq", "{!ltr model=slowModel reRankDocs=3}");
-    query.add("timeAllowed", "300");
+    query.add("timeAllowed", "3000");
 
     assertJQ(
         "/query" + query.toQueryString(),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17018

# Description

Learning To Rank was ignoring any queryLimit parameter (such as timeAllowed) during the reranking phase.
This means that a particularly expensive feature to extract may cause extremely slow responses and failures out of control.

# Solution

The idea is to check the query limits after the rescore of each search result (Learning To Rank rescore topK results).
If the query limit is exhausted before the completion of the rescoring, the reranking is aborted and reverted (all or nothing approach).
The response is marked as a partialResult and the original score and ranking are returned.

# Tests

A test has been added with a simple Learning To Rank model that uses just one single slow feature (implemented with a sleep function query).
This feature simulates a slow feature extraction.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
