### PR TITLE
SOLR-17274: allow JSON atomic updates to use multiple modifiers or a modifier like 'set' as a field name if child docs not enabled 

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -106,6 +106,9 @@ Improvements
 
 * SOLR-14115: Add linkconfig, cluster, and updateacls as commands to SolrCLI.  Allow bin/solr commands to have parity with zkcli.sh commands. (Eric Pugh)
 
+* SOLR-17274: Allow JSON atomic updates to use multiple modifiers or a modifier like 'set' as a field name
+  if child docs are not enabled. (Calvin Smith, David Smiley)
+
 Optimizations
 ---------------------
 * SOLR-17257: Both Minimize Cores and the Affinity replica placement strategies would over-gather

--- a/solr/core/src/test-files/solr/collection1/conf/atomic-update-json-test.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/atomic-update-json-test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<schema name="id-version-and-multivalued-name-field" version="1.1">
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+  <field name="id" type="string" indexed="true" stored="true"/>
+  <field name="_version_" type="string" indexed="true" stored="true"/>
+  <field name="name" type="string" indexed="true" stored="true" multiValued="true"/>
+    <!-- two fields (one multivalued, one not) for verifying correct behavior when
+         an atomic update modifier is used as a field name. -->
+  <field name="set" type="string" indexed="true" stored="true"/>
+  <field name="add" type="string" indexed="true" stored="true" multiValued="true"/>
+  <!-- If the following is uncommented, then the schema will support
+    nested docs, and all but one of the tests in AtomicUpdatesJsonTest.java
+    will fail. -->
+  <!-- <field name="_root_" type="string" indexed="true" stored="true"/> -->
+  <uniqueKey>id</uniqueKey>
+</schema>

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 // Tests atomic updates using JSON loader, since the existing
 // tests all use XML format, and there have been some atomic update
-// issues that were specific to the JSONformat.
+// issues that were specific to the JSON format.
 public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
 
   @BeforeClass

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -30,7 +30,7 @@ import org.junit.rules.TestRule;
 // Tests atomic updates using JSON loader, since the existing
 // tests all use XML format, and there have been some atomic update
 // issues that were specific to the JSONformat.
-public class AtomicUpdatesJsonTest extends SolrTestCaseJ4 {
+public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
 
   @ClassRule
   public static final TestRule noReverseMerge = RandomNoReverseMergePolicyFactory.createRule();
@@ -52,7 +52,7 @@ public class AtomicUpdatesJsonTest extends SolrTestCaseJ4 {
     // the schema we loaded shouldn't be usable for child docs,
     // since we're testing JSON loader functionality that only
     // works in that case and is ambiguous if nested docs are supported.
-    assert !h.getCore().getLatestSchema().isUsableForChildDocs();
+    assertFalse(h.getCore().getLatestSchema().isUsableForChildDocs());
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -149,7 +149,7 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
-    Map<String, String> removeSetField = new HashMap<String, String>();
+    Map<String, String> removeSetField = new HashMap<>();
     removeSetField.put("set", null);
     doc.setField("set", removeSetField);
     updateJ(jsonAdd(doc), null);

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -37,7 +37,7 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
 
   @Before
   public void before() {
-    h.update("<delete><query>*:*</query></delete>");
+    assertU(delQ("*:*"));
     assertU(commit());
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -62,14 +62,14 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
     doc.setField("name", new String[] {"aaa"});
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '0']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
     doc.setField("name", Map.of("add", "bbb"));
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '1']");
   }
 
   @Test
@@ -79,15 +79,15 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
     doc.setField("name", new String[] {"aaa", "bbb"});
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '1']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
     doc.setField("name", Map.of("remove", "bbb"));
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '0']");
-    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:aaa"), "//result[@numFound = '1']");
   }
 
   @Test
@@ -97,25 +97,19 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
     doc.setField("name", new String[] {"aaa", "bbb", "ccc"});
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '1']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
     doc.setField(
-        "name",
-        new HashMap<String, Object>() {
-          {
-            put("add", new String[] {"ddd", "eee"});
-            put("remove", new String[] {"aaa", "ccc"});
-          }
-        });
+        "name", Map.of("add", new String[] {"ddd", "eee"}, "remove", new String[] {"aaa", "ccc"}));
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '0']");
-    assertQ(req("q", "name:ccc", "indent", "true"), "//result[@numFound = '0']");
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "name:ddd", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "name:eee", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:aaa"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:ccc"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:ddd"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:eee"), "//result[@numFound = '1']");
   }
 
   @Test
