### PR TITLE
Correct command to reproduce test with a failure in classMethod

### DIFF
--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -25,11 +25,12 @@ allprojects {
   tasks.withType(Test) { Test task ->
     afterTest { desc, result ->
       if (result.resultType == TestResult.ResultType.FAILURE) {
+        def testOrClassName = desc.name == "classMethod" ? desc.className : "${desc.className}.${desc.name}"
         failedTests << [
             "name": "${desc.className}.${desc.name}",
             "project": "${test.project.path}",
             "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc.parent)}"),
-            "reproduce": "gradlew ${project.path}:test --tests \"${desc.className}.${desc.name}\" ${task.project.testOptionsForReproduceLine}"
+            "reproduce": "gradlew ${project.path}:test --tests \"$testOrClassName\" ${task.project.testOptionsForReproduceLine}"
         ]
       }
     }

--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -30,7 +30,7 @@ allprojects {
             "name": "${desc.className}.${desc.name}",
             "project": "${test.project.path}",
             "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc.parent)}"),
-            "reproduce": "gradlew ${project.path}:test --tests \"$testOrClassName\" ${task.project.testOptionsForReproduceLine}"
+            "reproduce": "./gradlew ${project.path}:test --tests \"$testOrClassName\" ${task.project.testOptionsForReproduceLine}"
         ]
       }
     }
@@ -41,7 +41,7 @@ allprojects {
             "name": "${desc.name}",
             "project": "${test.project.path}",
             "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc)}"),
-            "reproduce": "gradlew ${project.path}:test --tests \"${desc.name}\" ${task.project.testOptionsForReproduceLine}"
+            "reproduce": "./gradlew ${project.path}:test --tests \"${desc.name}\" ${task.project.testOptionsForReproduceLine}"
         ]
       }
     }


### PR DESCRIPTION
# Description

If a test fails due to some exception during static initialization, the logs contain message that looks like
```
Reproduce with: gradlew :solr:core:test --tests "org.apache.solr.response.JSONWriterTest.classMethod"
```
which is not a valid command to re-run the test.

This PR changes the message to be
```
Reproduce with: gradlew :solr:core:test --tests "org.apache.solr.response.JSONWriterTest"
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
