### PR TITLE
SOLR-17422: Remove v2 /api/cluster (CLUSTERSTATUS)

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -143,6 +143,8 @@ Other Changes
 
 * SOLR-17399: Replace the use of the deprecated java.util.Locale constructor with Locale Builder API. (Sanjay Dutt)
 
+* SOLR-17422: Remove V2 /api/cluster
+
 ==================  9.7.0 ==================
 New Features
 ---------------------

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -49,8 +49,6 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.common.params.CollectionParams.CollectionAction;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.DefaultSolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.ReflectMapWriter;
@@ -244,13 +242,6 @@ public class ClusterAPI {
   @EndPoint(method = GET, path = "/cluster/nodes", permission = COLL_READ_PERM)
   public void getNodes(SolrQueryRequest req, SolrQueryResponse rsp) {
     rsp.add("nodes", getCoreContainer().getZkController().getClusterState().getLiveNodes());
-  }
-
-  @EndPoint(method = GET, path = "/cluster", permission = COLL_READ_PERM)
-  public void getClusterStatus(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    final Map<String, Object> v1Params =
-        Map.of(CommonParams.ACTION, CollectionAction.CLUSTERSTATUS.toLower());
-    collectionsHandler.handleRequestBody(wrapParams(req, v1Params), rsp);
   }
 
   private CoreContainer getCoreContainer() {

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -969,7 +969,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         }),
     /**
      * Handle cluster status request. Can return status per specific collection/shard or per all
-     * collections.
+     * collections. note: there is no 1:1 V2 equivalent; instead separate endpoints are used.
      */
     CLUSTERSTATUS_OP(
         CLUSTERSTATUS,

--- a/solr/core/src/test/org/apache/solr/handler/V2ClusterAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/V2ClusterAPIMappingTest.java
@@ -32,7 +32,6 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.api.Api;
 import org.apache.solr.api.ApiBag;
 import org.apache.solr.common.params.CollectionParams;
-import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.CommandOperation;
 import org.apache.solr.common.util.ContentStreamBase;
@@ -84,13 +83,6 @@ public class V2ClusterAPIMappingTest extends SolrTestCaseJ4 {
     final SolrParams v1Params = captureConvertedV1Params("/cluster/overseer", "GET", null);
 
     assertEquals(CollectionParams.CollectionAction.OVERSEERSTATUS.lowerName, v1Params.get(ACTION));
-  }
-
-  @Test
-  public void testClusterStatusAllParams() throws Exception {
-    final SolrParams v1Params = captureConvertedV1Params("/cluster", "GET", null);
-
-    assertEquals(CollectionAction.CLUSTERSTATUS.lowerName, v1Params.get(ACTION));
   }
 
   @Test

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cluster-node-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cluster-node-management.adoc
@@ -55,15 +55,11 @@ http://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS
 
 ----
 ====
+[.tab-label]*V2 API*
 
-V2 API::
-+
-====
-[source,bash]
-----
-curl -X GET http://localhost:8983/api/cluster
+There will be no V2 API for this.
+Instead use more specific endpoints for the information desired.
 
-----
 ====
 ======
 


### PR DESCRIPTION
It's a kitchen sink API that is redundant with finer grain endpoints.

https://issues.apache.org/jira/browse/SOLR-17422

I generated the ref guide to review what the modified page looked like.  Not ideal but it was formatted the same before SOLR-15748 added the API that this PR removes.