### PR TITLE
SOLR-17044: Remove 'solr.v2RealPath' sysprop

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
@@ -33,7 +33,6 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.request.RequestWriter;
-import org.apache.solr.client.solrj.request.V2Request;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 import org.apache.solr.common.cloud.Slice;
@@ -85,11 +84,7 @@ public class ClientUtils {
     String basePath = solrRequest.getBasePath() == null ? serverRootUrl : solrRequest.getBasePath();
 
     if (solrRequest.getApiVersion() == SolrRequest.ApiVersion.V2) {
-      if (solrRequest instanceof V2Request && System.getProperty("solr.v2RealPath") != null) {
-        basePath = serverRootUrl + "/____v2";
-      } else {
-        basePath = addNormalV2ApiRoot(basePath);
-      }
+      basePath = addNormalV2ApiRoot(basePath);
     }
 
     if (solrRequest.requiresCollection() && collection != null) basePath += "/" + collection;

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/util/ClientUtilsTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/util/ClientUtilsTest.java
@@ -22,7 +22,6 @@ import org.apache.solr.client.solrj.request.HealthCheckRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
 import org.apache.solr.client.solrj.request.UpdateRequest;
-import org.apache.solr.client.solrj.request.V2Request;
 import org.junit.Test;
 
 /**
@@ -78,22 +77,6 @@ public class ClientUtilsTest extends SolrTestCase {
       request.setBasePath("http://alternate-url:7574/solr");
       final var url = ClientUtils.buildRequestUrl(request, rw, "http://localhost:8983/solr", null);
       assertEquals("http://alternate-url:7574/solr/admin/info/health", url);
-    }
-
-    // V2 path is correct when solr.v2RealPath sysprop set
-    {
-      System.setProperty("solr.v2RealPath", "true");
-      final var request = new V2Request.Builder("/collections").build();
-      final var url = ClientUtils.buildRequestUrl(request, rw, "http://localhost:8983/solr", null);
-      assertEquals("http://localhost:8983/solr/____v2/collections", url);
-    }
-
-    // V2 path is correct when solr.v2RealPath sysprop NOT set
-    {
-      System.clearProperty("solr.v2RealPath");
-      final var request = new V2Request.Builder("/collections").build();
-      final var url = ClientUtils.buildRequestUrl(request, rw, "http://localhost:8983/solr", null);
-      assertEquals("http://localhost:8983/api/collections", url);
     }
 
     // Ignores collection when not needed (i.e. obeys SolrRequest.requiresCollection)

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -284,7 +284,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     System.setProperty("solr.retries.on.forward", "1");
     System.setProperty("solr.retries.to.followers", "1");
 
-    System.setProperty("solr.v2RealPath", "true");
     System.setProperty("zookeeper.forceSync", "no");
     System.setProperty("jetty.testMode", "true");
     System.setProperty("solr.zookeeper.connectionStrategy", TestConnectionStrategy.class.getName());
@@ -335,7 +334,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     } finally {
       TestInjection.reset();
       initCoreDataDir = null;
-      System.clearProperty("solr.v2RealPath");
       System.clearProperty("zookeeper.forceSync");
       System.clearProperty("jetty.testMode");
       System.clearProperty("tests.shardhandler.randomSeed");


### PR DESCRIPTION
# Description

The 'solr.v2RealPath' system property was used to control how SolrJ built v2 API paths, seemingly as a workaround to allow certain tests to work which didn't at the time use a full Jetty stack. (Jetty.xml is involved in supporting our v2 API currently by rewriting the v2 API root "/api" to "/solr/____v2")

This workaround though is unnecessary and needlessly complicates SolrJ's path-building logic.

# Solution

Remove all references to 'solr.v2RealPath' in our codebase, and ensure that all tests still pass.

(This change targets 'main' only right now.  It may also be safe to backport to branch_9x, but more investigation is needed there to see whether the user-configurable context-root causes any complications.)

# Tests

Existing tests continue to pass.  No new tests, as this PR only removes functionality.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
