### PR TITLE
Fix assert tool url normalization

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/AssertTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/AssertTool.java
@@ -355,16 +355,16 @@ public class AssertTool extends ToolBase {
       ret += assertSolrNotRunning(cli.getOptionValue("not-started"));
     }
     if (cli.hasOption("c")) {
-      ret += assertSolrRunningInCloudMode(cli.getOptionValue("c"));
+      ret += assertSolrRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("c"), false));
     }
     if (cli.hasOption("cloud")) {
-      ret += assertSolrRunningInCloudMode(cli.getOptionValue("cloud"));
+      ret += assertSolrRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("cloud"), false));
     }
     if (cli.hasOption("C")) {
-      ret += assertSolrNotRunningInCloudMode(cli.getOptionValue("C"));
+      ret += assertSolrNotRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("C"), false));
     }
     if (cli.hasOption("not-cloud")) {
-      ret += assertSolrNotRunningInCloudMode(cli.getOptionValue("not-cloud"));
+      ret += assertSolrNotRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("not-cloud"), false));
     }
     return ret;
   }

--- a/solr/core/src/java/org/apache/solr/cli/AssertTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/AssertTool.java
@@ -32,7 +32,6 @@ import org.apache.commons.cli.Option;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.HealthCheckRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
@@ -355,16 +354,16 @@ public class AssertTool extends ToolBase {
       ret += assertSolrNotRunning(cli.getOptionValue("not-started"));
     }
     if (cli.hasOption("c")) {
-      ret += assertSolrRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("c"), false));
+      ret += assertSolrRunningInCloudMode(cli.getOptionValue("c"));
     }
     if (cli.hasOption("cloud")) {
-      ret += assertSolrRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("cloud"), false));
+      ret += assertSolrRunningInCloudMode(cli.getOptionValue("cloud"));
     }
     if (cli.hasOption("C")) {
-      ret += assertSolrNotRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("C"), false));
+      ret += assertSolrNotRunningInCloudMode(cli.getOptionValue("C"));
     }
     if (cli.hasOption("not-cloud")) {
-      ret += assertSolrNotRunningInCloudMode(SolrCLI.normalizeSolrUrl(cli.getOptionValue("not-cloud"), false));
+      ret += assertSolrNotRunningInCloudMode(cli.getOptionValue("not-cloud"));
     }
     return ret;
   }
@@ -531,7 +530,7 @@ public class AssertTool extends ToolBase {
   }
 
   private static boolean runningSolrIsCloud(String url) throws Exception {
-    try (final SolrClient client = new Http2SolrClient.Builder(url).build()) {
+    try (final SolrClient client = SolrCLI.getSolrClient(url)) {
       final SolrRequest<CollectionAdminResponse> request =
           new CollectionAdminRequest.ClusterStatus();
       final CollectionAdminResponse response = request.process(client);

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -315,8 +315,7 @@ public class PostTool extends ToolBase {
         throw new IllegalArgumentException(
             "Must specify -c / --name parameter with --solr-url to post documents.");
       }
-      String url =
-          SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name") + "/update";
+      String url = SolrCLI.normalizeSolrUrl(cli) + "/" + cli.getOptionValue("name") + "/update";
       solrUpdateUrl = new URI(url);
 
     } else if (cli.hasOption("solr-update-url")) {

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -315,7 +315,8 @@ public class PostTool extends ToolBase {
         throw new IllegalArgumentException(
             "Must specify -c / --name parameter with --solr-url to post documents.");
       }
-      String url = SolrCLI.normalizeSolrUrl(cli) + "/" + cli.getOptionValue("name") + "/update";
+      String url =
+          SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name") + "/update";
       solrUpdateUrl = new URI(url);
 
     } else if (cli.hasOption("solr-update-url")) {

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -316,7 +316,7 @@ public class PostTool extends ToolBase {
             "Must specify -c / --name parameter with --solr-url to post documents.");
       }
       String url =
-          SolrCLI.normalizeSolrUrl(cli) + "/solr/" + cli.getOptionValue("name") + "/update";
+          SolrCLI.normalizeSolrUrl(cli) + "/" + cli.getOptionValue("name") + "/update";
       solrUpdateUrl = new URI(url);
 
     } else if (cli.hasOption("solr-update-url")) {

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -315,8 +315,7 @@ public class PostTool extends ToolBase {
         throw new IllegalArgumentException(
             "Must specify -c / --name parameter with --solr-url to post documents.");
       }
-      String url =
-          SolrCLI.normalizeSolrUrl(cli) + "/" + cli.getOptionValue("name") + "/update";
+      String url = SolrCLI.normalizeSolrUrl(cli) + "/" + cli.getOptionValue("name") + "/update";
       solrUpdateUrl = new URI(url);
 
     } else if (cli.hasOption("solr-update-url")) {

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.invoke.MethodHandles;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
@@ -74,12 +75,16 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.util.RTimer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 public class PostTool extends ToolBase {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final String DEFAULT_FILE_TYPES =
       "xml,json,jsonl,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,ots,rtf,htm,html,txt,log";
@@ -315,7 +320,17 @@ public class PostTool extends ToolBase {
         throw new IllegalArgumentException(
             "Must specify -c / --name parameter with --solr-url to post documents.");
       }
-      String url = SolrCLI.normalizeSolrUrl(cli) + "/" + cli.getOptionValue("name") + "/update";
+
+      String solrUrl = cli.getOptionValue("solr-url");
+
+      String hostContext = System.getProperty("hostContext", "/solr");
+      if (hostContext.isBlank()) {
+        log.warn("Invalid hostContext {} provided, setting to /solr", hostContext);
+        hostContext = "/solr";
+      }
+
+      solrUrl = SolrCLI.normalizeSolrUrl(solrUrl, true, hostContext) + hostContext;
+      String url = solrUrl + "/" + cli.getOptionValue("name") + "/update";
       solrUpdateUrl = new URI(url);
 
     } else if (cli.hasOption("solr-update-url")) {

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -792,10 +792,10 @@ public class SolrCLI implements CLIO {
 
           String firstLiveNode = liveNodes.iterator().next();
           solrUrl = ZkStateReader.from(cloudSolrClient).getBaseUrlForNodeName(firstLiveNode);
-          solrUrl = normalizeSolrUrl(solrUrl, false);
         }
       }
     }
+    solrUrl = normalizeSolrUrl(solrUrl, false);
     return solrUrl;
   }
 

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -792,11 +792,10 @@ public class SolrCLI implements CLIO {
 
           String firstLiveNode = liveNodes.iterator().next();
           solrUrl = ZkStateReader.from(cloudSolrClient).getBaseUrlForNodeName(firstLiveNode);
-          // solrUrl = normalizeSolrUrl(solrUrl, false);
+          solrUrl = normalizeSolrUrl(solrUrl, false);
         }
       }
     }
