### PR TITLE
Release 9.6 - protect the release branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,7 @@ github:
     branch_9_3: {}
     branch_9_4: {}
     branch_9_5: {}
+    branch_9_6: {}
     branch_9x: {}
 
   protected_tags:


### PR DESCRIPTION
This prevents force push to branch_9_6 ( see https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#branchpro )