### PR TITLE
Benchmark: HTTP2 fix cancel_stream_error

### DIFF
--- a/solr/benchmark/src/java/org/apache/solr/bench/search/SimpleSearch.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/search/SimpleSearch.java
@@ -90,58 +90,6 @@ public class SimpleSearch {
     }
   }
 
-  /**
-   * Under high load http2 client could throw the below exception
-   *
-   * <pre>{@code
-   * org.apache.solr.client.solrj.SolrServerException: IOException occurred when talking to server at: http://127.0.0.1:49436/solr/c1/select?q=id%3A0&wt=javabin&version=2
-   * at org.apache.solr.client.solrj.impl.Http2SolrClient.request(Http2SolrClient.java:533)
-   * at org.apache.solr.bench.search.SimpleSearch.query(SimpleSearch.java:89)
-   * at org.apache.solr.bench.search.jmh_generated.SimpleSearch_query_jmhTest.query_thrpt_jmhStub(SimpleSearch_query_jmhTest.java:275)
-   * at org.apache.solr.bench.search.jmh_generated.SimpleSearch_query_jmhTest.query_Throughput(SimpleSearch_query_jmhTest.java:127)
-   * at jdk.internal.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
-   * at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-   * at java.base/java.lang.reflect.Method.invoke(Method.java:566)
-   * at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:475)
-   * at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:458)
-   * at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
-   * at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
-   * at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
-   * at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
-   * at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
-   * at java.base/java.lang.Thread.run(Thread.java:829)
-   * Caused by: java.io.IOException: cancel_stream_error
-   * at org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2.onReset(HttpReceiverOverHTTP2.java:202)
-   * at org.eclipse.jetty.http2.client.http.HttpChannelOverHTTP2$Listener.onReset(HttpChannelOverHTTP2.java:206)
-   * at org.eclipse.jetty.http2.api.Stream$Listener.onReset(Stream.java:271)
-   * at org.eclipse.jetty.http2.HTTP2Stream.notifyReset(HTTP2Stream.java:853)
-   * at org.eclipse.jetty.http2.HTTP2Stream.onReset(HTTP2Stream.java:563)
-   * at org.eclipse.jetty.http2.HTTP2Stream.process(HTTP2Stream.java:392)
-   * at org.eclipse.jetty.http2.HTTP2Session.onReset(HTTP2Session.java:320)
-   * at org.eclipse.jetty.http2.parser.Parser$Listener$Wrapper.onReset(Parser.java:367)
-   * at org.eclipse.jetty.http2.parser.BodyParser.notifyReset(BodyParser.java:139)
-   * at org.eclipse.jetty.http2.parser.ResetBodyParser.onReset(ResetBodyParser.java:92)
-   * at org.eclipse.jetty.http2.parser.ResetBodyParser.parse(ResetBodyParser.java:61)
-   * at org.eclipse.jetty.http2.parser.Parser.parseBody(Parser.java:193)
-   * at org.eclipse.jetty.http2.parser.Parser.parse(Parser.java:122)
-   * at org.eclipse.jetty.http2.HTTP2Connection$HTTP2Producer.produce(HTTP2Connection.java:278)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.produceTask(AdaptiveExecutionStrategy.java:450)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:243)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.produce(AdaptiveExecutionStrategy.java:194)
-   * at org.eclipse.jetty.http2.HTTP2Connection.produce(HTTP2Connection.java:208)
-   * at org.eclipse.jetty.http2.HTTP2Connection.onFillable(HTTP2Connection.java:155)
-   * at org.eclipse.jetty.http2.HTTP2Connection$FillableCallback.succeeded(HTTP2Connection.java:378)
-   * at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
-   * at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
-   * at org.eclipse.jetty.util.thread.Invocable.invokeNonBlocking(Invocable.java:151)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.invokeAsNonBlocking(AdaptiveExecutionStrategy.java:433)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:375)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:272)
-   * at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.produce(AdaptiveExecutionStrategy.java:194)
-   * at org.apache.solr.common.util.ExecutorUtil$MDCAwareThreadPoolExecutor.lambda$execute$0(ExecutorUtil.java:289)
-   * ... 3 more
-   * }</pre>
-   */
   @Benchmark
   public Object query(
       BenchState benchState, MiniClusterState.MiniClusterBenchState miniClusterState, Blackhole bh)

--- a/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
+++ b/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
@@ -75,6 +75,7 @@ import org.apache.solr.util.TimeOut;
 import org.apache.solr.util.configuration.SSLConfigurationsFactory;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http2.HTTP2Cipher;
+import org.eclipse.jetty.http2.parser.WindowRateControl;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
@@ -323,6 +324,8 @@ public class JettySolrRunner {
 
           HTTP2ServerConnectionFactory http2ConnectionFactory =
               new HTTP2ServerConnectionFactory(configuration);
+          // jetty.http2.rateControl.maxEventsPerSecond -- use a high value, esp. for benchmarking
+          http2ConnectionFactory.setRateControlFactory(new WindowRateControl.Factory(2000));
 
           ALPNServerConnectionFactory alpn =
               new ALPNServerConnectionFactory(

--- a/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
+++ b/solr/test-framework/src/java/org/apache/solr/embedded/JettySolrRunner.java
@@ -75,7 +75,7 @@ import org.apache.solr.util.TimeOut;
 import org.apache.solr.util.configuration.SSLConfigurationsFactory;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http2.HTTP2Cipher;
-import org.eclipse.jetty.http2.parser.WindowRateControl;
+import org.eclipse.jetty.http2.parser.RateControl;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
@@ -324,8 +324,7 @@ public class JettySolrRunner {
 
           HTTP2ServerConnectionFactory http2ConnectionFactory =
               new HTTP2ServerConnectionFactory(configuration);
-          // jetty.http2.rateControl.maxEventsPerSecond -- use a high value, esp. for benchmarking
-          http2ConnectionFactory.setRateControlFactory(new WindowRateControl.Factory(2000));
+          http2ConnectionFactory.setRateControlFactory(new RateControl.Factory() {}); // unlimited
 
           ALPNServerConnectionFactory alpn =
               new ALPNServerConnectionFactory(


### PR DESCRIPTION
Fixes Jetty HTTP2 cancel_stream_error by removing the flow control limit. 

I was encountering this issue with CloudIndexing, esp when using single-node, single-replica, single-shard -- like 30K ops/sec.   It'd routinely fail.  I bumped this to 1000, then still hit it sometimes, then bumped to 2000.  I haven't run it much since then to be honest.  Then I saw how to disable it, which looks a little weird TBH (the default method returns a NO_RATE_CONTROL impl).