### PR TITLE
SOLR-17349: (adjusted) SolrDocumentFetcher should always skip lazy field loading overhead if documentCache==null

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -225,7 +225,7 @@ public class SolrPluginUtils {
       ResponseBuilder rb, DocList docs, Query query, SolrQueryRequest req, SolrQueryResponse res)
       throws IOException {
     SolrIndexSearcher searcher = req.getSearcher();
-    if (!searcher.getDocFetcher().isLazyFieldLoadingEnabled()) {
+    if (!searcher.interrogateDocFetcher(SolrDocumentFetcher::isLazyFieldLoadingEnabled)) {
       // nothing to do
       return;
     }


### PR DESCRIPTION
this also reverts the code change from 390c30ff56ad354a6ee55eaae54713dd8ec4cce3, which is obviated by directly making `enableLazyFieldLoading` conditional on presence of `documentCache`.

See: https://issues.apache.org/jira/browse/SOLR-17349