### PR TITLE
SOLR-12089 follow-up: Remove deprecated `breakSugestionTieBreaker` parameter

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -56,6 +56,8 @@ Deprecation Removals
   end in "/solr").  Users may still specify a default collection through use of the `withDefaultCollection` method available
   on most SolrClient builders. (Jason Gerlowski, David Smiley, Eric Pugh)
 
+* SOLR-12089: Remove deprecated `breakSugestionTieBreaker` parameter in favor of `breakSuggestionTieBreaker`
+  in WordBreakSolrSpellChecker (Andrey Bozhko via Eric Pugh)
 
 Dependency Upgrades
 ---------------------

--- a/solr/core/src/java/org/apache/solr/spelling/WordBreakSolrSpellChecker.java
+++ b/solr/core/src/java/org/apache/solr/spelling/WordBreakSolrSpellChecker.java
@@ -17,7 +17,6 @@
 package org.apache.solr.spelling;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -33,8 +32,6 @@ import org.apache.lucene.search.spell.WordBreakSpellChecker.BreakSuggestionSortM
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.search.SolrIndexSearcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A spellchecker that breaks and combines words.
@@ -49,9 +46,6 @@ import org.slf4j.LoggerFactory;
  * properly sets these flags.
  */
 public class WordBreakSolrSpellChecker extends SolrSpellChecker {
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   /** Try to combine multiple words into one? [true|false] */
   public static final String PARAM_COMBINE_WORDS = "combineWords";
 
@@ -66,14 +60,6 @@ public class WordBreakSolrSpellChecker extends SolrSpellChecker {
 
   /** See {@link WordBreakSpellChecker#setMinBreakWordLength} */
   public static final String PARAM_MIN_BREAK_WORD_LENGTH = "minBreakLength";
-
-  /**
-   * See {@link BreakSuggestionTieBreaker} for options.
-   *
-   * @deprecated Only used for backwards compatibility. It will be removed in 10.x.
-   */
-  @Deprecated(since = "9.6")
-  private static final String PARAM_BREAK_SUGESTION_TIE_BREAKER = "breakSugestionTieBreaker";
 
   /** See {@link BreakSuggestionTieBreaker} for options. */
   public static final String PARAM_BREAK_SUGGESTION_TIE_BREAKER = "breakSuggestionTieBreaker";
@@ -106,17 +92,6 @@ public class WordBreakSolrSpellChecker extends SolrSpellChecker {
     breakWords = boolParam(config, PARAM_BREAK_WORDS);
     wbsp = new WordBreakSpellChecker();
     String bstb = strParam(config, PARAM_BREAK_SUGGESTION_TIE_BREAKER);
-    if (bstb == null) {
-      bstb = strParam(config, PARAM_BREAK_SUGESTION_TIE_BREAKER);
-      if (bstb != null && log.isWarnEnabled()) {
-        log.warn(
-            "Parameter '"
-                + PARAM_BREAK_SUGESTION_TIE_BREAKER
-                + "' is deprecated and will be removed in Solr 10.x. Please use '"
-                + PARAM_BREAK_SUGGESTION_TIE_BREAKER
-                + "' instead."); // nowarn
-      }
-    }
     if (bstb != null) {
       bstb = bstb.toUpperCase(Locale.ROOT);
       if (bstb.equals(BreakSuggestionTieBreaker.SUM_FREQ.name())) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-12089

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

`main` branch only: remove `breakSugestionTieBreaker` parameter from WordBreakSolrSpellChecker

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
