### PR TITLE
SOLR-17459: Fix unrecognized option -scheme

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -965,14 +965,6 @@ if [[ "$SCRIPT_CMD" == "config" ]]; then
               ZK_HOST="$2"
               shift 2
           ;;
-          -s|--scheme|-scheme)
-              if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                print_usage "$SCRIPT_CMD" "URL scheme is required when using the $1 option!"
-                exit 1
-              fi
-              SOLR_URL_SCHEME="$2"
-              shift 2
-          ;;
           *)  # Pass through all other params
               if [ "$1" != "" ]; then
                 CONFIG_PARAMS+=($1)
@@ -986,9 +978,6 @@ if [[ "$SCRIPT_CMD" == "config" ]]; then
   fi
   if [[ -n "$ZK_HOST" ]]; then
     CONFIG_PARAMS+=("-z" "$ZK_HOST")
-  fi
-  if [[ -n "$SOLR_URL_SCHEME" ]]; then
-    CONFIG_PARAMS+=("--scheme" "$SOLR_URL_SCHEME")
   fi
   run_tool config "${CONFIG_PARAMS[@]}"
   exit $?

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1579,9 +1579,6 @@ IF "%1"=="-z" goto set_config_zk
 IF "%1"=="--zk-host" goto set_config_zk
 IF "%1"=="-zkHost" goto set_config_zk
 IF "%1"=="--zkHost" goto set_config_zk
-IF "%1"=="-s" goto set_config_url_scheme
-IF "%1"=="--scheme" goto set_config_url_scheme
-IF "%1"=="-scheme" goto set_config_url_scheme
 set "CONFIG_ARGS=!CONFIG_ARGS! %1"
 SHIFT
 goto parse_config_args
@@ -1592,15 +1589,8 @@ SHIFT
 SHIFT
 goto parse_config_args
 
-:set_config_url_scheme
-set SOLR_URL_SCHEME=%~2
-SHIFT
-SHIFT
-goto parse_config_args
-
 :run_config
 IF NOT "!ZK_HOST!"=="" SET "CONFIG_ARGS=!CONFIG_ARGS! -z !ZK_HOST!"
-IF NOT "!SOLR_URL_SCHEME!"=="" SET "CONFIG_ARGS=!CONFIG_ARGS! --scheme !SOLR_URL_SCHEME!"
 
 "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
   -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -1272,16 +1272,6 @@ Unnecessary if `ZK_HOST` is defined in `solr.in.sh` or `solr.in.cmd`.
 +
 Base Solr URL, which can be used in SolrCloud mode to determine the ZooKeeper connection string if that's not known.
 
-`-s <scheme>` or `--scheme <scheme>`::
-+
-[%autowidth,frame=none]
-|===
-|Optional |Default: `http`
-|===
-+
-The scheme for accessing Solr. Accepted values: http or https.  Default is 'http'
-
-
 == ZooKeeper Operations
 
 The `bin/solr` script allows certain operations affecting ZooKeeper.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17459

# Description

This PR is a fix for the "unrecognized option: -scheme" exception thrown when using the `bin/solr config` tool.

# Solution

The PR fully removes the support of `-s`, `-scheme` and `--scheme`, which was only used in `ConfigTool` before the migration (see #2540). Note that the argument could be set by the users before the migration. With the migration, the URL scheme can no longer be set via the scheme argument and is now set via the `--solr-url` argument or the environment variable `solr.url.scheme` (in case the fallback URL is used).

Note that this bug occurs only in `branch_9x` and `branch_9_7` and does not affect `main`.

# Tests

_No tests were modified or added.__

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
