### PR TITLE
SOLR-17307: Use file separator instead of '/' in CachingDirectoryFactory

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -157,6 +157,8 @@ Bug Fixes
 ---------------------
 * SOLR-17296: Remove (broken) singlePass attempt when reRankScale + debug is used, and fix underlying NPE. (hossman)
 
+* SOLR-17307: Use the system file separator instead of an explicit '/' in CachingDirectoryFactory (Houston Putman, hossman)
+
 ==================  9.6.0 ==================
 New Features
 ---------------------

--- a/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.core;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.DirectoryStream;
@@ -362,10 +363,10 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
   }
 
   private static boolean isSubPath(CacheValue cacheValue, CacheValue otherCacheValue) {
-    int one = cacheValue.path.lastIndexOf('/');
-    int two = otherCacheValue.path.lastIndexOf('/');
+    int one = cacheValue.path.lastIndexOf(File.separatorChar);
+    int two = otherCacheValue.path.lastIndexOf(File.separatorChar);
 
-    return otherCacheValue.path.startsWith(cacheValue.path + "/") && two > one;
+    return otherCacheValue.path.startsWith(cacheValue.path + File.separatorChar) && two > one;
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/core/CachingDirectoryFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/core/CachingDirectoryFactoryTest.java
@@ -94,7 +94,9 @@ public class CachingDirectoryFactoryTest extends SolrTestCaseJ4 {
       df.remove(pathAString, addIfTrue(deleteAfter, pathAString, removeAfter.getAsBoolean()));
       df.doneWithDirectory(a);
       df.release(a);
-      assertTrue(pathA.toFile().exists()); // we know there are subdirs that should prevent removal
+      assertTrue(
+          "The path " + pathA + " should exist because it has subdirs that prevent removal",
+          pathA.toFile().exists()); // we know there are subdirs that should prevent removal
       Collections.shuffle(Arrays.asList(subdirs), r);
       for (Map.Entry<String, Directory> e : subdirs) {
         boolean after = removeAfter.getAsBoolean();
@@ -105,18 +107,26 @@ public class CachingDirectoryFactoryTest extends SolrTestCaseJ4 {
         df.release(d);
         boolean exists = Path.of(pathString).toFile().exists();
         if (after) {
-          assertTrue(exists);
+          assertTrue(
+              "Path " + pathString + " should be removed after, but it no longer exists", exists);
         } else {
-          assertFalse(exists);
+          assertFalse(
+              "Path " + pathString + " should not wait to be removed, but it still exists", exists);
         }
       }
       if (alwaysBefore) {
-        assertTrue(deleteAfter.isEmpty());
+        assertTrue(
+            "The directory should always be deleted before, but it has items that it should be deleted after",
+            deleteAfter.isEmpty());
       }
       if (deleteAfter.isEmpty()) {
-        assertTrue(PathUtils.isEmpty(tmpDir));
+        assertTrue(
+            "There are no subdirs to delete afterwards, therefore the directory should have been emptied",
+            PathUtils.isEmpty(tmpDir));
       } else {
-        assertTrue(pathA.toFile().exists()); // parent must still be present
+        assertTrue(
+            "There are subdirs to wait on, so the parent directory should still exist",
+            pathA.toFile().exists()); // parent must still be present
         for (Map.Entry<String, Directory> e : subdirs) {
           String pathString = e.getKey();
           boolean exists = new File(pathString).exists();
@@ -128,7 +138,7 @@ public class CachingDirectoryFactoryTest extends SolrTestCaseJ4 {
         }
       }
     }
-    assertTrue(PathUtils.isEmpty(tmpDir));
+    assertTrue("Dir " + tmpDir + " should be empty at the end", PathUtils.isEmpty(tmpDir));
   }
 
   private static boolean addIfTrue(Set<String> deleteAfter, String path, boolean after) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17307