-    solrUrl = normalizeSolrUrl(solrUrl, false);
     return solrUrl;
   }
 

--- a/solr/packaging/test/test_assert.bats
+++ b/solr/packaging/test/test_assert.bats
@@ -42,3 +42,17 @@ teardown() {
 
   run ! solr assert --cloud http://localhost:${SOLR_PORT} --exitcode
 }
+
+@test "assert for cloud mode" {
+  run solr start --cloud
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+
+  run solr assert --cloud http://localhost:${SOLR_PORT}
+  refute_output --partial "ERROR"
+
+  run solr assert --not-cloud http://localhost:${SOLR_PORT}/solr
+  assert_output --partial "needn't include Solr's context-root"
+  assert_output --partial "ERROR: Solr is not running in standalone mode"
+
+  run ! solr assert --not-cloud http://localhost:${SOLR_PORT} --exitcode
+}

--- a/solr/packaging/test/test_placement_plugin.bats
+++ b/solr/packaging/test/test_placement_plugin.bats
@@ -31,7 +31,7 @@ teardown() {
 
 @test "Affinity placement plugin using sysprop" {
   run solr start -c -Dsolr.placementplugin.default=affinity
-  solr assert --cloud http://localhost:${SOLR_PORT}/solr --timeout 3000
+  solr assert --cloud http://localhost:${SOLR_PORT} --timeout 3000
   run solr create -c COLL_NAME
   collection_exists COLL_NAME
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to affinity'
@@ -40,7 +40,7 @@ teardown() {
 @test "Random placement plugin using ENV" {
   export SOLR_PLACEMENTPLUGIN_DEFAULT=random
   run solr start -c
-  solr assert --cloud http://localhost:${SOLR_PORT}/solr --timeout 3000
+  solr assert --cloud http://localhost:${SOLR_PORT} --timeout 3000
   run solr create -c COLL_NAME
   collection_exists COLL_NAME
   assert_file_contains "${SOLR_LOGS_DIR}/solr.log" 'Default replica placement plugin set in solr\.placementplugin\.default to random'

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -53,7 +53,7 @@ teardown() {
 @test "start provides warning about SolrCloud mode" {
   run solr start
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
-  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.'
+  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --user-managed flag to run in User Managed (aka Standalone) mode.'
   solr stop
 }
 

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -53,7 +53,7 @@ teardown() {
 @test "start provides warning about SolrCloud mode" {
   run solr start
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
-  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --user-managed flag to run in User Managed (aka Standalone) mode.'
+  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --standalone flag to run in Standalone mode.'
   solr stop
 }
 


### PR DESCRIPTION
Draft PR to get a green state in branch_9x

Tests used to pass on branch_9x a few days ago. Some of the many `SolrCLI` changes touched the urlNormalization stuff so that you needed to add `/solr` at the end of some URLs passed to Solr.

In particular this was true for `AssertTool`, which I fix here by getting the SolrClient from SolrCLI util method instead of constructing an `Http2HttpSolrClient` manually. The difference is that the former adds a /solr before constructing the client, and this is consistent with other client initializations in AssertTool.

The whole Solr Base Path and `/solr` suffix is a mess, and it is different in main than in branch_9x. So this will keep cropping up for as long as we backport stuff from 10 to 9 :( 