### PR TITLE
Clarify the cache behavior in the Ref Guide

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
@@ -94,12 +94,12 @@ Details of each cache are described below.
 This cache holds parsed queries paired with an unordered set of all documents that match it.
 Unless such a set is trivially small, the set implementation is a bitset.
 
-The most typical way Solr uses the `filterCache` is to cache results of each `fq` search parameter, though there are some other cases as well.
+The most typical way Solr uses the `filterCache` is to cache results of each `fq` search parameter, though there are some other use cases as well.
 Subsequent queries using the same parameter filter query result in cache hits and rapid returns of results.
 See xref:query-guide:common-query-parameters.adoc#fq-filter-query-parameter[fq (Filter Query) Parameter] for a detailed discussion of `fq`.
 
 [TIP]
-Use of this cache can be disabled for a `fq` using the xref:query-guide:common-query-parameters.adoc#cache-local-parameter[`cache` local parameter].
+Use of this cache can be disabled for a specific query's `fq` using the xref:query-guide:common-query-parameters.adoc#cache-local-parameter[`cache` local parameter].
 
 Another Solr feature using this cache is the `filter(...)` syntax in the default Lucene query parser.
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
@@ -43,7 +43,7 @@ These settings are all configured in child elements of the `<query>` element in 
 
 Solr caches are associated with a specific instance of an Index Searcher, a specific view of an index that doesn't change during the lifetime of that searcher.
 As long as that Index Searcher is being used, any items in its cache will be valid and available for reuse.
-By default cached Solr objects do not expire after a time interval; instead, they remain valid for the lifetime of the Index Searcher.
+By default, cached Solr objects do not expire after a time interval; instead, they remain valid for the lifetime of the Index Searcher.
 Idle time-based expiration can be enabled by using `maxIdleTime` option.
 
 When a new searcher is opened, the current searcher continues servicing requests while the new one auto-warms its cache.
@@ -56,8 +56,8 @@ The old searcher will be closed once it has finished servicing all its requests.
 Solr comes with a default `SolrCache` implementation that is used for different types of caches.
 
 The `CaffeineCache` is an implementation backed by the https://github.com/ben-manes/caffeine[Caffeine caching library].
-By default it uses a Window TinyLFU (W-TinyLFU) eviction policy, which allows the eviction based on both frequency and recency of use in O(1) time with a small footprint.
-Generally this cache usually offers lower memory footprint, higher hit ratio, and better multi-threaded performance over legacy caches.
+By default, it uses a Window TinyLFU (W-TinyLFU) eviction policy, which allows the eviction based on both frequency and recency of use in O(1) time with a small footprint.
+Generally this cache usually offers lower memory footprint, higher hit ratio, and better multithreaded performance over legacy caches.
 
 `CaffeineCache` uses an auto-warm count that supports both integers and percentages which get evaluated relative to the current size of the cache when warming happens.
 
@@ -86,7 +86,6 @@ The async cache provides most significant improvement with many concurrent queri
 However, the async cache will not prevent data races for time-limited queries, since those are expected to provide partial results.
 
 All caches can be disabled using the parameter `enabled` with a value of `false`.
-Caches can also be disabled on a query-by-query basis with the `cache` parameter, as described in the section xref:query-guide:common-query-parameters.adoc#cache-local-parameter[cache Local Parameter].
 
 Details of each cache are described below.
 
@@ -98,6 +97,8 @@ Unless such a set is trivially small, the set implementation is a bitset.
 The most typical way Solr uses the `filterCache` is to cache results of each `fq` search parameter, though there are some other cases as well.
 Subsequent queries using the same parameter filter query result in cache hits and rapid returns of results.
 See xref:query-guide:common-query-parameters.adoc#fq-filter-query-parameter[fq (Filter Query) Parameter] for a detailed discussion of `fq`.
+
+[TIP]
 Use of this cache can be disabled for a `fq` using the xref:query-guide:common-query-parameters.adoc#cache-local-parameter[`cache` local parameter].
 
 Another Solr feature using this cache is the `filter(...)` syntax in the default Lucene query parser.
@@ -143,8 +144,6 @@ The `queryResultCache` has an optional setting to limit the maximum amount of RA
 This lets you specify the maximum heap size, in megabytes, used by the contents of this cache.
 When the cache grows beyond this size, oldest accessed queries will be evicted until the heap usage of the cache decreases below the specified limit.
 If a `size` is specified in addition to `maxRamMB` then only the heap usage limit is respected.
-
-Use of this cache can be disabled on a query-by-query basis in `q` using the xref:query-guide:common-query-parameters.adoc#cache-local-parameter[`cache` local parameter].
 
 [source,xml]
 ----
@@ -229,7 +228,7 @@ Query strings that specify more clauses than this will result in an error.
 If this per-collection limit is greater than the xref:configuring-solr-xml.adoc#global-maxbooleanclauses[global `maxBooleanClauses` limit] specified in `solr.xml`, it will have no effect, as that setting also limits the size of user specified boolean queries.
 
 In default configurations this property uses the value of the `solr.max.booleanClauses` system property if specified.
-This is the same system property used in the xref:configuring-solr-xml#global-maxbooleanclauses[global `maxBooleanClauses` setting] in the default `solr.xml` making it easy for Solr administrators to increase both values (in all collections) without needing to search through and update the `solrconfig.xml` files in each collection.
+This is the same system property used in the xref:configuring-solr-xml.adoc#global-maxbooleanclauses[global `maxBooleanClauses` setting] in the default `solr.xml` making it easy for Solr administrators to increase both values (in all collections) without needing to search through and update the `solrconfig.xml` files in each collection.
 
 [source,xml]
 ----
@@ -282,7 +281,7 @@ This parameter sets the maximum number of documents to cache for any entry in th
 === <useColdSearcher> Element
 
 This setting controls whether search requests for which there is not a currently registered searcher should wait for a new searcher to warm up (`false`) or proceed immediately (`true`).
-When set to "false`, requests will block until the searcher has warmed its caches.
+When set to `false`, requests will block until the searcher has warmed its caches.
 
 [source,xml]
 ----


### PR DESCRIPTION
# Description

Clarify that only the filter cache, and not any other caches, can be disabled by the `cache` local parameter.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
