### PR TITLE
TestExportWriter fix, loosen order constraint

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/export/TestExportWriter.java
+++ b/solr/core/src/test/org/apache/solr/handler/export/TestExportWriter.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1368,82 +1367,47 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     String sortStr = String.join(",", fieldWithOrderStrs); // sort : field1 asc, field2 desc
     String fieldsStr = String.join(",", fieldStrs); // fl :  field1, field2
 
-    String resp =
-        h.query(req("q", "*:*", "qt", "/export", "fl", "id," + fieldsStr, "sort", sortStr));
-    HashMap respMap = mapper.readValue(resp, HashMap.class);
-    List docs = (ArrayList) ((HashMap) respMap.get("response")).get("docs");
+    List<?> exportDocs =
+        queryJsonReturnDocs(
+            req("q", "*:*", "qt", "/export", "fl", "id," + fieldsStr, "sort", sortStr));
+    assertEquals(exportDocs.size(), numDocs);
 
-    SolrQueryRequest selectReq =
-        req(
-            "q",
-            "*:*",
-            "qt",
-            "/select",
-            "fl",
-            "id," + fieldsStr,
-            "sort",
-            sortStr,
-            "rows",
-            Integer.toString(numDocs),
-            "wt",
-            "json");
-    String response = h.query(selectReq);
-    Map rsp = (Map) Utils.fromJSONString(response);
-    List doclist = (List) (((Map) rsp.get("response")).get("docs"));
+    // equivalent for /select
+    List<?> selectDocs =
+        queryJsonReturnDocs(
+            req(
+                "q",
+                "*:*",
+                "qt",
+                "/select",
+                "fl",
+                "id," + fieldsStr,
+                "sort",
+                sortStr,
+                "rows",
+                Integer.toString(numDocs),
+                "wt",
+                "json"));
 
-    assertEquals(docs.size(), numDocs);
+    assertEquals(selectDocs.size(), numDocs);
 
-    for (int i = 0; i < docs.size() - 1; i++) { // docs..
-      assertEquals(
-          "Position:" + i + " has different id value",
-          ((LinkedHashMap) doclist.get(i)).get("id"),
-          String.valueOf(((HashMap<?, ?>) docs.get(i)).get("id")));
-
-      for (SortFields fieldSort : fieldSorts) { // fields ..
-        String field = fieldSort.getField();
-        String sort = fieldSort.getSort();
-        String fieldVal1 = String.valueOf(((HashMap) docs.get(i)).get(field)); // 1st doc
-        String fieldVal2 = String.valueOf(((HashMap) docs.get(i + 1)).get(field)); // 2nd obj
-        if (fieldVal1.equals(fieldVal2)) {
-          continue;
-        } else {
-          if (sort.equals("asc")) {
-            if (field.equals("stringdv")
-                || field.equals("field1_s_dv")
-                || field.equals("datedv")
-                || field.equals("booleandv")) { // use string comparator
-              assertTrue(fieldVal1.compareTo(fieldVal2) < 0);
-            } else if (field.equals("doubledv")) {
-              assertTrue(Double.compare(Double.valueOf(fieldVal1), Double.valueOf(fieldVal2)) <= 0);
-            } else if (field.equals("floatdv")) {
-              assertTrue(Float.compare(Float.valueOf(fieldVal1), Float.valueOf(fieldVal2)) <= 0);
-            } else if (field.equals("intdv") || "field2_i_p".equals(field)) {
-              assertTrue(
-                  Integer.compare(Integer.valueOf(fieldVal1), Integer.valueOf(fieldVal2)) <= 0);
-            } else if (field.equals("longdv") || field.equals("field3_l_p")) {
-              assertTrue(Long.compare(Integer.valueOf(fieldVal1), Long.valueOf(fieldVal2)) <= 0);
-            }
-          } else {
-            if (field.equals("stringdv")
-                || field.equals("field1_s_dv")
-                || field.equals("datedv")
-                || field.equals("booleandv")) { // use string comparator
-              assertTrue(fieldVal1.compareTo(fieldVal2) > 0);
-            } else if (field.equals("doubledv")) {
-              assertTrue(Double.compare(Double.valueOf(fieldVal1), Double.valueOf(fieldVal2)) >= 0);
-            } else if (field.equals("floatdv")) {
-              assertTrue(Float.compare(Float.valueOf(fieldVal1), Float.valueOf(fieldVal2)) >= 0);
-            } else if (field.equals("intdv") || "field2_i_p".equals(field)) {
-              assertTrue(
-                  Integer.compare(Integer.valueOf(fieldVal1), Integer.valueOf(fieldVal2)) >= 0);
-            } else if (field.equals("longdv") || field.equals("field3_l_p")) {
-              assertTrue(Long.compare(Integer.valueOf(fieldVal1), Long.valueOf(fieldVal2)) >= 0);
-            }
-          }
-          break;
-        }
+    // check that both /select and /export return docs with the same values for the sorted fields
+    for (int i = 0; i < exportDocs.size(); i++) {
+      Map exportDoc = (Map) exportDocs.get(i);
+      Map selectDoc = (Map) selectDocs.get(i);
+      for (SortFields fieldSort : fieldSorts) {
+        String field = fieldSort.fieldName;
+        assertEquals(
+            "doc " + i + " differs for field " + field, exportDoc.get(field), selectDoc.get(field));
       }
     }
+  }
+
+  @SuppressWarnings("rawtypes")
+  private List<?> queryJsonReturnDocs(SolrQueryRequest exportReq) throws Exception {
+    String respStr = h.query(exportReq);
+    Map respMap = mapper.readValue(respStr, Map.class);
+    return (List) ((Map) respMap.get("response")).get("docs");
   }
 
   private static class SortFields {


### PR DESCRIPTION
This test was asserting the docs from /export came in the same order as an equivalent from /select.  But that's too strong an expectation; only the sorted values should be equivalent.

It's remarkable to me how much code was written to test it as it was before... I wonder if I'm missing something by replacing it with something fairly trivial?

----

The following test was failing with this seed:
> ./gradlew :solr:core:test --tests "org.apache.solr.handler.export.TestExportWriter.testMultipleSorts"   -Ptests.seed=D7C851B5C905B099

I debugged it for a while; didn't fail due to any recent changes; isn't concurrency related.  Even optimizing to one segment still had the same test failure.