### PR TITLE
Refactor preparePutOrPost in HttpJdkSolrClient

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -143,6 +143,8 @@ Other Changes
 * SOLR-16505: Use Jetty HTTP2 for index replication and other "recovery" operations
   (Sanjay Dutt, David Smiley)
 
+* GITHUB#2454: Refactor preparePutOrPost method in HttpJdkSolrClient (Andy Webb)
+
 ==================  9.6.0 ==================
 New Features
 ---------------------

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -298,15 +298,17 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
 
       InputStream is = streams.iterator().next().getStream();
       bodyPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> is);
-    } else if (queryParams != null && urlParamNames != null) {
-      ModifiableSolrParams requestParams = queryParams;
-      queryParams = calculateQueryParams(urlParamNames, requestParams);
-      queryParams.add(calculateQueryParams(solrRequest.getQueryParams(), requestParams));
-      // note the toQueryString() method adds a leading question mark which needs to be removed here
-      bodyPublisher =
-          HttpRequest.BodyPublishers.ofString(requestParams.toQueryString().substring(1));
     } else {
-      bodyPublisher = HttpRequest.BodyPublishers.noBody();
+      // move any params specified in urlParamNames or solrRequest from queryParams into urlParams
+      ModifiableSolrParams urlParams = calculateQueryParams(urlParamNames, queryParams);
+      urlParams.add(calculateQueryParams(solrRequest.getQueryParams(), queryParams));
+
+      // put the remaining params in the request body
+      // note the toQueryString() method adds a leading question mark which needs to be removed here
+      bodyPublisher = HttpRequest.BodyPublishers.ofString(queryParams.toQueryString().substring(1));
+
+      // replace queryParams with the selected set
+      queryParams = urlParams;
     }
 
     decorateRequest(reqb, solrRequest);


### PR DESCRIPTION
# Description

This refactors the `preparePutOrPost` method in HttpJdkSolrClient to make the code clearer, and remove the previous unreachable `else` block.

# Tests

All tests still pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
