### PR TITLE
SOLR-17386: Fixed SyntheticSolrCore reload issue

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -221,6 +221,8 @@ Bug Fixes
 
 * SOLR-17337: Display all custom distributed stages in debug output. (Torsten Bøgh Köster, Christine Poerschke)
 
+* SOLR-17386: Fix coordinators (SyntheticSolrCore) reload issue. (ellaeln, Patson Luk, David Smiley, Christine Poerschke)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -174,7 +174,7 @@ Optimizations
 
 * SOLR-17099: Do not return spurious tags when fetching metrics from a Solr node to another. (Pierre Salagnac)
 
-* SOLR-17269: Prevent the "Coordinator node" feature from registering synthetic cores in ZooKeeper (Patson Luk)
+* SOLR-17269, SOLR-17386: Prevent the "Coordinator node" feature from registering synthetic cores in ZooKeeper (ellaeln, Patson Luk, David Smiley, Christine Poerschke)
 
 * SOLR-17330: When not set, loadOnStartup defaults to true, which is the default choice for a core. (Pierre Salagnac via Eric Pugh)
 
@@ -220,8 +220,6 @@ Bug Fixes
 * SOLR-17369: Fix "flags" usage in FunctionQParser that caused some issues in vectorSimilarity() with BYTE vector constants (hossman)
 
 * SOLR-17337: Display all custom distributed stages in debug output. (Torsten Bøgh Köster, Christine Poerschke)
