### PR TITLE
DelegatingBackupRepository extends AbstractBackupRepository.

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/backup/repository/DelegatingBackupRepository.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/DelegatingBackupRepository.java
@@ -27,7 +27,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.backup.Checksum;
 
 /** Delegates to another {@link BackupRepository}. */
-public class DelegatingBackupRepository implements BackupRepository {
+public class DelegatingBackupRepository extends AbstractBackupRepository {
 
   public static final String PARAM_DELEGATE_REPOSITORY_NAME = "delegateRepoName";
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractBackupRepositoryTest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractBackupRepositoryTest.java
@@ -20,7 +20,6 @@ package org.apache.solr.cloud.api.collections;
 import static org.apache.lucene.codecs.CodecUtil.FOOTER_MAGIC;
 import static org.apache.lucene.codecs.CodecUtil.writeBEInt;
 import static org.apache.lucene.codecs.CodecUtil.writeBELong;
-import static org.apache.solr.core.backup.repository.AbstractBackupRepository.PARAM_VERIFY_CHECKSUM;
 import static org.apache.solr.core.backup.repository.DelegatingBackupRepository.PARAM_DELEGATE_REPOSITORY_NAME;
 
 import java.io.File;


### PR DESCRIPTION
One line PR to make DelegatingBackupRepository extend AbstractBackupRepository, so it has the config and the shouldVerifyChecksum field.