### PR TITLE
Fix bin/solr handling of --version flag and version command to be backcompat compatible.

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -642,9 +642,12 @@ if [ $# -eq 1 ]; then
 fi
 
 if [ $# -gt 0 ]; then
-  # if first arg starts with a dash (and it's not --help or -info),
-  # then assume they are starting Solr, such as: solr -f
-  if [[ $1 == -* ]]; then
+  if [ $1 == -v ] || [ $1 == --version ] || [ $1 == -version ]; then
+    # capture this situation and set the script command to what was passed in
+    SCRIPT_CMD=$1
+  elif [[ $1 == -* ]]; then
+    # if first arg starts with a dash (and it's not --help or -info),
+    # then assume they are starting Solr, such as: solr -f
     SCRIPT_CMD="start"
   else
     SCRIPT_CMD="$1"

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -227,12 +227,13 @@ public class SolrCLI implements CLIO {
 
     if (Arrays.asList("-version", "version").contains(args[0])) {
       // select the version tool to be run
-      CLIO.out("Deprecated operation as of 9.8.  Please use -v or --version.");
-      args[0] = "version";
+      CLIO.out("Deprecated operation as of 9.8.  Please use bin/solr --version.");
+      // args[0] = "version";
+      args = new String[] {"version"};
     }
     if (Arrays.asList("-v", "--version").contains(args[0])) {
       // select the version tool to be run
-      args[0] = "version";
+      args = new String[] {"version"};
     }
     if (Arrays.asList(
             "upconfig", "downconfig", "cp", "rm", "mv", "ls", "mkroot", "linkconfig", "updateacls")

--- a/solr/packaging/test/test_version.bats
+++ b/solr/packaging/test/test_version.bats
@@ -33,10 +33,10 @@ setup() {
 @test "-version and version both return Solr version and deprecation" {
   run solr -version
   assert_output --partial "Solr version is:"
-  assert_output --partial "Deprecated operation as of 9.8.  Please use -v or --version."
+  assert_output --partial "Deprecated operation as of 9.8.  Please use bin/solr --version."
   
   run solr version
   assert_output --partial "Solr version is:"
-  assert_output --partial "Deprecated operation as of 9.8.  Please use -v or --version."
+  assert_output --partial "Deprecated operation as of 9.8.  Please use bin/solr --version."
   
 }


### PR DESCRIPTION
This ensures the `bin/solr --version`, `bin/solr -version` and `bin/solr version` all work in branch_9x.