### PR TITLE
SOLR-17488: CLI: Resolve -d conflicts

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1372,7 +1372,7 @@ function start_solr() {
   cd "$SOLR_SERVER_DIR" || (echo -e "\nCd to SOLR_SERVER_DIR failed" && exit 1)
 
   if [ ! -e "$SOLR_SERVER_DIR/start.jar" ]; then
-    echo -e "\nERROR: start.jar file not found in $SOLR_SERVER_DIR!\nPlease check your -d parameter to set the correct Solr server directory.\n"
+    echo -e "\nERROR: start.jar file not found in $SOLR_SERVER_DIR!\nPlease check your --server-dir parameter to set the correct Solr server directory.\n"
     exit 1
   fi
 

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -930,7 +930,7 @@ fi
 # otherwise let this script proceed to process the user request
 #
 if [ -n "${EXAMPLE:-}" ] && [ "$SCRIPT_CMD" == "start" ]; then
-  run_tool run_example -e "$EXAMPLE" -d "$SOLR_SERVER_DIR" --url-scheme "$SOLR_URL_SCHEME" "${PASS_TO_RUN_EXAMPLE[@]}"
+  run_tool run_example -e "$EXAMPLE" --server-dir "$SOLR_SERVER_DIR" --url-scheme "$SOLR_URL_SCHEME" "${PASS_TO_RUN_EXAMPLE[@]}"
   exit $?
 fi
 

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -367,7 +367,7 @@ function print_usage() {
 
   if [[ "$CMD" == "start" || "$CMD" == "restart" ]]; then
     echo ""
-    echo "Usage: solr $CMD [-f] [-c] [--host host] [-p port] [-d directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts \"jvm-opts\"] [-V]"
+    echo "Usage: solr $CMD [-f] [-c] [--host host] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts \"jvm-opts\"] [-V]"
     echo ""
     echo "  -f                    Start Solr in foreground; default starts Solr in the background"
     echo "                          and sends stdout / stderr to solr-PORT-console.log"
@@ -383,7 +383,7 @@ function print_usage() {
     echo "                          STOP_PORT=(\$SOLR_PORT-1000) and JMX RMI listen port RMI_PORT=(\$SOLR_PORT+10000). "
     echo "                          For instance, if you set -p 8985, then the STOP_PORT=7985 and RMI_PORT=18985"
     echo ""
-    echo "  -d <dir>              Specify the Solr server directory; defaults to server"
+    echo "  --server-dir <dir>   Specify the Solr server directory; defaults to server"
     echo ""
     echo "  -z/--zk-host <zkHost> Zookeeper connection string; only used when running in SolrCloud mode using -c"
     echo "                          If neither ZK_HOST is defined in solr.in.sh nor the -z parameter is specified,"
@@ -395,7 +395,7 @@ function print_usage() {
     echo ""
     echo "  --solr-home <dir>     Sets the solr.solr.home system property; Solr will create core directories under"
     echo "                          this directory. This allows you to run multiple Solr instances on the same host"
-    echo "                          while reusing the same server directory set using the -d parameter. If set, the"
+    echo "                          while reusing the same server directory set using the --server-dir parameter. If set, the"
     echo "                          specified directory should contain a solr.xml file, unless solr.xml exists in Zookeeper."
     echo "                          This parameter is ignored when running examples (-e), as the solr.solr.home depends"
     echo "                          on which example is run. The default value is server/solr. If passed relative dir,"
@@ -742,7 +742,7 @@ if [ $# -gt 0 ]; then
             PASS_TO_RUN_EXAMPLE+=("-c")
             shift
         ;;
-        -d|--dir|-dir)
+        -d|--dir|-dir|--server-dir)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
               print_usage "$SCRIPT_CMD" "Server directory is required when using the $1 option!"
               exit 1

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1202,7 +1202,7 @@ REM Run the requested example
   -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
   -Dsolr.install.symDir="%SOLR_TIP%" ^
   -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-  org.apache.solr.cli.SolrCLI run_example --script "%SDIR%\solr.cmd" -e %EXAMPLE% -d "%SOLR_SERVER_DIR%" ^
+  org.apache.solr.cli.SolrCLI run_example --script "%SDIR%\solr.cmd" -e %EXAMPLE% --server-dir "%SOLR_SERVER_DIR%" ^
   --url-scheme !SOLR_URL_SCHEME! !PASS_TO_RUN_EXAMPLE!
 
 REM End of run_example

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1521,7 +1521,9 @@ for %%a in (%*) do (
    ) else (
       set "option!option!=%%a"
       if "!option!" equ "-d" set "SOLR_SERVER_DIR=%%a"
+      if "!option!" equ "--server-dir" set "SOLR_SERVER_DIR=%%a"
       if "!option!" equ "-s" set "SOLR_HOME=%%a"
+      if "!option!" equ "--solr-home" set "SOLR_HOME=%%a"      
       if not "!option!" equ "-s" if not "!option!" equ "-d" (
         set "AUTH_PARAMS=!AUTH_PARAMS! !option! %%a"
       )

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -307,7 +307,7 @@ goto done
 
 :start_usage
 @echo.
-@echo Usage: solr %SCRIPT_CMD% [-f] [-c] [--host hostname] [-p port] [-d directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts "jvm-opts"] [-V]
+@echo Usage: solr %SCRIPT_CMD% [-f] [-c] [--host hostname] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts "jvm-opts"] [-V]
 @echo.
 @echo   -f            Start Solr in foreground; default starts Solr in the background
 @echo                   and sends stdout / stderr to solr-PORT-console.log
@@ -323,7 +323,7 @@ goto done
 @echo                   STOP_PORT=(%%SOLR_PORT%%-1000) and JMX RMI listen port RMI_PORT=(%%SOLR_PORT%%+10000).
 @echo                   For instance, if you set -p 8985, then the STOP_PORT=7985 and RMI_PORT=18985
 @echo.
-@echo   -d dir        Specify the Solr server directory; defaults to server
+@echo   --server-dir dir Specify the Solr server directory; defaults to server
 @echo.
 @echo   -z zkHost     Zookeeper connection string; only used when running in SolrCloud mode using -c
 @echo                   If neither ZK_HOST is defined in solr.in.cmd nor the -z parameter is specified,
@@ -335,13 +335,13 @@ goto done
 @echo.
 @echo   --solr.home dir  Sets the solr.solr.home system property; Solr will create core directories under
 @echo                   this directory. This allows you to run multiple Solr instances on the same host
-@echo                   while reusing the same server directory set using the -d parameter. If set, the
+@echo                   while reusing the same server directory set using the --server-dir parameter. If set, the
 @echo                   specified directory should contain a solr.xml file, unless solr.xml exists in Zookeeper.
 @echo                   This parameter is ignored when running examples (-e), as the solr.solr.home depends
 @echo                   on which example is run. The default value is server/solr. If passed a relative dir
 @echo                   validation with the current dir will be done before trying the default server/^<dir^>
 @echo.
-@echo   --data-hone dir Sets the solr.data.home system property, where Solr will store index data in ^<instance_dir^>/data subdirectories.
+@echo   --data-home dir Sets the solr.data.home system property, where Solr will store index data in ^<instance_dir^>/data subdirectories.
 @echo                   If not set, Solr uses solr.solr.home for both config and data.
 @echo.
 @echo   -e example    Name of the example to run; available examples:
@@ -406,6 +406,7 @@ IF "%1"=="-cloud" goto set_cloud_mode
 IF "%1"=="--cloud" goto set_cloud_mode
 IF "%1"=="-d" goto set_server_dir
 IF "%1"=="--dir" goto set_server_dir
+IF "%1"=="--server-dir" goto set_server_dir
 IF "%1"=="-s" goto set_solr_home_dir
 IF "%1"=="--solr-home" goto set_solr_home_dir
 IF "%1"=="-t" goto set_solr_data_dir

--- a/solr/core/src/java/org/apache/solr/cli/DeleteTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/DeleteTool.java
@@ -81,6 +81,19 @@ public class DeleteTool extends ToolBase {
             .desc("Name of the core / collection to delete.")
             .build(),
         Option.builder("d")
+            .deprecated(
+                DeprecatedAttributes.builder()
+                    .setForRemoval(true)
+                    .setSince("9.8")
+                    .setDescription("Use --delete-config instead")
+                    .get())
+            .hasArg()
+            .argName("true|false")
+            .required(false)
+            .desc(
+                "Flag to indicate if the underlying configuration directory for a collection should also be deleted; default is true.")
+            .build(),
+        Option.builder()
             .longOpt("delete-config")
             .hasArg()
             .argName("true|false")
@@ -188,6 +201,8 @@ public class DeleteTool extends ToolBase {
     boolean deleteConfig = true;
     if (cli.hasOption("delete-config")) {
       deleteConfig = "true".equals(cli.getOptionValue("delete-config"));
+    } else if (cli.hasOption("d")) {
+      deleteConfig = "true".equals(cli.getOptionValue("d"));
     } else if (cli.hasOption("deleteConfig")) {
       deleteConfig = "true".equals(cli.getOptionValue("deleteConfig"));
     }

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -222,6 +222,19 @@ public class PostTool extends ToolBase {
             .desc("For web crawl, how deep to go. default: 1")
             .build(),
         Option.builder("d")
+            .deprecated(
+                DeprecatedAttributes.builder()
+                    .setForRemoval(true)
+                    .setSince("9.8")
+                    .setDescription("Use --delay instead")
+                    .get())
+            .hasArg()
+            .argName("delay")
+            .required(false)
+            .desc(
+                "If recursive then delay will be the wait time between posts.  default: 10 for web, 0 for files")
+            .build(),
+        Option.builder()
             .longOpt("delay")
             .hasArg()
             .argName("delay")

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -340,8 +340,13 @@ public class PostTool extends ToolBase {
       fileTypes = cli.getOptionValue("filetypes");
     }
 
-    int defaultDelay = (mode.equals((DATA_MODE_WEB)) ? 10 : 0);
-    delay = Integer.parseInt(cli.getOptionValue("delay", String.valueOf(defaultDelay)));
+    delay = (mode.equals((DATA_MODE_WEB)) ? 10 : 0);
+    if (cli.hasOption("delay")) {
+      delay = Integer.parseInt(cli.getOptionValue("delay"));
+    } else if (cli.hasOption("d")) {
+      delay = Integer.parseInt(cli.getOptionValue("d"));
+    }
+
     recursive = Integer.parseInt(cli.getOptionValue("recursive", "1"));
 
     out = cli.hasOption("out") ? CLIO.getOutStream() : null;

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -126,7 +126,7 @@ public class RunExampleTool extends ToolBase {
             .required(false)
             .desc("Path to the bin/solr script.")
             .build(),
-        Option.builder("d")
+        Option.builder()
             .longOpt("server-dir")
             .hasArg()
             .argName("DIR")

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -96,7 +96,7 @@ For more details, see the section <<SolrCloud Mode>> below.
 +
 *Example*: `bin/solr start -c`
 
-`-d <dir>`::
+`--server-dir <dir>`::
 +
 [%autowidth,frame=none]
 |===
@@ -107,7 +107,7 @@ Define a server directory, defaults to `server` (as in, `$SOLR_TIP/server`).
 It is uncommon to override this option.
 When running multiple instances of Solr on the same host, it is more common to use the same server directory for each instance and use a unique Solr home directory using the `--solr-home` option.
 +
-*Example*: `bin/solr start -d newServerDir`
+*Example*: `bin/solr start --server-dir newServerDir`
 
 `-e <name>`::
 +
@@ -203,7 +203,7 @@ If this is not specified, `8983` will be used.
 +
 Sets the `solr.solr.home` system property.
 Solr will create core directories under this directory.
-This allows you to run multiple Solr instances on the same host while reusing the same server directory set using the `-d` parameter.
+This allows you to run multiple Solr instances on the same host while reusing the same server directory set using the `--server-dir` parameter.
 If set, the specified directory should contain a solr.xml file, unless solr.xml exists in Zookeeper.
 +
 This parameter is ignored when running examples (`-e`), as the `solr.solr.home` depends on which example is run.
@@ -278,7 +278,7 @@ To emphasize how the default settings work take a moment to understand that the 
 
 `bin/solr start`
 
-`bin/solr start --host localhost -p 8983 -d server --solr-home solr -m 512m`
+`bin/solr start --host localhost -p 8983 --server-dir server --solr-home solr -m 512m`
 
 It is not necessary to define all of the options when starting if the defaults are fine for your needs.
 
@@ -415,7 +415,7 @@ Stop key used to protect from stopping Solr inadvertently; default is "solrrocks
 +
 *Example*: `bin/solr stop -k solrrocks`
 
-`-d` or `--verbose`::
+`--verbose`::
 +
 [%autowidth,frame=none]
 |===
@@ -797,7 +797,7 @@ The `delete` command detects the mode that Solr is running in and then deletes t
 If you're deleting a collection in SolrCloud mode, the default behavior is to also delete the configuration directory from Zookeeper so long as it is not being used by another collection.
 
 For example, if you created a collection with `bin/solr create -c contacts`, then the delete command `bin/solr delete -c contacts` will check to see if the `/configs/contacts` configuration directory is being used by any other collections.
-If not, then the `/configs/contacts` directory is removed from ZooKeeper.  You can override this behavior by passing -deleteConfig false when running this command.atom
+If not, then the `/configs/contacts` directory is removed from ZooKeeper.  You can override this behavior by passing `--delete-config false` when running this command.atom
 
 ==== Delete Core or Collection Parameters
 
@@ -821,7 +821,7 @@ Name of the core or collection to delete.
 +
 Whether or not the configuration directory should also be deleted from ZooKeeper.
 +
-If the configuration directory is being used by another collection, then it will not be deleted even if you pass `--deleteConfig` as `true`.
+If the configuration directory is being used by another collection, then it will not be deleted even if you pass `--delete-config` as `true`.
 +
 *Example*: `bin/solr delete --delete-config false`
 
@@ -980,7 +980,7 @@ Defines the ZooKeeper connect string.
 This is useful if you want to enable authentication before all your Solr nodes have come up.
 Unnecessary if `ZK_HOST` is defined in `solr.in.sh` or `solr.in.cmd`.
 
-`-d <dir>`::
+`--server-dir <dir>`::
 +
 [%autowidth,frame=none]
 |===

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
@@ -43,7 +43,7 @@ The basic usage of `bin/solr post` is:
 ----
 usage: post
  -c,--name <NAME>                                 Name of the collection.
- -d,--delay <delay>                               If recursive then delay
+    --delay <delay>                               If recursive then delay
                                                   will be the wait time
                                                   between posts.  default:
                                                   10 for web, 0 for files


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-17488


# Description

see jira

# Solution

   * Deprecate -d for server-dir in RunExmapleTool. 
   *  Support --server-dir in bin/solr and  bin/solr.cmd 
   * Deprecate -d for delay in PostTool to avoid any confusion with conf-dir.


# Tests

bats and java tests
