### PR TITLE
SOLR-17332: Doing a clean first, discovered some more build references to post.jar related gradle

### DIFF
--- a/solr/example/build.gradle
+++ b/solr/example/build.gradle
@@ -23,11 +23,6 @@ description = 'Solr examples'
 
 configurations {
   packaging
-  postJar
-}
-
-dependencies {
-  postJar project(path: ":solr:core", configuration: "postJar")
 }
 
 ext {
@@ -40,11 +35,6 @@ task assemblePackaging(type: Sync) {
     include "files/**"
     include "films/**"
     include "README.md"
-    exclude "**/*.jar"
-  })
-
-  from(configurations.postJar, {
-    into "exampledocs/"
   })
 
   into packagingDir


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17332

Stripping out more references when building Solr examples.