### PR TITLE
SOLR-17490: Check for existence of perl executable and skip if it doesnt exist

### DIFF
--- a/gradle/documentation/changes-to-html.gradle
+++ b/gradle/documentation/changes-to-html.gradle
@@ -78,14 +78,13 @@ class ChangesToHtmlTask extends DefaultTask {
     def output = new ByteArrayOutputStream()
     
     // Check if the perl executable exists
-    def perlExecutable = project.externalTool("perl")
-    if (!file(perlExecutable).exists()) {
-        logger.warn("WARNING: Perl is not installed or could not be found at: ${perlExecutable}, skipping creating Changes.html")
+    if (!perlExists()) {
+        logger.warn("WARNING: Perl is not installed, skipping creating Changes.html")
         return
     }
-    
+
     def result = project.exec {
-      perlExecutable
+      executable project.externalTool("perl")
       standardInput changesFile.newInputStream()
       standardOutput project.file("${targetDir.get().getAsFile()}/Changes.html").newOutputStream()
       errorOutput = output
@@ -120,6 +119,16 @@ class ChangesToHtmlTask extends DefaultTask {
       versionsFile.delete()
     } else {
       throw new GradleException("Changes file ${changesFile} or Doap file ${changesDoapFile} not found.")
+    }
+  }
+  
+  def perlExists() {
+    try {
+        def process = "perl -v".execute()
+        process.waitFor()
+        return process.exitValue() == 0
+    } catch (Exception e) {
+        return false
     }
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17490


# Description

Make the first time developer experience better with Solr.    Today, everytime someone clones Solr for the first time, especially on Windows, they get bitten by the need to install perl..   just to product "Changes.html".   

# Solution

Add a check for the perl executable and log a warning if it isn't there, and continue on your Gradle process...

# Tests

Manual

