### PR TITLE
SOLR-17066 Fix ShardSplitTest & StressHdfsTest

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -1277,9 +1277,7 @@ public class ShardSplitTest extends BasicDistributedZkTest {
     QueryRequest request = new QueryRequest(params);
     request.setPath("/admin/collections");
 
-    String baseUrl =
-        ((HttpSolrClient) shardToJetty.get(SHARD1).get(0).client.getSolrClient()).getBaseURL();
-    baseUrl = baseUrl.substring(0, baseUrl.length() - "collection1".length());
+    String baseUrl = shardToJetty.get(SHARD1).get(0).jetty.getBaseUrl().toString();
 
     try (SolrClient baseServer =
         new HttpSolrClient.Builder(baseUrl)

--- a/solr/modules/hdfs/src/test/org/apache/solr/hdfs/cloud/StressHdfsTest.java
+++ b/solr/modules/hdfs/src/test/org/apache/solr/hdfs/cloud/StressHdfsTest.java
@@ -251,4 +251,8 @@ public class StressHdfsTest extends AbstractBasicDistributedZkTestBase {
       }
     }
   }
+
+  protected String getBaseUrl(SolrClient client) {
+    return ((HttpSolrClient) client).getBaseURL();
+  }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -801,6 +801,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
     return invariantParams;
   }
 
+  /** Typically looks like {@code http://localhost:8983/solr} (no core or collection) */
   public String getBaseURL() {
     return baseUrl;
   }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZkTestBase.java
@@ -1115,16 +1115,6 @@ public abstract class AbstractBasicDistributedZkTestBase extends AbstractFullDis
     }
   }
 
-  protected String getBaseUrl(SolrClient client) {
-    String url2 =
-        ((HttpSolrClient) client)
-            .getBaseURL()
-            .substring(
-                0,
-                ((HttpSolrClient) client).getBaseURL().length() - DEFAULT_COLLECTION.length() - 1);
-    return url2;
-  }
-
   @Override
   protected CollectionAdminResponse createCollection(
       Map<String, List<Integer>> collectionInfos,

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -159,8 +159,10 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     public JettySolrRunner jetty;
     public String nodeName;
     public String coreNodeName;
+
     /** Core or Collection URL */
     public String url;
+
     public CloudSolrServerClient client;
     public ZkNodeProps info;
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -159,6 +159,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     public JettySolrRunner jetty;
     public String nodeName;
     public String coreNodeName;
+    /** Core or Collection URL */
     public String url;
     public CloudSolrServerClient client;
     public ZkNodeProps info;

--- a/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
+++ b/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
@@ -834,10 +834,7 @@ public class JettySolrRunner {
     this.proxyPort = proxyPort;
   }
 
-  /**
-   * Returns a base URL consisting of the protocol, host, and port for a Connector in use by the
-   * Jetty Server contained in this runner.
-   */
+  /** Returns a base URL like {@code http://localhost:8983/solr} */
   public URL getBaseUrl() {
     try {
       return new URL(protocol, host, jettyPort, "/solr");


### PR DESCRIPTION
SOLR-17066 broke some tests marked Nightly since the beginning of February; they didn't fail previously then they fail always.  It's so sad we don't have mechanisms to bring our attention to something that is so glaring.  I just happened to be looking at build failures, and I saw so many and I started looking at them.

http://fucit.org/solr-jenkins-reports/history-trend-of-recent-failures.html#series/org.apache.solr.cloud.api.collections.ShardSplitTest.test
https://ge.apache.org/scans/tests?search.rootProjectNames=*solr*&search.timeZoneId=America%2FNew_York&tests.container=org.apache.solr.cloud.api.collections.ShardSplitTest&tests.help=executedTest&tests.test=test

Even though SOLR-17066 shipped, I'm nonetheless doing a PR against the same issue because I _basically_ just fixed tests.