### PR TITLE
SOLR-17194: CloudHttp2SolrClient doesn't properly use httpClient Builder on certain paths

### DIFF
--- a/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
@@ -263,7 +263,7 @@ public class TestExportTool extends SolrCloudTestCase {
 
     CloudSolrClient cloudSolrClient = cluster.getSolrClient();
 
-    CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 8, 1)
+    CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 2, 1)
         .setBasicAuthCredentials(USER, PASS)
         .process(cluster.getSolrClient());
     cluster.waitForActiveCollection(COLLECTION_NAME, 8, 8);

--- a/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
@@ -17,6 +17,12 @@
 
 package org.apache.solr.cli;
 
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.solr.cli.SolrCLI.findTool;
+import static org.apache.solr.cli.SolrCLI.parseCmdLine;
+import static org.apache.solr.security.Sha256AuthenticationProvider.getSaltedHashedValue;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,10 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import org.apache.commons.cli.CommandLine;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.AbstractUpdateRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -43,10 +51,15 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.util.FastInputStream;
 import org.apache.solr.common.util.JsonRecordReader;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.security.BasicAuthPlugin;
+import org.apache.solr.security.RuleBasedAuthorizationPlugin;
+import org.junit.Test;
 
 @SolrTestCaseJ4.SuppressSSL
 public class TestExportTool extends SolrCloudTestCase {
 
+  @Test
   public void testBasic() throws Exception {
     String COLLECTION_NAME = "globalLoaderColl";
     configureCluster(4).addConfig("conf", configset("cloud-dynamic")).configure();
@@ -216,6 +229,66 @@ public class TestExportTool extends SolrCloudTestCase {
     } finally {
       cluster.shutdown();
     }
+  }
+
+  @Test
+  public void testWithBasicAuth() throws Exception {
+    String COLLECTION_NAME = "secureCollection";
+    String USER = "solr";
+    String PASS = "SolrRocksAgain";
+    final String SECURITY_JSON =
+        Utils.toJSONString(
+            Map.of(
+                "authorization",
+                Map.of(
+                    "class",
+                    RuleBasedAuthorizationPlugin.class.getName(),
+                    "user-role",
+                    singletonMap(USER, "admin"),
+                    "permissions",
+                    singletonList(Map.of("name", "all", "role", "admin"))),
+                "authentication",
+                Map.of(
+                    "class",
+                    BasicAuthPlugin.class.getName(),
+                    "blockUnknown",
+                    true,
+                    "credentials",
+                    singletonMap(USER, getSaltedHashedValue(PASS)))));
+
+    configureCluster(2)
+        .addConfig("conf", configset("cloud-minimal"))
+        .withSecurityJson(SECURITY_JSON)
+        .configure();
+
+    CloudSolrClient cloudSolrClient = cluster.getSolrClient();
+
+    CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 8, 1)
+        .setBasicAuthCredentials(USER, PASS)
+        .process(cluster.getSolrClient());
+    cluster.waitForActiveCollection(COLLECTION_NAME, 8, 8);
+
+    File outFile = File.createTempFile("output", ".json");
+
+    String[] args = {
+      "export",
+      "-url",
+      cluster.getJettySolrRunner(0).getBaseUrl() + "/" + COLLECTION_NAME,
+      "-credentials",
+      USER + ":" + PASS,
+      "-out",
+      outFile.getAbsolutePath(),
+      "-verbose"
+    };
+
+    assertEquals(0, runTool(args));
+  }
+
+  private int runTool(String[] args) throws Exception {
+    Tool tool = findTool(args);
+    assertTrue(tool instanceof ExportTool);
+    CommandLine cli = parseCmdLine(tool.getName(), args, tool.getOptions());
+    return tool.runTool(cli);
   }
 
   private void assertJavabinDocsCount(ExportTool.Info info, int expected) throws IOException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -422,7 +422,10 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
           }
         } else if (!solrUrls.isEmpty()) {
           try {
-            stateProvider = new Http2ClusterStateProvider(solrUrls, httpClient);
+            if (this.internalClientBuilder != null) {
+              this.httpClient = internalClientBuilder.build();
+            }
+            stateProvider = new Http2ClusterStateProvider(solrUrls, this.httpClient);
           } catch (Exception e) {
             throw new RuntimeException(
                 "Couldn't initialize a HttpClusterStateProvider (is/are the "


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17194


# Description

Discovered a bug in the use of Export Tool with Basic Auth parameters doesn't create a proper CloudHttp2SolrClient.  

Undercovered that we pass in a httpClient builder to CloudHttp2SolrClient, but in at least this code path we never use, so we have a null httpClient, which means we build a default one, which means if you passed one in then you don't get your Basic Auth params!

# Solution

A test and a small fix.   I did not try to reasoon about all the builder stuff..  I find the combination of httpClient, and the solrClient and their various builders VERY hard to understand...   I wrote at test, I fixed the code, the test passes...

# Tests

Added a test to the Export Tool

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
