### PR TITLE
SOLR-17357 Bug fix.  Update to match SolrCLI.printToolHelp formatting rules

### DIFF
--- a/solr/packaging/test/test_help.bats
+++ b/solr/packaging/test/test_help.bats
@@ -68,25 +68,25 @@ setup() {
 
 @test "healthcheck help flag prints help" {
   run solr healthcheck --help
-  assert_output --partial 'usage: healthcheck'
+  assert_output --partial 'usage: bin/solr healthcheck'
   refute_output --partial 'ERROR'
 }
 
 @test "create help flag prints help" {
   run solr create --help
-  assert_output --partial 'usage: create'
+  assert_output --partial 'usage: bin/solr create'
   refute_output --partial 'ERROR'
 }
 
 @test "delete help flag prints help" {
   run solr delete -h
-  assert_output --partial 'usage: delete'
+  assert_output --partial 'usage: bin/solr delete'
   refute_output --partial 'ERROR'
 }
 
 @test "version help flag prints help" {
   run solr version -h
-  assert_output --partial 'usage: version'
+  assert_output --partial 'usage: bin/solr version'
   refute_output --partial 'ERROR'
 }
 
@@ -104,12 +104,12 @@ setup() {
 
 @test "assert help flag prints help" {
   run solr assert --help
-  assert_output --partial 'usage: assert'
+  assert_output --partial 'usage: bin/solr assert'
   refute_output --partial 'ERROR'
 }
 
 @test "post help flag prints help" {
   run solr post --help
-  assert_output --partial 'usage: post'
+  assert_output --partial 'usage: bin/solr post'
   refute_output --partial 'ERROR'
 }

--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -42,11 +42,11 @@ teardown() {
   assert_output --partial 'Must specify either --solr-update-url or -c parameter'
 
   run solr post -h
-  assert_output --partial 'usage: post'
+  assert_output --partial 'usage: bin/solr post'
   refute_output --partial 'ERROR'
 
   run solr post --help
-  assert_output --partial 'usage: post'
+  assert_output --partial 'usage: bin/solr post'
   refute_output --partial 'ERROR'
 
 }


### PR DESCRIPTION
# Description

[SOLR-17357](https://issues.apache.org/jira/browse/SOLR-17357): Improve SolrCLI tool --help printout introduced a new format for the usage description.   Some bats tests appear to not have been updated to match.

# Solution

Introduce the `bin/solr` part to the usage command checks to match what ` SolrCLI.printToolHelp` does.

# Tests

Manually rans BATS tests.

