### PR TITLE
Add 'score' field caveat to cursormark docs

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/pagination-of-results.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/pagination-of-results.adoc
@@ -118,6 +118,12 @@ If `id` is your uniqueKey field, then sort parameters like `id asc` and `name as
 This can easily result in cursors that never end, and constantly return the same documents over and over – even if the documents are never updated.
 +
 In this situation, choose & re-use a fixed value for the xref:indexing-guide:date-formatting-math.adoc#now[`NOW` request parameter] in all of your cursor requests.
+. `sort` clauses containing the `score` pseudo-field should also be used with care in multi-replica SolrCloud deployments.
++
+Scores rely on term statistics which may vary from replica to replica, causing the same document to score differently in each.
+As a result, a series of cursormark requests may inadvertently skip or repeat documents if the requests are served by different replicas
++
+SolrCloud users who wish to use `score` as a sort criteria on cursormark requests can avoid these issues, either by using `PULL` type replicas or by ensuring that all cursormark requests in a series are processed by the same replica.
 
 Cursor mark values are computed based on the sort values of each document in the result, which means multiple documents with identical sort values will produce identical Cursor mark values if one of them is the last document on a page of results.
 In that situation, the subsequent request using that `cursorMark` would not know which of the documents with the identical mark values should be skipped.


### PR DESCRIPTION
# Description

Cursormark can give some funky results if used across multiple replicas in a SolrCloud collection, if `score` is used as a sort field.  But there's not currently any warning of this in the ref-guide.

# Solution

This PR documents the limitation for users in the ref-guide.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
