### PR TITLE
SOLR-17260 ReleaseWizard should remove old minor versions from Docker Hub

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -110,7 +110,7 @@ def expand_jinja(text, vars=None):
         'get_next_version': state.get_next_version(),
         'current_git_rev': state.get_current_git_rev(),
         'keys_downloaded': keys_downloaded(),
-        'get_docker_version_to_remove': state.get_docker_version_to_remove(),
+        'docker_version_to_remove': state.get_docker_version_to_remove(),
         'editor': get_editor(),
         'rename_cmd': 'ren' if is_windows() else 'mv',
         'vote_close_72h': vote_close_72h_date().strftime("%Y-%m-%d %H:00 UTC"),

--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -110,6 +110,7 @@ def expand_jinja(text, vars=None):
         'get_next_version': state.get_next_version(),
         'current_git_rev': state.get_current_git_rev(),
         'keys_downloaded': keys_downloaded(),
+        'get_docker_version_to_remove': state.get_docker_version_to_remove(),
         'editor': get_editor(),
         'rename_cmd': 'ren' if is_windows() else 'mv',
         'vote_close_72h': vote_close_72h_date().strftime("%Y-%m-%d %H:00 UTC"),
@@ -601,6 +602,12 @@ class ReleaseState:
         if self.release_type == 'bugfix':
             return "%s.%s.%s" % (self.release_version_major, self.release_version_minor, self.release_version_bugfix + 1)
         return None
+
+    def get_docker_version_to_remove(self):
+        if self.release_type == 'minor' and self.release_version_minor >= 2:
+            return "%s.%s" % (self.release_version_major, self.release_version_minor - 2)
+        else:
+            return None
 
     def get_refguide_release(self):
         return "%s_%s" % (self.release_version_major, self.release_version_minor)

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1078,9 +1078,9 @@ groups:
           comment: Add the new slim distribution Dockerfile to the repo
           logfile: solr_docker_add_dockerfile_slim.log
         - !Command
-          comment: Mark docker image version N.M-2 as not supported (if applicable)
           cmd: "{% if get_docker_version_to_remove %}rm -rf {{ get_docker_version_to_remove }} && rm -rf {{ get_docker_version_to_remove }}-slim{% else %}echo Nothing to delete{% endif %}"
           cwd: solr-docker
+          comment: "Mark docker image version N.M-2 as not supported {% if get_docker_version_to_remove %}{% else %}(N/A for this release){% endif %}"
           logfile: solr_remove_old_docker_images.log
         - !Command
           cmd: 'git add . && git commit -m "Apache Solr release {{ release_version }}"'

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1078,9 +1078,9 @@ groups:
           comment: Add the new slim distribution Dockerfile to the repo
           logfile: solr_docker_add_dockerfile_slim.log
         - !Command
-          cmd: "{% if get_docker_version_to_remove %}rm -rf {{ get_docker_version_to_remove }} && rm -rf {{ get_docker_version_to_remove }}-slim{% else %}echo Nothing to delete{% endif %}"
+          cmd: "{% if docker_version_to_remove %}rm -rf {{ docker_version_to_remove }} {{ docker_version_to_remove }}-slim{% else %}echo Nothing to delete{% endif %}"
           cwd: solr-docker
-          comment: "{% if get_docker_version_to_remove %}Mark docker image version {{ get_docker_version_to_remove }} as not supported{% else %}N/A - No docker versions to delete for this release{% endif %}"
+          comment: "{% if docker_version_to_remove %}Mark docker image version {{ docker_version_to_remove }} as not supported{% else %}N/A - No docker versions to delete for this release{% endif %}"
           logfile: solr_remove_old_docker_images.log
         - !Command
           cmd: 'git add . && git commit -m "Apache Solr release {{ release_version }}"'

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1078,7 +1078,12 @@ groups:
           comment: Add the new slim distribution Dockerfile to the repo
           logfile: solr_docker_add_dockerfile_slim.log
         - !Command
-          cmd: 'git add {{ docker_version }}/Dockerfile {{ docker_version }}-slim/Dockerfile && git commit -m "Apache Solr release {{ release_version }}"'
+          comment: Mark docker image version N.M-2 as not supported (if applicable)
+          cmd: "{% if get_docker_version_to_remove %}rm -rf {{ get_docker_version_to_remove }} && rm -rf {{ get_docker_version_to_remove }}-slim{% else %}echo Nothing to delete{% endif %}"
+          cwd: solr-docker
+          logfile: solr_remove_old_docker_images.log
+        - !Command
+          cmd: 'git add . && git commit -m "Apache Solr release {{ release_version }}"'
           cwd: solr-docker
           comment: Commit the new Dockerfile
           logfile: solr_docker_commit.log

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1080,7 +1080,7 @@ groups:
         - !Command
           cmd: "{% if get_docker_version_to_remove %}rm -rf {{ get_docker_version_to_remove }} && rm -rf {{ get_docker_version_to_remove }}-slim{% else %}echo Nothing to delete{% endif %}"
           cwd: solr-docker
-          comment: "Mark docker image version N.M-2 as not supported {% if get_docker_version_to_remove %}{% else %}(N/A for this release){% endif %}"
+          comment: "{% if get_docker_version_to_remove %}Mark docker image version {{ get_docker_version_to_remove }} as not supported{% else %}N/A - No docker versions to delete for this release{% endif %}"
           logfile: solr_remove_old_docker_images.log
         - !Command
           cmd: 'git add . && git commit -m "Apache Solr release {{ release_version }}"'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17260

This PR implements the suggested policy of deleting version `N.M-2` from hub. This means that when we release 9.7, 9.5 will be marked as "unsupported" in docker hub. That is, it will still be available for pull but not advertised as "supported".