### PR TITLE
SOLR-17321: Bump up ecj to 3.36.0

### DIFF
--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -23,7 +23,7 @@ ext {
   scriptDepVersions = [
       "apache-rat": "0.15",
       "commons-codec": "1.16.0",
-      "ecj": "3.33.0",
+      "ecj": "3.36.0",
       "javacc": "7.0.12",
       "jgit": "6.7.0.202309050840-r",
       "flexmark": "0.64.8",


### PR DESCRIPTION
Upgrade Eclipse ECJ to 3.36.0 for Java 21 compatibility

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