@@ -125,19 +119,19 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
     doc.setField("name", new String[] {"aaa", "bbb", "ccc"});
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "name:ccc", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:aaa"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:ccc"), "//result[@numFound = '1']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
     doc.setField("name", Map.of("add", "ddd", "remove", "bbb"));
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "name:ddd", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '0']");
-    assertQ(req("q", "name:ccc", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:ddd"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:ccc"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:aaa"), "//result[@numFound = '1']");
   }
 
   @Test
@@ -149,18 +143,19 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
     doc.setField("name", new String[] {"aaa"});
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "set:setval", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "set:setval"), "//result[@numFound = '1']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
     doc.setField("set", Map.of("set", "modval"));
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "set:modval", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "set:setval", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "set:modval"), "//result[@numFound = '1']");
+    assertQ(req("q", "set:setval"), "//result[@numFound = '0']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
+    //    doc.setField("set", Map.of("set", null));
     doc.setField(
         "set",
         new HashMap<String, String>() {
@@ -170,8 +165,8 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
         });
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "set:modval", "indent", "true"), "//result[@numFound = '0']");
-    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "set:modval"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:aaa"), "//result[@numFound = '1']");
   }
 
   @Test
@@ -183,24 +178,18 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
     doc.setField("add", new String[] {"aaa", "bbb", "ccc"});
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "add:bbb", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:bbb"), "//result[@numFound = '1']");
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
     doc.setField(
-        "add",
-        new HashMap<String, Object>() {
-          {
-            put("add", new String[] {"ddd", "eee"});
-            put("remove", new String[] {"bbb", "ccc"});
-          }
-        });
+        "add", Map.of("add", new String[] {"ddd", "eee"}, "remove", new String[] {"bbb", "ccc"}));
     updateJ(jsonAdd(doc), null);
     assertU(commit());
