### PR TITLE
Close stale PRs after 60 more days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,14 +24,22 @@ jobs:
 
           days-before-pr-stale: 60
           days-before-issue-stale: -1   # we don't use issues
-          days-before-close: -1         # don't close stale PRs/issues
+          days-before-close: 60         # Close PRs marked as stale after 60 days
           exempt-draft-pr: true         # don't mark draft PRs as stale
+          exempt-pr-labels: "exempt-stale" # don't mark PRs with these labels as stale
           stale-pr-label: "stale"       # label to use when marking as stale
+          close-pr-label: "closed-stale" # label to use when closing a stale PR
 
           stale-pr-message: >
             This PR has had no activity for 60 days and is now labeled as stale. 
-            Any new activity or converting it to draft will remove the stale label. 
-            To attract more reviewers, please tag people who might be familiar with the code area and/or notify the dev@solr.apache.org mailing list. 
+            Any new activity will remove the stale label. 
+            To attract more reviewers, please tag people who might be familiar with the code area and/or notify the dev@solr.apache.org mailing list.
+            To exempt this PR from being marked as stale, make it a draft PR or add the label "exempt-stale".
+            If left unattended, this PR will be closed after another 60 days of inactivity.
             Thank you for your contribution!
+
+          close-pr-message: >
+            This PR is now closed due to 60 days of inactivity after being marked as stale. 
+            Re-opening this PR is still possible, in which case it will be marked as active again.
 
           operations-per-run: 100       # operations budget


### PR DESCRIPTION
Ref mailing list consensus https://lists.apache.org/thread/2v4b0l4vlvzls1vgl5sx2y8mr0c4p6wj

These changes will auto close PRs after 60 days of continued inactivity after receiving the `stale` label, and assign the `closed-stale` label. Further, it will exempt PR with the label `exempt-stale` from ever being marked as stale or auto closed.

Please proof-read the modified messages and settings.