### PR TITLE
SOLR-17442: Fix a errant deprecation of --verbose and it's message

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -147,17 +147,12 @@ public class SolrCLI implements CLIO {
           .build();
 
   public static final Option OPTION_VERBOSE =
-      Option.builder("v")
+      Option.builder()
           .longOpt("verbose")
-          .deprecated(
-              DeprecatedAttributes.builder()
-                  .setForRemoval(true)
-                  .setSince("9.8")
-                  .setDescription("Use --debug instead")
-                  .get())
           .required(false)
           .desc("Enable verbose command output.")
           .build();
+
   public static final Option OPTION_HELP =
       Option.builder("h").longOpt("help").required(false).desc("Print this message.").build();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17442

`--verbose` is now valid, so fix the deprecation message.

I honestly am not quite sure how to handle `-v`, I am somewhat challenged to mark it deprecated, but then still support it, but then also not break other tools that have a `-v` as well.   Will tackle that situation in another PR.