### PR TITLE
SOLR-17467: Fix Windows start script for default / cloud mode

### DIFF
--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -904,7 +904,7 @@ if !JAVA_MAJOR_VERSION! LSS 9  (
 )
 
 IF NOT "%ZK_HOST%"=="" set SOLR_MODE=solrcloud
-IF NOT "%SOLR_MODE%"=="" set SOLR_MODE=solrcloud
+IF "%SOLR_MODE%"=="" set SOLR_MODE=solrcloud
 
 IF "%SOLR_MODE%"=="solrcloud" (
   IF "%ZK_CLIENT_TIMEOUT%"=="" set "ZK_CLIENT_TIMEOUT=30000"
@@ -941,7 +941,7 @@ IF "%SOLR_MODE%"=="solrcloud" (
   IF EXIST "%SOLR_HOME%\collection1\core.properties" set "CLOUD_MODE_OPTS=!CLOUD_MODE_OPTS! -Dbootstrap_confdir=./solr/collection1/conf -Dcollection.configName=myconf -DnumShards=1"
 ) ELSE (
   REM change Cloud mode to User Managed mode with flag
-  set "CLOUD_MODE_OPTS=--user-managed"
+  set "CLOUD_MODE_OPTS="
   IF NOT EXIST "%SOLR_HOME%\solr.xml" (
     IF "%SOLR_SOLRXML_REQUIRED%"=="true" (
       set "SCRIPT_ERROR=Solr home directory %SOLR_HOME% must contain solr.xml!"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17467

# Description

The current changes of this issue that were introduced in #2729  broke the start script on Windows. Executing `bin\solr.cmd start` failed with errors. See https://github.com/apache/solr/pull/2729#issuecomment-2424106562 for details.

# Solution

Changing these two lines seems to solve the issue. The one change makes sense, the other one doesn't. I guess it's magic. 😕 

@epugh I added you as reviewer since you have made most of the work in the original PR and should better understand the logic of the changes.

# Tests

_No tests were modified._

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
