### PR TITLE
SOLR-3696: LBSolrClient use ObjectReleaseTracker

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -57,6 +57,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.ObjectReleaseTracker;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.URLUtil;
 import org.slf4j.MDC;
@@ -403,6 +404,7 @@ public abstract class LBSolrClient extends SolrClient {
       }
       updateAliveList();
     }
+    ObjectReleaseTracker.track(this);
   }
 
   protected void updateAliveList() {
@@ -793,5 +795,6 @@ public abstract class LBSolrClient extends SolrClient {
         ExecutorUtil.shutdownAndAwaitTermination(aliveCheckExecutor);
       }
     }
+    ObjectReleaseTracker.release(this);
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-3696

I haven't found the bug for SOLR-3696 yet but this is at least a step towards hopefully doing so eventually.  At least ruling out a missing close().

(no CHANGES.txt for trivial matter)