### PR TITLE
Clean openApiGenerate output dir before generating

### DIFF
--- a/solr/solrj/build.gradle
+++ b/solr/solrj/build.gradle
@@ -132,6 +132,7 @@ openApiGenerate {
   generateModelTests = false
   generateApiDocumentation = false
   generateModelDocumentation = false
+  cleanupOutput = true
   additionalProperties = ["modelPackage": "org.apache.solr.client.api.model"]
 }
 


### PR DESCRIPTION
# Description

Before compiling SolrJ, the gradle build creates an OpenAPI Spec ("OAS") describing our JAX-RS v2 APIs and then uses that spec to generate SolrRequest ".java" files.  The responsible task (`solr:solrj:openApiGenerate`) adds newly generated code to `solrj/build/generated`, but it doesn't (by default) wipe the directory at the start of each invocation.

This can cause generated files to "leak" across branches - sticking around in `solrj/build/generated` even when the developer has changed to a branch that shouldn't contain the file.

These leaks can cause compilation issues, as pointed out by @dsmiley recently [on the dev list](https://lists.apache.org/thread/rth0hbo8y0gtcvrntyvg9khvfl8xh4x8).

# Solution

The solution is to have the `solr:solrj:openApiGenerate` task clear its output directory each time it runs.  Luckily the OpenAPI tooling supports this, and it's a one-line change in build.gradle.
 
# Tests

Manual build testing.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
