### PR TITLE
SOLR-17245 Download KEYS from downloads server

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -1123,7 +1123,7 @@ def file_to_string(filename):
         return f.read().strip()
 
 def download_keys():
-    download('KEYS', "https://archive.apache.org/dist/solr/KEYS", state.config_path)
+    download('KEYS', "https://downloads.apache.org/solr/KEYS", state.config_path)
 
 def keys_downloaded():
     return os.path.exists(os.path.join(state.config_path, "KEYS"))


### PR DESCRIPTION
Just a new URL https://downloads.apache.org/solr/KEYS

When we used mirrors, KEYS was not present on the mirrors, naturally. Now it is safe to pull it from CDN since it is under ASF control.