### PR TITLE
Fix failure in PackageToolTest caused by --params instead of --param CLI command

### DIFF
--- a/solr/core/src/test/org/apache/solr/cli/PackageToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/PackageToolTest.java
@@ -157,7 +157,7 @@ public class PackageToolTest extends SolrCloudTestCase {
           SecurityJson.USER_PASS
         });
 
-    // Leaving -p in for --params to test the deprecated value continues to work.
+    // Leaving -p in for --param to test the deprecated value continues to work.
     run(
         tool,
         new String[] {
@@ -264,7 +264,7 @@ public class PackageToolTest extends SolrCloudTestCase {
               "question-answer",
               "--collections",
               "abc",
-              "--params",
+              "--param",
               "RH-HANDLER-PATH=" + rhPath,
               "--credentials",
               SecurityJson.USER_PASS


### PR DESCRIPTION
Just fixing test, no user impact so skipping CHANGES.txt