### PR TITLE
Add `alwaysStopwords` option to `edismax` so its "all stopwords" behaviour can be controlled

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -98,6 +98,9 @@ public class ExtendedDismaxQParser extends QParser {
 
     /** If set to true, stopwords are removed from the query. */
     public static String STOPWORDS = "stopwords";
+
+    /** If set to true, the stop word filter applies even if all terms are stop words */
+    public static String ALWAYS_STOPWORDS = "alwaysStopwords";
   }
 
   private ExtendedDismaxConfiguration config;
@@ -408,7 +411,7 @@ public class ExtendedDismaxQParser extends QParser {
       query = up.parse(mainUserQuery);
 
       if (shouldRemoveStopFilter(config, query)) {
-        // if the query was all stop words, remove none of them
+        // if the query was all stop words, remove none of them (unless alwaysStopwords is set)
         up.setRemoveStopFilter(true);
         query = up.parse(mainUserQuery);
       }
@@ -417,6 +420,9 @@ public class ExtendedDismaxQParser extends QParser {
       up.exceptions = false;
     }
 
+    // query may have become empty if it only contained tokenising characters or due to
+    // stop word removal if alwaysStopwords is set. The query plan becomes +() rather
+    // than MatchNoDocsQuery("") - does this make any difference?
     if (query == null) {
       return null;
     }
@@ -439,11 +445,11 @@ public class ExtendedDismaxQParser extends QParser {
   /**
    * Determines if query should be re-parsed removing the stop filter.
    *
-   * @return true if there are stopwords configured and the parsed query was empty false in any
-   *     other case.
+   * @return true if there are stopwords configured, the alwaysStopwords option hasn't been set
+   *     and the parsed query was empty - return false in any other case.
    */
   protected boolean shouldRemoveStopFilter(ExtendedDismaxConfiguration config, Query query) {
-    return config.stopwords && isEmpty(query);
+    return config.stopwords && !config.alwaysStopwords && isEmpty(query);
   }
 
   private String escapeUserQuery(List<Clause> clauses) {
@@ -1700,6 +1706,8 @@ public class ExtendedDismaxQParser extends QParser {
 
     protected boolean stopwords;
 
+    protected boolean alwaysStopwords;
+
     protected boolean mmAutoRelax;
 
     protected String altQ;
@@ -1749,6 +1757,8 @@ public class ExtendedDismaxQParser extends QParser {
       qslop = solrParams.getInt(DisMaxParams.QS, 0);
 
       stopwords = solrParams.getBool(DMP.STOPWORDS, true);
+
+      alwaysStopwords = solrParams.getBool(DMP.ALWAYS_STOPWORDS, false);
 
       mmAutoRelax = solrParams.getBool(DMP.MM_AUTORELAX, false);
 


### PR DESCRIPTION
_work in progress!_ If anyone sees this and has thoughts on it, please comment below :-)

# Description

We were surprised by `edismax`'s behaviour for pure-stopword queries, having expected that these would return zero results. Its _'If a query consists of all stopwords, such as "to be or not to be", then all words are required.'_ behaviour is the opposite to what we want as we're using query-time stopwords to prevent particular query terms matching, but there's no way to disable the behaviour other than using `dismax` instead, which may have other impacts.

# Solution

This PR adds an `alwaysStopwords` option that disables the default behaviour. Its name is TBD.

I've noticed that the query plan becomes `+()` rather than `MatchNoDocsQuery("")` for pure-stopword queries, also when the query contains only tokenising characters (e.g. punctuation). Does this make any difference?

# Tests

_TO DO!_

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
