### PR TITLE
Disable stale bot for forks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   stale:
-
+    if: github.repository == 'apache/solr'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Annoying that this attempts to run on forks, where it typically will fail