### PR TITLE
SOLR-17298 - ThreadCpuTimer safe for multi-threaded search

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -26,6 +26,7 @@ import static org.apache.solr.common.params.CommonParams.INFO_HANDLER_PATH;
 import static org.apache.solr.common.params.CommonParams.METRICS_PATH;
 import static org.apache.solr.common.params.CommonParams.ZK_PATH;
 import static org.apache.solr.common.params.CommonParams.ZK_STATUS_PATH;
+import static org.apache.solr.search.CpuAllowedLimit.TIMING_CONTEXT;
 import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGIN_PROP;
 
 import com.github.benmanes.caffeine.cache.Interner;
@@ -155,6 +156,7 @@ import org.apache.solr.update.UpdateShardHandler;
 import org.apache.solr.util.OrderedExecutor;
 import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.StartupLoggingUtils;
+import org.apache.solr.util.ThreadCpuTimer;
 import org.apache.solr.util.stats.MetricUtils;
 import org.apache.zookeeper.KeeperException;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -448,7 +450,8 @@ public class CoreContainer {
           ExecutorUtil.newMDCAwareFixedThreadPool(
               indexSearcherExecutorThreads, // thread count
               indexSearcherExecutorThreads * 1000, // queue size
-              new SolrNamedThreadFactory("searcherCollector"));
+              new SolrNamedThreadFactory("searcherCollector"),
+              () -> ThreadCpuTimer.reset(TIMING_CONTEXT));
     } else {
       this.collectorExecutor = null;
     }

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -43,8 +43,9 @@ import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
-import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.search.CpuAllowedLimit;
+import org.apache.solr.search.QueryLimits;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.security.PermissionNameProvider;
 import org.apache.solr.update.processor.DistributedUpdateProcessor;
