### PR TITLE
Produce test report for integration tests

### DIFF
--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -294,7 +294,7 @@ class BatsTask extends Exec {
 
     // Note: tests to run must be listed after all other arguments
     // Additional debugging output: -x, --verbose-run
-    setArgs(['-T', '--print-output-on-failure'] + (testFiles.empty ? testDir : testFiles))
+    setArgs(['-T', '--print-output-on-failure', '--report-formatter', 'junit', '--output', "$project.buildDir/test-output"] + (testFiles.empty ? testDir : testFiles))
 
 
     super.exec()


### PR DESCRIPTION
# Description

Although success and failures are written to stdout, `./gradlew integrationTest` doesn't produce any lasting artifact (i.e. a report) to indicate which tests succeeded and which failed.  BATS has built-in support for reporting, it's just not something that's on by default.

# Solution

This commit tweaks our BATS invocation so that a JUnit-style XML report ('report.xml') is produced in the packaging module's 'build/test-output' directory.

# Tests

N/A - this is a build-system-only change.  Though I've done manual testing to ensure that the test report is generated under various circumstances, as expected.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
