### PR TITLE
Refactor: dedupe Utils.RANDOM from other spots

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/DistributedClusterStateUpdater.java
+++ b/solr/core/src/java/org/apache/solr/cloud/DistributedClusterStateUpdater.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.solr.client.solrj.cloud.SolrCloudManager;
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider;
-import org.apache.solr.cloud.api.collections.CollectionHandlingUtils;
 import org.apache.solr.cloud.overseer.ClusterStateMutator;
 import org.apache.solr.cloud.overseer.CollectionMutator;
 import org.apache.solr.cloud.overseer.NodeMutator;
@@ -535,7 +534,7 @@ public class DistributedClusterStateUpdater {
         // exponential backoff instead. With "per replica states" collections, concurrent attempts
         // of even just two threads are expected to be extremely rare.
         Thread.sleep(
-            CollectionHandlingUtils.RANDOM.nextInt(
+            Utils.RANDOM.nextInt(
                 attempt < 13 ? 1 << attempt : 1 << 13)); // max wait 2^13ms=8.192 sec
       }
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CollectionHandlingUtils.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CollectionHandlingUtils.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -126,19 +125,6 @@ public class CollectionHandlingUtils {
           replicaType == Replica.Type.defaultType() ? "1" : "0");
     }
     return propsAndDefaults;
-  }
-
-  public static final Random RANDOM;
-
-  static {
-    // We try to make things reproducible in the context of our tests by initializing the random
-    // instance based on the current seed
-    String seed = System.getProperty("tests.seed");
-    if (seed == null) {
-      RANDOM = new Random();
-    } else {
-      RANDOM = new Random(seed.hashCode());
-    }
   }
 
   /** Returns names of properties that are used to specify a number of replicas of a given type. */

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -515,7 +515,7 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
         Assign.getLiveOrLiveAndCreateNodeSetList(
             clusterState.getLiveNodes(),
             message,
-            CollectionHandlingUtils.RANDOM,
+            Utils.RANDOM,
             cloudManager.getDistribStateManager());
     if (nodeList.isEmpty()) {
       log.warn("It is unusual to create a collection ({}) without cores.", collectionName);

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/MoveReplicaCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/MoveReplicaCmd.java
@@ -138,7 +138,7 @@ public class MoveReplicaCmd implements CollApiCmds.CollectionApiCommand {
                 + " does not have any replica belonging to shard: "
                 + shardId);
       }
-      Collections.shuffle(sliceReplicas, CollectionHandlingUtils.RANDOM);
+      Collections.shuffle(sliceReplicas, Utils.RANDOM);
       replica = sliceReplicas.iterator().next();
     }
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
@@ -70,6 +70,7 @@ import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.ConfigSetService;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.backup.BackupManager;
@@ -195,7 +196,7 @@ public class RestoreCmd implements CollApiCmds.CollectionApiCommand {
           Assign.getLiveOrLiveAndCreateNodeSetList(
               zkStateReader.getClusterState().getLiveNodes(),
               message,
-              CollectionHandlingUtils.RANDOM,
+              Utils.RANDOM,
               container.getZkController().getSolrCloudManager().getDistribStateManager());
     }
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.cloud.api.collections;
 
-import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.RANDOM;
 import static org.apache.solr.common.cloud.ZkStateReader.COLLECTION_PROP;
 import static org.apache.solr.common.cloud.ZkStateReader.REPLICA_TYPE;
 import static org.apache.solr.common.cloud.ZkStateReader.SHARD_ID_PROP;
@@ -555,7 +554,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
                   Assign.getLiveOrLiveAndCreateNodeSetList(
                       clusterState.getLiveNodes(),
                       message,
-                      RANDOM,
+                      Utils.RANDOM,
                       ccc.getSolrCloudManager().getDistribStateManager()))
               .build();
       Assign.AssignStrategy assignStrategy = Assign.createAssignStrategy(ccc.getCoreContainer());

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -141,19 +141,6 @@ public class HttpSolrCall {
 
   public static final String INTERNAL_REQUEST_COUNT = "_forwardedCount";
 
-  public static final Random random;
-
-  static {
-    // We try to make things reproducible in the context of our tests by initializing the random
-    // instance based on the current seed
-    String seed = System.getProperty("tests.seed");
-    if (seed == null) {
-      random = new Random();
-    } else {
-      random = new Random(seed.hashCode());
-    }
-  }
-
   protected final SolrDispatchFilter solrDispatchFilter;
   protected final CoreContainer cores;
   protected final HttpServletRequest req;
@@ -1095,7 +1082,7 @@ public class HttpSolrCall {
 
   private SolrCore randomlyGetSolrCore(Set<String> liveNodes, List<Replica> replicas) {
     if (replicas != null) {
-      RandomIterator<Replica> it = new RandomIterator<>(random, replicas);
+      RandomIterator<Replica> it = new RandomIterator<>(Utils.RANDOM, replicas);
       while (it.hasNext()) {
         Replica replica = it.next();
         if (liveNodes.contains(replica.getNodeName())
@@ -1200,11 +1187,11 @@ public class HttpSolrCall {
       boolean activeReplicas) {
     String coreUrl;
     Set<String> liveNodes = clusterState.getLiveNodes();
-    Collections.shuffle(slices, random);
+    Collections.shuffle(slices, Utils.RANDOM);
 
     for (Slice slice : slices) {
       List<Replica> randomizedReplicas = new ArrayList<>(slice.getReplicas());
-      Collections.shuffle(randomizedReplicas, random);
+      Collections.shuffle(randomizedReplicas, Utils.RANDOM);
 
       for (Replica replica : randomizedReplicas) {
         if (!activeReplicas


### PR DESCRIPTION
Recently Utils.RANDOM came to exist.  Let's remove all the other occurrences of this pattern, replacing references to this one.