### PR TITLE
Fixup releaseWizard deprecations, make jenkins tasks more explicit

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -47,8 +47,10 @@ import textwrap
 import time
 import urllib
 from collections import OrderedDict
-from datetime import datetime
+from datetime import date
 from datetime import timedelta
+from datetime import UTC
+from datetime import datetime
 
 try:
     import holidays
@@ -106,7 +108,7 @@ def expand_jinja(text, vars=None):
         'state': state,
         'gpg_key' : state.get_gpg_key(),
         'gradle_cmd' : 'gradlew.bat' if is_windows() else './gradlew',
-        'epoch': unix_time_millis(datetime.utcnow()),
+        'epoch': unix_time_millis(datetime.now(UTC)),
         'get_next_version': state.get_next_version(),
         'current_git_rev': state.get_current_git_rev(),
         'keys_downloaded': keys_downloaded(),
@@ -119,8 +121,14 @@ def expand_jinja(text, vars=None):
         'solr_news_file': state.get_solr_news_file(),
         'load_lines': load_lines,
         'set_java_home': set_java_home,
-        'latest_version': state.get_latest_version(),
-        'latest_lts_version': state.get_latest_lts_version(),
+        'latest_version': state.latest_version,
+        'latest_version_major': state.latest_version_major,
+        'latest_version_minor': state.latest_version_minor,
+        'latest_version_bugfix': state.latest_version_bugfix,
+        'latest_lts_version': state.latest_lts_version,
+        'latest_lts_version_major': state.latest_lts_version_major,
+        'latest_lts_version_minor': state.latest_lts_version_minor,
+        'latest_lts_version_bugfix': state.latest_lts_version_bugfix,
         'main_version': state.get_main_version(),
         'mirrored_versions': state.get_mirrored_versions(),
         'mirrored_versions_to_delete': state.get_mirrored_versions_to_delete(),
@@ -207,7 +215,7 @@ def check_prerequisites(todo=None):
     return True
 
 
-epoch = datetime.utcfromtimestamp(0)
+epoch = datetime.fromtimestamp(0, UTC)
 
 
 def unix_time_millis(dt):
@@ -287,7 +295,7 @@ class ReleaseState:
         self.latest_version = None
         self.previous_rcs = {}
         self.rc_number = 1
-        self.start_date = unix_time_millis(datetime.utcnow())
+        self.start_date = unix_time_millis(datetime.now(UTC))
         self.script_branch = run("git rev-parse --abbrev-ref HEAD").strip()
         self.mirrored_versions = None
         try:
@@ -296,6 +304,8 @@ class ReleaseState:
             print("WARNING: This script shold (ideally) run from the release branch, not a feature branch (%s)" % self.script_branch)
             self.script_branch_type = 'feature'
         self.set_release_version(release_version)
+        self.set_latest_version()
+        self.set_latest_lts_version()
 
     def set_release_version(self, version):
         self.validate_release_version(self.script_branch_type, self.script_branch, version)
@@ -336,58 +346,65 @@ class ReleaseState:
         else:
             return release_date.isoformat()[:10]
 
-    def get_latest_version(self):
-        if self.latest_version is None:
-            versions = self.get_mirrored_versions()
-            latest = versions[0]
-            for ver in versions:
-                if Version.parse(ver).gt(Version.parse(latest)):
-                    latest = ver
-            self.latest_version = latest
-            self.save()
-        return state.latest_version
-
-    def get_mirrored_versions(self):
-        if state.mirrored_versions is None:
-            # Add the solr release versions from lucene and solr projects
-            releases_str = load("https://projects.apache.org/json/foundation/releases.json", "utf-8")
-            releases_lucene_solr = json.loads(releases_str)['lucene']
-            releases_solr = json.loads(releases_str)['solr']
-            versions_l_s = [ r for r in list(map(lambda y: y[5:], filter(lambda x: x.startswith('solr-'), list(releases_lucene_solr.keys())))) ]
-            versions_s = [ r for r in list(map(lambda y: y[5:], filter(lambda x: re.match(r'^solr-(9|1\d)\.', x), list(releases_solr.keys())))) ]
-            state.mirrored_versions = versions_l_s + versions_s
-        return state.mirrored_versions
-
-    def get_mirrored_versions_to_delete(self):
+    def set_latest_version(self):
         versions = self.get_mirrored_versions()
-        to_keep = versions
-        if state.release_type == 'major':
-          to_keep = [self.release_version, self.get_latest_version()]
-        if state.release_type == 'minor':
-          to_keep = [self.release_version, self.get_latest_lts_version()]
-        if state.release_type == 'bugfix':
-          if Version.parse(state.release_version).major == Version.parse(state.get_latest_version()).major:
-            to_keep = [self.release_version, self.get_latest_lts_version()]
-          elif Version.parse(state.release_version).major == Version.parse(state.get_latest_lts_version()).major:
-            to_keep = [self.get_latest_version(), self.release_version]
-          else:
-            raise Exception("Release version %s must have same major version as current minor or lts release")
-        return [ver for ver in versions if ver not in to_keep]
+        latest = versions[0]
+        for ver in versions:
+            if Version.parse(ver).gt(Version.parse(latest)):
+                latest = ver
+        self.latest_version = latest
+        v = Version.parse(latest)
+        self.latest_version_major = v.major
+        self.latest_version_minor = v.minor
+        self.latest_version_bugfix = v.bugfix
+        self.latest_release_branch = "branch_%s_%s" % (v.major, v.minor)
 
