### PR TITLE
SOLR-17457: Fix support for --max-wait-secs for bin/solr.cmd

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -24,8 +24,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DeprecatedAttributes;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;

--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -24,10 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
+
+import org.apache.commons.cli.*;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -52,13 +50,27 @@ public class StatusTool extends ToolBase {
     return "status";
   }
 
-  public static final Option OPTION_MAXWAITSECS =
+  private static final Option OPTION_MAXWAITSECS =
       Option.builder()
           .longOpt("max-wait-secs")
           .argName("SECS")
           .hasArg()
           .required(false)
           .desc("Wait up to the specified number of seconds to see Solr running.")
+          .build();
+
+  private static final Option OPTION_MAXWAITSECS_DEPRECATED =
+      Option.builder("maxWaitSecs")
+          .argName("SECS")
+          .hasArg()
+          .required(false)
+          .desc("Wait up to the specified number of seconds to see Solr running.")
+          .deprecated(
+              DeprecatedAttributes.builder()
+                  .setForRemoval(true)
+                  .setSince("9.7")
+                  .setDescription("Use --max-wait-secs instead")
+                  .get())
           .build();
 
   @Override
@@ -77,12 +89,8 @@ public class StatusTool extends ToolBase {
                     + SolrCLI.getDefaultSolrUrl()
                     + '.')
             .build(),
-        Option.builder("maxWaitSecs")
-            .argName("SECS")
-            .hasArg()
-            .required(false)
-            .desc("Wait up to the specified number of seconds to see Solr running.")
-            .build());
+        OPTION_MAXWAITSECS,
+        OPTION_MAXWAITSECS_DEPRECATED);
   }
 
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17457

# Description

On Windows the `bin/solr.cmd` uses the StatusTool with `--max-wait-secs`, but the flag is not supported in the new notation, only in the old format `-maxWaitSecs`.

# Solution

This PR adds support for the new notation, so that the `bin/solr.cmd` does not fail anymore when running `bin/solr.cmd start`. 

Note that this change is not applicable to `main` because `maxWaitSecs` is already replaced in `StatusTool` with `max-wait-secs`.

# Tests

I have manually tested the changes on a Windows system, since I am not sure if we have any Windows-specific test bats.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
