### PR TITLE
Add an option in the gradle.properties for html junit reports

### DIFF
--- a/gradle/template.gradle.properties
+++ b/gradle/template.gradle.properties
@@ -49,6 +49,11 @@
 # tests.minheapsize=512m
 # tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1 -XX:ActiveProcessorCount=1
 #
+# If you want tests to produce an html report (which intellij provides a clickable link for
+# at the end of a failed build) set this to true, defaults to false to save a few seconds.
+#
+# tests.html=false
+#
 #################
 # Gradle Daemon #
 #################
@@ -97,6 +102,9 @@ org.gradle.workers.max=@MAX_WORKERS@
 
 # Maximum number of test JVMs forked per test task.
 tests.jvms=@TEST_JVMS@
+
+# By default skip html generation
+tests.html=false
 
 # Disable auto JVM provisioning (we don't use toolchains yet but want no surprises).
 org.gradle.java.installations.auto-download=false

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -153,7 +153,7 @@ allprojects {
       }
 
       // Disable HTML report generation. The reports are big and slow to generate.
-      reports.html.required = Boolean.parseBoolean(providers.gradleProperty("tests.html").get())
+      reports.html.required = Boolean.parseBoolean(providers.gradleProperty("tests.html").getOrElse("false"))
 
       // Set up logging.
       testLogging {

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -153,7 +153,7 @@ allprojects {
       }
 
       // Disable HTML report generation. The reports are big and slow to generate.
-      reports.html.required = false
+      reports.html.required = Boolean.parseBoolean(providers.gradleProperty("tests.html").get())
 
       // Set up logging.
       testLogging {


### PR DESCRIPTION
This is a simple enhancement that makes it easy to enable the html test report that gradle would normally produce (but we disable to save a few seconds). I frequently have a NO_COMMIT change list containing this, and so I've finally got around to formalizing it into a gradle.properties option so others can use it if they like. 

I find it far faster to click on the link displayed at the end of a failed build. YMMV, but now you won't have to edit anything that's version controlled to try it.