### PR TITLE
[SOLR-10654] Rename instances of SolrPrometheusExporter to SolrPrometheusFormatter

### DIFF
--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrMetric.java
@@ -25,9 +25,9 @@ import java.util.Map;
 /**
  * Base class is a wrapper to categorize and export {@link com.codahale.metrics.Metric} to {@link
  * io.prometheus.metrics.model.snapshots.DataPointSnapshot} and register to a {@link
- * SolrPrometheusExporter}. {@link com.codahale.metrics.MetricRegistry} does not support tags unlike
- * prometheus. Metrics registered to the registry need to be parsed out from the metric name to be
- * exported to {@link io.prometheus.metrics.model.snapshots.DataPointSnapshot}
+ * SolrPrometheusFormatter}. {@link com.codahale.metrics.MetricRegistry} does not support tags
+ * unlike prometheus. Metrics registered to the registry need to be parsed out from the metric name
+ * to be exported to {@link io.prometheus.metrics.model.snapshots.DataPointSnapshot}
  */
 public abstract class SolrMetric {
   public Metric dropwizardMetric;
@@ -49,7 +49,7 @@ public abstract class SolrMetric {
   /*
    * Export metric to Prometheus with labels
    */
-  public abstract void toPrometheus(SolrPrometheusExporter exporter);
+  public abstract void toPrometheus(SolrPrometheusFormatter formatter);
 
   public Labels getLabels() {
     return Labels.of(new ArrayList<>(labels.keySet()), new ArrayList<>(labels.values()));

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrNoOpMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrNoOpMetric.java
@@ -25,5 +25,5 @@ public class SolrNoOpMetric extends SolrMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {}
+  public void toPrometheus(SolrPrometheusFormatter formatter) {}
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
@@ -31,15 +31,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Base class for all {@link SolrPrometheusExporter} holding {@link MetricSnapshot}s. Can export
+ * Base class for all {@link SolrPrometheusFormatter} holding {@link MetricSnapshot}s. Can export
  * {@link com.codahale.metrics.Metric} to {@link MetricSnapshot} to be outputted for {@link
  * org.apache.solr.response.PrometheusResponseWriter}
  */
-public abstract class SolrPrometheusExporter {
+public abstract class SolrPrometheusFormatter {
   protected final Map<String, List<CounterSnapshot.CounterDataPointSnapshot>> metricCounters;
   protected final Map<String, List<GaugeSnapshot.GaugeDataPointSnapshot>> metricGauges;
 
-  public SolrPrometheusExporter() {
+  public SolrPrometheusFormatter() {
     this.metricCounters = new HashMap<>();
     this.metricGauges = new HashMap<>();
   }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/PrometheusCoreFormatterInfo.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/PrometheusCoreFormatterInfo.java
@@ -18,7 +18,7 @@ package org.apache.solr.metrics.prometheus.core;
 
 import java.util.regex.Pattern;
 
-public interface PrometheusCoreExporterInfo {
+public interface PrometheusCoreFormatterInfo {
   /** Category of prefix Solr Core dropwizard handler metric names */
   enum CoreCategory {
     ADMIN,

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreCacheMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreCacheMetric.java
@@ -18,7 +18,7 @@ package org.apache.solr.metrics.prometheus.core;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /** Dropwizard metrics of name CACHE.* */
 public class SolrCoreCacheMetric extends SolrCoreMetric {
@@ -44,9 +44,9 @@ public class SolrCoreCacheMetric extends SolrCoreMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (dropwizardMetric instanceof Gauge) {
-      exporter.exportGauge(CORE_CACHE_SEARCHER_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(CORE_CACHE_SEARCHER_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHandlerMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHandlerMetric.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /** Dropwizard metrics of name ADMIN/QUERY/UPDATE/REPLICATION.* */
 public class SolrCoreHandlerMetric extends SolrCoreMetric {
@@ -53,26 +53,26 @@ public class SolrCoreHandlerMetric extends SolrCoreMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (dropwizardMetric instanceof Meter) {
-      exporter.exportMeter(CORE_REQUESTS_TOTAL, (Meter) dropwizardMetric, getLabels());
+      formatter.exportMeter(CORE_REQUESTS_TOTAL, (Meter) dropwizardMetric, getLabels());
     } else if (dropwizardMetric instanceof Counter) {
       if (metricName.endsWith("requests")) {
-        exporter.exportCounter(CORE_REQUESTS_TOTAL, (Counter) dropwizardMetric, getLabels());
+        formatter.exportCounter(CORE_REQUESTS_TOTAL, (Counter) dropwizardMetric, getLabels());
       } else if (metricName.endsWith("totalTime")) {
         // Do not need type label for total time
         labels.remove("type");
-        exporter.exportCounter(CORE_REQUESTS_TOTAL_TIME, (Counter) dropwizardMetric, getLabels());
+        formatter.exportCounter(CORE_REQUESTS_TOTAL_TIME, (Counter) dropwizardMetric, getLabels());
       }
     } else if (dropwizardMetric instanceof Gauge) {
       if (!metricName.endsWith("handlerStart")) {
-        exporter.exportGauge(
+        formatter.exportGauge(
             CORE_REQUESTS_UPDATE_HANDLER, (Gauge<?>) dropwizardMetric, getLabels());
       }
     } else if (dropwizardMetric instanceof Timer) {
       // Do not need type label for request times
       labels.remove("type");
-      exporter.exportTimer(CORE_REQUEST_TIMES, (Timer) dropwizardMetric, getLabels());
+      formatter.exportTimer(CORE_REQUEST_TIMES, (Timer) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHighlighterMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHighlighterMetric.java
@@ -18,7 +18,7 @@ package org.apache.solr.metrics.prometheus.core;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Metric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /** Dropwizard metrics of name HIGHLIGHTER.* */
 public class SolrCoreHighlighterMetric extends SolrCoreMetric {
@@ -44,7 +44,7 @@ public class SolrCoreHighlighterMetric extends SolrCoreMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
-    exporter.exportCounter(CORE_HIGHLIGHER_METRICS, (Counter) dropwizardMetric, getLabels());
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
+    formatter.exportCounter(CORE_HIGHLIGHER_METRICS, (Counter) dropwizardMetric, getLabels());
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreIndexMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreIndexMetric.java
@@ -18,7 +18,7 @@ package org.apache.solr.metrics.prometheus.core;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /** Dropwizard metrics of name INDEX.* */
 public class SolrCoreIndexMetric extends SolrCoreMetric {
@@ -40,9 +40,9 @@ public class SolrCoreIndexMetric extends SolrCoreMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (metricName.endsWith("sizeInBytes")) {
-      exporter.exportGauge(CORE_INDEX_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(CORE_INDEX_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreMetric.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.metrics.prometheus.core;
 
-import static org.apache.solr.metrics.prometheus.core.PrometheusCoreExporterInfo.CLOUD_CORE_PATTERN;
+import static org.apache.solr.metrics.prometheus.core.PrometheusCoreFormatterInfo.CLOUD_CORE_PATTERN;
 
 import com.codahale.metrics.Metric;
 import java.util.regex.Matcher;

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreSearcherMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreSearcherMetric.java
@@ -22,7 +22,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /** Dropwizard metrics of name SEARCHER.* */
 public class SolrCoreSearcherMetric extends SolrCoreMetric {
@@ -50,15 +50,16 @@ public class SolrCoreSearcherMetric extends SolrCoreMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (dropwizardMetric instanceof Gauge) {
       if (metricName.endsWith("liveDocsCache")) {
-        exporter.exportGauge(CORE_CACHE_SEARCHER_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
+        formatter.exportGauge(
+            CORE_CACHE_SEARCHER_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
       } else {
-        exporter.exportGauge(CORE_SEARCHER_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
+        formatter.exportGauge(CORE_SEARCHER_METRICS, (Gauge<?>) dropwizardMetric, getLabels());
       }
     } else if (dropwizardMetric instanceof Timer) {
-      exporter.exportTimer(CORE_SEARCHER_TIMES, (Timer) dropwizardMetric, getLabels());
+      formatter.exportTimer(CORE_SEARCHER_TIMES, (Timer) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreTlogMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreTlogMetric.java
@@ -18,7 +18,7 @@ package org.apache.solr.metrics.prometheus.core;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /** Dropwizard metrics of name TLOG.* */
 public class SolrCoreTlogMetric extends SolrCoreMetric {
@@ -44,9 +44,9 @@ public class SolrCoreTlogMetric extends SolrCoreMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (dropwizardMetric instanceof Meter) {
-      exporter.exportMeter(CORE_TLOG_METRICS, (Meter) dropwizardMetric, getLabels());
+      formatter.exportMeter(CORE_TLOG_METRICS, (Meter) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrPrometheusCoreFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrPrometheusCoreFormatter.java
@@ -20,18 +20,18 @@ import com.codahale.metrics.Metric;
 import com.google.common.base.Enums;
 import org.apache.solr.metrics.prometheus.SolrMetric;
 import org.apache.solr.metrics.prometheus.SolrNoOpMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /**
  * This class maintains a {@link io.prometheus.metrics.model.snapshots.MetricSnapshot}s exported
  * from solr.core {@link com.codahale.metrics.MetricRegistry}
  */
-public class SolrPrometheusCoreExporter extends SolrPrometheusExporter
-    implements PrometheusCoreExporterInfo {
+public class SolrPrometheusCoreFormatter extends SolrPrometheusFormatter
+    implements PrometheusCoreFormatterInfo {
   public final String coreName;
   public final boolean cloudMode;
 
-  public SolrPrometheusCoreExporter(String coreName, boolean cloudMode) {
+  public SolrPrometheusCoreFormatter(String coreName, boolean cloudMode) {
     super();
     this.coreName = coreName;
     this.cloudMode = cloudMode;
@@ -46,7 +46,7 @@ public class SolrPrometheusCoreExporter extends SolrPrometheusExporter
   @Override
   public SolrMetric categorizeMetric(Metric dropwizardMetric, String metricName) {
     String metricCategory = metricName.split("\\.", 2)[0];
-    if (!Enums.getIfPresent(PrometheusCoreExporterInfo.CoreCategory.class, metricCategory)
+    if (!Enums.getIfPresent(PrometheusCoreFormatterInfo.CoreCategory.class, metricCategory)
         .isPresent()) {
       return new SolrNoOpMetric();
     }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/package-info.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/package-info.java
@@ -16,7 +16,7 @@
  */
 
 /**
- * The {@link org.apache.solr.metrics.prometheus.core.SolrPrometheusCoreExporter} is responsible for
- * exporting solr.core registry metrics to Prometheus.
+ * The {@link org.apache.solr.metrics.prometheus.core.SolrPrometheusCoreFormatter} is responsible
+ * for exporting solr.core registry metrics to Prometheus.
  */
 package org.apache.solr.metrics.prometheus.core;

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/SolrJettyDispatchesMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/SolrJettyDispatchesMetric.java
@@ -19,7 +19,7 @@ package org.apache.solr.metrics.prometheus.jetty;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name *.dispatches */
 public class SolrJettyDispatchesMetric extends SolrJettyMetric {
@@ -40,7 +40,7 @@ public class SolrJettyDispatchesMetric extends SolrJettyMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
-    exporter.exportTimerCount(JETTY_DISPATCHES_TOTAL, (Timer) dropwizardMetric, getLabels());
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
+    formatter.exportTimerCount(JETTY_DISPATCHES_TOTAL, (Timer) dropwizardMetric, getLabels());
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/SolrJettyReqRespMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/SolrJettyReqRespMetric.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name *.xx-responses and *-requests */
 public class SolrJettyReqRespMetric extends SolrJettyMetric {
@@ -51,14 +51,14 @@ public class SolrJettyReqRespMetric extends SolrJettyMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (metricName.endsWith("xx-responses")) {
-      exporter.exportMeter(JETTY_RESPONSES_TOTAL, (Meter) dropwizardMetric, getLabels());
+      formatter.exportMeter(JETTY_RESPONSES_TOTAL, (Meter) dropwizardMetric, getLabels());
     } else if (metricName.endsWith("-requests")) {
       if (dropwizardMetric instanceof Counter) {
-        exporter.exportCounter(JETTY_REQUESTS_TOTAL, (Counter) dropwizardMetric, getLabels());
+        formatter.exportCounter(JETTY_REQUESTS_TOTAL, (Counter) dropwizardMetric, getLabels());
       } else if (dropwizardMetric instanceof Timer) {
-        exporter.exportTimerCount(JETTY_REQUESTS_TOTAL, (Timer) dropwizardMetric, getLabels());
+        formatter.exportTimerCount(JETTY_REQUESTS_TOTAL, (Timer) dropwizardMetric, getLabels());
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/SolrPrometheusJettyFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/SolrPrometheusJettyFormatter.java
@@ -14,48 +14,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.solr.metrics.prometheus.jvm;
+package org.apache.solr.metrics.prometheus.jetty;
 
 import com.codahale.metrics.Metric;
-import com.google.common.base.Enums;
 import org.apache.solr.metrics.prometheus.SolrMetric;
 import org.apache.solr.metrics.prometheus.SolrNoOpMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /**
  * This class maintains a {@link io.prometheus.metrics.model.snapshots.MetricSnapshot}s exported
- * from solr.jvm {@link com.codahale.metrics.MetricRegistry}
+ * from solr.jetty {@link com.codahale.metrics.MetricRegistry}
  */
-public class SolrPrometheusJvmExporter extends SolrPrometheusExporter
-    implements PrometheusJvmExporterInfo {
-  public SolrPrometheusJvmExporter() {
+public class SolrPrometheusJettyFormatter extends SolrPrometheusFormatter {
+  public SolrPrometheusJettyFormatter() {
     super();
   }
 
   @Override
   public void exportDropwizardMetric(Metric dropwizardMetric, String metricName) {
-    SolrMetric solrJvmMetric = categorizeMetric(dropwizardMetric, metricName);
-    solrJvmMetric.parseLabels().toPrometheus(this);
+    SolrMetric solrJettyMetric = categorizeMetric(dropwizardMetric, metricName);
+    solrJettyMetric.parseLabels().toPrometheus(this);
   }
 
   @Override
   public SolrMetric categorizeMetric(Metric dropwizardMetric, String metricName) {
-    String metricCategory = metricName.split("\\.", 2)[0];
-    if (!Enums.getIfPresent(JvmCategory.class, metricCategory).isPresent()) {
+    if (metricName.endsWith("xx-responses") || metricName.endsWith("-requests")) {
+      return new SolrJettyReqRespMetric(dropwizardMetric, metricName);
+    } else if (metricName.endsWith(".dispatches")) {
+      return new SolrJettyDispatchesMetric(dropwizardMetric, metricName);
+    } else {
       return new SolrNoOpMetric();
-    }
-    switch (JvmCategory.valueOf(metricCategory)) {
-      case gc:
-        return new SolrJvmGcMetrics(dropwizardMetric, metricName);
-      case memory:
-        return new SolrJvmMemoryMetric(dropwizardMetric, metricName);
-      case os:
-      case threads:
-        return new SolrJvmOsMetric(dropwizardMetric, metricName);
-      case buffers:
-        return new SolrJvmBuffersMetric(dropwizardMetric, metricName);
-      default:
-        return new SolrNoOpMetric();
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/package-info.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jetty/package-info.java
@@ -16,7 +16,7 @@
  */
 
 /**
- * The {@link org.apache.solr.metrics.prometheus.jetty.SolrPrometheusJettyExporter} is responsible
+ * The {@link org.apache.solr.metrics.prometheus.jetty.SolrPrometheusJettyFormatter} is responsible
  * for exporting solr.jetty registry metrics to Prometheus.
  */
 package org.apache.solr.metrics.prometheus.jetty;

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/PrometheusJvmFormatterInfo.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/PrometheusJvmFormatterInfo.java
@@ -14,14 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.solr.metrics.prometheus.node;
+package org.apache.solr.metrics.prometheus.jvm;
 
-public interface PrometheusNodeExporterInfo {
-  /** Category of prefix Solr Node dropwizard handler metric names */
-  enum NodeCategory {
-    ADMIN,
-    UPDATE,
-    CONTAINER,
-    CACHE
+public interface PrometheusJvmFormatterInfo {
+  /** Category of prefix Solr JVM dropwizard handler metric names */
+  enum JvmCategory {
+    buffers,
+    gc,
+    memory,
+    os,
+    threads,
+    classes,
+    system
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmBuffersMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmBuffersMetric.java
@@ -18,7 +18,7 @@ package org.apache.solr.metrics.prometheus.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name buffers.* */
 public class SolrJvmBuffersMetric extends SolrJvmMetric {
@@ -44,13 +44,13 @@ public class SolrJvmBuffersMetric extends SolrJvmMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     String[] parsedMetric = metricName.split("\\.");
     String metricType = parsedMetric[parsedMetric.length - 1];
     if (metricType.equals("Count")) {
-      exporter.exportGauge(JVM_BUFFERS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(JVM_BUFFERS, (Gauge<?>) dropwizardMetric, getLabels());
     } else if (metricType.equals(("MemoryUsed")) || metricType.equals(("TotalCapacity"))) {
-      exporter.exportGauge(JVM_BUFFERS_BYTES, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(JVM_BUFFERS_BYTES, (Gauge<?>) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmGcMetrics.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmGcMetrics.java
@@ -19,7 +19,7 @@ package org.apache.solr.metrics.prometheus.jvm;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name gc.* */
 public class SolrJvmGcMetrics extends SolrJvmMetric {
@@ -44,11 +44,11 @@ public class SolrJvmGcMetrics extends SolrJvmMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (metricName.endsWith(".count")) {
-      exporter.exportGauge(JVM_GC, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(JVM_GC, (Gauge<?>) dropwizardMetric, getLabels());
     } else if (metricName.endsWith(".time")) {
-      exporter.exportGauge(JVM_GC_SECONDS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(JVM_GC_SECONDS, (Gauge<?>) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmMemoryMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmMemoryMetric.java
@@ -19,7 +19,7 @@ package org.apache.solr.metrics.prometheus.jvm;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name memory.* */
 public class SolrJvmMemoryMetric extends SolrJvmMetric {
@@ -46,7 +46,7 @@ public class SolrJvmMemoryMetric extends SolrJvmMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     String[] parsedMetric = metricName.split("\\.");
     String metricType = parsedMetric[1];
     switch (metricType) {
@@ -54,11 +54,11 @@ public class SolrJvmMemoryMetric extends SolrJvmMetric {
       case "non-heap":
       case "total":
         labels.put("memory", parsedMetric[1]);
-        exporter.exportGauge(JVM_MEMORY, (Gauge<?>) dropwizardMetric, getLabels());
+        formatter.exportGauge(JVM_MEMORY, (Gauge<?>) dropwizardMetric, getLabels());
         break;
       case "pools":
         labels.put("space", parsedMetric[2]);
-        exporter.exportGauge(JVM_MEMORY_POOL_BYTES, (Gauge<?>) dropwizardMetric, getLabels());
+        formatter.exportGauge(JVM_MEMORY_POOL_BYTES, (Gauge<?>) dropwizardMetric, getLabels());
         break;
     }
   }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmOsMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/SolrJvmOsMetric.java
@@ -19,7 +19,7 @@ package org.apache.solr.metrics.prometheus.jvm;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name os.* and threads.* */
 public class SolrJvmOsMetric extends SolrJvmMetric {
@@ -48,11 +48,11 @@ public class SolrJvmOsMetric extends SolrJvmMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (metricName.startsWith("threads.")) {
-      exporter.exportGauge(JVM_OS_THREADS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(JVM_OS_THREADS, (Gauge<?>) dropwizardMetric, getLabels());
     } else {
-      exporter.exportGauge(JVM_OS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(JVM_OS, (Gauge<?>) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/package-info.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/jvm/package-info.java
@@ -16,7 +16,7 @@
  */
 
 /**
- * The {@link org.apache.solr.metrics.prometheus.jvm.SolrPrometheusJvmExporter} is responsible for
+ * The {@link org.apache.solr.metrics.prometheus.jvm.SolrPrometheusJvmFormatter} is responsible for
  * exporting solr.jvm registry metrics to Prometheus.
  */
 package org.apache.solr.metrics.prometheus.jvm;

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/node/PrometheusNodeFormatterInfo.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/node/PrometheusNodeFormatterInfo.java
@@ -14,17 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.solr.metrics.prometheus.jvm;
+package org.apache.solr.metrics.prometheus.node;
 
-public interface PrometheusJvmExporterInfo {
-  /** Category of prefix Solr JVM dropwizard handler metric names */
-  enum JvmCategory {
-    buffers,
-    gc,
-    memory,
-    os,
-    threads,
-    classes,
-    system
+public interface PrometheusNodeFormatterInfo {
+  /** Category of prefix Solr Node dropwizard handler metric names */
+  enum NodeCategory {
+    ADMIN,
+    UPDATE,
+    CONTAINER,
+    CACHE
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/node/SolrNodeContainerMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/node/SolrNodeContainerMetric.java
@@ -19,7 +19,7 @@ package org.apache.solr.metrics.prometheus.node;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name CONTAINER.* */
 public class SolrNodeContainerMetric extends SolrNodeMetric {
@@ -44,14 +44,14 @@ public class SolrNodeContainerMetric extends SolrNodeMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     String[] parsedMetric = metricName.split("\\.");
     if (metricName.startsWith("CONTAINER.cores.")) {
       labels.put("item", parsedMetric[2]);
-      exporter.exportGauge(NODE_CORES, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(NODE_CORES, (Gauge<?>) dropwizardMetric, getLabels());
     } else if (metricName.startsWith("CONTAINER.fs.coreRoot.")) {
       labels.put("item", parsedMetric[3]);
-      exporter.exportGauge(NODE_CORE_FS_BYTES, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(NODE_CORE_FS_BYTES, (Gauge<?>) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/node/SolrNodeHandlerMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/node/SolrNodeHandlerMetric.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /* Dropwizard metrics of name ADMIN.* and UPDATE.* */
 public class SolrNodeHandlerMetric extends SolrNodeMetric {
@@ -49,16 +49,16 @@ public class SolrNodeHandlerMetric extends SolrNodeMetric {
   }
 
   @Override
-  public void toPrometheus(SolrPrometheusExporter exporter) {
+  public void toPrometheus(SolrPrometheusFormatter formatter) {
     if (metricName.endsWith(".totalTime")) {
       labels.remove("type");
-      exporter.exportCounter(NODE_SECONDS_TOTAL, (Counter) dropwizardMetric, getLabels());
+      formatter.exportCounter(NODE_SECONDS_TOTAL, (Counter) dropwizardMetric, getLabels());
     } else if (metricName.endsWith("Connections")) {
-      exporter.exportGauge(NODE_CONNECTIONS, (Gauge<?>) dropwizardMetric, getLabels());
+      formatter.exportGauge(NODE_CONNECTIONS, (Gauge<?>) dropwizardMetric, getLabels());
     } else if (dropwizardMetric instanceof Meter) {
-      exporter.exportMeter(NODE_REQUESTS, (Meter) dropwizardMetric, getLabels());
+      formatter.exportMeter(NODE_REQUESTS, (Meter) dropwizardMetric, getLabels());
     } else if (dropwizardMetric instanceof Counter) {
-      exporter.exportCounter(NODE_REQUESTS, (Counter) dropwizardMetric, getLabels());
+      formatter.exportCounter(NODE_REQUESTS, (Counter) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/node/SolrPrometheusNodeFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/node/SolrPrometheusNodeFormatter.java
@@ -25,15 +25,15 @@ import com.google.common.base.Enums;
 import io.prometheus.metrics.model.snapshots.Labels;
 import org.apache.solr.metrics.prometheus.SolrMetric;
 import org.apache.solr.metrics.prometheus.SolrNoOpMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 
 /**
  * This class maintains a {@link io.prometheus.metrics.model.snapshots.MetricSnapshot}s exported
  * from solr.node {@link com.codahale.metrics.MetricRegistry}
  */
-public class SolrPrometheusNodeExporter extends SolrPrometheusExporter
-    implements PrometheusNodeExporterInfo {
-  public SolrPrometheusNodeExporter() {
+public class SolrPrometheusNodeFormatter extends SolrPrometheusFormatter
+    implements PrometheusNodeFormatterInfo {
+  public SolrPrometheusNodeFormatter() {
     super();
   }
 
@@ -51,7 +51,7 @@ public class SolrPrometheusNodeExporter extends SolrPrometheusExporter
   @Override
   public SolrMetric categorizeMetric(Metric dropwizardMetric, String metricName) {
     String metricCategory = metricName.split("\\.", 2)[0];
-    if (!Enums.getIfPresent(PrometheusNodeExporterInfo.NodeCategory.class, metricCategory)
+    if (!Enums.getIfPresent(PrometheusNodeFormatterInfo.NodeCategory.class, metricCategory)
         .isPresent()) {
       return new SolrNoOpMetric();
     }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/node/package-info.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/node/package-info.java
@@ -16,7 +16,7 @@
  */
 
 /**
- * The {@link org.apache.solr.metrics.prometheus.node.SolrPrometheusNodeExporter} is responsible for
- * exporting solr.node registry metrics to Prometheus.
+ * The {@link org.apache.solr.metrics.prometheus.node.SolrPrometheusNodeFormatter} is responsible
+ * for exporting solr.node registry metrics to Prometheus.
  */
 package org.apache.solr.metrics.prometheus.node;

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/package-info.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/package-info.java
@@ -16,7 +16,7 @@
  */
 
 /**
- * The {@link org.apache.solr.metrics.prometheus.SolrPrometheusExporter} is responsible for
+ * The {@link org.apache.solr.metrics.prometheus.SolrPrometheusFormatter} is responsible for
  * collecting Prometheus metrics from exporting {@link com.codahale.metrics.Metric}'s from {@link
  * com.codahale.metrics.MetricRegistry} {@link org.apache.solr.metrics.prometheus.SolrMetric} is a
  * wrapper to export {@link com.codahale.metrics.Metric} to {@link

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -40,7 +40,7 @@ import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.metrics.MetricsMap;
 import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricsContext;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.response.SolrQueryResponse;
@@ -67,7 +67,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     c = h.getCoreContainer().getMetricManager().counter(null, "solr.jetty", "solrtest_foo:bar");
     c.inc(3);
 
-    // Manually register for Prometheus exporter tests
+    // Manually register for Prometheus Formatter tests
     registerGauge("solr.jvm", "gc.G1-Old-Generation.count");
     registerGauge("solr.jvm", "gc.G1-Old-Generation.time");
     registerGauge("solr.jvm", "memory.heap.committed");
@@ -725,9 +725,10 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     NamedList<?> values = resp.getValues();
     assertNotNull(values.get("metrics"));
     values = (NamedList<?>) values.get("metrics");
-    SolrPrometheusExporter exporter = (SolrPrometheusExporter) values.get("solr.core.collection1");
-    assertNotNull(exporter);
-    MetricSnapshots actualSnapshots = exporter.collect();
+    SolrPrometheusFormatter formatter =
+        (SolrPrometheusFormatter) values.get("solr.core.collection1");
+    assertNotNull(formatter);
+    MetricSnapshots actualSnapshots = formatter.collect();
     assertNotNull(actualSnapshots);
 
     MetricSnapshot actualSnapshot =
@@ -824,9 +825,9 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     NamedList<?> values = resp.getValues();
     assertNotNull(values.get("metrics"));
     values = (NamedList<?>) values.get("metrics");
-    SolrPrometheusExporter exporter = (SolrPrometheusExporter) values.get("solr.node");
-    assertNotNull(exporter);
-    MetricSnapshots actualSnapshots = exporter.collect();
+    SolrPrometheusFormatter formatter = (SolrPrometheusFormatter) values.get("solr.node");
+    assertNotNull(formatter);
+    MetricSnapshots actualSnapshots = formatter.collect();
     assertNotNull(actualSnapshots);
 
     MetricSnapshot actualSnapshot =
@@ -908,9 +909,9 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     NamedList<?> values = resp.getValues();
     assertNotNull(values.get("metrics"));
     values = (NamedList<?>) values.get("metrics");
-    SolrPrometheusExporter exporter = (SolrPrometheusExporter) values.get("solr.jvm");
-    assertNotNull(exporter);
-    MetricSnapshots actualSnapshots = exporter.collect();
+    SolrPrometheusFormatter formatter = (SolrPrometheusFormatter) values.get("solr.jvm");
+    assertNotNull(formatter);
+    MetricSnapshots actualSnapshots = formatter.collect();
     assertNotNull(actualSnapshots);
 
     MetricSnapshot actualSnapshot = getMetricSnapshot(actualSnapshots, "solr_metrics_jvm_threads");
@@ -962,9 +963,9 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     NamedList<?> values = resp.getValues();
     assertNotNull(values.get("metrics"));
     values = (NamedList<?>) values.get("metrics");
-    SolrPrometheusExporter exporter = (SolrPrometheusExporter) values.get("solr.jetty");
-    assertNotNull(exporter);
-    MetricSnapshots actualSnapshots = exporter.collect();
+    SolrPrometheusFormatter formatter = (SolrPrometheusFormatter) values.get("solr.jetty");
+    assertNotNull(formatter);
+    MetricSnapshots actualSnapshots = formatter.collect();
     assertNotNull(actualSnapshots);
 
     MetricSnapshot actualSnapshot =
@@ -1008,9 +1009,10 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     NamedList<?> values = resp.getValues();
     assertNotNull(values.get("metrics"));
     values = (NamedList<?>) values.get("metrics");
-    SolrPrometheusExporter exporter = (SolrPrometheusExporter) values.get("solr.core.collection1");
-    assertNotNull(exporter);
-    MetricSnapshots actualSnapshots = exporter.collect();
+    SolrPrometheusFormatter formatter =
+        (SolrPrometheusFormatter) values.get("solr.core.collection1");
+    assertNotNull(formatter);
+    MetricSnapshots actualSnapshots = formatter.collect();
     assertNotNull(actualSnapshots);
 
     actualSnapshots.forEach(

--- a/solr/core/src/test/org/apache/solr/metrics/SolrCoreMetricTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrCoreMetricTest.java
@@ -19,7 +19,7 @@ package org.apache.solr.metrics;
 import com.codahale.metrics.Metric;
 import io.prometheus.metrics.model.snapshots.Labels;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 import org.apache.solr.metrics.prometheus.core.SolrCoreMetric;
 import org.junit.Test;
 
@@ -76,6 +76,6 @@ public class SolrCoreMetricTest extends SolrTestCaseJ4 {
     }
 
     @Override
-    public void toPrometheus(SolrPrometheusExporter exporter) {}
+    public void toPrometheus(SolrPrometheusFormatter formatter) {}
   }
 }

--- a/solr/core/src/test/org/apache/solr/metrics/SolrPrometheusFormatterTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrPrometheusFormatterTest.java
@@ -31,47 +31,47 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.metrics.prometheus.SolrMetric;
-import org.apache.solr.metrics.prometheus.SolrPrometheusExporter;
+import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 import org.junit.Test;
 
-public class SolrPrometheusExporterTest extends SolrTestCaseJ4 {
+public class SolrPrometheusFormatterTest extends SolrTestCaseJ4 {
   @Test
   public void testExportMeter() {
-    TestSolrPrometheusExporter testExporter = new TestSolrPrometheusExporter();
+    TestSolrPrometheusFormatter testFormatter = new TestSolrPrometheusFormatter();
     String expectedMetricName = "test_metric";
     Meter metric = new Meter();
     metric.mark(123);
     Labels expectedLabels = Labels.of("test", "test-value");
 
-    testExporter.exportMeter(expectedMetricName, metric, expectedLabels);
-    assertTrue(testExporter.getMetricCounters().containsKey(expectedMetricName));
+    testFormatter.exportMeter(expectedMetricName, metric, expectedLabels);
+    assertTrue(testFormatter.getMetricCounters().containsKey(expectedMetricName));
 
     CounterSnapshot.CounterDataPointSnapshot actual =
-        testExporter.getMetricCounters().get("test_metric").get(0);
+        testFormatter.getMetricCounters().get("test_metric").get(0);
     assertEquals(123.0, actual.getValue(), 0);
     assertEquals(expectedLabels, actual.getLabels());
   }
 
   @Test
   public void testExportCounter() {
-    TestSolrPrometheusExporter testExporter = new TestSolrPrometheusExporter();
+    TestSolrPrometheusFormatter testFormatter = new TestSolrPrometheusFormatter();
     String expectedMetricName = "test_metric";
     Counter metric = new Counter();
     metric.inc(123);
     Labels expectedLabels = Labels.of("test", "test-value");
 
-    testExporter.exportCounter(expectedMetricName, metric, expectedLabels);
-    assertTrue(testExporter.getMetricCounters().containsKey(expectedMetricName));
+    testFormatter.exportCounter(expectedMetricName, metric, expectedLabels);
+    assertTrue(testFormatter.getMetricCounters().containsKey(expectedMetricName));
 
     CounterSnapshot.CounterDataPointSnapshot actual =
-        testExporter.getMetricCounters().get("test_metric").get(0);
+        testFormatter.getMetricCounters().get("test_metric").get(0);
     assertEquals(123.0, actual.getValue(), 0);
     assertEquals(expectedLabels, actual.getLabels());
   }
 
   @Test
   public void testExportTimer() throws InterruptedException {
-    TestSolrPrometheusExporter testExporter = new TestSolrPrometheusExporter();
+    TestSolrPrometheusFormatter testFormatter = new TestSolrPrometheusFormatter();
     String expectedMetricName = "test_metric";
     Timer metric = new Timer();
     Timer.Context context = metric.time();
@@ -79,18 +79,18 @@ public class SolrPrometheusExporterTest extends SolrTestCaseJ4 {
     context.stop();
 
     Labels expectedLabels = Labels.of("test", "test-value");
-    testExporter.exportTimer(expectedMetricName, metric, expectedLabels);
-    assertTrue(testExporter.getMetricGauges().containsKey(expectedMetricName));
+    testFormatter.exportTimer(expectedMetricName, metric, expectedLabels);
+    assertTrue(testFormatter.getMetricGauges().containsKey(expectedMetricName));
 
     GaugeSnapshot.GaugeDataPointSnapshot actual =
-        testExporter.getMetricGauges().get("test_metric").get(0);
+        testFormatter.getMetricGauges().get("test_metric").get(0);
     assertEquals(5000000000L, actual.getValue(), 500000000L);
     assertEquals(expectedLabels, actual.getLabels());
   }
 
   @Test
   public void testExportGaugeNumber() throws InterruptedException {
-    TestSolrPrometheusExporter testExporter = new TestSolrPrometheusExporter();
+    TestSolrPrometheusFormatter testFormatter = new TestSolrPrometheusFormatter();
     String expectedMetricName = "test_metric";
     Gauge<Number> metric =
         new SettableGauge<>() {
@@ -104,18 +104,18 @@ public class SolrPrometheusExporterTest extends SolrTestCaseJ4 {
         };
 
     Labels expectedLabels = Labels.of("test", "test-value");
-    testExporter.exportGauge(expectedMetricName, metric, expectedLabels);
-    assertTrue(testExporter.getMetricGauges().containsKey(expectedMetricName));
+    testFormatter.exportGauge(expectedMetricName, metric, expectedLabels);
+    assertTrue(testFormatter.getMetricGauges().containsKey(expectedMetricName));
 
     GaugeSnapshot.GaugeDataPointSnapshot actual =
-        testExporter.getMetricGauges().get("test_metric").get(0);
+        testFormatter.getMetricGauges().get("test_metric").get(0);
     assertEquals(123.0, actual.getValue(), 0);
     assertEquals(expectedLabels, actual.getLabels());
   }
 
   @Test
   public void testExportGaugeMap() throws InterruptedException {
-    TestSolrPrometheusExporter testExporter = new TestSolrPrometheusExporter();
+    TestSolrPrometheusFormatter testFormatter = new TestSolrPrometheusFormatter();
     String expectedMetricName = "test_metric";
     Gauge<Map<String, Number>> metric =
         new SettableGauge<>() {
@@ -131,17 +131,17 @@ public class SolrPrometheusExporterTest extends SolrTestCaseJ4 {
         };
 
     Labels labels = Labels.of("test", "test-value");
-    testExporter.exportGauge(expectedMetricName, metric, labels);
-    assertTrue(testExporter.getMetricGauges().containsKey(expectedMetricName));
+    testFormatter.exportGauge(expectedMetricName, metric, labels);
+    assertTrue(testFormatter.getMetricGauges().containsKey(expectedMetricName));
 
     GaugeSnapshot.GaugeDataPointSnapshot actual =
-        testExporter.getMetricGauges().get("test_metric").get(0);
+        testFormatter.getMetricGauges().get("test_metric").get(0);
     assertEquals(123.0, actual.getValue(), 0);
     Labels expectedLabels = Labels.of("test", "test-value", "item", "test-item");
     assertEquals(expectedLabels, actual.getLabels());
   }
 
-  static class TestSolrPrometheusExporter extends SolrPrometheusExporter {
+  static class TestSolrPrometheusFormatter extends SolrPrometheusFormatter {
     @Override
     public void exportDropwizardMetric(Metric dropwizardMetric, String metricName) {}
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-10654

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Internal `SolrPrometheusExporter` names was confusing with existing `Prometheus Exporter`. 

# Solution

Rename all instances of `SolrPrometheusExporter` to `SolrPrometheusFormatter` including class names, functions and parameters.

# Tests

Renamed test names as well.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
