### PR TITLE
Payload Score Parser: expand documentation's pointing to Lucene javadocs

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/PayloadScoreQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/PayloadScoreQParserPlugin.java
@@ -31,8 +31,8 @@ import org.apache.solr.schema.FieldType;
 import org.apache.solr.util.PayloadUtils;
 
 /**
- * Creates a PayloadScoreQuery wrapping a SpanQuery created from the input value, applying text
- * analysis and constructing SpanTermQuery or SpanNearQuery based on number of terms. <br>
+ * Creates a {@link PayloadScoreQuery} wrapping a SpanQuery created from the input value, applying
+ * text analysis and constructing SpanTermQuery or SpanNearQuery based on number of terms. <br>
  * Other parameters: <br>
  * <code>f</code>, the field (required) <br>
  * <code>func</code>, payload function (min, max, or average; required) <br>

--- a/solr/solr-ref-guide/modules/query-guide/pages/other-parsers.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/other-parsers.adoc
@@ -951,8 +951,8 @@ Payloads can be encoded on terms using either the `DelimitedPayloadTokenFilter` 
 
 === Payload Score Parser
 
-`PayloadScoreQParser` incorporates each matching term's numeric (integer or float) payloads into the scores.
-The main query is parsed from the field type's query analysis into a `SpanQuery` based on the value of the `operator` parameter below.
+`PayloadScoreQParser` incorporates each matching term's numeric (integer or float) payloads into the scores via a {lucene-javadocs}/queries/src/java/org/apache/lucene/queries/payloads/PayloadScoreQuery.html[PayloadScoreQuery] that is wrapping a {lucene-javadocs}/queries/src/java/org/apache/lucene/queries/spans/SpanQuery.html[SpanQuery].
+The main query is parsed from the field type's query analysis into the `SpanQuery` based on the value of the `operator` parameter below.
 
 This parser accepts the following parameters:
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/other-parsers.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/other-parsers.adoc
@@ -951,7 +951,7 @@ Payloads can be encoded on terms using either the `DelimitedPayloadTokenFilter` 
 
 === Payload Score Parser
 
-`PayloadScoreQParser` incorporates each matching term's numeric (integer or float) payloads into the scores via a {lucene-javadocs}/queries/src/java/org/apache/lucene/queries/payloads/PayloadScoreQuery.html[PayloadScoreQuery] that is wrapping a {lucene-javadocs}/queries/src/java/org/apache/lucene/queries/spans/SpanQuery.html[SpanQuery].
+`PayloadScoreQParser` incorporates each matching term's numeric (integer or float) payloads into the scores via a {lucene-javadocs}/queries/org/apache/lucene/queries/payloads/PayloadScoreQuery.html[PayloadScoreQuery] that is wrapping a {lucene-javadocs}/queries/org/apache/lucene/queries/spans/SpanQuery.html[SpanQuery].
 The main query is parsed from the field type's query analysis into the `SpanQuery` based on the value of the `operator` parameter below.
 
 This parser accepts the following parameters:


### PR DESCRIPTION
see also https://github.com/apache/lucene/pull/13731 PayloadScoreQuery javadoc update w.r.t. SpanQuery use