### PR TITLE
HttpShardHandler: Fix extension hook transformResponse

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -168,7 +168,7 @@ public class HttpShardHandler extends ShardHandler {
             srsp.setShardAddress(rsp.getServer());
             ssr.elapsedTime =
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-            responses.add(srsp);
+            responses.add(transfomResponse(sreq, srsp, shard));
           } else if (throwable != null) {
             ssr.elapsedTime =
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
@@ -176,7 +176,7 @@ public class HttpShardHandler extends ShardHandler {
             if (throwable instanceof SolrException) {
               srsp.setResponseCode(((SolrException) throwable).code());
             }
-            responses.add(srsp);
+            responses.add(transfomResponse(sreq, srsp, shard));
           }
         });
 


### PR DESCRIPTION
HttpShardHandler.transformResponse is an extension hook for subclasses to transform the shard response.  Ever since 9.0 when the HTTP2 Async stuff landed, this hook became inoperable/dormant (method existed but hasn't been called anymore).  This brings it back.

It's sufficiently minor that I'm thinking no JIRA/CHANGES.txt