### PR TITLE
Ref Guide Doc fixes to match on bin/solr post works in 9.7

### DIFF
--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-diy.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-diy.adoc
@@ -103,14 +103,14 @@ Execute the following command to delete a specific document:
 
 [,console]
 ----
-$ bin/solr post -c localDocs -d "<delete><id>SP2514N</id></delete>"
+$ bin/solr post -c localDocs --mode args "{delete: {id:'SP2514N'}}"
 ----
 
 To delete all documents, you can use "delete-by-query" command like:
 
 [,console]
 ----
-$ bin/solr post -c localDocs -d "<delete><query>*:*</query></delete>"
+$ bin/solr post -c localDocs --mode args "{delete: {query:'*:*'}}"
 ----
 
 You can also modify the above to only delete documents that match a specific query.

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
@@ -207,7 +207,7 @@ Notice the `-out` providing raw responses from Solr.
 
 [,console]
 ----
-$ echo '{commit: {}}' | bin/solr post --mode stdin -url http://localhost:8983/my_collection/update --out
+$ echo '{commit: {}}' | bin/solr post --mode stdin -url http://localhost:8983/solr/my_collection/update --out
 ----
 
 === Raw Data as Source for Indexing
@@ -216,5 +216,5 @@ Provide the raw document as a string for indexing.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/signals/update -mode args --type text/csv -out $'id,value\n1,0.47' 
+$ bin/solr post -url http://localhost:8983/solr/signals/update -mode args --type text/csv -out $'id,value\n1,0.47' 
 ----


### PR DESCRIPTION
Small changes from using the bin/solr post tool to index some PDF's!