### PR TITLE
SOLR-17195: Add 'minPrefixLength' soft limit

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -103,6 +103,8 @@ public class SolrConfig implements MapSerializable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final String DEFAULT_CONF_FILE = "solrconfig.xml";
+  public static final String MIN_PREFIX_LENGTH = "minPrefixLength";
+  public static final int DEFAULT_MIN_PREFIX_LENGTH = 0;
   private final String resourceName;
 
   private int znodeVersion;
@@ -291,6 +293,8 @@ public class SolrConfig implements MapSerializable {
             BooleanQuery.getMaxClauseCount(),
             "set 'maxBooleanClauses' in solr.xml to increase global limit");
       }
+      prefixQueryMinPrefixLength =
+          get("query").get(MIN_PREFIX_LENGTH).intVal(DEFAULT_MIN_PREFIX_LENGTH);
 
       // Warn about deprecated / discontinued parameters
       // boolToFilterOptimizer has had no effect since 3.1
@@ -667,6 +671,7 @@ public class SolrConfig implements MapSerializable {
 
   /* The set of materialized parameters: */
   public final int booleanQueryMaxClauseCount;
+  public final int prefixQueryMinPrefixLength;
   // SolrIndexSearcher - nutch optimizer -- Disabled since 3.1
   //  public final boolean filtOptEnabled;
   //  public final int filtOptCacheSize;
@@ -1018,6 +1023,7 @@ public class SolrConfig implements MapSerializable {
     m.put("queryResultMaxDocsCached", queryResultMaxDocsCached);
     m.put("enableLazyFieldLoading", enableLazyFieldLoading);
     m.put("maxBooleanClauses", booleanQueryMaxClauseCount);
+    m.put(MIN_PREFIX_LENGTH, prefixQueryMinPrefixLength);
 
     for (SolrPluginInfo plugin : plugins) {
       List<PluginInfo> infos = getPluginInfos(plugin.clazz.getName());

--- a/solr/core/src/java/org/apache/solr/schema/StrField.java
+++ b/solr/core/src/java/org/apache/solr/schema/StrField.java
@@ -20,17 +20,21 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.valuesource.SortedSetFieldSource;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.ByteArrayUtf8CharSequence;
+import org.apache.solr.core.SolrConfig;
 import org.apache.solr.response.TextResponseWriter;
 import org.apache.solr.search.QParser;
 import org.apache.solr.uninverting.UninvertingReader.Type;
@@ -66,6 +70,34 @@ public class StrField extends PrimitiveFieldType {
       fval = docval;
     }
     return Collections.singletonList(fval);
+  }
+
+  @Override
+  public Query getPrefixQuery(QParser parser, SchemaField sf, String termStr) {
+    final var query = super.getPrefixQuery(parser, sf, termStr);
+
+    // Some internal usage (e.g. faceting) creates PrefixQueries without a surrounding QParser, so
+    // check for null here before using QParser to access the limit value
+    if (query instanceof PrefixQuery && parser != null) {
+      final var minPrefixLength =
+          parser.getReq().getCore().getSolrConfig().prefixQueryMinPrefixLength;
+      // TODO Should we provide a query-param to disable the limit on a request-by-request basis?  I
+      // can imagine scenarios where advanced users may want to enforce the limit on most fields,
+      // but ignore it for a few fields that they know to be low-cardinality and therefore "less
+      // risky"
+      if (termStr.length() < minPrefixLength) {
+        final var message =
+            String.format(
+                Locale.ROOT,
+                "Query [%s] does not meet the minimum prefix length [%d] (actual=[%d]).  Please try with a larger prefix, or adjust %s in your solrconfig.xml",
+                query,
+                minPrefixLength,
+                termStr.length(),
+                SolrConfig.MIN_PREFIX_LENGTH);
+        throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, message);
+      }
+    }
+    return query;
   }
 
   public static BytesRef getBytesRef(Object value) {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessor.java
@@ -544,6 +544,10 @@ abstract class FacetFieldProcessor extends FacetProcessor<FacetField> {
   private void calculateNumBuckets(SimpleOrderedMap<Object> target) throws IOException {
     DocSet domain = fcontext.base;
     if (freq.prefix != null) {
+      // TODO - Should we enforce minPrefixLength here in the case of 'string' fields, or omit
+      //  since this is an "internal" request? If we want to enforce the limit in this case,
+      //  we should have StrField read the configured limit and cache it in 'init' so that it can
+      //  be read at 'getPrefixQuery' call-time without a QParser.
       Query prefixFilter = sf.getType().getPrefixQuery(null, sf, freq.prefix);
       domain = fcontext.searcher.getDocSet(prefixFilter, domain);
     }

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -89,6 +89,18 @@
     -->
     <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
 
+    <!-- Minimum acceptable prefix-size for prefix-based queries on string fields.
+
+         Prefix-based queries consume memory in proportion to the number of terms in the index
+         that start with that prefix.  Short prefixes tend to match many many more indexed-terms
+         and consume more memory as a result, sometimes causing stability issues on the node.
+
+         This setting allows administrators to require that prefixes meet or exceed a specified
+         minimum length requirement.  Prefix queries that don't meet this requirement return an
+         error to users.
+    -->
+    <minPrefixLength>${solr.min.prefixLength:2}</minPrefixLength>
+
     <!-- Cache specification for Filters or DocSets - unordered set of *all* documents
          that match a particular query.
       -->

--- a/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
+++ b/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
@@ -637,8 +637,8 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
         "<add><doc><field name=\"id\">107</field><field name=\"val_s\">port</field></doc></add>");
     assertU("<commit/>");
 
-    assertQ(req("val_s:a*"), "//*[@numFound='3']");
-    assertQ(req("val_s:p*"), "//*[@numFound='4']");
+    assertQ(req("val_s:ap*"), "//*[@numFound='3']");
+    assertQ(req("val_s:pe*"), "//*[@numFound='3']");
     // val_s:* %//*[@numFound="8"]
 
     // test wildcard query

--- a/solr/core/src/test/org/apache/solr/core/SolrCoreTest.java
+++ b/solr/core/src/test/org/apache/solr/core/SolrCoreTest.java
@@ -298,6 +298,7 @@ public class SolrCoreTest extends SolrTestCaseJ4 {
     assertEquals(
         "wrong config for slowQueryThresholdMillis", 2000, solrConfig.slowQueryThresholdMillis);
     assertEquals("wrong config for maxBooleanClauses", 1024, solrConfig.booleanQueryMaxClauseCount);
+    assertEquals("wrong config for minPrefixLength", 2, solrConfig.prefixQueryMinPrefixLength);
     assertTrue("wrong config for enableLazyFieldLoading", solrConfig.enableLazyFieldLoading);
     assertEquals("wrong config for queryResultWindowSize", 10, solrConfig.queryResultWindowSize);
   }

--- a/solr/core/src/test/org/apache/solr/search/TestFiltering.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFiltering.java
@@ -64,7 +64,7 @@ public class TestFiltering extends SolrTestCaseJ4 {
 
     String[] queries = {
       "foo_s:foo",
-      "foo_s:f*",
+      "foo_s:fo*",
       "*:*",
       "id:[* TO *]",
       "id:[0 TO 99]",

--- a/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
@@ -55,6 +55,7 @@ public class BJQParserTest extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    System.setProperty("solr.min.prefixLength", String.valueOf(1));
     initCore("solrconfig.xml", "schema15.xml");
     createIndex();
   }

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -360,6 +360,19 @@
       -->
     <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
 
+
+    <!-- Minimum acceptable prefix-size for prefix-based queries on string fields.
+
+         Prefix-based queries consume memory in proportion to the number of terms in the index
+         that start with that prefix.  Short prefixes tend to match many many more indexed-terms
+         and consume more memory as a result, sometimes causing stability issues on the node.
+
+         This setting allows administrators to require that prefixes meet or exceed a specified
+         minimum length requirement.  Prefix queries that don't meet this requirement return an
+         error to users.
+    -->
+    <minPrefixLength>${solr.min.prefixLength:2}</minPrefixLength>
+
     <!-- Solr Internal Query Caches
          Starting with Solr 9.0 the default cache implementation used is CaffeineCache.
     -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17195


# Description

Prefix-based queries consume memory in proportion to the number of terms in the index that start with the prefix.  Short prefixes tend to match many more indexed terms, and consume more memory as a result, often causing instability issues on the node.

Yet Solr (prior to this PR) offers no way to restrict the prefixes used in queries.

# Solution

This PR adds a solrconfig.xml property, `minPrefixLength`, which operates similarly to the existing `maxBooleanClauses`.  Users who submit a query with a prefix shorter than the minimal acceptable length will receive an error of the form:

```
Query <snip> does not meet the minimum prefix length [2] (actual=[1]).  Please try with a larger prefix, or adjust minPrefixLength in your solrconfig.xml
```
Some notes on the implementation:

- currently only enforced for 'string' fields, where this cardinality problem occurs most frequently
- defaults to '2' in the default configset, prohibiting only single-character prefixes.
- can be overridden in the default configset with the `solr.min.prefixLength` sysprop/env-var
  
# Tests

Tests for solrconfig.xml in `SolrCoreTest`. Additional tests on actual functionality still needed.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)