### PR TITLE
SOLR-17243: CloudSolrClient support for req.getBasePath

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -139,8 +139,11 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
   }
 
   /**
-   * The path of this request following the core or collection (if applicable). Sometimes called the
-   * "handler path". Example: {@code /select}
+   * The HTTP path suffix used when sending this request; sometimes called the handler path. The
+   * full path is basically {@link #getBasePath()} + {@link #getCollection()} + {@link #getPath()},
+   * albeit sometimes there is no core/collection component. A typical handler path for a
+   * core/collection is "/select" or "/update". Other handlers are "node handlers"; an example is
+   * "/admin/info/health".
    */
   public void setPath(String path) {
     this.path = path;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -31,9 +31,15 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
 
 /**
- * @since solr 1.3
+ * Base class for a SolrJ request to Solr. A common way to send it is via {@link
+ * #process(SolrClient)}.
+ *
+ * <p>Not thread-safe; in fact {@link org.apache.solr.client.solrj.impl.LBSolrClient} will
+ * temporarily modify {@link #setBasePath(String)} during request processing.
  */
 public abstract class SolrRequest<T extends SolrResponse> implements Serializable {
+  // TODO remove usage of setBasePath during processing
+
   // This user principal is typically used by Auth plugins during distributed/sharded search
   private Principal userPrincipal;
 
@@ -132,6 +138,10 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
     return path;
   }
 
+  /**
+   * The path of this request following the core or collection (if applicable). Sometimes called the
+   * "handler path". Example: {@code /select}
+   */
   public void setPath(String path) {
     this.path = path;
   }
@@ -248,8 +258,12 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
     return getParams() == null ? null : getParams().get("collection");
   }
 
+  /**
+   * The base URL to which this request should be executed. Generally it points to the Solr root URL
+   * on a node. Example: {@code http://localhost:8983/solr}
+   */
   public void setBasePath(String path) {
-    if (path.endsWith("/")) path = path.substring(0, path.length() - 1);
+    if (path != null && path.endsWith("/")) path = path.substring(0, path.length() - 1);
 
     this.basePath = path;
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -91,8 +91,8 @@ import org.slf4j.MDC;
  * SolrCloud-aware implementation of {@link SolrClient}. It's able to route requests to the ideal
  * node, knowing where the collection and it's replicas are hosted. It will even break up an update
  * request with a batch of documents knowing where each document goes (assuming there is more than
- * one shard). It will do some retries and fail-over to alternative replicas in an attempt to proces
- * the request successfully, using {@link LBSolrClient}.
+ * one shard). It will do some retries and fail-over to alternative replicas in an attempt to
+ * process the request successfully, using {@link LBSolrClient}.
  *
  * <p>If the request contains {@link SolrRequest#getBasePath()} (a URL) then the logic in this
  * client will be skipped, and it will be processed via an HTTP SolrClient.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -482,6 +482,9 @@ public abstract class LBSolrClient extends SolrClient {
   protected Exception doRequest(
       Endpoint baseUrl, Req req, Rsp rsp, boolean isNonRetryable, boolean isZombie)
       throws SolrServerException, IOException {
+    if (req.getRequest().getBasePath() != null) {
+      throw new IllegalArgumentException("BasePath is not supported here");
+    }
     Exception ex = null;
     try {
       rsp.server = baseUrl.toString();
@@ -528,6 +531,8 @@ public abstract class LBSolrClient extends SolrClient {
       }
     } catch (Exception e) {
       throw new SolrServerException(e);
+    } finally {
+      req.getRequest().setBasePath(null);
     }
 
     return ex;
@@ -664,6 +669,9 @@ public abstract class LBSolrClient extends SolrClient {
   public NamedList<Object> request(
       final SolrRequest<?> request, String collection, final Integer numServersToTry)
       throws SolrServerException, IOException {
+    if (request.getBasePath() != null) {
+      throw new IllegalArgumentException("BasePath is not supported here");
+    }
     Exception ex = null;
     EndpointWrapper[] serverList = aliveServerList;
 
@@ -705,6 +713,8 @@ public abstract class LBSolrClient extends SolrClient {
         }
       } catch (Exception e) {
         throw new SolrServerException(e);
+      } finally {
+        request.setBasePath(null);
       }
     }
 
@@ -740,6 +750,8 @@ public abstract class LBSolrClient extends SolrClient {
         }
       } catch (Exception e) {
         throw new SolrServerException(e);
+      } finally {
+        request.setBasePath(null);
       }
     }
 


### PR DESCRIPTION
Now CloudSolrClient can be used to route requests that specify a specific URL. LBSolrClient has never supported this and shouldn't.

https://issues.apache.org/jira/browse/SOLR-17243