### PR TITLE
Nest the script-update-processor page UNDER the update-request-processors page

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solrconfig-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solrconfig-xml.adoc
@@ -10,7 +10,6 @@
     initparams, \
     requestdispatcher, \
     update-request-processors, \
-    script-update-processor, \
     codec-factory
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/update-request-processors.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/update-request-processors.adoc
@@ -1,4 +1,5 @@
 = Update Request Processors
+:page-children: script-update-processor
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information


### PR DESCRIPTION
The script-update-processor page should be nested:
<img width="159" alt="image" src="https://github.com/user-attachments/assets/cfb80c50-b98c-4e53-852f-cbe656f56ccd">

However, I can't figure out why this isn't working in the ref guide!  