### PR TITLE
SOLR-17211:  HttpJdkSolrClient Support Async requests

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -122,6 +122,8 @@ Improvements
 
 * SOLR-17164: Add 2 arg variant of vectorSimilarity() function (Sanjay Dutt, hossman)
 
+* SOLR-17211: New SolrJ JDK client supports Async (James Dyer)
+
 Optimizations
 ---------------------
 * SOLR-17144: Close searcherExecutor thread per core after 1 minute (Pierre Salagnac, Christine Poerschke)

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solrj.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solrj.adoc
@@ -98,7 +98,7 @@ Requests are sent in the form of {solr-javadocs}/solrj/org/apache/solr/client/so
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/HttpSolrClient.html[`HttpSolrClient`] - geared towards query-centric workloads, though also a good general-purpose client.
 Communicates directly with a single Solr node.
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/Http2SolrClient.html[`Http2SolrClient`] - async, non-blocking and general-purpose client that leverage HTTP/2 using the Jetty Http library.
-- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.html[`HttpJdkSolrClient`] - General-purpose client using the JDK's built-in Http Client. Supports both Http/2 and Http/1.1.  Targeted for those users wishing to minimize application dependencies.
+- {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.html[`HttpJdkSolrClient`] - General-purpose client using the JDK's built-in Http Client. Supports both Http/2 and Http/1.1. Supports async. Targeted for those users wishing to minimize application dependencies.
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/LBHttpSolrClient.html[`LBHttpSolrClient`] - balances request load across a list of Solr nodes.
 Adjusts the list of "in-service" nodes based on node health.
 - {solr-javadocs}/solrj/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.html[`LBHttp2SolrClient`] - just like `LBHttpSolrClient` but using `Http2SolrClient` instead, with the Jetty Http library.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -422,6 +422,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
 
   private static final Cancellable FAILED_MAKING_REQUEST_CANCELLABLE = () -> {};
 
+  @Override
   public Cancellable asyncRequest(
       SolrRequest<?> solrRequest,
       String collection,
@@ -470,7 +471,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
               }
             }
           };
-
+      asyncListener.onStart();
       req = makeRequestAndSend(solrRequest, url, listener, true);
     } catch (SolrServerException | IOException e) {
       asyncListener.onFailure(e);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -176,14 +176,13 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
       this.response = response;
     }
 
-    protected CompletableFuture<NamedList<Object>> getResponse() {
-      return response;
-    }
-
-
     @Override
     public void cancel() {
       response.cancel(true);
+    }
+
+    protected CompletableFuture<NamedList<Object>> getResponse() {
+      return response;
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -136,6 +136,7 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     assert ObjectReleaseTracker.track(this);
   }
 
+  @Override
   public Cancellable asyncRequest(
       SolrRequest<?> solrRequest,
       String collection,
@@ -163,27 +164,10 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
                       asyncListener.onSuccess(nl);
                     }
                   });
-      return new HttpJdkSolrClientCancellable(response);
+      return new HttpSolrClientCancellable(response);
     } catch (Exception e) {
       asyncListener.onFailure(e);
       return () -> {};
-    }
-  }
-
-  protected class HttpJdkSolrClientCancellable implements Cancellable {
-    private final CompletableFuture<NamedList<Object>> response;
-
-    HttpJdkSolrClientCancellable(CompletableFuture<NamedList<Object>> response) {
-      this.response = response;
-    }
-
-    @Override
-    public void cancel() {
-      response.cancel(true);
-    }
-
-    protected CompletableFuture<NamedList<Object>> getResponse() {
-      return response;
     }
   }
 
@@ -545,6 +529,23 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
         .filter(Objects::nonNull)
         .map(s -> s.toLowerCase(Locale.ROOT).trim())
         .collect(Collectors.joining(", "));
+  }
+
+  protected static class HttpSolrClientCancellable implements Cancellable {
+    private final CompletableFuture<NamedList<Object>> response;
+
+    protected HttpSolrClientCancellable(CompletableFuture<NamedList<Object>> response) {
+      this.response = response;
+    }
+
+    @Override
+    public void cancel() {
+      response.cancel(true);
+    }
+
+    protected CompletableFuture<NamedList<Object>> getResponse() {
+      return response;
+    }
   }
 
   public static class Builder

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -51,6 +52,8 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
+import org.apache.solr.client.solrj.util.AsyncListener;
+import org.apache.solr.client.solrj.util.Cancellable;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -80,7 +83,7 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
 
   private boolean forceHttp11;
 
-  private boolean shutdownExecutor;
+  private final boolean shutdownExecutor;
 
   protected HttpJdkSolrClient(String serverBaseUrl, HttpJdkSolrClient.Builder builder) {
     super(serverBaseUrl, builder);
@@ -133,8 +136,75 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     assert ObjectReleaseTracker.track(this);
   }
 
