### PR TITLE
Solr Admin UI: fixed node list display bug caused by different hostname with same front part

### DIFF
--- a/solr/webapp/web/js/angular/controllers/cloud.js
+++ b/solr/webapp/web/js/angular/controllers/cloud.js
@@ -155,7 +155,8 @@ var nodesSubController = function($scope, Collections, System, Metrics) {
   $scope.isFirstNodeForHost = function(node) {
     var hostName = node.split(":")[0]; 
     var nodesInHost = $scope.filteredNodes.filter(function (node) {
-      return node.startsWith(hostName);
+      var hostName2 = node.split(":")[0];
+      return hostName2 === hostName;
     });
     return nodesInHost[0] === node;
   };


### PR DESCRIPTION

# Description
old code:
```// Checks if this node is the first (alphabetically) for a given host. Used to decide rowspan in table
  $scope.isFirstNodeForHost = function(node) {
    var hostName = node.split(":")[0]; 
    var nodesInHost = $scope.filteredNodes.filter(function (node) {
      return node.startsWith(hostName);
    });
    return nodesInHost[0] === node;
  };
```
hostname like `server-1`, `server-10`, this code will cause the node list to be displayed incorrectly

# Solution
```
  $scope.isFirstNodeForHost = function(node) {
    var hostName = node.split(":")[0]; 
    var nodesInHost = $scope.filteredNodes.filter(function (node) {
      var hostName2 = node.split(":")[0]; 
      return hostName2 === hostName;
    });
    return nodesInHost[0] === node;
  };
```