@@ -62,6 +63,7 @@ public abstract class RequestHandlerBase
         ApiSupport,
         PermissionNameProvider {
 
+  public static final String REQUEST_CPU_TIMER_CONTEXT = "publishCpuTime";
   protected NamedList<?> initArgs = null;
   protected SolrParams defaults;
   protected SolrParams appends;
@@ -217,12 +219,8 @@ public abstract class RequestHandlerBase
 
   @Override
   public void handleRequest(SolrQueryRequest req, SolrQueryResponse rsp) {
-    ThreadCpuTimer threadCpuTimer = null;
     if (publishCpuTime) {
-      threadCpuTimer =
-          SolrRequestInfo.getRequestInfo() == null
-              ? new ThreadCpuTimer()
-              : SolrRequestInfo.getRequestInfo().getThreadCpuTimer();
+      ThreadCpuTimer.beginContext(REQUEST_CPU_TIMER_CONTEXT);
     }
     HandlerMetrics metrics = getMetricsForThisRequest(req);
     metrics.requests.inc();
@@ -246,21 +244,36 @@ public abstract class RequestHandlerBase
       processErrorMetricsOnException(normalized, metrics);
       rsp.setException(normalized);
     } finally {
-      long elapsed = timer.stop();
-      metrics.totalTime.inc(elapsed);
+      try {
+        long elapsed = timer.stop();
+        metrics.totalTime.inc(elapsed);
 
-      if (publishCpuTime && threadCpuTimer != null) {
-        Optional<Long> cpuTime = threadCpuTimer.getElapsedCpuMs();
-        if (cpuTime.isPresent()) {
-          // add CPU_TIME if not already added by SearchHandler
-          NamedList<Object> header = rsp.getResponseHeader();
-          if (header != null) {
-            if (header.get(ThreadCpuTimer.CPU_TIME) == null) {
-              header.add(ThreadCpuTimer.CPU_TIME, cpuTime.get());
-            }
+        if (publishCpuTime) {
+          Optional<Long> cpuTime = ThreadCpuTimer.readMSandReset(REQUEST_CPU_TIMER_CONTEXT);
+          if (QueryLimits.getCurrentLimits().isLimitsEnabled()) {
+            // prefer the value from the limit if available to avoid confusing users with trivial
+            // differences. Not fond of the spotless formatting here...
+            cpuTime =
+                Optional.ofNullable(
+                    (Long)
+                        QueryLimits.getCurrentLimits()
+                            .currentLimitValueFor(CpuAllowedLimit.class)
+                            .orElse(cpuTime.orElse(null)));
           }
-          rsp.addToLog(ThreadCpuTimer.LOCAL_CPU_TIME, cpuTime.get());
+          if (cpuTime.isPresent()) {
+            // add CPU_TIME if not already added by SearchHandler
+            NamedList<Object> header = rsp.getResponseHeader();
+            if (header != null) {
+              if (header.get(ThreadCpuTimer.CPU_TIME) == null) {
+                header.add(ThreadCpuTimer.CPU_TIME, cpuTime.get());
+              }
+            }
+            rsp.addToLog(ThreadCpuTimer.LOCAL_CPU_TIME, cpuTime.get());
+          }
         }
+      } finally {
+        // whatever happens be sure to clear things out at end of request.
+        ThreadCpuTimer.reset();
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
+++ b/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
@@ -33,7 +33,6 @@ import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.QueryLimits;
 import org.apache.solr.servlet.SolrDispatchFilter;
-import org.apache.solr.util.ThreadCpuTimer;
 import org.apache.solr.util.TimeZoneUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +45,6 @@ public class SolrRequestInfo {
   private static final ThreadLocal<Deque<SolrRequestInfo>> threadLocal =
       ThreadLocal.withInitial(ArrayDeque::new);
   static final Object LIMITS_KEY = new Object();
-  static final Object CPU_TIMER_KEY = new Object();
 
   private int refCount = 1; // prevent closing when still used
 
@@ -80,10 +78,12 @@ public class SolrRequestInfo {
       assert false : "SolrRequestInfo Stack is full";
       log.error("SolrRequestInfo Stack is full");
     } else if (!stack.isEmpty() && info.req != null) {
-      // New SRI instances inherit limits and thread CPU from prior SRI regardless of parameters.
+      // New SRI instances inherit limits from prior SRI regardless of parameters.
       // This ensures these two properties cannot be changed or removed for a given thread once set.
       // if req is null then limits will be an empty instance with no limits anyway.
-      info.req.getContext().put(CPU_TIMER_KEY, stack.peek().getThreadCpuTimer());
+
+      // protected by !stack.isEmpty()
+      // noinspection DataFlowIssue
       info.req.getContext().put(LIMITS_KEY, stack.peek().getLimits());
     }
     // this creates both new QueryLimits and new ThreadCpuTime if not already set
@@ -244,25 +244,10 @@ public class SolrRequestInfo {
    */
   public QueryLimits getLimits() {
     // make sure the ThreadCpuTime is always initialized
-    getThreadCpuTimer();
     return req == null || rsp == null
         ? QueryLimits.NONE
         : (QueryLimits)
             req.getContext().computeIfAbsent(LIMITS_KEY, (k) -> new QueryLimits(req, rsp));
-  }
-
-  /**
-   * Get the thread CPU time monitor for the current request. This will either trigger the creation
-   * of a new instance if it hasn't been yet created, or will retrieve the already existing instance
-   * from the "bottom" of the request stack.
-   *
-   * @return the {@link ThreadCpuTimer} object for the current request.
-   */
-  public ThreadCpuTimer getThreadCpuTimer() {
-    return req == null
-        ? new ThreadCpuTimer()
-        : (ThreadCpuTimer)
-            req.getContext().computeIfAbsent(CPU_TIMER_KEY, k -> new ThreadCpuTimer());
   }
 
   public SolrDispatchFilter.Action getAction() {

--- a/solr/core/src/java/org/apache/solr/search/CpuAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/CpuAllowedLimit.java
@@ -16,13 +16,16 @@
  */
 package org.apache.solr.search;
 
+import static org.apache.solr.util.ThreadCpuTimer.readNSAndReset;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import net.jcip.annotations.NotThreadSafe;
-import org.apache.lucene.index.QueryTimeout;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
+import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.ThreadCpuTimer;
 
 /**
@@ -37,14 +40,17 @@ import org.apache.solr.util.ThreadCpuTimer;
  * @see ThreadCpuTimer
  */
 @NotThreadSafe
-public class CpuAllowedLimit implements QueryTimeout {
-  private final ThreadCpuTimer threadCpuTimer;
+public class CpuAllowedLimit implements QueryLimit {
+
   private final long requestedTimeoutNs;
+  private volatile long timedOutAt = 0L;
+  AtomicLong accumulatedTime = new AtomicLong(0);
+  public static final String TIMING_CONTEXT = CpuAllowedLimit.class.getName();
 
   /**
    * Create an object to represent a CPU time limit for the current request. NOTE: this
    * implementation will attempt to obtain an existing thread CPU time monitor, created when {@link
-   * SolrRequestInfo#getThreadCpuTimer()} is initialized.
+   * QueryLimits#QueryLimits(SolrQueryRequest, SolrQueryResponse)} is called.
    *
    * @param req solr request with a {@code cpuAllowed} parameter
    */
@@ -52,11 +58,6 @@ public class CpuAllowedLimit implements QueryTimeout {
     if (!ThreadCpuTimer.isSupported()) {
       throw new IllegalArgumentException("Thread CPU time monitoring is not available.");
     }
-    SolrRequestInfo solrRequestInfo = SolrRequestInfo.getRequestInfo();
-    // get existing timer if available to ensure sub-queries can't reset/exceed the intended time
-    // constraint.
-    threadCpuTimer =
-        solrRequestInfo != null ? solrRequestInfo.getThreadCpuTimer() : new ThreadCpuTimer();
     long reqCpuLimit = req.getParams().getLong(CommonParams.CPU_ALLOWED, -1L);
 
     if (reqCpuLimit <= 0L) {
@@ -65,11 +66,15 @@ public class CpuAllowedLimit implements QueryTimeout {
     }
     // calculate the time when the limit is reached, e.g. account for the time already spent
     requestedTimeoutNs = TimeUnit.NANOSECONDS.convert(reqCpuLimit, TimeUnit.MILLISECONDS);
+
+    // here we rely on the current thread never creating a second CpuAllowedLimit within the same
+    // request, and also rely on it always creating a new CpuAllowedLimit object for each
+    // request that requires it.
+    ThreadCpuTimer.beginContext(TIMING_CONTEXT);
   }
 
   @VisibleForTesting
   CpuAllowedLimit(long limitMs) {
-    this.threadCpuTimer = new ThreadCpuTimer();
     requestedTimeoutNs = TimeUnit.NANOSECONDS.convert(limitMs, TimeUnit.MILLISECONDS);
   }
 
@@ -81,6 +86,21 @@ public class CpuAllowedLimit implements QueryTimeout {
   /** Return true if usage has exceeded the limit. */
   @Override
   public boolean shouldExit() {
-    return threadCpuTimer.getElapsedCpuNs() > requestedTimeoutNs;
+    if (timedOutAt > 0L) {
+      return true;
+    }
+    // if unsupported, use zero, and thus never exit, expect jvm and/or cpu branch
+    // prediction to short circuit things if unsupported.
+    Long delta = readNSAndReset(TIMING_CONTEXT).orElse(0L);
+    if (accumulatedTime.addAndGet(delta) > requestedTimeoutNs) {
+      timedOutAt = accumulatedTime.get();
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public Object currentValue() {
+    return timedOutAt > 0 ? timedOutAt : accumulatedTime.get();
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/CpuAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/CpuAllowedLimit.java
@@ -20,6 +20,9 @@ import static org.apache.solr.util.ThreadCpuTimer.readNSAndReset;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.lang.invoke.MethodHandles;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import net.jcip.annotations.NotThreadSafe;
@@ -103,18 +106,20 @@ public class CpuAllowedLimit implements QueryLimit {
       }
       return false;
     } finally {
-      // uncomment for debugging. Our suspicious log checker will never be happy here... (nor should
-      // it be)
-
-      //      java.text.DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
-      //      DecimalFormat formatter = new DecimalFormat("#,###", symbols);
-      //
-      //      if (log.isInfoEnabled()) {
-      //        log.info("++++++++++++ SHOULD_EXIT {} accumulated:{} vs {} ++++ ON:{}",
-      // formatter.format(delta),
-      // formatter.format(accumulatedTime.get()),formatter.format(requestedTimeoutNs)
-      // ,Thread.currentThread().getName());
-      //      }
+      if (log.isTraceEnabled()) {
+        java.text.DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
+        DecimalFormat formatter = new DecimalFormat("#,###", symbols);
+        String threadName = Thread.currentThread().getName();
+        String deltaFmt = formatter.format(delta);
+        String accumulated = formatter.format(accumulatedTime.get());
+        String timeoutForComparison = formatter.format(requestedTimeoutNs);
+        log.trace(
+            "++++++++++++ SHOULD_EXIT - measuredDelta:{} accumulated:{} vs {} ++++ ON:{}",
+            deltaFmt,
+            accumulated,
+            timeoutForComparison,
+            threadName);
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
@@ -120,10 +120,7 @@ public class MultiThreadedSearcher {
   }
 
   static boolean allowMT(DelegatingCollector postFilter, QueryCommand cmd, Query query) {
-    if (postFilter != null
-        || cmd.getSegmentTerminateEarly()
-        || cmd.getTimeAllowed() > 0
-        || !cmd.getMultiThreaded()) {
+    if (postFilter != null || cmd.getSegmentTerminateEarly() || !cmd.getMultiThreaded()) {
       return false;
     } else {
       MTCollectorQueryCheck allowMT = new MTCollectorQueryCheck();

--- a/solr/core/src/java/org/apache/solr/search/QueryLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimit.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import org.apache.lucene.index.QueryTimeout;
+
+public interface QueryLimit extends QueryTimeout {
+  /**
+   * A value representing the portion of the specified limit that has been consumed. Reading this
+   * value should never affect the outcome (other than the time it takes to do it).
+   *
+   * @return an expression of the amount of the limit used so far, numeric if possible, if
+   *     non-numeric it should have toString() suitable for logging or similar expression to the
+   *     user.
+   */
+  Object currentValue();
+}

--- a/solr/core/src/java/org/apache/solr/search/QueryLimits.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimits.java
@@ -21,6 +21,7 @@ import static org.apache.solr.search.TimeAllowedLimit.hasTimeLimit;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.request.SolrQueryRequest;
@@ -34,7 +35,7 @@ import org.apache.solr.util.TestInjection;
  * return true the next time it is checked (it may be checked in either Lucene code or Solr code)
  */
 public class QueryLimits implements QueryTimeout {
-  private final List<QueryTimeout> limits =
+  private final List<QueryLimit> limits =
       new ArrayList<>(3); // timeAllowed, cpu, and memory anticipated
 
   public static QueryLimits NONE = new QueryLimits();
@@ -147,6 +148,15 @@ public class QueryLimits implements QueryTimeout {
       sb.append("]");
     }
     return sb.toString();
+  }
+
+  public Optional<Object> currentLimitValueFor(Class<? extends QueryLimit> limitClass) {
+    for (QueryLimit limit : limits) {
+      if (limit.getClass().isAssignableFrom(limitClass)) {
+        return Optional.of(limit.currentValue());
+      }
+    }
+    return Optional.empty();
   }
 
   /** Return true if there are any limits enabled for the current request. */

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1921,9 +1921,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       final TopDocs topDocs;
       final ScoreMode scoreModeUsed;
       if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, query)) {
-        if (log.isDebugEnabled()) {
-          log.debug("skipping collector manager");
-        }
+        log.debug("SINGLE THREADED search,skipping collector manager");
         final TopDocsCollector<?> topCollector = buildTopDocsCollector(len, cmd);
         MaxScoreCollector maxScoreCollector = null;
         Collector collector = topCollector;
@@ -1942,9 +1940,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
                 ? (maxScoreCollector == null ? Float.NaN : maxScoreCollector.getMaxScore())
                 : 0.0f;
       } else {
-        if (log.isDebugEnabled()) {
-          log.debug("using CollectorManager");
-        }
+        log.debug("MULTI-THREADED search, using CollectorManager");
         final MultiThreadedSearcher.SearchResult searchResult =
             new MultiThreadedSearcher(this)
                 .searchCollectorManagers(len, cmd, query, true, needScores, false);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1921,7 +1921,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       final TopDocs topDocs;
       final ScoreMode scoreModeUsed;
       if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, query)) {
-        log.debug("SINGLE THREADED search,skipping collector manager");
+        log.trace("SINGLE THREADED search, skipping collector manager in getDocListNC");
         final TopDocsCollector<?> topCollector = buildTopDocsCollector(len, cmd);
         MaxScoreCollector maxScoreCollector = null;
         Collector collector = topCollector;
@@ -1940,7 +1940,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
                 ? (maxScoreCollector == null ? Float.NaN : maxScoreCollector.getMaxScore())
                 : 0.0f;
       } else {
-        log.debug("MULTI-THREADED search, using CollectorManager");
+        log.trace("MULTI-THREADED search, using CollectorManager int getDocListNC");
         final MultiThreadedSearcher.SearchResult searchResult =
             new MultiThreadedSearcher(this)
                 .searchCollectorManagers(len, cmd, query, true, needScores, false);
@@ -2042,6 +2042,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     } else {
       final TopDocs topDocs;
       if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, query)) {
+        log.trace("SINGLE THREADED search, skipping collector manager in getDocListAndSetNC");
+
         @SuppressWarnings({"rawtypes"})
         final TopDocsCollector<? extends ScoreDoc> topCollector = buildTopDocsCollector(len, cmd);
         final DocSetCollector setCollector = new DocSetCollector(maxDoc);
@@ -2068,7 +2070,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
                 ? (maxScoreCollector == null ? Float.NaN : maxScoreCollector.getMaxScore())
                 : 0.0f;
       } else {
-        log.debug("using CollectorManager");
+        log.trace("MULTI-THREADED search, using CollectorManager in getDocListAndSetNC");
 
         boolean needMaxScore = needScores;
         MultiThreadedSearcher.SearchResult searchResult =

--- a/solr/core/src/java/org/apache/solr/util/TestInjection.java
+++ b/solr/core/src/java/org/apache/solr/util/TestInjection.java
@@ -32,13 +32,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.QueryTimeout;
 import org.apache.solr.common.NonExistentCoreException;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.Pair;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
+import org.apache.solr.search.QueryLimit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +154,7 @@ public class TestInjection {
 
   public static volatile AtomicInteger countDocSetDelays = new AtomicInteger(0);
 
-  public static volatile QueryTimeout queryTimeout = null;
+  public static volatile QueryLimit queryTimeout = null;
 
   public static volatile boolean failInExecutePlanAction = false;
 

--- a/solr/core/src/java/org/apache/solr/util/TestInjection.java
+++ b/solr/core/src/java/org/apache/solr/util/TestInjection.java
@@ -16,11 +16,18 @@
  */
 package org.apache.solr.util;
 
+import com.google.common.util.concurrent.AtomicDouble;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
 import java.util.Timer;
@@ -157,6 +164,22 @@ public class TestInjection {
   public static volatile QueryLimit queryTimeout = null;
 
   public static volatile boolean failInExecutePlanAction = false;
+
+  public static volatile AtomicInteger cpuTimerDelayInjectedNS = null;
+
+  private static final KeyPairGenerator kpg;
+
+  static {
+    KeyPairGenerator generator;
+    try {
+      generator = KeyPairGenerator.getInstance("RSA");
+    } catch (NoSuchAlgorithmException e) {
+      generator = null;
+    }
+    kpg = generator;
+  }
+
+  private static volatile AtomicDouble cpuLoadPerKey = null;
 
   /**
    * Defaults to <code>false</code>, If set to <code>true</code>, then {@link
@@ -529,6 +552,55 @@ public class TestInjection {
       }
     }
     return true;
+  }
+
+  public static void measureCpu() {
+    if (kpg == null || cpuLoadPerKey != null) {
+      return;
+    }
+    long start = System.nanoTime();
+    for (int i = 0; i < 100; i++) {
+      genKeyPairAndDiscard();
+    }
+    // note that this is potentially imprecise because our thread could get paused in the middle of
+    // this, but
+    // it should give us some notion
+    long end = System.nanoTime();
+    cpuLoadPerKey = new AtomicDouble((end - start) / 100.0);
+    log.info("CPU per key = {}", cpuLoadPerKey);
+  }
+
+  private static void genKeyPairAndDiscard() {
+    kpg.initialize(1024);
+    KeyPair kp = kpg.generateKeyPair();
+    // avoid this getting optimized away by logging it
+    if (log.isTraceEnabled()) {
+      log.trace("{}", kp.getPublic());
+    }
+  }
+
+  private static void wasteCpu(int nanos) {
+    double wasteMe = nanos;
+    double loadPerKey = cpuLoadPerKey.get();
+    if (loadPerKey > nanos) {
+      java.text.DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
+
+      DecimalFormat formatter = new DecimalFormat("#,###.00", symbols);
+      // yes this is still wasting formatting when not warn, but not important here.
+      log.warn(
+          "Test requests smaller simulated cpu lag than a single keypair generation actual lag is {} ns",
+          formatter.format(loadPerKey));
+    }
+    do {
+      genKeyPairAndDiscard();
+    } while ((wasteMe = wasteMe - loadPerKey) > 0.0);
+  }
+
+  public static void injectCpuUseInSearcherCpuLimitCheck() {
+    if (LUCENE_TEST_CASE == null) return;
+    if (cpuTimerDelayInjectedNS != null) {
+      wasteCpu(cpuTimerDelayInjectedNS.get());
+    }
   }
 
   public static boolean injectReindexFailure() {

--- a/solr/core/src/java/org/apache/solr/util/ThreadCpuTimer.java
+++ b/solr/core/src/java/org/apache/solr/util/ThreadCpuTimer.java
@@ -78,6 +78,8 @@ public class ThreadCpuTimer {
    *     unavailable.
    */
   public static Optional<Long> readNSAndReset(String context) {
+    // simulate heavy query and/or heavy CPU load in tests
+    TestInjection.injectCpuUseInSearcherCpuLimitCheck();
     if (THREAD_MX_BEAN == null) {
       return Optional.empty();
     } else {

--- a/solr/core/src/java/org/apache/solr/util/ThreadCpuTimer.java
+++ b/solr/core/src/java/org/apache/solr/util/ThreadCpuTimer.java
@@ -95,6 +95,21 @@ public class ThreadCpuTimer {
     }
   }
 
+  /**
+   * Discard any accumulated time for a given context since the last invocation.
+   *
+   * @param context the context to reset
+   */
+  public static void reset(String context) {
+    if (THREAD_MX_BEAN != null) {
+      threadLocalTimer
+          .get()
+          .computeIfAbsent(
+              context, (ctx) -> new AtomicLong(THREAD_MX_BEAN.getCurrentThreadCpuTime()))
+          .set(THREAD_MX_BEAN.getCurrentThreadCpuTime());
+    }
+  }
+
   public static Optional<Long> readMSandReset(String context) {
     return readNSAndReset(context)
         .map((cpuTimeNs) -> TimeUnit.MILLISECONDS.convert(cpuTimeNs, TimeUnit.NANOSECONDS));

--- a/solr/core/src/test/org/apache/solr/search/CallerSpecificQueryLimit.java
+++ b/solr/core/src/test/org/apache/solr/search/CallerSpecificQueryLimit.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.lucene.index.QueryTimeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * and optionally a method name, e.g. <code>MoreLikeThisComponent</code> or <code>
  * ClusteringComponent.finishStage</code>.
  */
-public class CallerSpecificQueryLimit implements QueryTimeout {
+public class CallerSpecificQueryLimit implements QueryLimit {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   final StackWalker stackWalker =
@@ -101,5 +100,10 @@ public class CallerSpecificQueryLimit implements QueryTimeout {
       trippedBy = matchingExpr.get();
     }
     return matchingExpr.isPresent();
+  }
+
+  @Override
+  public Object currentValue() {
+    return "This class just for testing, not a real limit";
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestCpuAllowedLimit.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCpuAllowedLimit.java
@@ -163,6 +163,28 @@ public class TestCpuAllowedLimit extends SolrCloudTestCase {
                 String.valueOf(sleepMs),
                 "stages",
                 "prepare,process",
+                "multiThreaded",
+                "false",
+                "timeAllowed",
+                "500"));
+    // System.err.println("rsp=" + rsp.jsonStr());
+    assertNotNull("should have partial results", rsp.getHeader().get("partialResults"));
+
+    log.info("--- timeAllowed, partial results, multithreading ---");
+    rsp =
+        solrClient.query(
+            COLLECTION,
+            params(
+                "q",
+                "id:*",
+                "sort",
+                "id asc",
+                ExpensiveSearchComponent.SLEEP_MS_PARAM,
+                String.valueOf(sleepMs),
+                "stages",
+                "prepare,process",
+                "multiThreaded",
+                "true",
                 "timeAllowed",
                 "500"));
     // System.err.println("rsp=" + rsp.jsonStr());

--- a/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
@@ -357,7 +357,7 @@ public class ExecutorUtil {
       this.beforeExecuteTask = NOOP;
     }
 
-    public <E> MDCAwareThreadPoolExecutor(
+    public MDCAwareThreadPoolExecutor(
         int i,
         int maxValue,
         long l,

--- a/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
@@ -370,7 +370,7 @@ public class ExecutorUtil {
 
     @Override
     protected void beforeExecute(Thread t, Runnable r) {
-      super.beforeExecute(t, this.beforeExecuteTask);
+      this.beforeExecuteTask.run();
     }
 
     @Override

--- a/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
@@ -202,14 +202,15 @@ public class ExecutorUtil {
   }
 
   public static ExecutorService newMDCAwareFixedThreadPool(
-      int nThreads, int queueCapacity, ThreadFactory threadFactory) {
+      int nThreads, int queueCapacity, ThreadFactory threadFactory, Runnable beforeExecute) {
     return new MDCAwareThreadPoolExecutor(
         nThreads,
         nThreads,
         0L,
         TimeUnit.MILLISECONDS,
         new LinkedBlockingQueue<>(queueCapacity),
-        threadFactory);
+        threadFactory,
+        beforeExecute);
   }
 
   /**
@@ -257,8 +258,10 @@ public class ExecutorUtil {
   public static class MDCAwareThreadPoolExecutor extends ThreadPoolExecutor {
 
     private static final int MAX_THREAD_NAME_LEN = 512;
+    public static final Runnable NOOP = () -> {};
 
     private final boolean enableSubmitterStackTrace;
+    private final Runnable beforeExecuteTask;
 
     public MDCAwareThreadPoolExecutor(
         int corePoolSize,
@@ -270,6 +273,7 @@ public class ExecutorUtil {
         RejectedExecutionHandler handler) {
       super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
       this.enableSubmitterStackTrace = true;
+      this.beforeExecuteTask = NOOP;
     }
 
     public MDCAwareThreadPoolExecutor(
@@ -280,6 +284,7 @@ public class ExecutorUtil {
         BlockingQueue<Runnable> workQueue) {
       super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
       this.enableSubmitterStackTrace = true;
+      this.beforeExecuteTask = NOOP;
     }
 
     public MDCAwareThreadPoolExecutor(
@@ -289,7 +294,8 @@ public class ExecutorUtil {
         TimeUnit unit,
         BlockingQueue<Runnable> workQueue,
         ThreadFactory threadFactory) {
-      this(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, true);
+      this(
+          corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, true, NOOP);
     }
 
     public MDCAwareThreadPoolExecutor(
@@ -299,9 +305,30 @@ public class ExecutorUtil {
         TimeUnit unit,
         BlockingQueue<Runnable> workQueue,
         ThreadFactory threadFactory,
-        boolean enableSubmitterStackTrace) {
+        Runnable beforeExecuteTask) {
+      this(
+          corePoolSize,
+          maximumPoolSize,
+          keepAliveTime,
+          unit,
+          workQueue,
+          threadFactory,
+          true,
+          beforeExecuteTask);
+    }
+
+    public MDCAwareThreadPoolExecutor(
+        int corePoolSize,
+        int maximumPoolSize,
+        long keepAliveTime,
+        TimeUnit unit,
+        BlockingQueue<Runnable> workQueue,
+        ThreadFactory threadFactory,
+        boolean enableSubmitterStackTrace,
+        Runnable beforeExecuteTask) {
       super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
       this.enableSubmitterStackTrace = enableSubmitterStackTrace;
+      this.beforeExecuteTask = beforeExecuteTask;
     }
 
     public MDCAwareThreadPoolExecutor(
@@ -313,6 +340,37 @@ public class ExecutorUtil {
         RejectedExecutionHandler handler) {
       super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
       this.enableSubmitterStackTrace = true;
+      this.beforeExecuteTask = NOOP;
+    }
+
+    public MDCAwareThreadPoolExecutor(
+        int corePoolSize,
+        int maximumPoolSize,
+        int keepAliveTime,
+        TimeUnit timeUnit,
+        BlockingQueue<Runnable> blockingQueue,
+        SolrNamedThreadFactory httpShardExecutor,
+        boolean enableSubmitterStackTrace) {
+      super(
+          corePoolSize, maximumPoolSize, keepAliveTime, timeUnit, blockingQueue, httpShardExecutor);
+      this.enableSubmitterStackTrace = enableSubmitterStackTrace;
+      this.beforeExecuteTask = NOOP;
+    }
+
+    public <E> MDCAwareThreadPoolExecutor(
+        int i,
+        int maxValue,
+        long l,
+        TimeUnit timeUnit,
+        BlockingQueue<Runnable> es,
+        SolrNamedThreadFactory testExecutor,
+        boolean b) {
+      this(i, maxValue, l, timeUnit, es, testExecutor, b, NOOP);
+    }
+
+    @Override
+    protected void beforeExecute(Thread t, Runnable r) {
+      super.beforeExecute(t, this.beforeExecuteTask);
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17298

This introduces a version of ThreadCpuTimer class that does not need to depend on the request context or be instantiated to track timing. This approach turns ThreadCpuTimer into a "stopwatch" service that simply answers the question of how long has it been since the last time this thread asked for time... I added an override of beforeExecute() to MDCAwareThreadPoolExecutor and some related methods to ExecutorUtil to allow the "stopwatch" to be reset just before lucene asks the executor to execute a task. Every shouldExit() causes a read operation which returns the time since last read by that thread and resets the timer. An atomic long is used to accumulate the total and test the timeout.

Additionally the ThreadCpuTimer also can track multiple timings within the same thread by use of a "context" denoted by a string parameter, this allows it to continue to serve as a timer for cpu usage logging as well. 

The Tests for this also required some tweaks to ensure that there were multiple segments in the index being searched, and enough segments were generated to ensure more than one task is assigned to the executor by Lucene (It groups segments up to a max total size or a maximum of 5 segments, whichever comes first, see [IndexSearcher#MAX_SEGMENTS_PER_SLICE](https://github.com/apache/lucene/blob/8d4f7a6e99d2da802b7019247b0f8f305d71c024/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java#L105), and also I added a TestInjection with code mimicking the ExpensiveSearchComponent code to allow us to waste some CPU before each call to shouldExit() for better simulation of actual load.

Tests pass including TestCpuAllowedLimit with both multiThreaded=true and multiThreaded=false cases enabled. We should however observe how it behaves in Jenkins/Crave test runs.

Also it would be super good to get more eyes on this.