### PR TITLE
SOLR-17489: CLI: Deprecate variations on solr urls options

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/ExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ExportTool.java
@@ -271,8 +271,11 @@ public class ExportTool extends ToolBase {
       }
       url = SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name");
 
-    } else {
+    } else if (cli.hasOption("solr-collection-url")) {
       url = cli.getOptionValue("solr-collection-url");
+    } else {
+      // Swap to required Option when --solr-collection-url removed.
+      throw new IllegalArgumentException("Must specify --solr-url.");
     }
     String credentials = cli.getOptionValue(SolrCLI.OPTION_CREDENTIALS.getLongOpt());
     Info info = new MultiThreadedRunner(url, credentials);

--- a/solr/core/src/java/org/apache/solr/cli/ExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ExportTool.java
@@ -54,6 +54,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DeprecatedAttributes;
 import org.apache.commons.cli.Option;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.solr.client.solrj.SolrClient;
@@ -98,10 +99,22 @@ public class ExportTool extends ToolBase {
     return List.of(
         Option.builder("url")
             .longOpt("solr-collection-url")
+            .deprecated(
+                DeprecatedAttributes.builder()
+                    .setForRemoval(true)
+                    .setSince("9.8")
+                    .setDescription("Use --solr-url and -c / --name instead")
+                    .get())
             .hasArg()
             .argName("URL")
-            .required()
             .desc("Address of the collection, example http://localhost:8983/solr/gettingstarted.")
+            .build(),
+        Option.builder("c")
+            .longOpt("name")
+            .hasArg()
+            .argName("NAME")
+            .required(false)
+            .desc("Name of the collection.")
             .build(),
         Option.builder("out")
             .hasArg()
@@ -130,6 +143,7 @@ public class ExportTool extends ToolBase {
             .argName("FIELDA,FIELDB")
             .desc("Comma separated list of fields to export. By default all fields are fetched.")
             .build(),
+        SolrCLI.OPTION_SOLRURL,
         SolrCLI.OPTION_CREDENTIALS);
   }
 
@@ -250,7 +264,17 @@ public class ExportTool extends ToolBase {
 
   @Override
   public void runImpl(CommandLine cli) throws Exception {
-    String url = cli.getOptionValue("solr-collection-url");
+    String url = null;
+    if (cli.hasOption("solr-url")) {
+      if (!cli.hasOption("name")) {
+        throw new IllegalArgumentException(
+            "Must specify -c / --name parameter with --solr-url to post documents.");
+      }
+      url = SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name");
+
+    } else {
+      url = cli.getOptionValue("solr-collection-url");
+    }
     String credentials = cli.getOptionValue(SolrCLI.OPTION_CREDENTIALS.getLongOpt());
     Info info = new MultiThreadedRunner(url, credentials);
     info.query = cli.getOptionValue("query", "*:*");

--- a/solr/core/src/java/org/apache/solr/cli/ExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ExportTool.java
@@ -113,7 +113,6 @@ public class ExportTool extends ToolBase {
             .longOpt("name")
             .hasArg()
             .argName("NAME")
-            .required(false)
             .desc("Name of the collection.")
             .build(),
         Option.builder("out")

--- a/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
@@ -75,14 +75,12 @@ public class PostLogsTool extends ToolBase {
                     .get())
             .hasArg()
             .argName("ADDRESS")
-            .required(true)
             .desc("Address of the collection, example http://localhost:8983/solr/collection1/.")
             .build(),
         Option.builder("c")
             .longOpt("name")
             .hasArg()
-            .argName("NAME")
-            .required(false)
+            .argName("NAME")`
             .desc("Name of the collection.")
             .build(),
         Option.builder("rootdir")

--- a/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
@@ -80,7 +80,7 @@ public class PostLogsTool extends ToolBase {
         Option.builder("c")
             .longOpt("name")
             .hasArg()
-            .argName("NAME")`
+            .argName("NAME")
             .desc("Name of the collection.")
             .build(),
         Option.builder("rootdir")

--- a/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostLogsTool.java
@@ -104,8 +104,11 @@ public class PostLogsTool extends ToolBase {
       }
       url = SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name");
 
-    } else {
+    } else if (cli.hasOption("solr-collection-url")) {
       url = cli.getOptionValue("solr-collection-url");
+    } else {
+      // Swap to required Option when --solr-collection-url removed.
+      throw new IllegalArgumentException("Must specify --solr-url.");
     }
     String rootDir = cli.getOptionValue("rootdir");
     String credentials = cli.getOptionValue("credentials");

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -174,6 +174,12 @@ public class PostTool extends ToolBase {
     return List.of(
         Option.builder("url")
             .longOpt("solr-update-url")
+            .deprecated(
+                DeprecatedAttributes.builder()
+                    .setForRemoval(true)
+                    .setSince("9.8")
+                    .setDescription("Use --solr-url and -c / --name instead")
+                    .get())
             .hasArg()
             .argName("UPDATEURL")
             .desc("Solr Update URL, the full url to the update handler, including the /update.")
@@ -290,6 +296,7 @@ public class PostTool extends ToolBase {
             .desc(
                 "Performs a dry run of the posting process without actually sending documents to Solr.  Only works with files mode.")
             .build(),
+        SolrCLI.OPTION_SOLRURL,
         SolrCLI.OPTION_CREDENTIALS);
   }
 
@@ -298,7 +305,16 @@ public class PostTool extends ToolBase {
     SolrCLI.raiseLogLevelUnlessVerbose(cli);
 
     solrUpdateUrl = null;
-    if (cli.hasOption("solr-update-url")) {
+    if (cli.hasOption("solr-url")) {
+      if (!cli.hasOption("name")) {
+        throw new IllegalArgumentException(
+            "Must specify -c / --name parameter with --solr-url to post documents.");
+      }
+      String url =
+          SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name") + "/update";
+      solrUpdateUrl = new URI(url);
+
+    } else if (cli.hasOption("solr-update-url")) {
       String url = cli.getOptionValue("solr-update-url");
       solrUpdateUrl = new URI(url);
     } else if (cli.hasOption("name")) {

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -188,12 +188,10 @@ public class PostTool extends ToolBase {
             .longOpt("name")
             .hasArg()
             .argName("NAME")
-            .required(false)
             .desc("Name of the collection.")
             .build(),
         Option.builder()
             .longOpt("skip-commit")
-            .required(false)
             .desc("Do not 'commit', and thus changes won't be visible till a commit occurs.")
             .build(),
         Option.builder()
@@ -204,19 +202,16 @@ public class PostTool extends ToolBase {
                     .setSince("9.7")
                     .setDescription("Use --skip-commit instead")
                     .get())
-            .required(false)
             .desc("Do not 'commit', and thus changes won't be visible till a commit occurs.")
             .build(),
         Option.builder("o")
             .longOpt("optimize")
-            .required(false)
             .desc("Issue an optimize at end of posting documents.")
             .build(),
         Option.builder()
             .longOpt("mode")
             .hasArg()
             .argName("mode")
-            .required(false)
             .desc(
                 "Which mode the Post tool is running in, 'files' crawls local directory, 'web' crawls website, 'args' processes input args, and 'stdin' reads a command from standard in. default: files.")
             .build(),

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -334,14 +334,15 @@ public class RunExampleTool extends ToolBase {
       }
 
       if (exampledocsDir.isDirectory()) {
-        String updateUrl = String.format(Locale.ROOT, "%s/%s/update", solrUrl, collectionName);
         echo("Indexing tech product example docs from " + exampledocsDir.getAbsolutePath());
 
         String[] args =
             new String[] {
               "post",
-              "--solr-update-url",
-              updateUrl,
+              "--solr-url",
+              solrUrl,
+              "--name",
+              collectionName,
               "--type",
               "application/xml",
               exampledocsDir.getAbsolutePath() + "/*.xml"
@@ -416,13 +417,14 @@ public class RunExampleTool extends ToolBase {
                 + "        }\n");
 
         File filmsJsonFile = new File(exampleDir, "films/films.json");
-        String updateUrl = String.format(Locale.ROOT, "%s/%s/update", solrUrl, collectionName);
         echo("Indexing films example docs from " + filmsJsonFile.getAbsolutePath());
         String[] args =
             new String[] {
               "post",
-              "--solr-update-url",
-              updateUrl,
+              "--solr-url",
+              solrUrl,
+              "--name",
+              collectionName,
               "--type",
               "application/json",
               filmsJsonFile.getAbsolutePath()

--- a/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
@@ -85,8 +85,10 @@ public class PostToolTest extends SolrCloudTestCase {
 
     String[] args = {
       "post",
-      "--solr-update-url",
-      cluster.getJettySolrRunner(0).getBaseUrl() + "/" + collection + "/update",
+      "--solr-url",
+      cluster.getJettySolrRunner(0).getBaseUrl().toString(),
+      "--name",
+      collection,
       "--credentials",
       SecurityJson.USER_PASS,
       jsonDoc.getAbsolutePath()

--- a/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
@@ -243,8 +243,10 @@ public class TestExportTool extends SolrCloudTestCase {
 
       String[] args = {
         "export",
-        "-url",
-        cluster.getJettySolrRunner(0).getBaseUrl() + "/" + COLLECTION_NAME,
+        "--solr-url",
+        cluster.getJettySolrRunner(0).getBaseUrl().toString(),
+        "--name",
+        COLLECTION_NAME,
         "--credentials",
         SecurityJson.USER_PASS,
         "-out",

--- a/solr/core/src/test/org/apache/solr/cloud/SolrCloudExampleTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCloudExampleTest.java
@@ -115,8 +115,10 @@ public class SolrCloudExampleTest extends AbstractFullDistribZkTestBase {
 
     String[] argsForPost =
         new String[] {
-          "--solr-update-url",
-          solrUrl + "/" + testCollectionName + "/update",
+          "--solr-url",
+          solrUrl,
+          "--name",
+          testCollectionName,
           "--filetypes",
           "xml",
           exampleDocsDir.toAbsolutePath().toString()

--- a/solr/packaging/test/test_basic_auth.bats
+++ b/solr/packaging/test/test_basic_auth.bats
@@ -73,11 +73,11 @@ run solr create -c COLL_NAME
   assert_output --partial '1 files indexed.'
 
   # Test postlogs
-  run solr postlogs -u name:password --solr-collection-url http://localhost:${SOLR_PORT}/solr/COLL_NAME -rootdir ${SOLR_LOGS_DIR}/solr.log
+  run solr postlogs -u name:password --solr-url http://localhost:${SOLR_PORT} --name COLL_NAME -rootdir ${SOLR_LOGS_DIR}/solr.log
   assert_output --partial 'Committed'
   
   # Test export
-  #run solr export -u name:password --solr-collection-url "http://localhost:${SOLR_PORT}/solr/COLL_NAME" -query "*:*" -out "${BATS_TEST_TMPDIR}/output"
+  #run solr export -u name:password --solr-url "http://localhost:${SOLR_PORT} --name COLL_NAME" -query "*:*" -out "${BATS_TEST_TMPDIR}/output"
   #assert_output --partial 'Export complete'
   
 }

--- a/solr/packaging/test/test_basic_auth.bats
+++ b/solr/packaging/test/test_basic_auth.bats
@@ -69,7 +69,7 @@ run solr create -c COLL_NAME
   assert_output --partial "Created collection 'COLL_NAME'"
 
   # Test post
-  run solr post -u name:password -t application/xml --solr-update-url http://localhost:${SOLR_PORT}/solr/monitors/update ${SOLR_TIP}/example/exampledocs/monitor.xml
+  run solr post -u name:password -t application/xml --solr-url http://localhost:${SOLR_PORT} --name monitors ${SOLR_TIP}/example/exampledocs/monitor.xml
   assert_output --partial '1 files indexed.'
 
   # Test postlogs

--- a/solr/packaging/test/test_export.bats
+++ b/solr/packaging/test/test_export.bats
@@ -30,7 +30,7 @@ teardown() {
 
 @test "Check export command" {
   run solr start -c -e techproducts
-  run solr export --solr-collection-url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output"
+  run solr export --solr-url http://localhost:${SOLR_PORT} --name techproducts -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output"
 
   refute_output --partial 'Unrecognized option'
   assert_output --partial 'Export complete'

--- a/solr/packaging/test/test_export.bats
+++ b/solr/packaging/test/test_export.bats
@@ -29,7 +29,7 @@ teardown() {
 }
 
 @test "Check export command" {
-  run solr start -c -e techproducts
+  run solr start -e techproducts
   run solr export --solr-url http://localhost:${SOLR_PORT} --name techproducts -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output"
 
   refute_output --partial 'Unrecognized option'

--- a/solr/packaging/test/test_extraction.bats
+++ b/solr/packaging/test/test_extraction.bats
@@ -73,7 +73,7 @@ teardown() {
   }' "http://localhost:${SOLR_PORT}/solr/content_extraction/config"
   
   # We filter to pdf to invoke the Extract handler.
-  run solr post --filetypes pdf -url http://localhost:${SOLR_PORT}/solr/content_extraction/update ${SOLR_TIP}/example/exampledocs
+  run solr post --filetypes pdf --solr-url http://localhost:${SOLR_PORT} --name content_extraction ${SOLR_TIP}/example/exampledocs
 
   assert_output --partial '1 files indexed.'
   refute_output --partial 'ERROR'

--- a/solr/packaging/test/test_extraction.bats
+++ b/solr/packaging/test/test_extraction.bats
@@ -100,7 +100,7 @@ teardown() {
   }' "http://localhost:${SOLR_PORT}/solr/website_extraction/config"
   
   # Change to --recursive 1 to crawl multiple pages, but may be too slow.
-  run solr post --mode web --solr-update-url http://localhost:${SOLR_PORT}/solr/website_extraction/update --recursive 0 --delay 1 https://solr.apache.org/
+  run solr post --mode web --solr-url http://localhost:${SOLR_PORT} -c website_extraction --recursive 0 --delay 1 https://solr.apache.org/
 
   assert_output --partial 'POSTed web resource https://solr.apache.org (depth: 0)'
   refute_output --partial 'ERROR'

--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -74,6 +74,17 @@ teardown() {
   refute_output --partial 'ERROR'
 }
 
+@test "basic post with solr-url and collection" {
+
+  run solr create -c monitors_solr_url_param -d _default
+  assert_output --partial "Created collection 'monitors_solr_url_param'"
+
+  run solr post --type application/xml -c monitors_solr_url_param --solr-url http://localhost:${SOLR_PORT} ${SOLR_TIP}/example/exampledocs/monitor.xml
+
+  assert_output --partial '1 files indexed.'
+  refute_output --partial 'ERROR'
+}
+
 @test "basic post WITHOUT a type specified" {
 
   solr create -c monitors_no_type -d _default

--- a/solr/packaging/test/test_snapshots.bats
+++ b/solr/packaging/test/test_snapshots.bats
@@ -45,7 +45,7 @@ teardown() {
   run solr snapshot-create -c films --snapshot-name snapshot1 --solr-url http://localhost:${SOLR_PORT}
   assert_output --partial "Successfully created snapshot with name snapshot1 for collection films"  
   
-  run solr snapshot-delete -c films --snapshot-name snapshot1 -url http://localhost:${SOLR_PORT}
+  run solr snapshot-delete -c films --snapshot-name snapshot1 --solr-url http://localhost:${SOLR_PORT}
   assert_output --partial "Successfully deleted snapshot with name snapshot1 for collection films"
   
    # make sure you can create it again!

--- a/solr/packaging/test/test_ssl.bats
+++ b/solr/packaging/test/test_ssl.bats
@@ -606,7 +606,7 @@ teardown() {
   run solr api --solr-url "https://localhost:${SOLR2_PORT}/solr/test-single-shard/select?q=query4"
   assert_output --partial '"numFound":0'
 
-  run solr post --solr-update-url https://localhost:${SOLR_PORT}/solr/test/update ${SOLR_TIP}/example/exampledocs/books.csv
+  run solr post --solr-url https://localhost:${SOLR_PORT} -c test ${SOLR_TIP}/example/exampledocs/books.csv
 
   run solr api --solr-url "https://localhost:${SOLR_PORT}/solr/test/select?q=*:*"
   assert_output --partial '"numFound":10'

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrExporter.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrExporter.java
@@ -145,7 +145,7 @@ public class SolrExporter {
     Options mainOptions = new Options();
     Options deprecatedOptions = new Options();
 
-    // Change to -s and --solr-url in main once -s for --scrape-interval removed.
+    // Change to -s and --solr-url in main once deprecated -s flag for --scrape-interval is removed.
     Option baseUrlOption =
         Option.builder("b")
             .longOpt("base-url")
@@ -338,6 +338,7 @@ public class SolrExporter {
         defaultClusterId = makeShortHash(zkHost);
         scrapeConfiguration = SolrScrapeConfiguration.solrCloud(zkHost);
       } else if (commandLine.hasOption(baseUrlOption) || commandLine.hasOption(baseUrlDepOption)) {
+        log.warn("-b and --base-url will be replaced with -s and --solr-url in Solr 10");
         String baseUrl =
             commandLine.hasOption(baseUrlOption)
                 ? commandLine.getOptionValue(baseUrlOption)

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
@@ -437,7 +437,7 @@ Use `bin/solr post` to index some example documents to the SolrCloud collection 
 
 [source,console]
 ----
-$ bin/solr post --solr-update-url https://localhost:8984/solr/mycollection/update example/exampledocs/*.xml
+$ bin/solr post --solr-url https://localhost:8984 --name mycollection example/exampledocs/*.xml
 ----
 
 === Query Using curl

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
@@ -41,63 +41,37 @@ The basic usage of `bin/solr post` is:
 
 [source,plain]
 ----
-usage: post
+usage: bin/solr post [-c <NAME>] [-d <delay>] [--dry-run] [--format] [-ft <<type>[,<type>,...]>] [-h] [--mode <mode>]
+       [-o] [--out] [--params <<key>=<value>[&<key>=<value>...]>] [-r <recursive>] [-s <HOST>] [--skip-commit] [-t
+       <content-type>] [-u <credentials>] [--verbose]
+
+List of options:
  -c,--name <NAME>                                 Name of the collection.
- -d,--delay <delay>                               If recursive then delay
-                                                  will be the wait time
-                                                  between posts.  default:
+ -d,--delay <delay>                               If recursive then delay will be the wait time between posts.  default:
                                                   10 for web, 0 for files
-    --dry-run                                     Performs a dry run of
-                                                  the posting process
-                                                  without actually sending
-                                                  documents to Solr.  Only
-                                                  works with files mode.
-    --format                                      sends application/json
-                                                  content as Solr commands
-                                                  to /update instead of
+    --dry-run                                     Performs a dry run of the posting process without actually sending
+                                                  documents to Solr.  Only works with files mode.
+    --format                                      sends application/json content as Solr commands to /update instead of
                                                   /update/json/docs.
  -ft,--filetypes <<type>[,<type>,...]>            default:
-                                                  xml,json,jsonl,csv,pdf,d
-                                                  oc,docx,ppt,pptx,xls,xls
-                                                  x,odt,odp,ods,ott,otp,ot
-                                                  s,rtf,htm,html,txt,log
+                                                  xml,json,jsonl,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,
+                                                  ots,rtf,htm,html,txt,log
  -h,--help                                        Print this message.
-    --mode <mode>                                 Which mode the Post tool
-                                                  is running in, 'files'
-                                                  crawls local directory,
-                                                  'web' crawls website,
-                                                  'args' processes input
-                                                  args, and 'stdin' reads
-                                                  a command from standard
-                                                  in. default: files.
- -o,--optimize                                    Issue an optimize at end
-                                                  of posting documents.
-    --out                                         sends Solr response
-                                                  outputs to console.
- --params <<key>=<value>[&<key>=<value>...]>      values must be
-                                                  URL-encoded; these pass
-                                                  through to Solr update
-                                                  request.
- -r,--recursive <recursive>                       For web crawl, how deep
-                                                  to go. default: 1
-    --skip-commit                                 Do not 'commit', and
-                                                  thus changes won't be
-                                                  visible till a commit
+    --mode <mode>                                 Which mode the Post tool is running in, 'files' crawls local
+                                                  directory, 'web' crawls website, 'args' processes input args, and
+                                                  'stdin' reads a command from standard in. default: files.
+ -o,--optimize                                    Issue an optimize at end of posting documents.
+    --out                                         sends Solr response outputs to console.
+    --params <<key>=<value>[&<key>=<value>...]>   Values must be URL-encoded; these pass through to Solr update request.
+ -r,--recursive <recursive>                       For web crawl, how deep to go. default: 1
+ -s,--solr-url <HOST>                             Base Solr URL, which can be used to determine the zk-host if that's
+                                                  not known; defaults to: http://localhost:8983.
+    --skip-commit                                 Do not 'commit', and thus changes won't be visible till a commit
                                                   occurs.
- -t,--type <content-type>                         Specify a specific
-                                                  mimetype to use, such as
-                                                  application/json.
- -u,--credentials <credentials>                   Credentials in the
-                                                  format
-                                                  username:password.
-                                                  Example: --credentials
+ -t,--type <content-type>                         Specify a specific mimetype to use, such as application/json.
+ -u,--credentials <credentials>                   Credentials in the format username:password. Example: --credentials
                                                   solr:SolrRocks
- -url,--solr-update-url <UPDATEURL>               Solr Update URL, the
-                                                  full url to the update
-                                                  handler, including the
-                                                  /update.
- -v,--verbose                                     Enable more verbose
-                                                  command output.
+    --verbose                                     Enable verbose command output.
 
 ----
 

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/post-tool.adoc
@@ -24,7 +24,7 @@ To run it, open a window and enter:
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/gettingstarted/update example/films/films.json
+$ bin/solr post --solr-url http://localhost:8983 --name gettingstarted example/films/films.json
 ----
 
 This will contact the server at `localhost:8983`.
@@ -86,7 +86,7 @@ Index all JSON files into `gettingstarted`.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/gettingstarted/update *.json
+$ bin/solr post --solr-url http://localhost:8983 --name gettingstarted *.json
 ----
 
 === Indexing XML
@@ -95,21 +95,21 @@ Add all documents with file extension `.xml` to the collection named `gettingsta
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/gettingstarted/update *.xml
+$ bin/solr post --solr-url http://localhost:8983 --name gettingstarted *.xml
 ----
 
 Add all documents starting with `article` with file extension `.xml` to the `gettingstarted` collection on Solr running on port `8984`.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8984/solr/gettingstarted/update article*.xml
+$ bin/solr post --solr-url http://localhost:8984 --name gettingstarted article*.xml
 ----
 
 Send XML arguments to delete a document from `gettingstarted`.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/gettingstarted/update --mode args --type application/xml '<delete><id>42</id></delete>'
+$ bin/solr post --solr-url http://localhost:8983 --name gettingstarted --mode args --type application/xml '<delete><id>42</id></delete>'
 ----
 
 === Indexing CSV and JSON
@@ -125,7 +125,7 @@ Index a tab-separated file into `gettingstarted`:
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8984/solr/signals/update --params "separator=%09" --type text/csv data.tsv
+$ bin/solr post --solr-url http://localhost:8984 --name signals --params "separator=%09" --type text/csv data.tsv
 ----
 
 The content type (`-type`) parameter is required to treat the file as the proper type, otherwise it will be ignored and a WARNING logged as it does not know what type of content a .tsv file is.
@@ -137,21 +137,21 @@ Index a PDF file into `gettingstarted`.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/gettingstarted/update a.pdf
+$ bin/solr post --solr-url http://localhost:8983/solr --name gettingstarted a.pdf
 ----
 
 Automatically detect content types in a folder, and recursively scan it for documents for indexing into `gettingstarted`.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/gettingstarted/update afolder/
+$ bin/solr post --solr-url http://localhost:8983 --name gettingstarted  afolder/
 ----
 
 Automatically detect content types in a folder, but limit it to PPT and HTML files and index into `gettingstarted`.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/gettingstarted/update --filetypes ppt,html afolder/
+$ bin/solr post --solr-url http://localhost:8983 --name gettingstarted --filetypes ppt,html afolder/
 ----
 
 === Indexing to a Password Protected Solr (Basic Auth)
@@ -160,7 +160,7 @@ Index a PDF as the user "solr" with password "SolrRocks":
 
 [,console]
 ----
-$ bin/solr post -u solr:SolrRocks -url http://localhost:8983/solr/gettingstarted/update a.pdf
+$ bin/solr post -u solr:SolrRocks --solr-url http://localhost:8983 --name gettingstarted a.pdf
 ----
 
 === Crawling a Website to Index Documents 
@@ -181,7 +181,7 @@ Notice the `-out` providing raw responses from Solr.
 
 [,console]
 ----
-$ echo '{commit: {}}' | bin/solr post --mode stdin -url http://localhost:8983/solr/my_collection/update --out
+$ echo '{commit: {}}' | bin/solr post --mode stdin --solr-url http://localhost:8983 --name my_collection --out
 ----
 
 === Raw Data as Source for Indexing
@@ -190,5 +190,5 @@ Provide the raw document as a string for indexing.
 
 [,console]
 ----
-$ bin/solr post -url http://localhost:8983/solr/signals/update -mode args --type text/csv -out $'id,value\n1,0.47' 
+$ bin/solr post --solr-url http://localhost:8983 --name signals -mode args --type text/csv -out $'id,value\n1,0.47' 
 ----

--- a/solr/solr-ref-guide/modules/query-guide/pages/spatial-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/spatial-search.adoc
@@ -71,7 +71,7 @@ However, it's much bulkier than the raw coordinates for such simple data.
 Using the `bin/solr post` tool:
 
 [,console]
-$ bin/solr post -t "application/json" -url "http://localhost:8983/solr/mycollection/update?format=geojson" /path/to/geojson.file
+$ bin/solr post -t "application/json" --solr-url http://localhost:8983 --name mycollection --params "format=geojson" /path/to/geojson.file
 
 The key parameter to pass in with your request is:
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17489

# Description

See JIRA

# Solution

Deprecate old options in favour of `--solr-url` and `--name`.   I am really liking how this looks after going through the code...

Debating if we should be using `--collection` instead of `--name`....   That can be a seperate ticket.

# Tests

bats and java

