### PR TITLE
Run more workflows for branch_9x

### DIFF
--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'branch_9x'
     paths:
       - '.github/workflows/bin-solr-test.yml'
       - 'solr/bin/**'

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'branch_9x'
     paths:
       - '.github/workflows/docker-test.yml'
       - 'solr/bin/**'

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -3,7 +3,8 @@ name: Gradle Precommit
 on: 
   pull_request:
     branches:
-    - '**'
+      - 'main'
+      - 'branch_9x'
 
 jobs:
   test:

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'branch_9x'
     paths:
       - '.github/workflows/solrj-test.yml'
       - 'solr/solrj/**'

--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'branch_9x'
 
 jobs:
   test:


### PR DESCRIPTION
Spinoff from #2540 

We should run all tests on PRs against `branch_9x`, to catch errors in larger backport efforts.

This should work fine at least until we bump main to some newer java version or make the branches incompatible, but then we can introduce separate workflows for stable and main branches..