-    def get_main_version(self):
-        v = Version.parse(self.get_latest_version())
-        return "%s.%s.%s" % (v.major + 1, 0, 0)
-
-    def get_latest_lts_version(self):
+    def set_latest_lts_version(self):
         versions = self.get_mirrored_versions()
-        latest = self.get_latest_version()
+        latest = self.latest_version
         lts_prefix = "%s." % (Version.parse(latest).major - 1)
         lts_versions = list(filter(lambda x: x.startswith(lts_prefix), versions))
         latest_lts = lts_versions[0]
         for ver in lts_versions:
             if Version.parse(ver).gt(Version.parse(latest_lts)):
                 latest_lts = ver
-        return latest_lts
+        self.latest_lts_version =latest_lts
+        v = Version.parse(latest_lts)
+        self.latest_lts_version_major = v.major
+        self.latest_lts_version_minor = v.minor
+        self.latest_lts_version_bugfix = v.bugfix
+        self.latest_lts_release_branch = "branch_%s_%s" % (v.major, v.minor)
+
+    def get_mirrored_versions(self):
+        if self.mirrored_versions is None:
+            # Add the solr release versions from lucene and solr projects
+            releases_str = load("https://projects.apache.org/json/foundation/releases.json", "utf-8")
+            releases_lucene_solr = json.loads(releases_str)['lucene']
+            releases_solr = json.loads(releases_str)['solr']
+            versions_l_s = [ r for r in list(map(lambda y: y[5:], filter(lambda x: x.startswith('solr-'), list(releases_lucene_solr.keys())))) ]
+            versions_s = [ r for r in list(map(lambda y: y[5:], filter(lambda x: re.match(r'^solr-(9|1\d)\.', x), list(releases_solr.keys())))) ]
+            self.mirrored_versions = versions_l_s + versions_s
+        return self.mirrored_versions
+
+    def get_mirrored_versions_to_delete(self):
+        versions = self.get_mirrored_versions()
+        to_keep = versions
+        if state.release_type == 'major':
+          to_keep = [self.release_version, self.latest_version]
+        if state.release_type == 'minor':
+          to_keep = [self.release_version, self.latest_lts_version]
+        if state.release_type == 'bugfix':
+          if state.release_version_major == state.latest_version_major:
+            to_keep = [self.release_version, self.latest_lts_version]
+          elif state.release_version_major == state.latest_lts_version_major:
+            to_keep = [self.latest_version, self.release_version]
+          else:
+            raise Exception("Release version %s must have same major version as current minor or lts release")
+        return [ver for ver in versions if ver not in to_keep]
+
+    def get_main_version(self):
+        v = Version.parse(self.latest_version)
+        return "%s.%s.%s" % (v.major + 1, 0, 0)
 
     def validate_release_version(self, branch_type, branch, release_version):
         ver = Version.parse(release_version)
@@ -417,7 +434,7 @@ class ReleaseState:
             return 'main'
         elif v.is_minor_release():
             return self.get_stable_branch_name()
-        elif v.major == Version.parse(self.get_latest_version()).major:
+        elif v.major == Version.parse(self.latest_version).major:
             return self.get_minor_branch_name()
         else:
             return self.release_branch
@@ -465,6 +482,16 @@ class ReleaseState:
         }
         if self.latest_version:
             dict['latest_version'] = self.latest_version
+            dict['latest_version_major'] = self.latest_version_major
+            dict['latest_version_minor'] = self.latest_version_minor
+            dict['latest_version_bugfix'] = self.latest_version_bugfix
+            dict['latest_release_branch'] = self.latest_release_branch
+        if self.latest_lts_version:
+            dict['latest_lts_version'] = self.latest_lts_version
+            dict['latest_lts_version_major'] = self.latest_lts_version_major
+            dict['latest_lts_version_minor'] = self.latest_lts_version_minor
+            dict['latest_lts_version_bugfix'] = self.latest_lts_version_bugfix
+            dict['latest_lts_release_branch'] = self.latest_lts_release_branch
         return dict
 
     def restore_from_dict(self, dict):
@@ -580,7 +607,7 @@ class ReleaseState:
         return folder
 
     def get_minor_branch_name(self):
-        latest = state.get_latest_version()
+        latest = state.latest_version
         if latest is not None:
           v = Version.parse(latest)
           return "branch_%s_%s" % (v.major, v.minor)
@@ -591,7 +618,7 @@ class ReleaseState:
         if self.release_type == 'major':
             v = Version.parse(self.get_main_version())
         else:
