### PR TITLE
SOLR-17349: SolrDocumentFetcher should always skip lazy field loading overhead if documentCache==null

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -150,6 +150,8 @@ Optimizations
   stored field state, reducing heap usage especially for high-core-count, high-field-count, high-thread-count
   cases (Vinayak Hegde, Christine Poerschke, Kevin Risden, David Smiley, Michael Gibney)
 
+* SOLR-17349: SolrDocumentFetcher should always skip lazy field loading overhead if documentCache==null (Michael Gibney)
+
 Bug Fixes
 ---------------------
 * SOLR-12813: subqueries should respect basic auth. (Rudy Seitz via Eric Pugh)

--- a/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
@@ -327,9 +327,15 @@ public class SolrDocumentFetcher {
       super(toLoad);
       this.docId = docId;
       this.doc = getDocument();
-      this.lazyFieldProducer =
-          toLoad != null && enableLazyFieldLoading ? new LazyDocument(reader, docId) : null;
-      this.addLargeFieldsLazily = (documentCache != null && !largeFields.isEmpty());
+      if (documentCache == null) {
+        // lazy loading makes no sense if we don't have a `documentCache`
+        this.lazyFieldProducer = null;
+        this.addLargeFieldsLazily = false;
+      } else {
+        this.lazyFieldProducer =
+            toLoad != null && enableLazyFieldLoading ? new LazyDocument(reader, docId) : null;
+        this.addLargeFieldsLazily = !largeFields.isEmpty();
+      }
       // TODO can we return Status.STOP after a val is loaded and we know there are no other fields
       // of interest?
       //    When: toLoad is one single-valued field, no lazyFieldProducer


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17349