### PR TITLE
remove deprecated SolrParams methods

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/FacetParser.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetParser.java
@@ -454,7 +454,7 @@ abstract class FacetParser<T extends FacetRequest> {
     // HACK, but NamedList already handles the list processing for us...
     NamedList<String> nl = new NamedList<>();
     nl.addAll(jsonObject);
-    return SolrParams.toSolrParams(nl);
+    return nl.toSolrParams();
   }
 
   // TODO Make this private (or at least not static) and introduce

--- a/solr/core/src/test/org/apache/solr/search/TestMinHashQParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMinHashQParser.java
@@ -417,8 +417,7 @@ public class TestMinHashQParser extends SolrTestCaseJ4 {
     QParser qparser =
         h.getCore()
             .getQueryPlugin("minhash")
-            .createParser(
-                "1, 2, 3, 4, 5, 6, 7, 8, 9, 10", SolrParams.toSolrParams(par), null, null);
+            .createParser("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", par.toSolrParams(), null, null);
     Query query = qparser.getQuery();
 
     BooleanQuery bq = (BooleanQuery) query;
@@ -436,7 +435,7 @@ public class TestMinHashQParser extends SolrTestCaseJ4 {
     par.add("rows", "30");
     par.add("fl", "id,score");
     par.remove("qt");
-    SolrParams newp = SolrParams.toSolrParams(par);
+    SolrParams newp = par.toSolrParams();
     qr.setParams(newp);
     return qr;
   }

--- a/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
@@ -22,12 +22,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -435,66 +430,6 @@ public abstract class SolrParams
     return AppendedSolrParams.wrapAppended(params, defaults);
   }
 
-  /** Create a Map&lt;String,String&gt; from a NamedList given no keys are repeated */
-  @Deprecated // Doesn't belong here (no SolrParams).  Just remove.
-  public static Map<String, String> toMap(NamedList<?> params) {
-    HashMap<String, String> map = new HashMap<>();
-    for (int i = 0; i < params.size(); i++) {
-      map.put(params.getName(i), params.getVal(i).toString());
-    }
-    return map;
-  }
-
-  /** Create a Map&lt;String,String[]&gt; from a NamedList */
-  @Deprecated // Doesn't belong here (no SolrParams).  Just remove.
-  public static Map<String, String[]> toMultiMap(NamedList<?> params) {
-    HashMap<String, String[]> map = new HashMap<>();
-    for (int i = 0; i < params.size(); i++) {
-      String name = params.getName(i);
-      Object val = params.getVal(i);
-      if (val instanceof String[]) {
-        MultiMapSolrParams.addParam(name, (String[]) val, map);
-      } else if (val instanceof List) {
-        List<?> l = (List<?>) val;
-        String[] s = new String[l.size()];
-        for (int j = 0; j < l.size(); j++) {
-          s[j] = l.get(j) == null ? null : String.valueOf(l.get(j));
-        }
-        MultiMapSolrParams.addParam(name, s, map);
-      } else {
-        MultiMapSolrParams.addParam(name, val.toString(), map);
-      }
-    }
-    return map;
-  }
-
-  /**
-   * Create SolrParams from NamedList.
-   *
-   * @deprecated Use {@link NamedList#toSolrParams()}.
-   */
-  @Deprecated // move to NamedList to allow easier flow
-  public static SolrParams toSolrParams(NamedList<?> params) {
-    return params.toSolrParams();
-  }
-
-  @Deprecated
-  public SolrParams toFilteredSolrParams(List<String> names) {
-    // TODO do this better somehow via a view that filters?  See SolrCore.preDecorateResponse.
-    //   ... and/or add some optional predicates to iterator()?
-    NamedList<String> nl = new NamedList<>();
-    for (Iterator<String> it = getParameterNamesIterator(); it.hasNext(); ) {
-      final String name = it.next();
-      if (names.contains(name)) {
-        final String[] values = getParams(name);
-        for (String value : values) {
-          nl.add(name, value);
-        }
-      }
-    }
-    return nl.toSolrParams();
-  }
-
   /**
    * Convert this to a NamedList of unique keys with either String or String[] values depending on
    * how many values there are for the parameter.
@@ -513,31 +448,6 @@ public abstract class SolrParams
       }
     }
     return result;
-  }
-
-  // Deprecated because there isn't a universal way to deal with multi-values (always
-  //  String[] or only for > 1 or always 1st value).  And what to do with nulls or empty string.
-  //  And SolrParams now implements MapWriter.toMap(Map) (a default method).  So what do we do?
-  @Deprecated
-  public Map<String, Object> getAll(Map<String, Object> sink, Collection<String> params) {
-    if (sink == null) sink = new LinkedHashMap<>();
-    for (String param : params) {
-      String[] v = getParams(param);
-      if (v != null && v.length > 0) {
-        if (v.length == 1) {
-          sink.put(param, v[0]);
-        } else {
-          sink.put(param, v);
-        }
-      }
-    }
-    return sink;
-  }
-
-  /** Copy all params to the given map or if the given map is null create a new one */
-  @Deprecated
-  public Map<String, Object> getAll(Map<String, Object> sink, String... params) {
-    return getAll(sink, params == null ? Collections.emptyList() : Arrays.asList(params));
   }
 
   /**


### PR DESCRIPTION
Noticed whilst code reading. The methods appear to have been deprecated in Solr 7.4 -- https://issues.apache.org/jira/browse/SOLR-11914 -- and so the removal here can be both for `main` and `branch_9x` branches.