### PR TITLE
SOLR-17317: Correct 'wt' interpretation for v2 APIs

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -142,6 +142,8 @@ Bug Fixes
 
 * SOLR-17118: Simplify CoreContainerProvider initialization and JettySolrRunner. Avoid deadlock/hang. (David Smiley)
 
+* SOLR-17317: v2 APIs no longer return the incorrect content-type when 'wt=json' specified (Jason Gerlowski)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/core/src/java/org/apache/solr/handler/api/V2ApiUtils.java
+++ b/solr/core/src/java/org/apache/solr/handler/api/V2ApiUtils.java
@@ -26,9 +26,10 @@ import java.util.List;
 import java.util.Map;
 import org.apache.solr.client.api.model.SolrJerseyResponse;
 import org.apache.solr.common.MapWriter.EntryWriter;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.Utils;
-import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 
 /** Utilities helpful for common V2 API declaration tasks. */
@@ -87,13 +88,14 @@ public class V2ApiUtils {
     squashObjectIntoNamedList(destination, toSquash, true);
   }
 
-  public static String getMediaTypeFromWtParam(
-      SolrQueryRequest solrQueryRequest, String defaultMediaType) {
-    final String wtParam = solrQueryRequest.getParams().get(WT);
-    if (wtParam == null) return "application/json";
+  public static String getMediaTypeFromWtParam(SolrParams params, String defaultMediaType) {
+    final String wtParam = params.get(WT);
+    if (StrUtils.isBlank(wtParam)) return defaultMediaType;
 
     // The only currently-supported response-formats for JAX-RS v2 endpoints.
     switch (wtParam) {
+      case "json":
+        return "application/json";
       case "xml":
         return "application/xml";
       case "javabin":

--- a/solr/core/src/java/org/apache/solr/jersey/CatchAllExceptionMapper.java
+++ b/solr/core/src/java/org/apache/solr/jersey/CatchAllExceptionMapper.java
@@ -116,7 +116,8 @@ public class CatchAllExceptionMapper implements ExceptionMapper<Exception> {
                 && solrQueryRequest.getCore().getCoreContainer().hideStackTrace());
     response.responseHeader.status = response.error.code;
     final String mediaType =
-        V2ApiUtils.getMediaTypeFromWtParam(solrQueryRequest, MediaType.APPLICATION_JSON);
+        V2ApiUtils.getMediaTypeFromWtParam(
+            solrQueryRequest.getParams(), MediaType.APPLICATION_JSON);
     return Response.status(response.error.code).type(mediaType).entity(response).build();
   }
 

--- a/solr/core/src/java/org/apache/solr/jersey/MediaTypeOverridingFilter.java
+++ b/solr/core/src/java/org/apache/solr/jersey/MediaTypeOverridingFilter.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.List;
 import org.apache.solr.api.JerseyResource;
@@ -62,7 +63,9 @@ public class MediaTypeOverridingFilter implements ContainerResponseFilter {
 
     final SolrQueryRequest solrQueryRequest =
         (SolrQueryRequest) requestContext.getProperty(SOLR_QUERY_REQUEST);
-    final String mediaType = V2ApiUtils.getMediaTypeFromWtParam(solrQueryRequest, null);
+    final String mediaType =
+        V2ApiUtils.getMediaTypeFromWtParam(
+            solrQueryRequest.getParams(), MediaType.APPLICATION_JSON);
     if (mediaType != null) {
       responseContext.getHeaders().putSingle(CONTENT_TYPE, mediaType);
     }

--- a/solr/core/src/test/org/apache/solr/handler/api/V2ApiUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/api/V2ApiUtilsTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.solr.handler.api;
 
+import static org.apache.solr.client.solrj.impl.BinaryResponseParser.BINARY_CONTENT_TYPE_V2;
+
+import jakarta.ws.rs.core.MediaType;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.junit.Test;
 
 public class V2ApiUtilsTest extends SolrTestCaseJ4 {
@@ -35,5 +39,22 @@ public class V2ApiUtilsTest extends SolrTestCaseJ4 {
     System.setProperty("disable.v2.api", "true");
     assertFalse(
         "v2 API should be disabled if sysprop explicitly disables it", V2ApiUtils.isEnabled());
+  }
+
+  @Test
+  public void testConvertsWtToMediaTypeString() {
+    assertEquals(
+        "someDefault",
+        V2ApiUtils.getMediaTypeFromWtParam(new ModifiableSolrParams(), "someDefault"));
+
+    var params = new ModifiableSolrParams();
+    params.add("wt", "json");
+    assertEquals(MediaType.APPLICATION_JSON, V2ApiUtils.getMediaTypeFromWtParam(params, null));
+
+    params.set("wt", "xml");
+    assertEquals(MediaType.APPLICATION_XML, V2ApiUtils.getMediaTypeFromWtParam(params, null));
+
+    params.set("wt", "javabin");
+    assertEquals(BINARY_CONTENT_TYPE_V2, V2ApiUtils.getMediaTypeFromWtParam(params, null));
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/api/V2ApiUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/api/V2ApiUtilsTest.java
@@ -56,5 +56,9 @@ public class V2ApiUtilsTest extends SolrTestCaseJ4 {
 
     params.set("wt", "javabin");
     assertEquals(BINARY_CONTENT_TYPE_V2, V2ApiUtils.getMediaTypeFromWtParam(params, null));
+
+    // Defaults to, well the default, whenever an unknown/unexpected/typo'd 'wt' is provided
+    params.set("wt", "josn");
+    assertEquals("someDefault", V2ApiUtils.getMediaTypeFromWtParam(params, "someDefault"));
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17317


# Description

A mailing list user recently pointed out that certain JAX-RS v2 APIs return XML content when "wt=json" is specified.  The cause is an embarrassing little coding error: a missing switch-case clause for "wt=json" in `V2ApiUtils` 

# Solution

This PR trivially corrects the error.

# Tests

Tests added for various 'wt' cases in `V2ApiUtilsTest`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.