### PR TITLE
Fix xref references in Ref Guide

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/client-apis.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/client-apis.adoc
@@ -66,7 +66,7 @@ Parsing the responses is a slightly more thorny problem.
 Fortunately, Solr makes it easy to choose an output format that will be easy to handle on the client side.
 
 Specify a response format using the `wt` parameter in a query.
-The available response formats are documented in xref:query-guide:response-writers.adoc.
+The available response formats are documented in xref:query-guide:response-writers.adoc[Response Writers].
 
 Most client APIs hide this detail for you, so for many types of client applications, you won't ever have to specify a `wt` parameter.
 In JavaScript, however, the interface to Solr is a little closer to the metal, so you will need to add this parameter yourself.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/zookeeper-file-management.adoc
@@ -94,4 +94,4 @@ If you for example would like to enable authentication, you can push your `secur
 bin/solr zk cp file:local/file/path/to/security.json zk:/security.json -z localhost:2181
 ----
 
-NOTE: If you have defined `ZK_HOST` in `solr.in.sh`/`solr.in.cmd` (see xref:zookeeper-ensemble.adoc#updating-solr-include-files,Updating Solr Include Files>>) you can omit `-z <zk host string>` from the above command.
+NOTE: If you have defined `ZK_HOST` in `solr.in.sh`/`solr.in.cmd` (see xref:zookeeper-ensemble.adoc#updating-solr-include-files[Updating Solr Include Files]) you can omit `-z <zk host string>` from the above command.


### PR DESCRIPTION
Searched for "xref" in ref guide using javascript search thing, and found TWO broken links.  Fixing them.

No changes.txt.