### PR TITLE
SOLR-17504: CoreContainer calls UpdateHandler.commit.

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/TimeOut.java
+++ b/solr/core/src/java/org/apache/solr/util/TimeOut.java
@@ -28,6 +28,10 @@ public class TimeOut {
   private final long timeoutAt, startTime;
   private final TimeSource timeSource;
 
+  public TimeOut(long intervalSeconds) {
+    this(intervalSeconds, TimeUnit.SECONDS, TimeSource.NANO_TIME);
+  }
+
   public TimeOut(long interval, TimeUnit unit, TimeSource timeSource) {
     this.timeSource = timeSource;
     startTime = timeSource.getTimeNs();

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -59,7 +59,7 @@
 
   <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
-  <updateHandler class="solr.DirectUpdateHandler2">
+  <updateHandler class="${solr.updateHandler:solr.DirectUpdateHandler2}">
 
     <autoCommit>
       <maxTime>${solr.autoCommit.maxTime:-1}</maxTime>

--- a/solr/core/src/test/org/apache/solr/update/DirectUpdateHandlerWithUpdateLogTest.java
+++ b/solr/core/src/test/org/apache/solr/update/DirectUpdateHandlerWithUpdateLogTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.util.LogLevel;
+import org.apache.solr.util.TimeOut;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@LogLevel("org.apache.solr.update=INFO")
+public class DirectUpdateHandlerWithUpdateLogTest extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    System.setProperty("solr.updateHandler", SpyingUpdateHandler.class.getName());
+    initCore("solrconfig.xml", "schema11.xml");
+  }
+
+  @Test
+  public void testShouldCommitHook() throws Exception {
+    // Given a core.
+    SolrCore core = h.getCore();
+    assertNotNull(core);
+    SpyingUpdateHandler updater = (SpyingUpdateHandler) core.getUpdateHandler();
+    updater.shouldCommitCallCount.set(0);
+
+    // When we add a doc and commit.
+    assertU(adoc("id", "1"));
+    assertU(commit());
+    // Then the shouldCommit hook is called.
+    assertEquals(1, updater.shouldCommitCallCount.get());
+
+    // When we add a doc and soft commit.
+    assertU(adoc("id", "2"));
+    assertU(commit("softCommit", "true"));
+    // Then the shouldCommit hook is not called.
+    assertEquals(1, updater.shouldCommitCallCount.get());
+    // And when we commit.
+    assertU(commit());
+    // Then the shouldCommit hook is called.
+    assertEquals(2, updater.shouldCommitCallCount.get());
+
+    // When we commit with no updates (empty commit).
+    assertU(commit());
+    // Then the shouldCommit hook is called (may commit only user metadata).
+    assertEquals(3, updater.shouldCommitCallCount.get());
+
+    // When we add a doc, do not commit, and close the IndexWriter.
+    assertU(adoc("id", "3"));
+    h.close();
+    // Then the shouldCommit hook is called.
+    new TimeOut(10)
+        .waitFor(
+            "Timeout waiting for should commit hook",
+            () -> updater.shouldCommitCallCount.get() == 4);
+  }
+
+  public static class SpyingUpdateHandler extends DirectUpdateHandler2 {
+
+    final AtomicInteger shouldCommitCallCount = new AtomicInteger();
+
+    public SpyingUpdateHandler(SolrCore core) {
+      super(core);
+    }
+
+    public SpyingUpdateHandler(SolrCore core, UpdateHandler updateHandler) {
+      super(core, updateHandler);
+    }
+
+    @Override
+    protected boolean shouldCommit(CommitUpdateCommand cmd, IndexWriter writer) throws IOException {
+      shouldCommitCallCount.incrementAndGet();
+      return super.shouldCommit(cmd, writer);
+    }
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17504

# Description

This proposal is about unifying calls to UpdateHandler.commit.

CoreContainer.reload may call directly IndexWriter.commit if the core to reload is readonly (property of the Collection). This is an issue because it bypasses some logic in UpdateHandler.commit. In addition, the current code commits without taking the commit lock.

DirectUpdateHandler2.closeWriter may commit if the update log is not empty (not committed yet). But it does not call DirectUpdateHandler2.commit(), it copies commit() code instead for some reasons (comments in the code mention test failures). 

# Solution

Make CoreContainer.reload call UpdateHandler.commit.

Add the same call to DirectUpdateHandler2.shouldCommit() as in the commit() method, otherwise commit metadata are lost. In addition shouldCommit() can be extended correctly, for example in the solr-sandbox encryption module which needs to intercept calls to shouldCommit().

# Tests

A new DirectUpdateHandlerWithUpdateLogTest is added to test specifically that the UpdateHandler.shouldCommit hook is called. It's a new test because it requires the update log to test the UpdateHandler.closeWriter logic, but DirectUpdateHandlerTest does not support the update log.