### PR TITLE
Stalebot: increase to 100 operations per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,10 +29,9 @@ jobs:
           stale-pr-label: "stale"       # label to use when marking as stale
 
           stale-pr-message: >
-            This PR had no visible activity in the past 60 days, labeling it as stale.
-            Any new activity will remove the stale label. To attract more reviewers, please tag
-            someone or notify the dev@solr.apache.org mailing list.
+            This PR has had no activity for 60 days and is now labeled as stale. 
+            Any new activity or setting it as a draft will remove the stale label. 
+            To attract more reviewers, tag someone or notify the dev@solr.apache.org mailing list. 
             Thank you for your contribution!
 
-          # TODO: Increase budget after initial testing
-          operations-per-run: 30        # operations budget
+          operations-per-run: 100       # operations budget

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,7 +31,7 @@ jobs:
           stale-pr-message: >
             This PR has had no activity for 60 days and is now labeled as stale. 
             Any new activity or converting it to draft will remove the stale label. 
-            To attract more reviewers, tag someone or notify the dev@solr.apache.org mailing list. 
+            To attract more reviewers, please tag people who might be familiar with the code area and/or notify the dev@solr.apache.org mailing list. 
             Thank you for your contribution!
 
           operations-per-run: 100       # operations budget

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
 
           stale-pr-message: >
             This PR has had no activity for 60 days and is now labeled as stale. 
-            Any new activity or setting it as a draft will remove the stale label. 
+            Any new activity or converting it to draft will remove the stale label. 
             To attract more reviewers, tag someone or notify the dev@solr.apache.org mailing list. 
             Thank you for your contribution!
 


### PR DESCRIPTION
Also re-word the stale-message text (with help from GPT).

Increasing operations budget will allow for more PRs to be tagged as stale per run - there is currently a backlog..