### PR TITLE
Enabling test-retry-gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ apply from: file('gradle/testing/fail-on-no-tests.gradle')
 apply from: file('gradle/testing/fail-on-unsupported-jdk.gradle')
 apply from: file('gradle/testing/alternative-jdk-support.gradle')
 apply from: file('gradle/java/jar-manifest.gradle')
+apply from: file('gradle/testing/retry-test.gradle')
 
 // Publishing and releasing
 apply from: file('gradle/maven/defaults-maven.gradle')

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -181,9 +181,9 @@ allprojects {
         // Print some diagnostics about locations used.
         logger.info("Test folders for {}: cwd={}, tmp={}", project.path, testsCwd, testsTmpDir)
       }
-      if(isCIBuild) {
+      if (isCIBuild) {
         retry {
-          maxRetries = 20
+          maxRetries = 3
           maxFailures = 20
           failOnPassedAfterRetry = false
         }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -181,14 +181,6 @@ allprojects {
         // Print some diagnostics about locations used.
         logger.info("Test folders for {}: cwd={}, tmp={}", project.path, testsCwd, testsTmpDir)
       }
-      if (isCIBuild) {
-        // For info on params: https://github.com/gradle/test-retry-gradle-plugin
-        retry {
-          maxRetries = 3
-          maxFailures = 10
-          failOnPassedAfterRetry = true
-        }
-      }
     }
   }
 }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -181,13 +181,13 @@ allprojects {
         // Print some diagnostics about locations used.
         logger.info("Test folders for {}: cwd={}, tmp={}", project.path, testsCwd, testsTmpDir)
       }
-
-      retry {
-        maxRetries = 3
-        maxFailures = 20
-        failOnPassedAfterRetry = false
+      if(isCIBuild) {
+        retry {
+          maxRetries = 20
+          maxFailures = 20
+          failOnPassedAfterRetry = false
+        }
       }
-
     }
   }
 }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -181,6 +181,13 @@ allprojects {
         // Print some diagnostics about locations used.
         logger.info("Test folders for {}: cwd={}, tmp={}", project.path, testsCwd, testsTmpDir)
       }
+
+      retry {
+        maxRetries = 3
+        maxFailures = 20
+        failOnPassedAfterRetry = false
+      }
+
     }
   }
 }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -182,10 +182,11 @@ allprojects {
         logger.info("Test folders for {}: cwd={}, tmp={}", project.path, testsCwd, testsTmpDir)
       }
       if (isCIBuild) {
+        // For info on params: https://github.com/gradle/test-retry-gradle-plugin
         retry {
           maxRetries = 3
-          maxFailures = 20
-          failOnPassedAfterRetry = false
+          maxFailures = 10
+          failOnPassedAfterRetry = true
         }
       }
     }

--- a/gradle/testing/retry-test.gradle
+++ b/gradle/testing/retry-test.gradle
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+allprojects {
+    plugins.withType(JavaPlugin) {
+        tasks.withType(Test) {
+            develocity.testRetry {
+                if (isCIBuild) {
+                    // For more info on params: https://github.com/gradle/test-retry-gradle-plugin
+                    maxRetries = 3
+                    maxFailures = 10
+                    failOnPassedAfterRetry = true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The test-retry mechanism allows failed test cases to be automatically re-run. It also includes functionality to mark the build as "successful" if the tests pass on re-run, though we’re not focusing on that feature at this time. Our primary goal in enabling this mechanism for Develocity is to classify tests as deterministic or non-deterministic. This classification will provide developers with better insights into failed test cases and help them make more informed decisions.

Additionally, it saves time by automating the re-running of failed test cases, so developers don’t have to manually retry them.

```
 retry {
        maxRetries = 3
        maxFailures = 20
        failOnPassedAfterRetry = false
      }
```

I believe the retry-test functionality is already integrated into the Gradle Enterprise plugin, which our project is currently using. Therefore, we don't need to add an explicit plugin to enable this feature.

https://github.com/apache/solr/pull/2467#issuecomment-2122297638