-            v = Version.parse(self.get_latest_version())
+            v = Version.parse(self.latest_version)
         return "branch_%sx" % v.major
 
     def get_next_version(self):
@@ -781,7 +808,7 @@ class Todo(SecretYamlObject):
 
     def set_done(self, is_done):
         if is_done:
-            self.state['done_date'] = unix_time_millis(datetime.utcnow())
+            self.state['done_date'] = unix_time_millis(datetime.now(UTC))
             if self.persist_vars:
                 for k in self.persist_vars:
                     self.state[k] = self.get_vars()[k]
@@ -975,13 +1002,13 @@ def expand_multiline(cmd_txt, indent=0):
 
 
 def unix_to_datetime(unix_stamp):
-    return datetime.utcfromtimestamp(unix_stamp / 1000)
+    return datetime.fromtimestamp(unix_stamp / 1000, UTC)
 
 
 def generate_asciidoc():
     base_filename = os.path.join(state.get_release_folder(),
                                  "solr_release_%s"
-                                 % (state.release_version.replace("\.", "_")))
+                                 % (state.release_version.replace("\\.", "_")))
 
     filename_adoc = "%s.adoc" % base_filename
     filename_html = "%s.html" % base_filename
@@ -989,7 +1016,7 @@ def generate_asciidoc():
 
     fh.write("= Solr Release %s\n\n" % state.release_version)
     fh.write("(_Generated by releaseWizard.py v%s at %s_)\n\n"
-             % (getScriptVersion(), datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")))
+             % (getScriptVersion(), datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")))
     fh.write(":numbered:\n\n")
     fh.write("%s\n\n" % template('help'))
     for group in state.todo_groups:
@@ -1859,9 +1886,9 @@ def create_ical(todo): # pylint: disable=unused-argument
     return True
 
 
-today = datetime.utcnow().date()
+today = datetime.now(UTC).date()
 sundays = {(today + timedelta(days=x)): 'Sunday' for x in range(10) if (today + timedelta(days=x)).weekday() == 6}
-y = datetime.utcnow().year
+y = today.year
 years = [y, y+1]
 non_working = holidays.CA(years=years) + holidays.US(years=years) + holidays.UK(years=years) \
               + holidays.DE(years=years) + holidays.NO(years=years) + holidays.IND(years=years) + holidays.RU(years=years)
@@ -1869,7 +1896,7 @@ non_working = holidays.CA(years=years) + holidays.US(years=years) + holidays.UK(
 
 def vote_close_72h_date():
     # Voting open at least 72 hours according to ASF policy
-    return datetime.utcnow() + timedelta(hours=73)
+    return datetime.now(UTC) + timedelta(hours=73)
 
 
 def vote_close_72h_holidays():

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -530,14 +530,44 @@ groups:
     links:
     - https://projects.apache.org/doap.html
   - !Todo
-    id: jenkins_builds
-    title: Add Jenkins task for the release branch
-    description: '...so that builds run for the new branch. Consult the JenkinsReleaseBuilds page.'
+    id: new_jenkins_builds
+    title: Add Jenkins tasks for new branch(es)
+    description: |
+      This will make sure we are continuously testing the new branch(es) we have created.
+      Consult the JenkinsReleaseBuilds page for more information.
+      
+      Job Suffixes to create:
+        {% if release_type == 'major' %}
+        *-{{release_version_major}}.x (The new stable branch)
+        {% endif %}
+        *-{{release_version_major}}.{{release_version_minor}} (The new release branch)
     types:
     - major
     - minor
     links:
-    - https://cwiki.apache.org/confluence/display/SOLR/JenkinsReleaseBuilds+-+Solr
+      - https://cwiki.apache.org/confluence/display/SOLR/JenkinsReleaseBuilds+-+Solr
+      - https://ci-builds.apache.org/job/Solr/
+  - !Todo
+    id: old_jenkins_builds
+    title: Remove old Jenkins tasks for decommissioned branches
+    description: |
+      This will make sure we aren't using resources to test branches no longer in development.
+      Consult the JenkinsReleaseBuilds page for more information.
+      
+      Job Suffixes to delete:
+        {% if release_type == 'major' %}
+        *-{{latest_lts_version_major}}.{{latest_lts_version_minor}} (The previous LTS release branch)
+        *-{{latest_version_major}}.x (The previous stable branch)
+        {% else %}
+        *-{{latest_version_major}}.{{latest_version_minor}} (The previous release branch)
+        {% endif %}
+    depends: new_jenkins_builds
+    types:
+      - major
+      - minor
+    links:
+      - https://cwiki.apache.org/confluence/display/SOLR/JenkinsReleaseBuilds+-+Solr
+      - https://ci-builds.apache.org/job/Solr/
   - !Todo
     id: inform_devs
     title: Inform Devs of the new Release Branch


### PR DESCRIPTION
No jira, this is just release wizard stuff as discussed on the dev list.

Here we have

- Explicitly listed the suffixes of the jenkins tasks to add
- Explicitly listed the suffixes of the jenkins tasks to delete
- Fixed deprecations in python