### PR TITLE
fix MoveReplicaHdfsFailoverTest after SOLR-16962

### DIFF
--- a/solr/modules/hdfs/src/test/org/apache/solr/hdfs/cloud/MoveReplicaHdfsFailoverTest.java
+++ b/solr/modules/hdfs/src/test/org/apache/solr/hdfs/cloud/MoveReplicaHdfsFailoverTest.java
@@ -91,7 +91,6 @@ public class MoveReplicaHdfsFailoverTest extends SolrCloudTestCase {
             .setNode(cluster.getJettySolrRunner(0).getNodeName())
             .process(cluster.getSolrClient());
 
-    ulogDir += "/tlog";
     ZkStateReader zkStateReader = cluster.getZkStateReader();
     assertTrue(ClusterStateUtil.waitForAllActiveAndLiveReplicas(zkStateReader, 120000));
 


### PR DESCRIPTION
the changes made by SOLR-16962 to ZkController and MoveReplicaCmd resolve the conflation of ulog and tlog dir, and remove some related hacky compensations for this conflation. The nightly test MoveReplicaHdfsFailoverTest was still compensating for this issue when it no longer needs to, and was thus failing.

(no jira)