### PR TITLE
Move setShardAttributesToParams

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -526,7 +526,7 @@ public class SearchHandler extends RequestHandlerBase
             // TODO: map from shard to address[]
             for (String shard : sreq.actualShards) {
               ModifiableSolrParams params = new ModifiableSolrParams(sreq.params);
-              params.setShardAttributesToParams(sreq.purpose);
+              ShardHandler.setShardAttributesToParams(params, sreq.purpose);
 
               // Distributed request -- need to send queryID as a part of the distributed request
               params.setNonNull(ShardParams.QUERY_ID, rb.queryID);

--- a/solr/core/src/java/org/apache/solr/handler/component/ShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ShardHandler.java
@@ -16,7 +16,12 @@
  */
 package org.apache.solr.handler.component;
 
+import static org.apache.solr.common.params.CommonParams.DISTRIB;
+import static org.apache.solr.common.params.CommonParams.INDENT;
+
+import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.ShardParams;
 
 public abstract class ShardHandler {
   public abstract void prepDistributed(ResponseBuilder rb);
@@ -30,4 +35,14 @@ public abstract class ShardHandler {
   public abstract void cancelAll();
 
   public abstract ShardHandlerFactory getShardHandlerFactory();
+
+  public static void setShardAttributesToParams(ModifiableSolrParams params, int purpose) {
+    params.remove(ShardParams.SHARDS); // not a top-level request
+    params.set(DISTRIB, Boolean.FALSE.toString()); // not a top-level request
+    params.remove(INDENT);
+    params.remove(CommonParams.HEADER_ECHO_PARAMS);
+    params.set(ShardParams.IS_SHARD, true); // a sub (shard) request
+    params.set(ShardParams.SHARDS_PURPOSE, purpose);
+    params.set(CommonParams.OMIT_HEADER, false);
+  }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/TaskManagementHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TaskManagementHandler.java
@@ -79,7 +79,7 @@ public abstract class TaskManagementHandler extends RequestHandlerBase
         String reqPath = (String) req.getContext().get(PATH);
 
         params.set(CommonParams.QT, reqPath);
-        params.setShardAttributesToParams(sreq.purpose);
+        ShardHandler.setShardAttributesToParams(params, sreq.purpose);
 
         if (extraParams != null) {
           for (Map.Entry<String, String> entry : extraParams.entrySet()) {

--- a/solr/core/src/test/org/apache/solr/core/TestShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/core/TestShardHandlerFactory.java
@@ -39,8 +39,9 @@ public class TestShardHandlerFactory extends SolrTestCaseJ4 {
     cc.shutdown();
   }
 
-  /** Test {@link ShardHandler#setShardAttributesToParams */
+  /** Test {@link ShardHandler#setShardAttributesToParams} */
   public void testSetShardAttributesToParams() {
+    // NOTE: the value of this test is really questionable; we should feel free to remove it
     ModifiableSolrParams modifiable = new ModifiableSolrParams();
     var dummyIndent = "Dummy-Indent";
 

--- a/solr/core/src/test/org/apache/solr/core/TestShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/core/TestShardHandlerFactory.java
@@ -18,7 +18,11 @@ package org.apache.solr.core;
 
 import java.nio.file.Path;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.component.ShardHandler;
 import org.apache.solr.handler.component.ShardHandlerFactory;
 
 /** Tests specifying a custom ShardHandlerFactory */
@@ -33,5 +37,26 @@ public class TestShardHandlerFactory extends SolrTestCaseJ4 {
     assertEquals("myMagicRequiredValue", args.get("myMagicRequiredParameter"));
     factory.close();
     cc.shutdown();
+  }
+
+  /** Test {@link ShardHandler#setShardAttributesToParams */
+  public void testSetShardAttributesToParams() {
+    ModifiableSolrParams modifiable = new ModifiableSolrParams();
+    var dummyIndent = "Dummy-Indent";
+
+    modifiable.set(ShardParams.SHARDS, "dummyValue");
+    modifiable.set(CommonParams.HEADER_ECHO_PARAMS, "dummyValue");
+    modifiable.set(CommonParams.INDENT, dummyIndent);
+
+    ShardHandler.setShardAttributesToParams(modifiable, 2);
+
+    assertEquals(Boolean.FALSE.toString(), modifiable.get(CommonParams.DISTRIB));
+    assertEquals("2", modifiable.get(ShardParams.SHARDS_PURPOSE));
+    assertEquals(Boolean.FALSE.toString(), modifiable.get(CommonParams.OMIT_HEADER));
+    assertEquals(Boolean.TRUE.toString(), modifiable.get(ShardParams.IS_SHARD));
+
+    assertNull(modifiable.get(CommonParams.HEADER_ECHO_PARAMS));
+    assertNull(modifiable.get(ShardParams.SHARDS));
+    assertNull(modifiable.get(CommonParams.INDENT));
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/params/ModifiableSolrParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/ModifiableSolrParams.java
@@ -16,9 +16,6 @@
  */
 package org.apache.solr.common.params;
 
-import static org.apache.solr.common.params.CommonParams.DISTRIB;
-import static org.apache.solr.common.params.CommonParams.INDENT;
-
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -178,16 +175,6 @@ public class ModifiableSolrParams extends SolrParams {
 
   // ----------------------------------------------------------------
   // ----------------------------------------------------------------
-
-  public void setShardAttributesToParams(int purpose) {
-    remove(ShardParams.SHARDS); // not a top-level request
-    set(DISTRIB, Boolean.FALSE.toString()); // not a top-level request
-    remove(INDENT);
-    remove(CommonParams.HEADER_ECHO_PARAMS);
-    set(ShardParams.IS_SHARD, true); // a sub (shard) request
-    set(ShardParams.SHARDS_PURPOSE, purpose);
-    set(CommonParams.OMIT_HEADER, false);
-  }
 
   @Override
   public String get(String param) {

--- a/solr/solrj/src/test/org/apache/solr/common/params/ModifiableSolrParamsTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/params/ModifiableSolrParamsTest.java
@@ -127,25 +127,6 @@ public class ModifiableSolrParamsTest extends SolrTestCase {
     compareArrays("checking Hello World Universe ", helloWorldUniverse, result);
   }
 
-  public void testSetShardAttributesToParams() {
-    var dummyIndent = "Dummy-Indent";
-
-    modifiable.set(ShardParams.SHARDS, "dummyValue");
-    modifiable.set(CommonParams.HEADER_ECHO_PARAMS, "dummyValue");
-    modifiable.set(CommonParams.INDENT, dummyIndent);
-
-    modifiable.setShardAttributesToParams(2);
-
-    assertEquals(Boolean.FALSE.toString(), modifiable.get(CommonParams.DISTRIB));
-    assertEquals("2", modifiable.get(ShardParams.SHARDS_PURPOSE));
-    assertEquals(Boolean.FALSE.toString(), modifiable.get(CommonParams.OMIT_HEADER));
-    assertEquals(Boolean.TRUE.toString(), modifiable.get(ShardParams.IS_SHARD));
-
-    assertNull(modifiable.get(CommonParams.HEADER_ECHO_PARAMS));
-    assertNull(modifiable.get(ShardParams.SHARDS));
-    assertNull(modifiable.get(CommonParams.INDENT));
-  }
-
   private void compareArrays(String prefix, String[] expected, String[] actual) {
     assertEquals(prefix + "length: ", expected.length, actual.length);
     for (int i = 0; i < expected.length; ++i) {


### PR DESCRIPTION
From ModifiableSolrParams to SearchHandler.  Too special-purpose to warrant any back-compat concern.  Was here since 2023-06