### PR TITLE
SOLR-17337: Show proper distributed stage id

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
@@ -44,6 +44,8 @@ import org.apache.solr.search.stats.StatsCache;
 import org.apache.solr.util.SolrPluginUtils;
 import org.apache.solr.util.SolrResponseUtil;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Adds debugging information to a request.
  *
@@ -181,7 +183,8 @@ public class DebugComponent extends SearchComponent {
     }
   }
 
-  private String getDistributedStageName(int stage) {
+  @VisibleForTesting
+  static String getDistributedStageName(int stage) {
     String stageName = stages.get(stage);
 
     if (stageName == null) {

--- a/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
@@ -181,16 +181,27 @@ public class DebugComponent extends SearchComponent {
     }
   }
 
+  private String getDistributedStageName(int stage) {
+    String stageName = stages.get(stage);
+
+    if (stageName == null) {
+      stageName = "STAGE_" + Integer.toString(stage);
+    }
+
+    return stageName;
+  }
+
   @Override
   public void handleResponses(ResponseBuilder rb, ShardRequest sreq) {
     if (rb.isDebugTrack() && rb.isDistrib && !rb.finished.isEmpty()) {
       @SuppressWarnings("unchecked")
       NamedList<Object> stageList =
           (NamedList<Object>)
-              ((NamedList<Object>) rb.getDebugInfo().get("track")).get(stages.get(rb.stage));
+              ((NamedList<Object>) rb.getDebugInfo().get("track"))
+                  .get(getDistributedStageName(rb.stage));
       if (stageList == null) {
         stageList = new SimpleOrderedMap<>();
-        rb.addDebug(stageList, "track", stages.get(rb.stage));
+        rb.addDebug(stageList, "track", getDistributedStageName(rb.stage));
       }
       for (ShardResponse response : sreq.responses) {
         stageList.add(response.getShard(), getTrackResponse(response));

--- a/solr/core/src/test/org/apache/solr/handler/component/DebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DebugComponentTest.java
@@ -297,4 +297,12 @@ public class DebugComponentTest extends SolrTestCaseJ4 {
     params.add(CommonParams.REQUEST_ID, requestId);
     rb.req.setParams(params);
   }
+
+  @Test
+  public void testDistributedStageResolution() throws IOException {
+    assertEquals("PARSE_QUERY", DebugComponent.getDistributedStageName(ResponseBuilder.STAGE_PARSE_QUERY));
+    assertEquals("DONE", DebugComponent.getDistributedStageName(ResponseBuilder.STAGE_DONE));
+    assertEquals("STAGE_400", DebugComponent.getDistributedStageName(400));
+    assertEquals("STAGE_10000", DebugComponent.getDistributedStageName(10000));
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17337

# Description

When showing track debug for custom stages in distributed requests, the stage id is not translated into a meaningful string. It is displayed as an empty string (see attachment). Furthermore, if you have multiple custom stages, the details for the most recent stage is displayed. The details for other stages is omitted.

# Solution

If a given stage has no translation in the `stage` map, we format it's name in the format `STAGE_<STAGE_ID>`. By doing so, no stage details are omitted, even if you have multiple custom stages.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