+  public Cancellable asyncRequest(
+      SolrRequest<?> solrRequest,
+      String collection,
+      AsyncListener<NamedList<Object>> asyncListener) {
+    try {
+      PreparedRequest pReq = prepareRequest(solrRequest, collection);
+      asyncListener.onStart();
+      CompletableFuture<NamedList<Object>> resp =
+          httpClient
+              .sendAsync(pReq.reqb.build(), HttpResponse.BodyHandlers.ofInputStream())
+              .thenApply(
+                  response -> {
+                    try {
+                      return processErrorsAndResponse(solrRequest, pReq.parserToUse, response, pReq.url);
+                    } catch (SolrServerException e) {
+                      throw new RuntimeException(e);
+                    }
+                  })
+              .whenComplete(
+                  (nl, t) -> {
+                    if (t != null) {
+                      asyncListener.onFailure(t);
+                    } else {
+                      asyncListener.onSuccess(nl);
+                    }
+                  });
+      return () -> resp.cancel(true);
+    } catch (Exception e) {
+      asyncListener.onFailure(e);
+      return () -> {};
+    }
+  }
+
   @Override
   public NamedList<Object> request(SolrRequest<?> solrRequest, String collection)
+      throws SolrServerException, IOException {
+    PreparedRequest pReq = prepareRequest(solrRequest, collection);
+    HttpResponse<InputStream> response = null;
+    try {
+      response = httpClient.send(pReq.reqb.build(), HttpResponse.BodyHandlers.ofInputStream());
+      return processErrorsAndResponse(solrRequest, pReq.parserToUse, response, pReq.url);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (HttpTimeoutException e) {
+      throw new SolrServerException(
+          "Timeout occurred while waiting response from server at: " + pReq.url, e);
+    } catch (SolrException se) {
+      throw se;
+    } catch (RuntimeException re) {
+      throw new SolrServerException(re);
+    } finally {
+      if (pReq.contentWritingFuture != null) {
+        pReq.contentWritingFuture.cancel(true);
+      }
+
+      // See
+      // https://docs.oracle.com/en/java/javase/17/docs/api/java.net.http/java/net/http/HttpResponse.BodySubscribers.html#ofInputStream()
+      if (!wantStream(pReq.parserToUse)) {
+        try {
+          response.body().close();
+        } catch (Exception e1) {
+          // ignore
+        }
+      }
+    }
+  }
+
+  private PreparedRequest prepareRequest(SolrRequest<?> solrRequest, String collection)
       throws SolrServerException, IOException {
     checkClosed();
     if (ClientUtils.shouldApplyDefaultCollection(collection, solrRequest)) {
@@ -143,19 +213,19 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     String url = getRequestPath(solrRequest, collection);
     ResponseParser parserToUse = responseParser(solrRequest);
     ModifiableSolrParams queryParams = initalizeSolrParams(solrRequest, parserToUse);
-    HttpResponse<InputStream> resp = null;
+    var reqb = HttpRequest.newBuilder();
+    PreparedRequest pReq = null;
     try {
-      var reqb = HttpRequest.newBuilder();
       switch (solrRequest.getMethod()) {
         case GET:
           {
-            resp = doGet(url, reqb, solrRequest, queryParams);
+            pReq = prepareGet(url, reqb, solrRequest, queryParams);
             break;
           }
         case POST:
         case PUT:
           {
-            resp = doPutOrPost(url, solrRequest.getMethod(), reqb, solrRequest, queryParams);
+            pReq = preparePutOrPost(url, solrRequest.getMethod(), reqb, solrRequest, queryParams);
             break;
           }
         default:
@@ -163,50 +233,34 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
             throw new IllegalStateException("Unsupported method: " + solrRequest.getMethod());
           }
       }
-      return processErrorsAndResponse(solrRequest, parserToUse, resp, url);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
-    } catch (HttpTimeoutException e) {
-      throw new SolrServerException(
-          "Timeout occurred while waiting response from server at: " + url, e);
-    } catch (SolrException se) {
-      throw se;
     } catch (URISyntaxException | RuntimeException re) {
       throw new SolrServerException(re);
-    } finally {
-      // See
-      // https://docs.oracle.com/en/java/javase/17/docs/api/java.net.http/java/net/http/HttpResponse.BodySubscribers.html#ofInputStream()
-      if (!wantStream(parserToUse)) {
-        try {
-          resp.body().close();
-        } catch (Exception e1) {
-          // ignore
-        }
-      }
     }
+    pReq.parserToUse = parserToUse;
+    pReq.url = url;
+    return pReq;
   }
 
-  private HttpResponse<InputStream> doGet(
+  private PreparedRequest prepareGet(
       String url,
       HttpRequest.Builder reqb,
       SolrRequest<?> solrRequest,
       ModifiableSolrParams queryParams)
-      throws IOException, InterruptedException, URISyntaxException {
+      throws IOException, URISyntaxException {
     validateGetRequest(solrRequest);
     reqb.GET();
     decorateRequest(reqb, solrRequest);
     reqb.uri(new URI(url + "?" + queryParams));
-    return httpClient.send(reqb.build(), HttpResponse.BodyHandlers.ofInputStream());
+    return new PreparedRequest(reqb, null);
   }
 
-  private HttpResponse<InputStream> doPutOrPost(
+  private PreparedRequest preparePutOrPost(
       String url,
       SolrRequest.METHOD method,
       HttpRequest.Builder reqb,
       SolrRequest<?> solrRequest,
       ModifiableSolrParams queryParams)
-      throws IOException, InterruptedException, URISyntaxException {
+      throws IOException, URISyntaxException {
 
     final RequestWriter.ContentWriter contentWriter = requestWriter.getContentWriter(solrRequest);
 
@@ -274,15 +328,21 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     URI uriWithQueryParams = new URI(url + "?" + queryParams);
     reqb.uri(uriWithQueryParams);
 
-    HttpResponse<InputStream> response;
-    try {
-      response = httpClient.send(reqb.build(), HttpResponse.BodyHandlers.ofInputStream());
-    } finally {
-      if (contentWritingFuture != null) {
-        contentWritingFuture.cancel(true);
-      }
+    return new PreparedRequest(reqb, contentWritingFuture);
+  }
+
+  private static class PreparedRequest {
+    Future<?> contentWritingFuture;
+    HttpRequest.Builder reqb;
+
+    ResponseParser parserToUse;
+
+    String url;
+
+    PreparedRequest(HttpRequest.Builder reqb, Future<?> contentWritingFuture) {
+      this.reqb = reqb;
+      this.contentWritingFuture = contentWritingFuture;
     }
-    return response;
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -149,7 +149,8 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
               .thenApply(
                   httpResponse -> {
                     try {
-                      return processErrorsAndResponse(solrRequest, pReq.parserToUse, httpResponse, pReq.url);
+                      return processErrorsAndResponse(
+                          solrRequest, pReq.parserToUse, httpResponse, pReq.url);
                     } catch (SolrServerException e) {
                       throw new RuntimeException(e);
                     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
@@ -375,13 +375,14 @@ public abstract class HttpSolrClientBase extends SolrClient {
    *
    * @param solrRequest the request to perform
    * @param collection if null the default collection is used
-   * @param asyncListener callers should provide an implementation to handle events: start, success, exception
+   * @param asyncListener callers should provide an implementation to handle events: start, success,
+   *     exception
    * @return Cancellable allowing the caller to attempt cancellation
    */
   public abstract Cancellable asyncRequest(
-          SolrRequest<?> solrRequest,
-          String collection,
-          AsyncListener<NamedList<Object>> asyncListener) ;
+      SolrRequest<?> solrRequest,
+      String collection,
+      AsyncListener<NamedList<Object>> asyncListener);
 
   public boolean isV2ApiRequest(final SolrRequest<?> request) {
     return request instanceof V2Request || request.getPath().contains("/____v2");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
@@ -39,6 +39,8 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.RequestWriter;
 import org.apache.solr.client.solrj.request.V2Request;
+import org.apache.solr.client.solrj.util.AsyncListener;
+import org.apache.solr.client.solrj.util.Cancellable;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -367,6 +369,19 @@ public abstract class HttpSolrClientBase extends SolrClient {
   }
 
   protected abstract void updateDefaultMimeTypeForParser();
+
+  /**
+   * Execute an asynchronous request to a Solr collection
+   *
+   * @param solrRequest the request to perform
+   * @param collection if null the default collection is used
+   * @param asyncListener callers should provide an implementation to handle events: start, success, exception
+   * @return Cancellable allowing the caller to attempt cancellation
+   */
+  public abstract Cancellable asyncRequest(
+          SolrRequest<?> solrRequest,
+          String collection,
+          AsyncListener<NamedList<Object>> asyncListener) ;
 
   public boolean isV2ApiRequest(final SolrRequest<?> request) {
     return request instanceof V2Request || request.getPath().contains("/____v2");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/AsyncListener.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/AsyncListener.java
@@ -17,12 +17,18 @@
 
 package org.apache.solr.client.solrj.util;
 
-/** Listener for async requests */
+/**
+ * Listener for async requests
+ *
+ * @param <T> The result type returned by the {@code onSuccess} method
+ */
 public interface AsyncListener<T> {
   /** Callback method invoked before processing the request */
   default void onStart() {}
 
+  /** Callback method invoked when the request completes successfully  */
   void onSuccess(T t);
 
+  /** Callback method invoked when the request completes in failure  */
   void onFailure(Throwable throwable);
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/AsyncListener.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/AsyncListener.java
@@ -26,9 +26,9 @@ public interface AsyncListener<T> {
   /** Callback method invoked before processing the request */
   default void onStart() {}
 
-  /** Callback method invoked when the request completes successfully  */
+  /** Callback method invoked when the request completes successfully */
   void onSuccess(T t);
 
-  /** Callback method invoked when the request completes in failure  */
+  /** Callback method invoked when the request completes in failure */
   void onFailure(Throwable throwable);
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/Cancellable.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/Cancellable.java
@@ -18,12 +18,14 @@
 package org.apache.solr.client.solrj.util;
 
 /**
- * The return type for solrJ asynchronous requests, providing a mechanism whereby callers may request cancellation.
+ * The return type for solrJ asynchronous requests, providing a mechanism whereby callers may
+ * request cancellation.
  */
 public interface Cancellable {
 
   /**
-   * Request to cancel the asynchronous request.  This may be a no-op in some situations, for instance, if the request failed or otherwise is complete.
+   * Request to cancel the asynchronous request. This may be a no-op in some situations, for
+   * instance, if the request failed or otherwise is complete.
    */
   void cancel();
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/Cancellable.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/Cancellable.java
@@ -23,7 +23,7 @@ package org.apache.solr.client.solrj.util;
 public interface Cancellable {
 
   /**
-   * Request to cancel the asynchronous request.  This may be a no-op in some situations, for instance, if the request failed or otherwise is finished.
+   * Request to cancel the asynchronous request.  This may be a no-op in some situations, for instance, if the request failed or otherwise is complete.
    */
   void cancel();
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/Cancellable.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/Cancellable.java
@@ -17,6 +17,13 @@
 
 package org.apache.solr.client.solrj.util;
 
+/**
+ * The return type for solrJ asynchronous requests, providing a mechanism whereby callers may request cancellation.
+ */
 public interface Cancellable {
+
+  /**
+   * Request to cancel the asynchronous request.  This may be a no-op in some situations, for instance, if the request failed or otherwise is finished.
+   */
   void cancel();
 }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugAsyncListener.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugAsyncListener.java
@@ -1,11 +1,27 @@
-package org.apache.solr.client.solrj.impl;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.apache.solr.client.solrj.util.AsyncListener;
-import org.apache.solr.common.util.NamedList;
-import org.junit.Assert;
+package org.apache.solr.client.solrj.impl;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
+import org.apache.solr.client.solrj.util.AsyncListener;
+import org.apache.solr.common.util.NamedList;
+import org.junit.Assert;
 
 public class DebugAsyncListener implements AsyncListener<NamedList<Object>> {
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugAsyncListener.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugAsyncListener.java
@@ -1,0 +1,68 @@
+package org.apache.solr.client.solrj.impl;
+
+import org.apache.solr.client.solrj.util.AsyncListener;
+import org.apache.solr.common.util.NamedList;
+import org.junit.Assert;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+
+public class DebugAsyncListener implements AsyncListener<NamedList<Object>> {
+
+  private final CountDownLatch cdl;
+
+  private final Semaphore wait = new Semaphore(1);
+
+  public volatile boolean onStartCalled;
+
+  public volatile boolean latchCounted;
+
+  public volatile NamedList<Object> onSuccessResult = null;
+
+  public volatile Throwable onFailureResult = null;
+
+  public DebugAsyncListener(CountDownLatch cdl) {
+    this.cdl = cdl;
+  }
+
+  @Override
+  public void onStart() {
+    onStartCalled = true;
+  }
+
+  public void pause() {
+    try {
+      wait.acquire();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  public void unPause() {
+    wait.release();
+  }
+
+  @Override
+  public void onSuccess(NamedList<Object> entries) {
+    pause();
+    onSuccessResult = entries;
+    if (latchCounted) {
+      Assert.fail("either 'onSuccess' or 'onFailure' should be called exactly once.");
+    }
+    cdl.countDown();
+    latchCounted = true;
+    unPause();
+  }
+
+  @Override
+  public void onFailure(Throwable throwable) {
+    pause();
+    onFailureResult = throwable;
+    if (latchCounted) {
+      Assert.fail("either 'onSuccess' or 'onFailure' should be called exactly once.");
+    }
+    cdl.countDown();
+    latchCounted = true;
+    unPause();
+  }
+}

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,7 +50,7 @@ public class DebugServlet extends HttpServlet {
   public static String queryString = null;
   public static javax.servlet.http.Cookie[] cookies = null;
   public static List<String[]> responseHeaders = null;
-  public static Map<String, Object> responseBodyByQueryFragment = new LinkedHashMap<>();
+  public static Map<String, Object> responseBodyByQueryFragment = new ConcurrentHashMap<>();
   public static byte[] requestBody = null;
 
   public static void setErrorCode(Integer code) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
@@ -140,6 +140,8 @@ public class DebugServlet extends HttpServlet {
     String qs = req.getQueryString();
     qs = qs == null ? "" : qs;
     Object responseBody = null;
+
+    // Tests can set this up to return different response bodies based on substrings in the query string
     for (Map.Entry<String, Object> entry : responseBodyByQueryFragment.entrySet()) {
       if (qs.contains(entry.getKey())) {
         responseBody = entry.getValue();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
@@ -141,7 +141,8 @@ public class DebugServlet extends HttpServlet {
     qs = qs == null ? "" : qs;
     Object responseBody = null;
 
-    // Tests can set this up to return different response bodies based on substrings in the query string
+    // Tests can set this up to return different response bodies based on substrings in the query
+    // string
     for (Map.Entry<String, Object> entry : responseBodyByQueryFragment.entrySet()) {
       if (qs.contains(entry.getKey())) {
         responseBody = entry.getValue();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/DebugServlet.java
@@ -67,21 +67,21 @@ public class DebugServlet extends HttpServlet {
 
   @Override
   protected void doDelete(HttpServletRequest req, HttpServletResponse resp)
-          throws ServletException, IOException {
+      throws ServletException, IOException {
     lastMethod = "delete";
     recordRequest(req, resp);
   }
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-          throws ServletException, IOException {
+      throws ServletException, IOException {
     lastMethod = "get";
     recordRequest(req, resp);
   }
 
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp)
-          throws ServletException, IOException {
+      throws ServletException, IOException {
     lastMethod = "head";
     recordRequest(req, resp);
   }
@@ -111,14 +111,14 @@ public class DebugServlet extends HttpServlet {
 
   @Override
   protected void doPost(HttpServletRequest req, HttpServletResponse resp)
-          throws ServletException, IOException {
+      throws ServletException, IOException {
     lastMethod = "post";
     recordRequest(req, resp);
   }
 
   @Override
   protected void doPut(HttpServletRequest req, HttpServletResponse resp)
-          throws ServletException, IOException {
+      throws ServletException, IOException {
     lastMethod = "put";
     recordRequest(req, resp);
   }
@@ -141,13 +141,12 @@ public class DebugServlet extends HttpServlet {
     String qs = req.getQueryString();
     qs = qs == null ? "" : qs;
     Object responseBody = null;
-    for(Map.Entry<String, Object> entry : responseBodyByQueryFragment.entrySet()) {
-      if(qs.contains(entry.getKey())) {
+    for (Map.Entry<String, Object> entry : responseBodyByQueryFragment.entrySet()) {
+      if (qs.contains(entry.getKey())) {
         responseBody = entry.getValue();
         break;
       }
     }
-
 
     if (responseBody != null) {
       try {
@@ -157,7 +156,7 @@ public class DebugServlet extends HttpServlet {
           resp.getOutputStream().write((byte[]) responseBody);
         } else {
           throw new IllegalArgumentException(
-                  "Only String and byte[] are supported for responseBody.");
+              "Only String and byte[] are supported for responseBody.");
         }
       } catch (IOException ioe) {
         throw new RuntimeException(ioe);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -270,7 +270,7 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
 
   @Test
   public void testAsyncPost() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.GET);
+    super.testQueryAsync(SolrRequest.METHOD.POST);
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -265,12 +265,12 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
 
   @Test
   public void testAsyncGet() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.GET);
+    super.testQueryAsync();
   }
 
   @Test
   public void testAsyncPost() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.POST);
+    super.testUpdateAsync();
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -264,6 +264,26 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
   }
 
   @Test
+  public void testAsyncGet() throws Exception {
+    super.testQueryAsync(SolrRequest.METHOD.GET);
+  }
+
+  @Test
+  public void testAsyncPost() throws Exception {
+    super.testQueryAsync(SolrRequest.METHOD.GET);
+  }
+
+  @Test
+  public void testAsyncPut() throws Exception {
+    super.testQueryAsync(SolrRequest.METHOD.GET);
+  }
+
+  @Test
+  public void testAsyncException() throws Exception {
+    super.testAsyncExceptionBase();
+  }
+
+  @Test
   public void testFollowRedirect() throws Exception {
     final String clientUrl = getBaseUrl() + REDIRECT_SERVLET_PATH;
     try (Http2SolrClient client =

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -272,12 +272,6 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
   public void testAsyncPost() throws Exception {
     super.testQueryAsync(SolrRequest.METHOD.GET);
   }
-
-  @Test
-  public void testAsyncPut() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.GET);
-  }
-
   @Test
   public void testAsyncException() throws Exception {
     super.testAsyncExceptionBase();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -272,6 +272,7 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
   public void testAsyncPost() throws Exception {
     super.testQueryAsync(SolrRequest.METHOD.GET);
   }
+
   @Test
   public void testAsyncException() throws Exception {
     super.testAsyncExceptionBase();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -114,7 +114,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     testQueryAsync(SolrRequest.METHOD.GET);
   }
 
-    protected void testQueryAsync(SolrRequest.METHOD method) throws Exception {
+  protected void testQueryAsync(SolrRequest.METHOD method) throws Exception {
     ResponseParser rp = new XMLResponseParser();
     DebugServlet.clear();
     DebugServlet.addResponseHeader("Content-Type", "application/xml; charset=UTF-8");
@@ -126,7 +126,8 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     Cancellable[] cancellables = new Cancellable[limit];
     try (HttpJdkSolrClient client = b.build()) {
       for (int i = 0; i < limit; i++) {
-        DebugServlet.responseBodyByQueryFragment.put(("id=KEY-" + i),
+        DebugServlet.responseBodyByQueryFragment.put(
+            ("id=KEY-" + i),
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response><result name=\"response\" numFound=\"2\" start=\"1\" numFoundExact=\"true\"><doc><str name=\"id\">KEY-"
                 + i
                 + "</str></doc></result></response>");
@@ -147,7 +148,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
       assertTrue(sdl.getNumFoundExact());
       assertEquals(1, sdl.size());
       assertEquals(1, sdl.iterator().next().size());
-      assertEquals("KEY-"+i, sdl.iterator().next().get("id"));
+      assertEquals("KEY-" + i, sdl.iterator().next().get("id"));
 
       assertNull(listeners[i].onFailureResult);
       assertTrue(listeners[i].onStartCalled);
@@ -159,15 +160,15 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     ResponseParser rp = new XMLResponseParser();
     DebugServlet.clear();
     DebugServlet.addResponseHeader("Content-Type", "application/xml; charset=UTF-8");
-    DebugServlet.responseBodyByQueryFragment.put("", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response />");
+    DebugServlet.responseBodyByQueryFragment.put(
+        "", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response />");
     String url = getBaseUrl() + DEBUG_SERVLET_PATH;
     HttpJdkSolrClient.Builder b = builder(url).withResponseParser(rp);
     CountDownLatch cdl = new CountDownLatch(0);
     DebugAsyncListener listener = new DebugAsyncListener(cdl);
     Cancellable cancelMe = null;
     try (HttpJdkSolrClient client = b.build()) {
-      QueryRequest query =
-              new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "1")));
+      QueryRequest query = new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "1")));
       listener.pause();
       cancelMe = client.asyncRequest(query, "collection1", listener);
       cancelMe.cancel();
@@ -175,7 +176,8 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     }
     assertTrue(listener.onStartCalled);
     assertTrue(cancelMe instanceof HttpJdkSolrClient.HttpJdkSolrClientCancellable);
-    CompletableFuture<NamedList<Object>> response = ((HttpJdkSolrClient.HttpJdkSolrClientCancellable) cancelMe).getResponse();
+    CompletableFuture<NamedList<Object>> response =
+        ((HttpJdkSolrClient.HttpJdkSolrClientCancellable) cancelMe).getResponse();
     assertTrue(response.isCancelled());
   }
 
@@ -189,8 +191,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     CountDownLatch cdl = new CountDownLatch(1);
     DebugAsyncListener listener = new DebugAsyncListener(cdl);
     try (HttpJdkSolrClient client = b.build()) {
-      QueryRequest query =
-              new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "1")));
+      QueryRequest query = new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "1")));
       client.asyncRequest(query, "collection1", listener);
       cdl.await(1, TimeUnit.MINUTES);
     }
@@ -277,7 +278,8 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     DebugServlet.clear();
     if (rp instanceof XMLResponseParser) {
       DebugServlet.addResponseHeader("Content-Type", "application/xml; charset=UTF-8");
-      DebugServlet.responseBodyByQueryFragment.put("", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response />");
+      DebugServlet.responseBodyByQueryFragment.put(
+          "", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response />");
     } else {
       DebugServlet.addResponseHeader("Content-Type", "application/octet-stream");
       DebugServlet.responseBodyByQueryFragment.put("", javabinResponse());
@@ -702,7 +704,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     public void pause() {
       try {
         wait.acquire();
-      } catch(InterruptedException ie) {
+      } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
       }
     }
@@ -710,7 +712,6 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     public void unPause() {
       wait.release();
     }
-
 
     @Override
     public void onSuccess(NamedList<Object> entries) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -228,7 +228,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     DebugServlet.clear();
     DebugServlet.addResponseHeader("Content-Type", "application/xml; charset=UTF-8");
     DebugServlet.responseBodyByQueryFragment.put(
-            "", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response />");
+        "", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response />");
     String url = getBaseUrl() + DEBUG_SERVLET_PATH;
     HttpJdkSolrClient.Builder b = builder(url).withResponseParser(rp);
     CountDownLatch cdl = new CountDownLatch(0);
@@ -244,7 +244,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     assertTrue(listener.onStartCalled);
     assertTrue(cancelMe instanceof HttpJdkSolrClient.HttpSolrClientCancellable);
     CompletableFuture<NamedList<Object>> response =
-            ((HttpJdkSolrClient.HttpSolrClientCancellable) cancelMe).getResponse();
+        ((HttpJdkSolrClient.HttpSolrClientCancellable) cancelMe).getResponse();
     assertTrue(response.isCancelled());
   }
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -258,8 +258,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     assertTrue(response.isCancelled());
 
     // But we cannot guarantee the response will have been returned, or that "onFailure" was fired
-    // with
-    // a "CompletionException".  This depends on where we were when the cancellation hit.
+    // with a "CompletionException".  This depends on where we were when the cancellation hit.
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -209,11 +209,6 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
   }
 
   @Test
-  public void testAsyncPut() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.GET);
-  }
-
-  @Test
   public void testAsyncException() throws Exception {
     DebugAsyncListener listener = super.testAsyncExceptionBase();
     assertTrue(listener.onFailureResult instanceof CompletionException);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -240,7 +240,8 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
       cancelMe = client.asyncRequest(query, "collection1", listener);
       cancelMe.cancel();
 
-      // We are safe to unpause our client, having guaranteed that our cancel was before everything completed.
+      // We are safe to unpause our client, having guaranteed that our cancel was before everything
+      // completed.
       listener.unPause();
     }
 
@@ -256,7 +257,8 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
     // have set "isCancelled".
     assertTrue(response.isCancelled());
 
-    // But we cannot guarantee the response will have been returned, or that "onFailure" was fired with
+    // But we cannot guarantee the response will have been returned, or that "onFailure" was fired
+    // with
     // a "CompletionException".  This depends on where we were when the cancellation hit.
   }
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -205,7 +205,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
 
   @Test
   public void testAsyncPost() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.GET);
+    super.testQueryAsync(SolrRequest.METHOD.POST);
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -200,12 +200,12 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
 
   @Test
   public void testAsyncGet() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.GET);
+    super.testQueryAsync();
   }
 
   @Test
   public void testAsyncPost() throws Exception {
-    super.testQueryAsync(SolrRequest.METHOD.POST);
+    super.testUpdateAsync();
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpJdkSolrClientTest.java
@@ -101,6 +101,20 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
 
   @Test
   public void testAsyncGet() throws Exception {
+    testQueryAsync(SolrRequest.METHOD.GET);
+  }
+
+  @Test
+  public void testAsyncPost() throws Exception {
+    testQueryAsync(SolrRequest.METHOD.GET);
+  }
+
+  @Test
+  public void testAsyncPut() throws Exception {
+    testQueryAsync(SolrRequest.METHOD.GET);
+  }
+
+    protected void testQueryAsync(SolrRequest.METHOD method) throws Exception {
     ResponseParser rp = new XMLResponseParser();
     DebugServlet.clear();
     DebugServlet.addResponseHeader("Content-Type", "application/xml; charset=UTF-8");
@@ -118,6 +132,7 @@ public class HttpJdkSolrClientTest extends HttpSolrClientTestBase {
                 + "</str></doc></result></response>");
         QueryRequest query =
             new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "KEY-" + i)));
+        query.setMethod(SolrRequest.METHOD.GET);
         listeners[i] = new DebugAsyncListener(cdl);
         client.asyncRequest(query, "collection1", listeners[i]);
       }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
@@ -545,7 +545,7 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
     ResponseParser rp = new XMLResponseParser();
     String url = getBaseUrl();
     HttpSolrClientBuilderBase<?, ?> b =
-            builder(url, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT).withResponseParser(rp);
+        builder(url, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT).withResponseParser(rp);
     int limit = 10;
     CountDownLatch cdl = new CountDownLatch(limit);
     DebugAsyncListener[] listeners = new DebugAsyncListener[limit];
@@ -555,7 +555,11 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
       // ensure the collection is empty to start
       client.deleteByQuery(COLLECTION_1, "*:*");
       client.commit(COLLECTION_1);
-      QueryResponse qr = client.query(COLLECTION_1, new MapSolrParams(Collections.singletonMap("q", "*:*")), SolrRequest.METHOD.POST);
+      QueryResponse qr =
+          client.query(
+              COLLECTION_1,
+              new MapSolrParams(Collections.singletonMap("q", "*:*")),
+              SolrRequest.METHOD.POST);
       assertEquals(0, qr.getResults().getNumFound());
 
       for (int i = 0; i < limit; i++) {
@@ -569,10 +573,13 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
       client.commit(COLLECTION_1);
 
       // check that the correct number of documents were added
-      qr = client.query(COLLECTION_1, new MapSolrParams(Collections.singletonMap("q", "*:*")), SolrRequest.METHOD.POST);
+      qr =
+          client.query(
+              COLLECTION_1,
+              new MapSolrParams(Collections.singletonMap("q", "*:*")),
+              SolrRequest.METHOD.POST);
       assertEquals(limit, qr.getResults().getNumFound());
     }
-
   }
 
   protected void testQueryAsync() throws Exception {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
@@ -30,7 +30,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.solr.SolrJettyTestBase;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -545,7 +544,8 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
     DebugServlet.clear();
     DebugServlet.addResponseHeader("Content-Type", "application/xml; charset=UTF-8");
     String url = getBaseUrl() + DEBUG_SERVLET_PATH;
-    HttpSolrClientBuilderBase<?, ?> b = builder(url, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT).withResponseParser(rp);
+    HttpSolrClientBuilderBase<?, ?> b =
+        builder(url, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT).withResponseParser(rp);
     int limit = 10;
     CountDownLatch cdl = new CountDownLatch(limit);
     DebugAsyncListener[] listeners = new DebugAsyncListener[limit];
@@ -553,12 +553,12 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
     try (HttpSolrClientBase client = b.build()) {
       for (int i = 0; i < limit; i++) {
         DebugServlet.responseBodyByQueryFragment.put(
-                ("id=KEY-" + i),
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response><result name=\"response\" numFound=\"2\" start=\"1\" numFoundExact=\"true\"><doc><str name=\"id\">KEY-"
-                        + i
-                        + "</str></doc></result></response>");
+            ("id=KEY-" + i),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<response><result name=\"response\" numFound=\"2\" start=\"1\" numFoundExact=\"true\"><doc><str name=\"id\">KEY-"
+                + i
+                + "</str></doc></result></response>");
         QueryRequest query =
-                new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "KEY-" + i)));
+            new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "KEY-" + i)));
         query.setMethod(SolrRequest.METHOD.GET);
         listeners[i] = new DebugAsyncListener(cdl);
         client.asyncRequest(query, null, listeners[i]);
@@ -586,7 +586,8 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
     DebugServlet.clear();
     DebugServlet.addResponseHeader("Content-Type", "Wrong Content Type!");
     String url = getBaseUrl() + DEBUG_SERVLET_PATH;
-    HttpSolrClientBuilderBase<?, ?> b = builder(url, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT).withResponseParser(rp);
+    HttpSolrClientBuilderBase<?, ?> b =
+        builder(url, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT).withResponseParser(rp);
     CountDownLatch cdl = new CountDownLatch(1);
     DebugAsyncListener listener = new DebugAsyncListener(cdl);
     try (HttpSolrClientBase client = b.build()) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
@@ -559,7 +559,7 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
                 + "</str></doc></result></response>");
         QueryRequest query =
             new QueryRequest(new MapSolrParams(Collections.singletonMap("id", "KEY-" + i)));
-        query.setMethod(SolrRequest.METHOD.GET);
+        query.setMethod(method);
         listeners[i] = new DebugAsyncListener(cdl);
         client.asyncRequest(query, null, listeners[i]);
       }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientTestBase.java
@@ -579,6 +579,10 @@ public abstract class HttpSolrClientTestBase extends SolrJettyTestBase {
               new MapSolrParams(Collections.singletonMap("q", "*:*")),
               SolrRequest.METHOD.POST);
       assertEquals(limit, qr.getResults().getNumFound());
+
+      // clean up
+      client.deleteByQuery(COLLECTION_1, "*:*");
+      client.commit(COLLECTION_1);
     }
   }
 


### PR DESCRIPTION
This PR adds method  `asyncRequest` to abstract supertype `HttpSolrClientBase` and implements it on `HttpJdkSolrClient`.  Also adds unit tests for normal, exceptional and cancelled asynchronous requests, both for `HttpJdkSolrClient` and `Http2SolrClient`.  Also includes a few javadoc improvements.