### PR TITLE
SOLR-17110: Fix JacksonJsonWriter to properly quote uuid values in json query response

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -150,7 +150,7 @@ Bug Fixes
 * SOLR-14892: Queries with shards.info and shards.tolerant can yield multiple null keys in place of shard names
   (Mathieu Marie, David Smiley)
 
-* SOLR-17110: Fixed JacksonJsonWriter to properly quote uuid values in json query response (Andrey Bozhko)
+* SOLR-17110: Fixed JacksonJsonWriter to properly quote uuid values in json query response (Andrey Bozhkoi via Eric Pugh)
 
 * SOLR-17209: Fix NullPointerException in QueryComponent (Vincent Primault via Eric Pugh)
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -148,6 +148,8 @@ Bug Fixes
 * SOLR-14892: Queries with shards.info and shards.tolerant can yield multiple null keys in place of shard names
   (Mathieu Marie, David Smiley)
 
+* SOLR-17110: Fixed JacksonJsonWriter to properly quote uuid values in json query response (Andrey Bozhko)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -150,7 +150,7 @@ Bug Fixes
 * SOLR-14892: Queries with shards.info and shards.tolerant can yield multiple null keys in place of shard names
   (Mathieu Marie, David Smiley)
 
-* SOLR-17110: Fixed JacksonJsonWriter to properly quote uuid values in json query response (Andrey Bozhkoi via Eric Pugh)
+* SOLR-17110: Fixed JacksonJsonWriter to properly quote uuid values in json query response (Andrey Bozhko via Eric Pugh)
 
 * SOLR-17209: Fix NullPointerException in QueryComponent (Vincent Primault via Eric Pugh)
 

--- a/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JacksonJsonWriter.java
@@ -83,11 +83,11 @@ public class JacksonJsonWriter extends BinaryResponseWriter {
     @Override
     public void writeResponse() throws IOException {
       if (wrapperFunction != null) {
-        writeStr(null, wrapperFunction + "(", false);
+        writeStrRaw(null, wrapperFunction + "(");
       }
       super.writeNamedList(null, rsp.getValues());
       if (wrapperFunction != null) {
-        writeStr(null, ")", false);
+        writeStrRaw(null, ")");
       }
       gen.close();
     }
@@ -128,11 +128,7 @@ public class JacksonJsonWriter extends BinaryResponseWriter {
 
     @Override
     public void writeStr(String name, String val, boolean needsEscaping) throws IOException {
-      if (needsEscaping) {
-        gen.writeString(val);
-      } else {
-        gen.writeRawValue(val);
-      }
+      gen.writeString(val);
     }
 
     @Override

--- a/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/response/JSONWriterTest.java
@@ -346,4 +346,62 @@ public class JSONWriterTest extends SolrTestCaseJ4 {
     jsonEq(expected, buf.toString());
     req.close();
   }
+
+  @Test
+  public void testResponseValuesProperlyQuoted() throws Exception {
+    assertU(
+        adoc(
+            "id",
+            "1",
+            "name",
+            "John Doe",
+            "cat",
+            "foo\"b'ar",
+            "uuid",
+            "6e2fb55b-dd42-4e2d-84ca-71a599403aa3",
+            "bsto",
+            "true",
+            "isto",
+            "42",
+            "amount",
+            "100,USD",
+            "price",
+            "3.14",
+            "severity",
+            "High",
+            "dateRange",
+            "[2024-03-01 TO 2024-03-31]",
+            "timestamp",
+            "2024-03-20T12:34:56Z"));
+    assertU(commit());
+
+    String expected =
+        "{\n"
+            + "  \"response\":{\n"
+            + "    \"numFound\":1,\n"
+            + "    \"start\":0,\n"
+            + "    \"numFoundExact\":true,\n"
+            + "    \"docs\":[{\n"
+            + "      \"id\":\"1\",\n"
+            + "      \"name\":[\"John Doe\"],\n"
+            + "      \"cat\":[\"foo\\\"b'ar\"],\n"
+            + "      \"uuid\":[\"6e2fb55b-dd42-4e2d-84ca-71a599403aa3\"],\n"
+            + "      \"bsto\":[true],\n"
+            + "      \"isto\":[42],\n"
+            + "      \"amount\":\"100,USD\",\n"
+            + "      \"price\":3.14,\n"
+            + "      \"severity\":\"High\",\n"
+            + "      \"dateRange\":[\"[2024-03-01 TO 2024-03-31]\"],\n"
+            + "      \"timestamp\":\"2024-03-20T12:34:56Z\"\n"
+            + "    }]\n"
+            + "  }\n"
+            + "}";
+
+    String fl = "id,name,cat,uuid,bsto,isto,amount,price,severity,dateRange,timestamp";
+    var req = req("q", "id:*", "fl", fl, "wt", "json", "omitHeader", "true");
+    try (req) {
+      String response = h.query("/select", req);
+      jsonEq(expected, response);
+    }
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17110

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Fix JacksonJsonWriter to properly quote uuid values in json query response

# Tests

Added a test to assert that different field types properly serialize their values with `wt=json`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
