### PR TITLE
Build: report test history via GE

### DIFF
--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -31,7 +31,7 @@ def genFailInfo(def task, TestDescriptor desc) {
   }
   def logName = ErrorReportingTestListener.getOutputLogName(desc.parent ?: desc)
   def output = file("${task.testOutputsDir}/${logName}")
-  def repro = "gradlew ${task.project.path}:test --tests \"${name}\" ${task.project.testOptionsForReproduceLine}"
+  def repro = "./gradlew ${task.project.path}:test --tests \"${name}\" ${task.project.testOptionsForReproduceLine}"
   return ["name": name, "project": "${task.project.path}", "historyUrl": historyUrl, "output": output, "reproduce": repro]
 }
 

--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -28,6 +28,7 @@ allprojects {
         failedTests << [
             "name": "${desc.className}.${desc.name}",
             "project": "${test.project.path}",
+            "historyUrl": "https://ge.apache.org/scans/tests?search.rootProjectNames=solr-root&tests.container=$desc.className&tests.test=$desc.name",
             "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc.parent)}"),
             "reproduce": "gradlew ${project.path}:test --tests \"${desc.className}.${desc.name}\" ${task.project.testOptionsForReproduceLine}"
         ]
@@ -39,6 +40,7 @@ allprojects {
         failedTests << [
             "name": "${desc.name}",
             "project": "${test.project.path}",
+            "historyUrl": "https://ge.apache.org/scans/tests?search.rootProjectNames=solr-root&tests.container=$desc.className",
             "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc)}"),
             "reproduce": "gradlew ${project.path}:test --tests \"${desc.name}\" ${task.project.testOptionsForReproduceLine}"
         ]
@@ -48,14 +50,17 @@ allprojects {
 }
 
 gradle.buildFinished { result ->
-  if (failedTests) {
-    def formatted = failedTests
-      .sort { a, b -> b.project.compareTo(a.project) }
-      .collect { e -> String.format(Locale.ROOT,
-          "  - %s (%s)\n    Test output: %s\n    Reproduce with: %s\n",
-          e.name, e.project, e.output, e.reproduce) }
-      .join("\n")
+  if (!failedTests) return
+  def formatted = failedTests
+      .sort { a, b -> b.project <=> a.project }
+      .collect { e -> """
+  - ${e.name} (${e.project})
+    Test history: ${e.historyUrl}
+    Test output: ${e.output}
+    Reproduce with: ${e.reproduce}
+""" // In Groovy there is no incidental leading whitespace, so must fully left justify
+      }
+      .join()
 
-    logger.error("\nERROR: The following test(s) have failed:\n${formatted}")
-  }
+  logger.error("ERROR: The following test(s) have failed:${formatted}")
 }

--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -19,7 +19,7 @@ import org.apache.lucene.gradle.ErrorReportingTestListener
 
 // Display all failed tests at the end of the build.
 
-def failedTests = []
+def failedTests = new LinkedHashSet() // for dedupe due to weird afterTest classMethod issue
 
 def genFailInfo(def task, TestDescriptor desc) {
   boolean isSuite = (desc.name == 'classMethod')

--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -21,29 +21,31 @@ import org.apache.lucene.gradle.ErrorReportingTestListener
 
 def failedTests = []
 
+def genFailInfo(def task, TestDescriptor desc) {
+  boolean isSuite = (desc.name == 'classMethod')
+  def name = isSuite ? desc.className : "${desc.className}.${desc.name}"
+  def historyUrl = "https://ge.apache.org/scans/tests?search.rootProjectNames=solr-root&tests.container=$desc.className"
+  if (!isSuite) { // is test method specific
+    historyUrl += "&tests.test=$desc.name"
+    historyUrl += " http://fucit.org/solr-jenkins-reports/history-trend-of-recent-failures.html#series/$name"
+  }
+  def logName = ErrorReportingTestListener.getOutputLogName(desc.parent ?: desc)
+  def output = file("${task.testOutputsDir}/${logName}")
+  def repro = "gradlew ${task.project.path}:test --tests \"${name}\" ${task.project.testOptionsForReproduceLine}"
+  return ["name": name, "project": "${task.project.path}", "historyUrl": historyUrl, "output": output, "reproduce": repro]
+}
+
 allprojects {
   tasks.withType(Test) { Test task ->
     afterTest { desc, result ->
       if (result.resultType == TestResult.ResultType.FAILURE) {
-        failedTests << [
-            "name": "${desc.className}.${desc.name}",
-            "project": "${test.project.path}",
-            "historyUrl": "https://ge.apache.org/scans/tests?search.rootProjectNames=solr-root&tests.container=$desc.className&tests.test=$desc.name",
-            "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc.parent)}"),
-            "reproduce": "gradlew ${project.path}:test --tests \"${desc.className}.${desc.name}\" ${task.project.testOptionsForReproduceLine}"
-        ]
+        failedTests << genFailInfo(task, desc)
       }
     }
 
     afterSuite { desc, result ->
       if (result.exceptions) {
-        failedTests << [
-            "name": "${desc.name}",
-            "project": "${test.project.path}",
-            "historyUrl": "https://ge.apache.org/scans/tests?search.rootProjectNames=solr-root&tests.container=$desc.className",
-            "output": file("${task.testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc)}"),
-            "reproduce": "gradlew ${project.path}:test --tests \"${desc.name}\" ${task.project.testOptionsForReproduceLine}"
-        ]
+        failedTests << genFailInfo(task, desc)
       }
     }
   }


### PR DESCRIPTION
Put a convenient link to test history, powered by Gradle Enterprise.
Could be enhanced to also include fucit.org

Improve the corresponding build logic to be more "groovy", as it's said.

Example, with me forcing some failures to demo:
```
> Task :solr:core:test FAILED
ERROR: The following test(s) have failed:
  - org.apache.solr.search.TestThinCache.testInitCore (:solr:core)
    Test history: https://ge.apache.org/scans/tests?search.rootProjectNames=solr-root&tests.container=org.apache.solr.search.TestThinCache&tests.test=testInitCore
    Test output: /Users/dsmiley/SFDCDev/solr_main/solr/core/build/test-results/test/outputs/OUTPUT-org.apache.solr.search.TestThinCache.txt
    Reproduce with: gradlew :solr:core:test --tests "org.apache.solr.search.TestThinCache.testInitCore" -Ptests.jvms=8 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 -XX:ReservedCodeCacheSize=120m" -Ptests.seed=4701215A96003B03 -Ptests.useSecurityManager=false -Ptests.locale=cs-CZ -Ptests.timezone=America/Dawson_Creek -Ptests.badapples=false -Ptests.file.encoding=UTF-8

```

Indentation should be the same as it was; just added a URL.

Note that gradle.buildFinished is deprecated but [it doesn't yet have a concise replacement](https://docs.google.com/document/d/1nS1JTwdCMQN_0WaaFrSUxoQOj3zOqmKmXxC6k0OXUR0/edit#heading=h.4691loc5bp0p) so I'm leaving it be.