### PR TITLE
Don't create a Thread when there is no thread

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/SyncStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/SyncStrategy.java
@@ -33,7 +33,6 @@ import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.params.CoreAdminParams.CoreAdminAction;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
-import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.core.SolrCore;
@@ -346,39 +345,37 @@ public class SyncStrategy {
     }
   }
 
-  @SuppressForbidden(reason = "Passed to an executor with a naming thread factory")
   private void requestRecovery(
       final ZkNodeProps leaderProps, final String baseUrl, final String coreName)
       throws SolrServerException, IOException {
-    Thread thread =
-        new Thread(
-            () -> {
-              if (isClosed) {
-                log.info("We have been closed, won't request recovery");
-                return;
-              }
-              RequestRecovery recoverRequestCmd = new RequestRecovery();
-              recoverRequestCmd.setAction(CoreAdminAction.REQUESTRECOVERY);
-              recoverRequestCmd.setCoreName(coreName);
-              try (SolrClient client =
-                  new Http2SolrClient.Builder(baseUrl)
-                      .withHttpClient(solrClient)
-                      .withConnectionTimeout(30000, TimeUnit.MILLISECONDS)
-                      .withIdleTimeout(120000, TimeUnit.MILLISECONDS)
-                      .build()) {
-                client.request(recoverRequestCmd);
-              } catch (Throwable t) {
-                log.error(
-                    "{}: Could not tell a replica to recover",
-                    ZkCoreNodeProps.getCoreUrl(leaderProps),
-                    t);
-                if (t instanceof Error) {
-                  throw (Error) t;
-                }
-              }
-            });
-    thread.setDaemon(true);
-    updateExecutor.execute(thread);
+    Runnable runnable =
+        () -> {
+          if (isClosed) {
+            log.info("We have been closed, won't request recovery");
+            return;
+          }
+          RequestRecovery recoverRequestCmd = new RequestRecovery();
+          recoverRequestCmd.setAction(CoreAdminAction.REQUESTRECOVERY);
+          recoverRequestCmd.setCoreName(coreName);
+          try (SolrClient client =
+              new Http2SolrClient.Builder(baseUrl)
+                  .withHttpClient(solrClient)
+                  .withConnectionTimeout(30000, TimeUnit.MILLISECONDS)
+                  .withIdleTimeout(120000, TimeUnit.MILLISECONDS)
+                  .build()) {
+            client.request(recoverRequestCmd);
+          } catch (Throwable t) {
+            log.error(
+                "{}: Could not tell a replica to recover",
+                ZkCoreNodeProps.getCoreUrl(leaderProps),
+                t);
+            if (t instanceof Error) {
+              throw (Error) t;
+            }
+          }
+        };
+
+    updateExecutor.execute(runnable);
   }
 
   public static ModifiableSolrParams params(String... params) {


### PR DESCRIPTION
No Jira.
This is just to clean-up a bad smell in the code.


# Description

We create a `java.lang.Thread` instance, but this thread is never started. It just acts as a target for another existing thread, from the executor pool. The call to `setDaemon()` has no effect.

This code was reported by errorprone because of the thread creation without a name (hence the removed `@SuppressForbidden`)

Replacing the thread by a Runnable makes the full thing cleaner.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
