### PR TITLE
SOLR-17456: TransactionLog ctor integrity

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/TransactionLog.java
+++ b/solr/core/src/java/org/apache/solr/update/TransactionLog.java
@@ -38,6 +38,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.DataInputInputStream;
@@ -221,8 +222,9 @@ public class TransactionLog implements Closeable {
         }
       } else {
         if (Files.exists(tlog)) {
-          log.warn("New transaction log already exists:{} size={}", tlog, Files.size(tlog));
-          return;
+          throw new SolrException(
+              ErrorCode.SERVER_ERROR,
+              "New transaction log already exists:" + tlog + " size=" + Files.size(tlog));
         }
 
         channel =
@@ -238,9 +240,6 @@ public class TransactionLog implements Closeable {
       }
 
       success = true;
-
-      assert ObjectReleaseTracker.track(this);
-
     } catch (IOException e) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
     } finally {
@@ -252,6 +251,7 @@ public class TransactionLog implements Closeable {
         }
       }
     }
+    assert ObjectReleaseTracker.track(this);
   }
 
   // for subclasses


### PR DESCRIPTION
The TransactionLog constructor can't handle an existing file being present; it shouldn't be there.  Should throw an exception in this case, NOT log a warning, leaving the object in a partially constructed state.

https://issues.apache.org/jira/browse/SOLR-17456

BTW I experienced this on a fork of Solr and I don't know the root cause.  Since applying the fix in this PR, I have not seen it since (perhaps by chance).  It should never happen!

Not sure if needs CHANGES.txt