### PR TITLE
SOLR-13350, SOLR-17298: multi-threaded search: don't (yet) support query limits

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
@@ -119,8 +119,10 @@ public class MultiThreadedSearcher {
     return new SearchResult(scoreMode, ret);
   }
 
-  static boolean allowMT(DelegatingCollector postFilter, QueryCommand cmd, Query query) {
+  static boolean allowMT(
+      DelegatingCollector postFilter, boolean queryLimitsEnabled, QueryCommand cmd, Query query) {
     if (postFilter != null
+        || queryLimitsEnabled
         || cmd.getSegmentTerminateEarly()
         || cmd.getTimeAllowed() > 0
         || !cmd.getMultiThreaded()) {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1920,7 +1920,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       }
       final TopDocs topDocs;
       final ScoreMode scoreModeUsed;
-      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, query)) {
+      if (!MultiThreadedSearcher.allowMT(
+          pf.postFilter, QueryLimits.getCurrentLimits().isLimitsEnabled(), cmd, query)) {
         if (log.isDebugEnabled()) {
           log.debug("skipping collector manager");
         }
@@ -2045,7 +2046,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
       final TopDocs topDocs;
-      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, query)) {
+      if (!MultiThreadedSearcher.allowMT(
+          pf.postFilter, QueryLimits.getCurrentLimits().isLimitsEnabled(), cmd, query)) {
         @SuppressWarnings({"rawtypes"})
         final TopDocsCollector<? extends ScoreDoc> topCollector = buildTopDocsCollector(len, cmd);
         final DocSetCollector setCollector = new DocSetCollector(maxDoc);

--- a/solr/core/src/test/org/apache/solr/search/TestCpuAllowedLimit.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCpuAllowedLimit.java
@@ -185,9 +185,7 @@ public class TestCpuAllowedLimit extends SolrCloudTestCase {
                 "stages",
                 "prepare,process",
                 "cpuAllowed",
-                "50",
-                "multiThreaded",
-                "false"));
+                "50"));
     // System.err.println("rsp=" + rsp.jsonStr());
     assertNotNull("should have partial results", rsp.getHeader().get("partialResults"));
 
@@ -206,9 +204,7 @@ public class TestCpuAllowedLimit extends SolrCloudTestCase {
                 "stages",
                 "prepare,process",
                 "cpuAllowed",
-                "50",
-                "multiThreaded",
-                "false"));
+                "50"));
     // System.err.println("rsp=" + rsp.jsonStr());
     assertNotNull("should have partial results", rsp.getHeader().get("partialResults"));
   }

--- a/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
+++ b/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
@@ -76,17 +76,7 @@ public class TestQueryLimits extends SolrCloudTestCase {
       rsp =
           solrClient.query(
               COLLECTION,
-              params(
-                  "q",
-                  "id:*",
-                  "sort",
-                  "id asc",
-                  "facet",
-                  "true",
-                  "facet.field",
-                  "val_i",
-                  "multiThreaded",
-                  "false"));
+              params("q", "id:*", "sort", "id asc", "facet", "true", "facet.field", "val_i"));
       assertNotNull(
           "should have partial results for expr " + matchingExpr,
           rsp.getHeader().get("partialResults"));


### PR DESCRIPTION
Code change only here. Separately we still need to document that the `multiThreaded=true` parameter is not yet supported for queries with query limits amongst other things.

https://issues.apache.org/jira/browse/SOLR-13350
https://issues.apache.org/jira/browse/SOLR-17298