### PR TITLE
SOLR-17256: Deprecate SolrRequest get/set BasePath

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -248,12 +248,14 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
     return getParams() == null ? null : getParams().get("collection");
   }
 
+  @Deprecated // SOLR-17256 Slated for removal in Solr 10; only used internally
   public void setBasePath(String path) {
     if (path.endsWith("/")) path = path.substring(0, path.length() - 1);
 
     this.basePath = path;
   }
 
+  @Deprecated // SOLR-17256 Slated for removal in Solr 10; only used internally
   public String getBasePath() {
     return basePath;
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/RequestWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/RequestWriter.java
@@ -89,6 +89,7 @@ public class RequestWriter {
         && updateRequest.getDocIterator() == null;
   }
 
+  @Deprecated // SOLR-17256 Slated for removal in Solr 10; only used internally
   public String getPath(SolrRequest<?> req) {
     return req.getPath();
   }


### PR DESCRIPTION
 and RequestWriter.getPath

https://issues.apache.org/jira/browse/SOLR-17256

First commit is deprecation; maybe just take this PR now and then follow up in another PR with replacements and removal.  Not touching CHANGES.txt merely to mark some obscure methods deprecated but will eventually add to CHANGES.txt when there's something more interesting.