### PR TITLE
SOLR-17367 Unbreak the build caused by bad backport

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -929,8 +929,8 @@ public class PostTool extends ToolBase {
 
     if (params.length() > 0) {
       try {
-        uri = new URI(appendParam(uri.toString(), params));
-      } catch (URISyntaxException e) {
+        url = new URL(appendParam(url.toString(), params));
+      } catch (MalformedURLException e) {
         warn("Malformed params");
       }
     }

--- a/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
@@ -139,7 +139,7 @@ public class PostToolTest extends SolrCloudTestCase {
     // Provide the port for the PostTool to look up.
     EnvUtils.setProperty("jetty.port", cluster.getJettySolrRunner(0).getLocalPort() + "");
 
-    withBasicAuth(CollectionAdminRequest.createCollection(collection, "conf1", 1, 1, 0, 0))
+    CollectionAdminRequest.createCollection(collection, "conf1", 1, 1, 0, 0)
         .processAndWait(cluster.getSolrClient(), 10);
 
     File tsvDoc = File.createTempFile("temp", ".tsv");
@@ -152,8 +152,6 @@ public class PostToolTest extends SolrCloudTestCase {
       "post",
       "-c",
       collection,
-      "-credentials",
-      SecurityJson.USER_PASS,
       "--params",
       "\"separator=%09&header=false&fieldnames=id,title_s\"",
       "--type",
@@ -166,7 +164,7 @@ public class PostToolTest extends SolrCloudTestCase {
     int expectedDocCount = 1;
 
     for (int idx = 0; idx < 100; ++idx) {
-      QueryRequest req = withBasicAuth(new QueryRequest(params("q", "*:*")));
+      QueryRequest req = new QueryRequest(params("q", "*:*"));
       QueryResponse rsp = req.process(cluster.getSolrClient(), collection);
 
       numFound = (int) rsp.getResults().getNumFound();


### PR DESCRIPTION
PostTool did not compile after https://github.com/apache/solr/commit/a405b3b2245350c2dae7e6979f33827e4b979511 due to the backport not being tailored to branch_9x which does not care about testing with basic auth.

Patched PostTool so that the new test creates collection and does the query without auth credentials, also using `url` variable, which actually exists in the class, as opposed to `uri`.