### PR TITLE
SOLR-17320: Added support for timeAllowed time out in HttpShardHandler

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -202,7 +202,12 @@ public class HttpShardHandler extends ShardHandler {
    */
   @Override
   public ShardResponse takeCompletedIncludingErrors() {
-    return take(false);
+    return take(false, -1);
+  }
+
+  @Override
+  public ShardResponse takeCompletedIncludingErrorsWithTimeout(long maxAllowedTimeInMillis) {
+    return take(false, maxAllowedTimeInMillis);
   }
 
   /**
@@ -211,14 +216,23 @@ public class HttpShardHandler extends ShardHandler {
    */
   @Override
   public ShardResponse takeCompletedOrError() {
-    return take(true);
+    return take(true, -1);
   }
 
-  private ShardResponse take(boolean bailOnError) {
+  private ShardResponse take(boolean bailOnError, long maxAllowedTimeInMillis) {
     try {
+      long deadline = System.nanoTime();
+      if (maxAllowedTimeInMillis > 0) {
+        deadline += TimeUnit.MILLISECONDS.toNanos(maxAllowedTimeInMillis);
+      } else {
+        deadline = System.nanoTime() + TimeUnit.DAYS.toNanos(1);
+      }
+
+      ShardResponse previousResponse = null;
       while (pending.get() > 0) {
-        ShardResponse rsp = responses.take();
-        responseFutureMap.remove(rsp);
+        long waitTime = deadline - System.nanoTime();
+        ShardResponse rsp = responses.poll(waitTime, TimeUnit.NANOSECONDS);
+        if (rsp == null) return previousResponse;
 
         pending.decrementAndGet();
         if (bailOnError && rsp.getException() != null)
@@ -228,6 +242,7 @@ public class HttpShardHandler extends ShardHandler {
         // for a request was received.  Otherwise we might return the same
         // request more than once.
         rsp.getShardRequest().responses.add(rsp);
+        previousResponse = rsp;
         if (rsp.getShardRequest().responses.size() == rsp.getShardRequest().actualShards.length) {
           return rsp;
         }
@@ -381,5 +396,15 @@ public class HttpShardHandler extends ShardHandler {
   @Override
   public ShardHandlerFactory getShardHandlerFactory() {
     return httpShardHandlerFactory;
+  }
+
+  // test helper function
+  void setPendingRequest(int val) {
+    this.pending.set(val);
+  }
+
+  // test helper function
+  void setResponse(ShardResponse shardResponse) {
+    this.responses.add(shardResponse);
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -232,9 +232,9 @@ public class HttpShardHandler extends ShardHandler {
       while (pending.get() > 0) {
         long waitTime = deadline - System.nanoTime();
         ShardResponse rsp = responses.poll(waitTime, TimeUnit.NANOSECONDS);
+        pending.decrementAndGet();
         if (rsp == null) return previousResponse;
 
-        pending.decrementAndGet();
         if (bailOnError && rsp.getException() != null)
           return rsp; // if exception, return immediately
         // add response to the response list... we do this after the take() and

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -492,7 +492,7 @@ public class SearchHandler extends RequestHandlerBase
       }
     } else {
       // a distributed request
-      long maxTimeAllowed = req.getParams().getLong(CommonParams.TIME_ALLOWED, -1);
+      long maxTimeAllowed = req.getParams().getLong(CommonParams.TIME_ALLOWED, 24 * 60 * 60 * 1000);
 
       if (rb.outgoing == null) {
         rb.outgoing = new ArrayList<>();
@@ -556,9 +556,10 @@ public class SearchHandler extends RequestHandlerBase
           // this loop)
           boolean tolerant = ShardParams.getShardsTolerantAsBool(rb.req.getParams());
           while (rb.outgoing.size() == 0) {
+            long timeAllowed = maxTimeAllowed - (long) req.getRequestTimer().getTime();
             ShardResponse srsp =
                 tolerant
-                    ? shardHandler1.takeCompletedIncludingErrorsWithTimeout(maxTimeAllowed)
+                    ? shardHandler1.takeCompletedIncludingErrorsWithTimeout(timeAllowed)
                     : shardHandler1.takeCompletedOrError();
             if (srsp == null) break; // no more requests to wait for
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -492,6 +492,7 @@ public class SearchHandler extends RequestHandlerBase
       }
     } else {
       // a distributed request
+      long maxTimeAllowed = req.getParams().getLong(CommonParams.TIME_ALLOWED, -1);
 
       if (rb.outgoing == null) {
         rb.outgoing = new ArrayList<>();
@@ -557,7 +558,7 @@ public class SearchHandler extends RequestHandlerBase
           while (rb.outgoing.size() == 0) {
             ShardResponse srsp =
                 tolerant
-                    ? shardHandler1.takeCompletedIncludingErrors()
+                    ? shardHandler1.takeCompletedIncludingErrorsWithTimeout(maxTimeAllowed)
                     : shardHandler1.takeCompletedOrError();
             if (srsp == null) break; // no more requests to wait for
 

--- a/solr/core/src/java/org/apache/solr/handler/component/ShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ShardHandler.java
@@ -30,6 +30,9 @@ public abstract class ShardHandler {
 
   public abstract ShardResponse takeCompletedIncludingErrors();
 
+  public abstract ShardResponse takeCompletedIncludingErrorsWithTimeout(
+      long maxAllowedTimeInMillis);
+
   public abstract ShardResponse takeCompletedOrError();
 
   public abstract void cancelAll();

--- a/solr/core/src/test/org/apache/solr/TestTimeAllowedSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestTimeAllowedSearch.java
@@ -1,0 +1,104 @@
+package org.apache.solr;
+
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.cloud.MiniSolrCloudCluster;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ShardParams;
+
+public class TestTimeAllowedSearch extends SolrCloudTestCase {
+
+  /**
+   * This test demonstrates timeAllowed expectation at @{@link
+   * org.apache.solr.handler.component.HttpShardHandler} level This test creates collection with
+   * 'implicit` router, which has two shards shard_1 has 100000 docs, so that query should take some
+   * time shard_2 has only 1 doc to demonstrate the HttpSHardHandler timeout Then it execute
+   * substring query with TIME_ALLOWED 50, assuming this query will time out on shard_1
+   */
+  public void testTimeAllowed() throws Exception {
+    MiniSolrCloudCluster cluster =
+        configureCluster(2).addConfig("conf", configset("cloud-minimal")).configure();
+    try {
+      CloudSolrClient client = cluster.getSolrClient();
+      String COLLECTION_NAME = "test_coll";
+      CollectionAdminRequest.createCollection(COLLECTION_NAME, "conf", 2, 1)
+          .setRouterName("implicit")
+          .setShards("shard_1,shard_2")
+          .process(cluster.getSolrClient());
+      cluster.waitForActiveCollection(COLLECTION_NAME, 2, 2);
+      UpdateRequest ur = new UpdateRequest();
+      for (int i = 0; i < 100000; i++) {
+        SolrInputDocument doc = new SolrInputDocument();
+        doc.addField("id", "" + i);
+        final String s =
+            RandomStrings.randomAsciiLettersOfLengthBetween(random(), 10, 100)
+                .toLowerCase(Locale.ROOT);
+        doc.setField("subject_s", s);
+        doc.setField("_route_", "shard_1");
+        ur.add(doc);
+      }
+
+      // adding "abc" in each shard as we will have query *abc*
+      SolrInputDocument doc = new SolrInputDocument();
+      doc.addField("id", "" + 10000);
+      doc.setField("subject_s", "abc");
+      doc.setField("_route_", "shard_2");
+      ur.add(doc);
+
+      doc = new SolrInputDocument();
+      doc.addField("id", "" + 100001);
+      doc.setField("subject_s", "abc");
+      doc.setField("_route_", "shard_1");
+      ur.add(doc);
+
+      ur.commit(client, COLLECTION_NAME);
+
+      // warm up query
+      SolrQuery query = new SolrQuery();
+      query.setQuery("subject_s:*abcd*");
+      query.set(ShardParams.SHARDS_TOLERANT, "true");
+      QueryResponse response = client.query(COLLECTION_NAME, query);
+
+      query = new SolrQuery();
+      query.setQuery("subject_s:*abc*");
+      query.set(CommonParams.TIME_ALLOWED, 40);
+      query.set(ShardParams.SHARDS_TOLERANT, "true");
+      response = client.query(COLLECTION_NAME, query);
+      assertTrue(
+          "Should have found 1 doc (shard_2) as timeallowed is 25ms found:"
+              + response.getResults().getNumFound(),
+          response.getResults().getNumFound() == 1);
+
+      query = new SolrQuery();
+      query.setQuery("subject_s:*abc*");
+      query.set(ShardParams.SHARDS_TOLERANT, "true");
+      response = client.query(COLLECTION_NAME, query);
+      assertTrue(
+          "Should have found few docs as timeallowed is unlimited ",
+          response.getResults().getNumFound() > 1);
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
+  public void testTimeZone() {
+    Calendar calendar = new GregorianCalendar();
+    TimeZone timeZone = calendar.getTimeZone();
+
+    for (String s : TimeZone.getAvailableIDs()) {
+      System.out.println(s);
+    }
+
+    System.out.println("Total time zones " + TimeZone.getAvailableIDs().length);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/core/MockShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/core/MockShardHandlerFactory.java
@@ -49,6 +49,11 @@ public class MockShardHandlerFactory extends ShardHandlerFactory implements Plug
       }
 
       @Override
+      public ShardResponse takeCompletedIncludingErrorsWithTimeout(long maxAllowedTime) {
+        return null;
+      }
+
+      @Override
       public ShardResponse takeCompletedOrError() {
         return null;
       }

--- a/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestHttpShardHandlerFactory.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.impl.LBSolrClient;
 import org.apache.solr.client.solrj.request.QueryRequest;
@@ -181,7 +180,7 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
       ExecutorUtil.shutdownAndAwaitTermination(exec);
     }
     ShardResponse gotResponse =
-            shardHandler.takeCompletedIncludingErrorsWithTimeout(timeAllowedInMillis);
+        shardHandler.takeCompletedIncludingErrorsWithTimeout(timeAllowedInMillis);
 
     assertEquals(shardResponse, gotResponse);
   }
@@ -212,7 +211,7 @@ public class TestHttpShardHandlerFactory extends SolrTestCaseJ4 {
 
     // partial response
     ShardResponse gotResponse =
-            shardHandler.takeCompletedIncludingErrorsWithTimeout(timeAllowedInMillis);
+        shardHandler.takeCompletedIncludingErrorsWithTimeout(timeAllowedInMillis);
 
     assertEquals(shardResponse, gotResponse);
   }

--- a/solr/test-framework/src/java/org/apache/solr/handler/component/TrackingShardHandlerFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/handler/component/TrackingShardHandlerFactory.java
@@ -104,6 +104,11 @@ public class TrackingShardHandlerFactory extends HttpShardHandlerFactory {
       }
 
       @Override
+      public ShardResponse takeCompletedIncludingErrorsWithTimeout(long maxAllowedTimeInMillis) {
+        return wrapped.takeCompletedIncludingErrors();
+      }
+
+      @Override
       public ShardResponse takeCompletedOrError() {
         return wrapped.takeCompletedOrError();
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17320


# Description

HttpShardHandler should obey the timeAllowed parameter in query. Sometime different shard takes different time to process the query. But, if user has provided the `timeAllowed` parameter then  HttpShardHandler should use that parameter to return the any partial response.

# Solution

HttpShardHandler take `timeallowed` parameter and waits for that much only to all shard responses. And then returns any partial response.

# Tests

Added TestTimeAllowedSearch test to demonstrate this issue. In this test, we have two shards, one shard has more more data then other. And it uses small timeAllowed to show that issue with fix.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
