### PR TITLE
SOLR-17466: Inform 9x users about upcoming change to solrcloud default mode

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1219,7 +1219,7 @@ else
     exit 1
   fi
   
-  echo -e "\nSolr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.\n"
+  echo -e "\nSolr will start in SolrCloud mode by default in version 10.  You will need to pass in --user-managed flag to run in User Managed (aka Standalone) mode.\n"
 fi
 
 # Exit if old syntax found

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1185,7 +1185,7 @@ if [ "${SOLR_MODE:-}" == 'solrcloud' ]; then
   : "${ZK_CLIENT_TIMEOUT:=30000}"
   CLOUD_MODE_OPTS=("-DzkClientTimeout=$ZK_CLIENT_TIMEOUT")
 
-  echo -e "\nSolr will start in SolrCloud mode by default in version 10, and you will no longer need to pass in -c or --cloud flag.\n"
+  echo -e "\nSolr will start in SolrCloud mode by default in version 10, even if no -c or --cloud flag is specified.\n"
   
   if [ -n "${ZK_HOST:-}" ]; then
     CLOUD_MODE_OPTS+=("-DzkHost=$ZK_HOST")

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1185,6 +1185,8 @@ if [ "${SOLR_MODE:-}" == 'solrcloud' ]; then
   : "${ZK_CLIENT_TIMEOUT:=30000}"
   CLOUD_MODE_OPTS=("-DzkClientTimeout=$ZK_CLIENT_TIMEOUT")
 
+  echo -e "\nSolr will start in SolrCloud mode by default in version 10, and you will no longer need to pass in -c or --cloud flag.\n"
+  
   if [ -n "${ZK_HOST:-}" ]; then
     CLOUD_MODE_OPTS+=("-DzkHost=$ZK_HOST")
   else
@@ -1216,6 +1218,8 @@ else
     echo -e "\nSolr home directory $SOLR_HOME must contain a solr.xml file!\n"
     exit 1
   fi
+  
+  echo -e "\nSolr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.\n"
 fi
 
 # Exit if old syntax found

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -950,6 +950,7 @@ if !JAVA_MAJOR_VERSION! LSS 9  (
 IF NOT "%ZK_HOST%"=="" set SOLR_MODE=solrcloud
 
 IF "%SOLR_MODE%"=="solrcloud" (
+  @echo Solr will start in SolrCloud mode by default in version 10, and you will no longer need to pass in -c or --cloud flag.
   IF "%ZK_CLIENT_TIMEOUT%"=="" set "ZK_CLIENT_TIMEOUT=30000"
 
   set "CLOUD_MODE_OPTS=-DzkClientTimeout=!ZK_CLIENT_TIMEOUT!"
@@ -984,6 +985,7 @@ IF "%SOLR_MODE%"=="solrcloud" (
   IF EXIST "%SOLR_HOME%\collection1\core.properties" set "CLOUD_MODE_OPTS=!CLOUD_MODE_OPTS! -Dbootstrap_confdir=./solr/collection1/conf -Dcollection.configName=myconf -DnumShards=1"
 ) ELSE (
   set CLOUD_MODE_OPTS=
+  @echo Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.
   IF NOT EXIST "%SOLR_HOME%\solr.xml" (
     IF "%SOLR_SOLRXML_REQUIRED%"=="true" (
       set "SCRIPT_ERROR=Solr home directory %SOLR_HOME% must contain solr.xml!"

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -951,6 +951,7 @@ IF NOT "%ZK_HOST%"=="" set SOLR_MODE=solrcloud
 
 IF "%SOLR_MODE%"=="solrcloud" (
   @echo Solr will start in SolrCloud mode by default in version 10, and you will no longer need to pass in -c or --cloud flag.
+  @echo.
   IF "%ZK_CLIENT_TIMEOUT%"=="" set "ZK_CLIENT_TIMEOUT=30000"
 
   set "CLOUD_MODE_OPTS=-DzkClientTimeout=!ZK_CLIENT_TIMEOUT!"

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -986,7 +986,7 @@ IF "%SOLR_MODE%"=="solrcloud" (
   IF EXIST "%SOLR_HOME%\collection1\core.properties" set "CLOUD_MODE_OPTS=!CLOUD_MODE_OPTS! -Dbootstrap_confdir=./solr/collection1/conf -Dcollection.configName=myconf -DnumShards=1"
 ) ELSE (
   set CLOUD_MODE_OPTS=
-  @echo Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.
+  @echo Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --user-managed flag to run in User Managed (aka Standalone) mode.
   IF NOT EXIST "%SOLR_HOME%\solr.xml" (
     IF "%SOLR_SOLRXML_REQUIRED%"=="true" (
       set "SCRIPT_ERROR=Solr home directory %SOLR_HOME% must contain solr.xml!"

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -50,6 +50,13 @@ teardown() {
 
 }
 
+@test "start provides warning about SolrCloud mode" {
+  run solr start
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.'
+  solr stop
+}
+
 @test "check stop command doesn't hang" {
   # for start/stop/restart we parse the args separate from picking the command
   # which means you don't get an error message for passing a start arg, like --jvm-opts to a stop commmand.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17466


# Description

Let 9x users know about bin/solr start being cloud mode by default and that they need `--standalone` in 10.

# Solution

Warnings

# Tests

bats

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
