### PR TITLE
SOLR-17265: Fix randomized PRS testing

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -76,6 +76,7 @@ import org.apache.solr.common.params.CollectionAdminParams;
 import org.apache.solr.common.params.CommonAdminParams;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.Utils;
@@ -94,6 +95,8 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final CollectionCommandContext ccc;
 
+  public static final String PRS_DEFAULT_PROP = "solr.prs.default";
+
   public CreateCollectionCmd(CollectionCommandContext ccc) {
     this.ccc = ccc;
   }
@@ -109,7 +112,7 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
     final boolean waitForFinalState = message.getBool(WAIT_FOR_FINAL_STATE, false);
     final String alias = message.getStr(ALIAS, collectionName);
     log.info("Create collection {}", collectionName);
-    boolean prsDefault = Boolean.parseBoolean(System.getProperty("solr.prs.default", "false"));
+    boolean prsDefault = EnvUtils.getEnvAsBool(PRS_DEFAULT_PROP, false);
     final boolean isPRS = message.getBool(CollectionStateProps.PER_REPLICA_STATE, prsDefault);
     if (log.isInfoEnabled()) {
       log.info(

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZk2TestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZk2TestBase.java
@@ -17,14 +17,12 @@
 package org.apache.solr.cloud;
 
 import static org.apache.solr.cloud.SolrCloudTestCase.configurePrsDefault;
-import static org.apache.solr.cloud.api.collections.CreateCollectionCmd.PRS_DEFAULT_PROP;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.tests.util.TestRuleRestoreSystemProperties;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -42,9 +40,7 @@ import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.handler.BackupStatusChecker;
 import org.apache.solr.handler.ReplicationHandler;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
 
 /**
  * This test simply does a bunch of basic things in solrcloud mode and asserts things work as
@@ -57,10 +53,6 @@ public abstract class AbstractBasicDistributedZk2TestBase extends AbstractFullDi
   private static final String SHARD1 = "shard1";
   private static final String ONE_NODE_COLLECTION = "onenodecollection";
   private final boolean onlyLeaderIndexes = random().nextBoolean();
-
-  @ClassRule
-  public static TestRule syspropRestore =
-      new TestRuleRestoreSystemProperties(NUMERIC_DOCVALUES_SYSPROP, PRS_DEFAULT_PROP);
 
   public AbstractBasicDistributedZk2TestBase() {
     super();

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZk2TestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZk2TestBase.java
@@ -16,14 +16,15 @@
  */
 package org.apache.solr.cloud;
 
-import static org.apache.solr.cloud.SolrCloudTestCase.setPrsDefault;
-import static org.apache.solr.cloud.SolrCloudTestCase.unsetPrsDefault;
+import static org.apache.solr.cloud.SolrCloudTestCase.configurePrsDefault;
+import static org.apache.solr.cloud.api.collections.CreateCollectionCmd.PRS_DEFAULT_PROP;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestRuleRestoreSystemProperties;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -40,9 +41,10 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.handler.BackupStatusChecker;
 import org.apache.solr.handler.ReplicationHandler;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 /**
  * This test simply does a bunch of basic things in solrcloud mode and asserts things work as
@@ -55,6 +57,10 @@ public abstract class AbstractBasicDistributedZk2TestBase extends AbstractFullDi
   private static final String SHARD1 = "shard1";
   private static final String ONE_NODE_COLLECTION = "onenodecollection";
   private final boolean onlyLeaderIndexes = random().nextBoolean();
+
+  @ClassRule
+  public static TestRule syspropRestore =
+      new TestRuleRestoreSystemProperties(NUMERIC_DOCVALUES_SYSPROP, PRS_DEFAULT_PROP);
 
   public AbstractBasicDistributedZk2TestBase() {
     super();
@@ -71,14 +77,9 @@ public abstract class AbstractBasicDistributedZk2TestBase extends AbstractFullDi
     // and it's TestInjection use
   }
 
-  @After
-  public void _unsetPrsDefault() {
-    unsetPrsDefault();
-  }
-
-  @Before
-  public void _setPrsDefault() {
-    setPrsDefault();
+  @BeforeClass
+  public static void _setPrsDefault() {
+    configurePrsDefault();
   }
 
   @Test

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.tests.util.TestRuleRestoreSystemProperties;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -59,8 +58,6 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,9 +83,6 @@ import org.slf4j.LoggerFactory;
 public class SolrCloudTestCase extends SolrTestCaseJ4 {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  @ClassRule
-  public static TestRule syspropRestore = new TestRuleRestoreSystemProperties(PRS_DEFAULT_PROP);
 
   // this is an important timeout for test stability - can't be too short
   public static final int DEFAULT_TIMEOUT = 45;

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
@@ -104,7 +104,7 @@ public class SolrCloudTestCase extends SolrTestCaseJ4 {
    * beforeClass method.
    */
   public static boolean isPRS() {
-    return Boolean.parseBoolean(System.getProperty(PRS_DEFAULT_PROP, "false"));
+    return EnvUtils.getEnvAsBool(PRS_DEFAULT_PROP, false);
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17265

This fixes the test errors introduced by https://github.com/apache/solr/pull/2230

I'm not really certain what the previous logic was supposed to be doing, but `isPRS()` practically returned a random true or false every time it was called, since the `"use.per-replica"` sysProp was never set.

I've simplified the logic considerably. Before a class is run `"solr.prs.default"` is set to either `true` or `false` (either randomly, or determined by the Class annotation). Then ever call to `isPRS()` will read that sysProp to determine if the default is PRS or not.