-    assertQ(req("q", "add:ddd", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "add:eee", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "add:aaa", "indent", "true"), "//result[@numFound = '1']");
-    assertQ(req("q", "add:bbb", "indent", "true"), "//result[@numFound = '0']");
-    assertQ(req("q", "add:ccc", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "add:ddd"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:eee"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:aaa"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:bbb"), "//result[@numFound = '0']");
+    assertQ(req("q", "add:ccc"), "//result[@numFound = '0']");
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -20,20 +20,14 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.util.RandomNoReverseMergePolicyFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
 
 // Tests atomic updates using JSON loader, since the existing
 // tests all use XML format, and there have been some atomic update
 // issues that were specific to the JSONformat.
 public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
-
-  @ClassRule
-  public static final TestRule noReverseMerge = RandomNoReverseMergePolicyFactory.createRule();
 
   @BeforeClass
   public static void beforeTests() throws Exception {

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJsonTest.java
@@ -149,14 +149,9 @@ public class AtomicUpdateJsonTest extends SolrTestCaseJ4 {
 
     doc = new SolrInputDocument();
     doc.setField("id", "1");
-    //    doc.setField("set", Map.of("set", null));
-    doc.setField(
-        "set",
-        new HashMap<String, String>() {
-          {
-            put("set", null);
-          }
-        });
+    Map<String, String> removeSetField = new HashMap<String, String>();
+    removeSetField.put("set", null);
+    doc.setField("set", removeSetField);
     updateJ(jsonAdd(doc), null);
     assertU(commit());
     assertQ(req("q", "set:modval"), "//result[@numFound = '0']");

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesJsonTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesJsonTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update.processor;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.util.RandomNoReverseMergePolicyFactory;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+// Tests atomic updates using JSON loader, since the existing
+// tests all use XML format, and there have been some atomic update
+// issues that were specific to the JSONformat.
+public class AtomicUpdatesJsonTest extends SolrTestCaseJ4 {
+
+  @ClassRule
+  public static final TestRule noReverseMerge = RandomNoReverseMergePolicyFactory.createRule();
+
+  @BeforeClass
+  public static void beforeTests() throws Exception {
+    System.setProperty("enable.update.log", "true");
+    initCore("solrconfig.xml", "atomic-update-json-test.xml");
+  }
+
+  @Before
+  public void before() {
+    h.update("<delete><query>*:*</query></delete>");
+    assertU(commit());
+  }
+
+  @Test
+  public void testSchemaIsNotUsableForChildDocs() throws Exception {
+    // the schema we loaded shouldn't be usable for child docs,
+    // since we're testing JSON loader functionality that only
+    // works in that case and is ambiguous if nested docs are supported.
+    assert !h.getCore().getLatestSchema().isUsableForChildDocs();
+  }
+
+  @Test
+  public void testAddOne() throws Exception {
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", new String[] {"aaa"});
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '0']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", Map.of("add", "bbb"));
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+  }
+
+  @Test
+  public void testRemoveOne() throws Exception {
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", new String[] {"aaa", "bbb"});
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", Map.of("remove", "bbb"));
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+  }
+
+  @Test
+  public void testRemoveMultiple() throws Exception {
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", new String[] {"aaa", "bbb", "ccc"});
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField(
+        "name",
+        new HashMap<String, Object>() {
+          {
+            put("add", new String[] {"ddd", "eee"});
+            put("remove", new String[] {"aaa", "ccc"});
+          }
+        });
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:ccc", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:ddd", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:eee", "indent", "true"), "//result[@numFound = '1']");
+  }
+
+  @Test
+  public void testAddAndRemove() throws Exception {
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", new String[] {"aaa", "bbb", "ccc"});
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:ccc", "indent", "true"), "//result[@numFound = '1']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", Map.of("add", "ddd", "remove", "bbb"));
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "name:ddd", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:bbb", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:ccc", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+  }
+
+  @Test
+  public void testAtomicUpdateModifierNameSingleValued() throws Exception {
+    // Testing atomic update with a single-valued field named 'set'
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("set", "setval");
+    doc.setField("name", new String[] {"aaa"});
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "set:setval", "indent", "true"), "//result[@numFound = '1']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("set", Map.of("set", "modval"));
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "set:modval", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "set:setval", "indent", "true"), "//result[@numFound = '0']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField(
+        "set",
+        new HashMap<String, String>() {
+          {
+            put("set", null);
+          }
+        });
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "set:modval", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "name:aaa", "indent", "true"), "//result[@numFound = '1']");
+  }
+
+  @Test
+  public void testAtomicUpdateModifierNameMultiValued() throws Exception {
+    // Testing atomic update with a multi-valued field named 'add'
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("name", new String[] {"aaa"});
+    doc.setField("add", new String[] {"aaa", "bbb", "ccc"});
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "add:bbb", "indent", "true"), "//result[@numFound = '1']");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField(
+        "add",
+        new HashMap<String, Object>() {
+          {
+            put("add", new String[] {"ddd", "eee"});
+            put("remove", new String[] {"bbb", "ccc"});
+          }
+        });
+    updateJ(jsonAdd(doc), null);
+    assertU(commit());
+    assertQ(req("q", "add:ddd", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:eee", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:aaa", "indent", "true"), "//result[@numFound = '1']");
+    assertQ(req("q", "add:bbb", "indent", "true"), "//result[@numFound = '0']");
+    assertQ(req("q", "add:ccc", "indent", "true"), "//result[@numFound = '0']");
+  }
+}


### PR DESCRIPTION
Fixes problems with the JsonLoader's parsing of atomic update values that use multiple modifiers in a single update or reference a field name that matches a modifier (like `set` or `add`).

https://issues.apache.org/jira/browse/SOLR-17274

# Description

Fixes two problems with JSON atomic updates where an atomic update value like `{"set": {"set": "foo"}}` (set a field named `set` to value `foo`) or `{"foo": {"add": "bar", "remove": "baz"}}` (add `bar` value to and remove `baz` values from field `foo`) would throw an exception due to `isChildDoc` thinking a nested doc was being updated. The exact exception message was:

`Unable to index docs with children: the schema must include definitions for both a uniqueKey field and the '_root_' field, using the exact same fieldType`

# Solution

I modified the `isChildDoc` method of `JsonLoader` to check if the schema is usable for child docs, and to return `false` if not. I also had to revert a part of the logic in `parseObjectFieldValue` so that it would return all the modifier values when there are multiple. The `isChildDoc` behavior is unchanged if the schema does support child docs, so the same error with continue to be thrown in that case.

# Tests

There weren't any atomic update tests that used the JSON loader previously, so I added a new schema file with the minimal fields needed to test this functionality and some tests for existing functionality via Json and for what is changed by this PR.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)

The only tests that failed were the S3 tests, which I believe is common and not necessarily a problem if my changes shouldn't have affected the s3 functionality.