### PR TITLE
SOLR-17327: remove trailing /solr unless we actually are actually testing it works in backwards compatible fashion.

### DIFF
--- a/solr/packaging/test/test_assert.bats
+++ b/solr/packaging/test/test_assert.bats
@@ -38,7 +38,7 @@ teardown() {
   run solr assert --cloud http://localhost:${SOLR_PORT}
   assert_output --partial "ERROR: Solr is not running in cloud mode"
 
-  run ! solr assert --cloud http://localhost:${SOLR_PORT}/solr -e
+  run ! solr assert --cloud http://localhost:${SOLR_PORT} -e
 }
 
 @test "assert for cloud mode" {

--- a/solr/packaging/test/test_auth.bats
+++ b/solr/packaging/test/test_auth.bats
@@ -38,7 +38,7 @@ setup() {
 @test "auth enable/disable lifecycle" {
   solr start -c
   solr auth enable -type basicAuth -credentials name:password
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
 
   run curl -u name:password --basic "http://localhost:${SOLR_PORT}/solr/admin/collections?action=CREATE&collection.configName=_default&name=test&numShards=2&replicationFactor=1&router.name=compositeId&wt=json"
   assert_output --partial '"status":0'

--- a/solr/packaging/test/test_create_collection.bats
+++ b/solr/packaging/test/test_create_collection.bats
@@ -63,12 +63,12 @@ teardown() {
 }
 
 @test "reject d option with invalid config dir" {
-  run ! solr create -c COLL_NAME -d /asdf  -solrUrl http://localhost:${SOLR_PORT}/solr
+  run ! solr create -c COLL_NAME -d /asdf  -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Specified configuration directory /asdf not found!"
 }
 
 @test "accept d option with builtin config" {
-  run solr create -c COLL_NAME -d sample_techproducts_configs -solrUrl http://localhost:${SOLR_PORT}/solr
+  run solr create -c COLL_NAME -d sample_techproducts_configs -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
 }
 
@@ -78,34 +78,34 @@ teardown() {
   test -d $source_configset_dir
   cp -r "${source_configset_dir}" "${dest_configset_dir}"
 
-  run solr create -c COLL_NAME -d "${dest_configset_dir}" -solrUrl http://localhost:${SOLR_PORT}/solr
+  run solr create -c COLL_NAME -d "${dest_configset_dir}" -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
 }
 
 @test "accept n option as config name" {
-  run solr create -c COLL_NAME -n other_conf_name -solrUrl http://localhost:${SOLR_PORT}/solr
+  run solr create -c COLL_NAME -n other_conf_name -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "config-set 'other_conf_name'"
 }
 
 @test "allow config reuse when n option specifies same config" {
-  run -0 solr create -c COLL_NAME_1 -n shared_config -solrUrl http://localhost:${SOLR_PORT}/solr
+  run -0 solr create -c COLL_NAME_1 -n shared_config -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME_1'"
   assert_output --partial "config-set 'shared_config'"
 
-  run -0 solr create -c COLL_NAME_2 -n shared_config -solrUrl http://localhost:${SOLR_PORT}/solr
+  run -0 solr create -c COLL_NAME_2 -n shared_config -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME_2'"
   assert_output --partial "config-set 'shared_config'"
 }
 
 @test "create multisharded collections when s provided" {
-  run -0 solr create -c COLL_NAME -s 2 -solrUrl http://localhost:${SOLR_PORT}/solr
+  run -0 solr create -c COLL_NAME -s 2 -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "2 shard(s)"
 }
 
 @test "create replicated collections when rf provided" {
-  run -0 solr create -c COLL_NAME -rf 2 -solrUrl http://localhost:${SOLR_PORT}/solr
+  run -0 solr create -c COLL_NAME -rf 2 -solrUrl http://localhost:${SOLR_PORT}
   assert_output --partial "Created collection 'COLL_NAME'"
   assert_output --partial "2 replica(s)"
 }

--- a/solr/packaging/test/test_example_noprompt.bats
+++ b/solr/packaging/test/test_example_noprompt.bats
@@ -30,6 +30,6 @@ teardown() {
 
 @test "SOLR-16755 test works with noprompt" {
   solr start -e cloud -noprompt
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 10000
-  solr assert --started http://localhost:${SOLR2_PORT}/solr --timeout 10000
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 10000
+  solr assert --started http://localhost:${SOLR2_PORT} --timeout 10000
 }

--- a/solr/packaging/test/test_placement_plugin.bats
+++ b/solr/packaging/test/test_placement_plugin.bats
@@ -31,7 +31,7 @@ teardown() {
 
 @test "Affinity placement plugin using sysprop" {
   run solr start -c -Dsolr.placementplugin.default=affinity
-  solr assert -c http://localhost:${SOLR_PORT}/solr -t 3000
+  solr assert -c http://localhost:${SOLR_PORT} -t 3000
   run solr create -c COLL_NAME
   collection_exists COLL_NAME
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to affinity'
@@ -40,7 +40,7 @@ teardown() {
 @test "Random placement plugin using ENV" {
   export SOLR_PLACEMENTPLUGIN_DEFAULT=random
   run solr start -c
-  solr assert -c http://localhost:${SOLR_PORT}/solr -t 3000
+  solr assert -c http://localhost:${SOLR_PORT} -t 3000
   run solr create -c COLL_NAME
   collection_exists COLL_NAME
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to random'

--- a/solr/packaging/test/test_prometheus.bats
+++ b/solr/packaging/test/test_prometheus.bats
@@ -32,7 +32,7 @@ teardown() {
 
 @test "should start solr prometheus exporter that scrapes solr for metrics" {
   solr start
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
   
   run solr create -c COLL_NAME
   assert_output --partial "Created new core 'COLL_NAME'"

--- a/solr/packaging/test/test_ssl.bats
+++ b/solr/packaging/test/test_ssl.bats
@@ -52,7 +52,7 @@ teardown() {
   export SOLR_HOST=localhost
 
   solr start -c
-  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
@@ -90,7 +90,7 @@ teardown() {
   export SOLR_HOST=127.0.0.1
 
   solr start -c
-  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
@@ -152,7 +152,7 @@ teardown() {
   export SOLR_HOST=localhost
 
   solr start -c
-  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
   solr auth enable -type basicAuth -credentials name:password
 
   run curl -u name:password --basic --cacert "$ssl_dir/solr-ssl.pem" "https://localhost:${SOLR_PORT}/solr/admin/collections?action=CREATE&collection.configName=_default&name=test&numShards=2&replicationFactor=1&router.name=compositeId&wt=json"
@@ -210,7 +210,7 @@ teardown() {
 
   run solr start -c
 
-  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
 
   export SOLR_SSL_KEY_STORE=
   export SOLR_SSL_KEY_STORE_PASSWORD=
@@ -332,8 +332,8 @@ teardown() {
     export SOLR_SSL_TRUST_STORE=
     export SOLR_SSL_TRUST_STORE_PASSWORD=
 
-    solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
-    solr assert --started https://localhost:${SOLR2_PORT}/solr --timeout 5000
+    solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
+    solr assert --started https://localhost:${SOLR2_PORT} --timeout 5000
 
     run solr create -c test -s 2
     assert_output --partial "Created collection 'test'"
@@ -469,8 +469,8 @@ teardown() {
   export SOLR_SSL_TRUST_STORE=
   export SOLR_SSL_TRUST_STORE_PASSWORD=
 
-  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
-  solr assert --started https://localhost:${SOLR2_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
+  solr assert --started https://localhost:${SOLR2_PORT} --timeout 5000
 
   run solr create -c test -s 2
   assert_output --partial "Created collection 'test'"
@@ -527,13 +527,13 @@ teardown() {
   export SOLR_SSL_KEY_STORE=$ssl_dir/server1.keystore.p12
   export SOLR_SSL_TRUST_STORE=$ssl_dir/server1.keystore.p12
   solr start -c -a "-Dsolr.jetty.sslContext.reload.scanInterval=1 -DsocketTimeout=5000"
-  solr assert --started https://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR_PORT} --timeout 5000
 
   # server2 will run on $SOLR2_PORT and will use server2.keystore. Initially, this is the same as server1.keystore
   export SOLR_SSL_KEY_STORE=$ssl_dir/server2.keystore.p12
   export SOLR_SSL_TRUST_STORE=$ssl_dir/server2.keystore.p12
   solr start -c -z localhost:${ZK_PORT} -p ${SOLR2_PORT} -a "-Dsolr.jetty.sslContext.reload.scanInterval=1 -DsocketTimeout=5000"
-  solr assert --started https://localhost:${SOLR2_PORT}/solr --timeout 5000
+  solr assert --started https://localhost:${SOLR2_PORT} --timeout 5000
 
   # "test" collection is two shards, meaning there must be communication between shards for queries (handled by http shard handler factory)
   run solr create -c test -s 2

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -31,8 +31,8 @@ teardown() {
 @test "SOLR-11740 check 'solr stop' connection" {
   solr start
   solr start -p ${SOLR2_PORT}
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
-  solr assert --started http://localhost:${SOLR2_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+  solr assert --started http://localhost:${SOLR2_PORT} --timeout 5000
   run bash -c 'solr stop -all 2>&1'
   refute_output --partial 'forcefully killing'
 }
@@ -41,11 +41,11 @@ teardown() {
 
   solr start
   solr start -p ${SOLR2_PORT}
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
-  solr assert --started http://localhost:${SOLR2_PORT}/solr --timeout 5000
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+  solr assert --started http://localhost:${SOLR2_PORT} --timeout 5000
   
   run solr stop -p ${SOLR2_PORT}
-  solr assert --not-started http://localhost:${SOLR2_PORT}/solr --timeout 5000
-  solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
+  solr assert --not-started http://localhost:${SOLR2_PORT} --timeout 5000
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
 
 }

--- a/solr/packaging/test/test_status.bats
+++ b/solr/packaging/test/test_status.bats
@@ -42,7 +42,7 @@ teardown() {
 
 @test "status shell script ignores passed in -solrUrl cli parameter from user" {
   solr start
-  run solr status -solrUrl http://localhost:9999/solr
+  run solr status -solrUrl http://localhost:9999
   assert_output --partial "needn't include Solr's context-root"
   assert_output --partial "Found 1 Solr nodes:"
   assert_output --partial "running on port ${SOLR_PORT}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17327

bin/solr cli tools that end in /solr is an old approach, and we shouldn't model using it.