### PR TITLE
SOLR-17142: Fix Gradle build sometimes gives spurious "unreferenced license file" warnings

### DIFF
--- a/gradle/validation/jar-checks.gradle
+++ b/gradle/validation/jar-checks.gradle
@@ -20,6 +20,10 @@
 // 2) notice file
 // 3) checksum validation/ generation.
 
+// WARNING: The tasks in this file share internal state between tasks without using files.
+// Because of this all tasks here must always execute together, so they cannot define task outputs.
+// TODO: Rewrite the internal state to use state files containing the ext.jarInfos and its referencedFiles
+
 import org.apache.commons.codec.digest.DigestUtils
 
 // This should be false only for debugging.
@@ -210,13 +214,6 @@ subprojects {
     description = "Validate license and notice files of dependencies"
     dependsOn collectJarInfos
 
-    def outputFileName = 'validateJarLicenses'
-    inputs.dir(file(project.rootDir.path + '/solr/licenses'))
-        .withPropertyName('licenses')
-        .withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.file(layout.buildDirectory.file(outputFileName))
-        .withPropertyName('validateJarLicensesResult')
-
     doLast {
       def errors = []
       jarInfos.each { dep ->
@@ -262,8 +259,7 @@ subprojects {
           }
         }
       }
-      def f = new File(project.buildDir.path + "/" + outputFileName)
-      f.text = errors
+
       if (errors) {
         def msg = "Certain license/ notice files are missing:\n  - " + errors.join("\n  - ")
         if (failOnError) {

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -148,6 +148,8 @@ Other Changes
 
 * SOLR-17399: Replace the use of the deprecated java.util.Locale constructor with Locale Builder API. (Sanjay Dutt)
 
+* SOLR-17142: Fix Gradle build sometimes gives spurious "unreferenced license file" warnings. (Uwe Schindler)
+
 ==================  9.7.0 ==================
 New Features
 ---------------------


### PR DESCRIPTION
see https://github.com/apache/lucene/issues/13695 for details what the problem was.