### PR TITLE
SOLR-17429, SOLR-17338: Use stderr for SolrCLI deprecation logs

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -69,6 +69,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.util.StartupLoggingUtils;
 import org.apache.solr.util.configuration.SSLConfigurationsFactory;
 import org.slf4j.Logger;
@@ -373,6 +374,7 @@ public class SolrCLI implements CLIO {
 
   // TODO: SOLR-17429 - remove the custom logic when CommonsCLI is upgraded and
   // makes stderr the default, or makes Option.toDeprecatedString() public.
+  @SuppressForbidden(reason = "The CLI needs to log warnings to stderr")
   private static void deprecatedHandlerStdErr(Option o) {
     if (o.isDeprecated()) {
       final StringBuilder buf =

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -69,7 +69,6 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.NamedList;
-import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.util.StartupLoggingUtils;
 import org.apache.solr.util.configuration.SSLConfigurationsFactory;
 import org.slf4j.Logger;
@@ -374,7 +373,6 @@ public class SolrCLI implements CLIO {
 
   // TODO: SOLR-17429 - remove the custom logic when CommonsCLI is upgraded and
   // makes stderr the default, or makes Option.toDeprecatedString() public.
-  @SuppressForbidden(reason = "The CLI needs to log warnings to stderr")
   private static void deprecatedHandlerStdErr(Option o) {
     if (o.isDeprecated()) {
       final StringBuilder buf =
@@ -383,7 +381,7 @@ public class SolrCLI implements CLIO {
         buf.append(",'--").append(o.getLongOpt()).append('\'');
       }
       buf.append(": ").append(o.getDeprecated());
-      System.err.println(buf);
+      CLIO.err(buf.toString());
     }
   }
 
@@ -659,7 +657,7 @@ public class SolrCLI implements CLIO {
       if (solrUrl.contains("/solr")) { //
         String newSolrUrl = solrUrl.substring(0, solrUrl.indexOf("/solr"));
         if (logUrlFormatWarning) {
-          CLIO.out(
+          CLIO.err(
               "WARNING: URLs provided to this tool needn't include Solr's context-root (e.g. \"/solr\"). Such URLs are deprecated and support for them will be removed in a future release. Correcting from ["
                   + solrUrl
                   + "] to ["

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -685,13 +685,11 @@ public class SolrCLI implements CLIO {
           cli.hasOption("zk-host") ? cli.getOptionValue("zk-host") : cli.getOptionValue("zkHost");
       if (zkHost == null) {
         solrUrl = SolrCLI.getDefaultSolrUrl();
-        CLIO.getOutStream()
-            .println(
-                "Neither --zk-host or --solr-url parameters provided so assuming solr url is "
-                    + solrUrl
-                    + ".");
+        CLIO.err(
+            "Neither --zk-host or --solr-url parameters provided so assuming solr url is "
+                + solrUrl
+                + ".");
       } else {
-
         try (CloudSolrClient cloudSolrClient = getCloudHttp2SolrClient(zkHost)) {
           cloudSolrClient.connect();
           Set<String> liveNodes = cloudSolrClient.getClusterState().getLiveNodes();

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -373,7 +373,7 @@ public class SolrCLI implements CLIO {
 
   // TODO: SOLR-17429 - remove the custom logic when CommonsCLI is upgraded and
   // makes stderr the default, or makes Option.toDeprecatedString() public.
-  private static final void deprecatedHandlerStdErr(Option o) {
+  private static void deprecatedHandlerStdErr(Option o) {
     if (o.isDeprecated()) {
       final StringBuilder buf =
           new StringBuilder().append("Option '-").append(o.getOpt()).append('\'');


### PR DESCRIPTION
Tools that parse the output of the Solr CLI will be broken with the new deprecation notices. Moving the deprecation notices to stderr instead of stdout will fix this.

Unfortunately we can't make the Deprecation Handler:
```java
o -> System.err.println(o.toDeprecatedString())
```
because `Option.toDeprecatedString()` is package protected for some reason. Because of this, I've basically copied the method until a release of CommonsCLI will make that method public. (or even make stderr the default, which it likely should be)