### PR TITLE
Parse authors from git log

### DIFF
--- a/dev-tools/scripts/parseAuthorsFromGitLog.py
+++ b/dev-tools/scripts/parseAuthorsFromGitLog.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Script to parse authors and co-authors from git log output
+"""
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+from scriptutil import *
+
+import argparse
+import re
+
+line_re = re.compile(r"(.*?) \(#(\d+)\)$")
+
+
+def get_prev_release_tag(ver):
+    """
+    Based on a given version, compute the git tag for the "previous" version to calculate changes since.
+    For a major version, we want all commits since last release, i.e. X-1.Y.Z
+    For a minor version, we want all commits since X.Y-1.0
+    For a patch version, we want all commits since X.Y.Z-1
+    TODO: This is duplicated in addDepsToChanges.py
+    """
+    releases_arr = run('git tag |grep "releases/solr" | cut -c 15-').strip().split("\n")
+    releases = list(map(lambda x: Version.parse(x), releases_arr))
+    if ver.is_major_release():
+        last = releases.pop()
+        return "releases/solr/%s" % last.dot
+    if ver.is_minor_release():
+        return "releases/solr/%s.%s.0" % (ver.major, ver.minor - 1)
+    if ver.is_bugfix_release():
+        return "releases/solr/%s.%s.%s" % (ver.major, ver.minor, ver.bugfix - 1)
+    return None
+
+
+def read_config():
+    parser = argparse.ArgumentParser(description='Parse authors and co-authors from git log output.')
+    parser.add_argument('--version', type=Version.parse, help='Solr version to select commits for', required=True)
+    newconf = parser.parse_args()
+    return newconf
+
+
+def parse_authors(log):
+    """
+    Parse git log and extract authors and co-authors.
+
+    Args:
+    - log: String containing the git log.
+
+    Returns:
+    - Dictionary containing author names as keys and number of contributions as values.
+    """
+    authors = set()
+    author_names = {}
+
+    # Split the log into individual commits based on the start of each commit.
+    commits = re.split(r'\ncommit [a-f0-9]', log)
+
+    def add_to_author_names(author_line):
+        name = author_line.split(' <')[0].strip()
+        if name in author_names:
+            author_names[name] += 1
+        else:
+            author_names[name] = 1
+
+    for commit in commits:
+        # Split the commit message into lines.
+        lines = commit.split('\n')
+
+        # Get the author from the first line starting with "Author:".
+        author_line = next((line for line in lines if line.lower().startswith('author:')), None)
+        if author_line:
+            author = author_line.split(':')[1].strip()
+            authors.add(author)
+            add_to_author_names(author)
+
+        # Get the co-authors from lines starting with "Co-authored-by:".
+        co_author_lines = [line for line in lines if line.lower().startswith('    co-authored-by:')]
+        for line in co_author_lines:
+            co_author = line.split(':')[1].strip()
+            authors.add(co_author)
+            add_to_author_names(co_author)
+
+    return author_names
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def main():
+    if not os.path.exists('solr/CHANGES.txt'):
+        sys.exit("Tool must be run from the root of a source checkout.")
+    newconf = read_config()
+    prev_tag = get_prev_release_tag(newconf.version)
+    eprint("Selecting git log since %s" % prev_tag)
+    try:
+        gitlog = run(
+            'git log --no-merges ' + prev_tag + '..')
+        authors = parse_authors(gitlog)
+        # Sort authos by number of contributions
+        authors = [f"{k} ({v})" for k, v in sorted(authors.items(), key=lambda item: item[1], reverse=True)]
+        if len(authors) > 0:
+            print("\n".join(authors))
+        else:
+            epring("No authors found")
+    except subprocess.CalledProcessError:
+        print("Error running git log - check your --version")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('\nReceived Ctrl-C, exiting early')


### PR DESCRIPTION
Script that parses authors and co-authors from git log since last release. Intended for use by Release Manager to obtain a list of developers to credit for a release.

```
usage: parseAuthorsFromGitLog.py [-h] --version VERSION

Parse authors and co-authors from git log output.

options:
  -h, --help         show this help message and exit
  --version VERSION  Solr version to select commits for
```

When on the HEAD of `branch_9_6` this outputs:

```
> dev-tools/scripts/parseAuthorsFromGitLog.py --version 9.6.0
Selecting git log since releases/solr/9.5.0
Eric Pugh (24)
Jason Gerlowski (22)
Solr Bot (18)
Jan Høydahl (15)
Christine Poerschke (13)
Andrey Bozhko (11)
David Smiley (10)
Chris Hostetter (9)
Michael Gibney (5)
pjmcarthur (5)
Paul McArthur (5)
Mikhail Khludnev (5)
Pierre Salagnac (5)
Houston Putman (5)
Gus Heck (4)
jdyer1 (4)
James Dyer (4)
Vincent Primault (4)
Drini Cami (3)
Andrzej Białecki (3)
Bruno Roustant (2)
Vincenzo D'Amore (2)
Radu Gheorghe (2)
aparnasuresh85 (2)
Przemyslaw Ciezkowski (2)
Rahul Goswami (2)
Justin Sweeney (2)
Jeb Nix (2)
Sanjay Dutt (2)
iamsanjay (2)
Nazerke Seidan (2)
Alessandro Benedetti (1)
Peter Molnar (1)
Torsten Bøgh Köster (1)
ejn (1)
mariemat (1)
Mathieu Marie (1)
Kevin Risden (1)
Vickie Karasic (1)
Antoine Bursaux (1)
weiwang19 (1)
wwang30 (1)
Clay Johnson (1)
Ere Maijala (1)
Dan Niles (1)
Arnout Engelen (1)
Matteias Collet (1)
Julien Pilourdault (1)
Calvin Smith (1)
Yohann Callea (1)
```

The list is sorted by number of contributions. The number is sum of `Author:` and `Co-authored-by:` for a user with that unique NAME. Email addresses may vary for the same person, so they are disregarded.

Ideas:

* The list could of course be sorted alphabetically instead of by number of contributions
* Filter out committers to focus on external contributors? Would be easy if everyone used their apache email, but sadly not
* Integrate directly as a function in releaseWizard so it could be added to release email template

For this to be as good quality as CHANGES.txt names we'd need to step up the game on adding `Co-Authored-By` tags in final commit message whenever we squash-merge a PR, and also add such tags manually when committing a patch from JIRA or when we feel that a person has contributed a lot in e.g. review process without having done commits.