-
-* SOLR-17386: Fix coordinators (SyntheticSolrCore) reload issue. (ellaeln, Patson Luk, David Smiley, Christine Poerschke)
 
 Dependency Upgrades
 ---------------------

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -2056,10 +2056,11 @@ public class CoreContainer {
         newCore = core.reload(coreConfig);
 
         DocCollection docCollection = null;
-        if (getZkController() != null && !newCore.isSynthetic()) {
-          docCollection = getZkController().getClusterState().getCollection(cd.getCollectionName());
+        if (getZkController() != null) {
+          docCollection =
+              getZkController().getClusterState().getCollectionOrNull(cd.getCollectionName());
           // turn off indexing now, before the new core is registered
-          if (docCollection.getBool(ZkStateReader.READ_ONLY, false)) {
+          if (docCollection != null && docCollection.getBool(ZkStateReader.READ_ONLY, false)) {
             newCore.readOnly = true;
           }
         }

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -2056,7 +2056,7 @@ public class CoreContainer {
         newCore = core.reload(coreConfig);
 
         DocCollection docCollection = null;
-        if (getZkController() != null) {
+        if (getZkController() != null && !newCore.isSynthetic()) {
           docCollection = getZkController().getClusterState().getCollection(cd.getCollectionName());
           // turn off indexing now, before the new core is registered
           if (docCollection.getBool(ZkStateReader.READ_ONLY, false)) {

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -225,7 +225,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   private final NamedList<?> configSetProperties;
   private final String dataDir;
   private final UpdateHandler updateHandler;
-  protected final SolrCoreState solrCoreState;
+  private final SolrCoreState solrCoreState;
 
   private final Date startTime = new Date();
   private final long startNanoTime = System.nanoTime();
@@ -1059,7 +1059,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
     this(coreContainer, cd, configSet, null, null, null, null, false);
   }
 
-  protected SolrCore(
+  private SolrCore(
       CoreContainer coreContainer,
       CoreDescriptor coreDescriptor,
       ConfigSet configSet,

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3276,13 +3276,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
     return codec;
   }
 
-  /**
-   * @return whether this is a synthetic core that simply forward queries to other cores
-   */
-  protected boolean isSynthetic() {
-    return false;
-  }
-
   public void unloadOnClose(
       final CoreDescriptor desc,
       boolean deleteIndexDir,

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -1059,7 +1059,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
     this(coreContainer, cd, configSet, null, null, null, null, false);
   }
 
-  private SolrCore(
+  protected SolrCore(
       CoreContainer coreContainer,
       CoreDescriptor coreDescriptor,
       ConfigSet configSet,

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -775,7 +775,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
       try {
         CoreDescriptor cd = new CoreDescriptor(name, getCoreDescriptor());
         cd.loadExtraProperties(); // Reload the extra properties
-        core = cloneAsReloadCore(cd, coreConfig, cloneCoreState);
+        core = cloneForReloadCore(cd, coreConfig, cloneCoreState);
 
         // we open a new IndexWriter to pick up the latest config
         core.getUpdateHandler().getSolrCoreState().newIndexWriter(core, false);
@@ -795,9 +795,9 @@ public class SolrCore implements SolrInfoBean, Closeable {
   /**
    * Clones the current core for core reload, with the provided CoreDescriptor and ConfigSet.
    *
-   * @return the cloned core to be used for SolrCore#load
+   * @return the cloned core to be used for {@link SolrCore#reload}
    */
-  protected SolrCore cloneAsReloadCore(
+  protected SolrCore cloneForReloadCore(
       CoreDescriptor newCoreDescriptor, ConfigSet newCoreConfig, boolean cloneCoreState) {
     return new SolrCore(
         coreContainer,

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -225,7 +225,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   private final NamedList<?> configSetProperties;
   private final String dataDir;
   private final UpdateHandler updateHandler;
-  private final SolrCoreState solrCoreState;
+  protected final SolrCoreState solrCoreState;
 
   private final Date startTime = new Date();
   private final long startNanoTime = System.nanoTime();
@@ -1054,7 +1054,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
     this(coreContainer, cd, configSet, null, null, null, null, false);
   }
 
-  private SolrCore(
+  protected SolrCore(
       CoreContainer coreContainer,
       CoreDescriptor coreDescriptor,
       ConfigSet configSet,
@@ -3269,6 +3269,13 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
   public Codec getCodec() {
     return codec;
+  }
+
+  /**
+   * @return whether this is a synthetic core that simply forward queries to other cores
+   */
+  protected boolean isSynthetic() {
+    return false;
   }
 
   public void unloadOnClose(

--- a/solr/core/src/java/org/apache/solr/core/SyntheticSolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SyntheticSolrCore.java
@@ -88,7 +88,7 @@ public class SyntheticSolrCore extends SolrCore {
   }
 
   @Override
-  protected SyntheticSolrCore cloneAsReloadCore(
+  protected SyntheticSolrCore cloneForReloadCore(
       CoreDescriptor newCoreDescriptor, ConfigSet newCoreConfig, boolean cloneCurrentState) {
     return new SyntheticSolrCore(
         getCoreContainer(),

--- a/solr/core/src/java/org/apache/solr/core/SyntheticSolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SyntheticSolrCore.java
@@ -100,9 +100,4 @@ public class SyntheticSolrCore extends SolrCore {
         cloneCurrentState ? this : null,
         true);
   }
-
-  @Override
-  protected boolean isSynthetic() {
-    return true;
-  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17386

# Description
It was reported by user (with nice details!) that calling /admin/cores?action=RELOAD&core=<synthetic core on coordinator node> gives 500

# Cause
This is caused by the change introduced in https://github.com/apache/solr/pull/2438, which core from coordinator node is now of class `SyntheticSolrCore`, which is a child class of `SolrCore`, (instead of being `SolrCore`) and the dummy coordinator collection no longer registers against the zk. 

There are 2 main issues arise because of this change:
1. On a `reload` call of the coordinator core, since the implementation class `SyntheticSolrCore` does not override `reload`, it will run the `SolrCore` implementation which create a new `SolrCore` (instead of `SyntheticSorlCore`) as a replacement.
2. In `CoreContainer#reload`, it will attempt to load the `DocCollection` from ZK (via cluster state) of the core's collection, and perform various logic (index writer, replication) base on the result. However, for synthetic solr core, such collection does not really exist.

# Solution
Corresponding to the causes:
1. Overload the `reload` method in `SyntheticSolrCore` , it is a bit hard to just call `super.reload` as it will require quite a bit of refactoring. Instead, we will just use a simplified (ignore all the write/indexing handling) version of `reload`.
2. Introduce a `SolrCore#isSynthetic` method, which return false for all cores except from `SyntheticSolrCore`. Then in `CoreContainer#reload` make a check on such method before getting the `DocCollection` from ZK. For `SyntheticSolrCore`, it will get null `DocCollection` which is already being handled in existing `CoreContainer` logic


# Concerns
I have concerns on the scope of change in this PR, in particular we will need to modify existing core classes `SolrCore` and `CoreContainer`. Both need to be somehow aware of the `Synthetic` core, which is really not ideal. Another option is to refactor the code to break things down and then override the corresponding parts in `SyntheticSolrCore`, this could be quite a bit of refactoring and might even change more of the existing core classes (but then they will not be "synthetic core" aware anymore!)

Any thoughts please? @dsmiley @noblepaul  🙏🏼

# Tests

Added `TestCoordinatorRole#testCoreReload` to perform config update then followed by a core reload. Ensure that core reload returns success response code and query updates according to the config update.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
