### PR TITLE
Update GC logging options for Zookeeper

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-ensemble.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-ensemble.adoc
@@ -304,7 +304,7 @@ This file will need to exist on each server of the ensemble.
 ZOO_LOG_DIR="/path/for/log/files"
 ZOO_LOG4J_PROP="INFO,ROLLINGFILE"
 
-SERVER_JVMFLAGS="-Xms2048m -Xmx2048m -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -Xloggc:$ZOO_LOG_DIR/zookeeper_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=9 -XX:GCLogFileSize=20M"
+SERVER_JVMFLAGS="-Xms2048m -Xmx2048m -Xlog:gc*:file=$ZOO_LOG_DIR/zookeeper_gc.log:time,uptime:filecount=9,filesize=20M"
 ----
 +
 The property `ZOO_LOG_DIR` defines the location on the server where ZooKeeper will print its logs.


### PR DESCRIPTION
So they work for Java 9+, given that we require Java 11+. Existing ones are for Java 8.

Manually tested these options (which are stolen from Solr's own GC logging options) on a 9.5 installation with Java 17.
