### PR TITLE
SOLR-13350: multi-threaded search: (undocumented) opt-out ability

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -442,11 +442,16 @@ public class CoreContainer {
 
     this.allowListUrlChecker = AllowListUrlChecker.create(config);
 
-    this.collectorExecutor =
-        ExecutorUtil.newMDCAwareCachedThreadPool(
-            cfg.getIndexSearcherExecutorThreads(), // thread count
-            cfg.getIndexSearcherExecutorThreads() * 1000, // queue size
-            new SolrNamedThreadFactory("searcherCollector"));
+    final int indexSearcherExecutorThreads = cfg.getIndexSearcherExecutorThreads();
+    if (0 < indexSearcherExecutorThreads) {
+      this.collectorExecutor =
+          ExecutorUtil.newMDCAwareCachedThreadPool(
+              indexSearcherExecutorThreads, // thread count
+              indexSearcherExecutorThreads * 1000, // queue size
+              new SolrNamedThreadFactory("searcherCollector"));
+    } else {
+      this.collectorExecutor = null;
+    }
   }
 
   @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
On a request level, `multiThreaded=false` is already possible but for full (node level) opt-out SolrIndexSearcher must pass a null executor to Lucene's IndexSearcher.

https://issues.apache.org/jira/browse/SOLR-13350