### PR TITLE
Add extra if in pseudocode fetch all docs

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/pagination-of-results.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/pagination-of-results.adoc
@@ -144,6 +144,9 @@ $done = false
 while (not $done) {
   $results = fetch_solr($params)
   // do something with $results
+  if (count($results[response][docs]) < $r) {
+    $done = true
+  }
   if ($params[cursorMark] == $results[nextCursorMark]) {
     $done = true
   }


### PR DESCRIPTION
# Description

"You can repeat this process until you’ve fetched as many docs as you want, or until the nextCursorMark returned matches the cursorMark you’ve already specified — indicating that there are no more results."

The pseudo code misses the first part.

# Solution

Add an extra if for checking whether the number of documents in the result is less than the specified rows. The extra if also prevents an unnecessary extra request.

It could also be shortened, by replacing the two ifs by:

`$done = count($results[response][docs]) < $r || $params[cursorMark] == $results[nextCursorMark]`

I don't know whether that's good for readability.

In addition this could be transformed into a `do while` statement.

# Tests

None. This is a documentation change.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)

Not all of the above is checked, because it is a documentation change.