### PR TITLE
SOLR-17423: Remove -h as short option for --host, and use --host.

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -160,7 +160,7 @@ public class RunExampleTool extends ToolBase {
             .desc("Specify the port to start the Solr HTTP listener on; default is 8983.")
             .longOpt("port")
             .build(),
-        Option.builder("h")
+        Option.builder()
             .argName("HOSTNAME")
             .hasArg()
             .required(false)
@@ -272,9 +272,6 @@ public class RunExampleTool extends ToolBase {
     Map<String, Object> nodeStatus =
         startSolr(new File(exDir, "solr"), isCloudMode, cli, port, zkHost, 30);
 
-    // invoke the CreateTool
-    File configsetsDir = new File(serverDir, "solr/configsets");
-
     String solrUrl = (String) nodeStatus.get("baseUrl");
 
     // If the example already exists then let the user know they should delete it, or
@@ -310,6 +307,7 @@ public class RunExampleTool extends ToolBase {
     }
 
     if (!alreadyExists) {
+      // invoke the CreateTool
       String[] createArgs =
           new String[] {
             "--name", collectionName,
@@ -609,10 +607,10 @@ public class RunExampleTool extends ToolBase {
 
     String extraArgs = readExtraArgs(cli.getArgs());
 
-    String host = cli.getOptionValue('h');
+    String host = cli.getOptionValue("host");
     String memory = cli.getOptionValue('m');
 
-    String hostArg = (host != null && !"localhost".equals(host)) ? " -h " + host : "";
+    String hostArg = (host != null && !"localhost".equals(host)) ? " --host " + host : "";
     String zkHostArg = (zkHost != null) ? " -z " + zkHost : "";
     String memArg = (memory != null) ? " -m " + memory : "";
     String cloudModeArg = cloudMode ? "--cloud " : "";

--- a/solr/core/src/test/org/apache/solr/cli/TestSolrCLIRunExample.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestSolrCLIRunExample.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteResultHandler;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -83,7 +84,7 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
   private static class RunExampleExecutor extends DefaultExecutor implements Closeable {
 
     private PrintStream stdout;
-    private List<org.apache.commons.exec.CommandLine> commandsExecuted = new ArrayList<>();
+    private final List<CommandLine> commandsExecuted = new ArrayList<>();
     private MiniSolrCloudCluster solrCloudCluster;
     private JettySolrRunner standaloneSolr;
 
@@ -121,9 +122,8 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
           String solrHomeDir = getArg("-s", args);
           int port = Integer.parseInt(getArg("-p", args));
           String solrxml =
-              new String(
-                  Files.readAllBytes(Paths.get(solrHomeDir).resolve("solr.xml")),
-                  Charset.defaultCharset());
+              Files.readString(
+                  Paths.get(solrHomeDir).resolve("solr.xml"), Charset.defaultCharset());
 
           JettyConfig jettyConfig = JettyConfig.builder().setPort(port).build();
           try {
@@ -405,9 +405,8 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
           exampleSolrHomeDir.isDirectory());
 
       if ("techproducts".equals(exampleName)) {
-        SolrClient solrClient =
-            getHttpSolrClient("http://localhost:" + bindPort + "/solr", exampleName);
-        try {
+        try (SolrClient solrClient =
+            getHttpSolrClient("http://localhost:" + bindPort + "/solr", exampleName)) {
           SolrQuery query = new SolrQuery("*:*");
           QueryResponse qr = solrClient.query(query);
           long numFound = qr.getResults().getNumFound();
@@ -431,8 +430,6 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
                   + toolOutput,
               32,
               numFound);
-        } finally {
-          solrClient.close();
         }
       }
 
@@ -444,7 +441,7 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
   /**
    * Tests the interactive SolrCloud example; we cannot test the non-interactive because we need
    * control over the port and can only test with one node since the test relies on setting the host
-   * and jetty.port system properties, i.e. there is no test coverage for the --noprompt option.
+   * and jetty.port system properties, i.e. there is no test coverage for the --no-prompt option.
    */
   @Test
   public void testInteractiveSolrCloudExample() throws Exception {
@@ -587,14 +584,14 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
           "--server-dir", solrServerDir.getAbsolutePath(),
           "--example-dir", solrExampleDir.getAbsolutePath(),
           "-p", String.valueOf(bindPort),
-          "-script", toExecute.getAbsolutePath().toString()
+          "-script", toExecute.getAbsolutePath()
         };
 
     // capture tool output to stdout
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintStream stdoutSim = new PrintStream(baos, true, StandardCharsets.UTF_8.name());
 
-    DefaultExecutor executor = new DefaultExecutor();
+    DefaultExecutor executor = DefaultExecutor.builder().get();
 
     RunExampleTool tool = new RunExampleTool(executor, System.in, stdoutSim);
     int code = tool.runTool(SolrCLI.processCommandLineArgs(tool, toolArgs));

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
@@ -117,7 +117,7 @@ docker run -it solr --host myhostname
 ----
 
 This is the same as the previous one, but an additional argument is passed.
-The image will run the "solr" command with "-f --h myhostname".
+The image will run the "solr" command with "-f --host myhostname".
 
 To run solr as an arbitrary command:
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
@@ -135,7 +135,7 @@ For example:
 
 [source,bash]
 ----
-docker run -it solr bin/solr start -f --h myhostname
+docker run -it solr bin/solr start -f --host myhostname
 ----
 
 Finally, the Solr docker image offers several commands that do some work before then invoking the Solr server, like "solr-precreate" and "solr-demo".

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
@@ -104,7 +104,7 @@ To run the Solr server:
 
 [source,bash]
 ----
-docker run -it solr
+docker run -it solr start
 ----
 
 Here "solr" is the name of the image, and there is no specific command, so the image defaults to run the "solr" command with "-f" to run it in the foreground.
@@ -113,11 +113,11 @@ To run the Solr server with extra arguments:
 
 [source,bash]
 ----
-docker run -it solr -h myhostname
+docker run -it solr start --host myhostname
 ----
 
 This is the same as the previous one, but an additional argument is passed.
-The image will run the "solr" command with "-f -h myhostname".
+The image will run the "solr" command with "-f --h myhostname".
 
 To run solr as an arbitrary command:
 
@@ -135,7 +135,7 @@ For example:
 
 [source,bash]
 ----
-docker run -it solr bin/solr start -f -h myhostname
+docker run -it solr bin/solr start -f --h myhostname
 ----
 
 Finally, the Solr docker image offers several commands that do some work before then invoking the Solr server, like "solr-precreate" and "solr-demo".
@@ -162,7 +162,7 @@ whereas:
 
 [source,bash]
 ----
-docker run -it solr solr -f
+docker run -it solr solr start -f
 ----
 
 is slightly different: the "solr" there is a generic command, not treated in any special way by `docker-entrypoint.sh`.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/docker-faq.adoc
@@ -104,16 +104,16 @@ To run the Solr server:
 
 [source,bash]
 ----
-docker run -it solr start
+docker run -it solr
 ----
 
-Here "solr" is the name of the image, and there is no specific command, so the image defaults to run the "solr" command with "-f" to run it in the foreground.
+Here "solr" is the name of the image, and there is no specific command, so the image defaults to run the "solr" command with "start -f" to run it in the foreground.
 
 To run the Solr server with extra arguments:
 
 [source,bash]
 ----
-docker run -it solr start --host myhostname
+docker run -it solr --host myhostname
 ----
 
 This is the same as the previous one, but an additional argument is passed.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -289,7 +289,7 @@ To emphasize how the default settings work take a moment to understand that the 
 
 `bin/solr start`
 
-`bin/solr start -h localhost -p 8983 -d server -s solr -m 512m`
+`bin/solr start --host localhost -p 8983 -d server -s solr -m 512m`
 
 It is not necessary to define all of the options when starting if the defaults are fine for your needs.
 

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-aws.adoc
@@ -206,7 +206,7 @@ Inside the `ec2-101-1-2-3.us-east-2.compute.amazonaws.com` (`solr-node-1`)
 $ cd $SOLR_HOME
 
 # start Solr node on 8983 and ZooKeeper will start on 9983 (8983+1000)
-$ bin/solr start -c -p 8983 -h solr-node-1
+$ bin/solr start -c -p 8983 --host solr-node-1
 ----
 +
 On the other node, `ec2-101-4-5-6.us-east-2.compute.amazonaws.com` (`solr-node-2`)
@@ -216,7 +216,7 @@ On the other node, `ec2-101-4-5-6.us-east-2.compute.amazonaws.com` (`solr-node-2
 $ cd $SOLR_HOME
 
 # start Solr node on 8983 and connect to ZooKeeper running on first node
-$ bin/solr start -c -p 8983 -h solr-node-2 -z solr-node-1:9983
+$ bin/solr start -c -p 8983 --host solr-node-2 -z solr-node-1:9983
 ----
 
 . Inspect and Verify.
@@ -328,7 +328,7 @@ $ bin/zkServer.sh start
 $ cd $SOLR_HOME
 
 # start Solr node on 8983 and connect to ZooKeeper running on ZooKeeper node
-$ bin/solr start -c -p 8983 -h solr-node-1 -z zookeeper-node:2181
+$ bin/solr start -c -p 8983 --host solr-node-1 -z zookeeper-node:2181
 ----
 +
 . On the second Solr node (`solr-node-2`), again start Solr and tell it where to find ZooKeeper.
@@ -338,7 +338,7 @@ $ bin/solr start -c -p 8983 -h solr-node-1 -z zookeeper-node:2181
 $ cd $SOLR_HOME
 
 # start Solr node on 8983 and connect to ZooKeeper running on ZooKeeper node
-$ bin/solr start -c -p 8983 -h solr-node-2 -z zookeeper-node:2181
+$ bin/solr start -c -p 8983 --host solr-node-2 -z zookeeper-node:2181
 ----
 
 [TIP]


### PR DESCRIPTION
Couple of small code cleanups..

https://issues.apache.org/jira/browse/SOLR-17423



# Description

Deal with `-h` confusion.

# Solution

Got lucky and found out RunExampleTool never uses `-h` option, so easy removal!

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
