### PR TITLE
SOLR-17289: OrderedNodePlacementPlugin: optimize don't loop collections

### DIFF
--- a/solr/core/src/java/org/apache/solr/cluster/placement/plugins/AffinityPlacementFactory.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/AffinityPlacementFactory.java
@@ -257,6 +257,28 @@ public class AffinityPlacementFactory implements PlacementPluginFactory<Affinity
     }
 
     @Override
+    protected Map<Node, WeightedNode> getWeightedNodes(
+        PlacementContext placementContext,
+        Set<Node> nodes,
+        Iterable<SolrCollection> relevantCollections,
+        boolean skipNodesWithErrors)
+        throws PlacementException {
+      Map<Node, WeightedNode> weightedNodes =
+          getBaseWeightedNodes(placementContext, nodes, relevantCollections, skipNodesWithErrors);
+
+      Iterable<SolrCollection> initCollections;
+      if (withCollections.isEmpty() && withCollectionShards.isEmpty()) {
+        initCollections = relevantCollections;
+      } else {
+        // TODO this doesn't scale to many collections
+        initCollections = placementContext.getCluster().collections();
+      }
+      initWeightedNodeReplicas(weightedNodes, initCollections);
+
+      return weightedNodes;
+    }
+
+    @Override
     protected Map<Node, WeightedNode> getBaseWeightedNodes(
         PlacementContext placementContext,
         Set<Node> nodes,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17289

Not sure if the first version here is right; maybe there are untested issues where this won't work?  And maybe with withCollection/withShards can be made to be scalable too.  Like init the replicas of those collections only (not the whole cluster!)