### PR TITLE
Resolve CLI tool issues for hostContext "/"

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/SimplePostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/SimplePostTool.java
@@ -19,6 +19,7 @@ package org.apache.solr.cli;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import jakarta.ws.rs.core.UriBuilder;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -377,38 +378,34 @@ public class SimplePostTool {
   private void doWebMode() {
     reset();
     int numPagesPosted = 0;
-    try {
-      if (type != null) {
-        fatal("Specifying content-type with \"-Ddata=web\" is not supported");
-      }
-      if (args[0].equals("-")) {
-        // Skip posting url if special param "-" given
-        return;
-      }
-      // Set Extracting handler as default
-      solrUrl = appendUrlPath(solrUrl, "/extract");
-
-      info("Posting web pages to Solr url " + solrUrl);
-      auto = true;
-      info(
-          "Entering auto mode. Indexing pages with content-types corresponding to file endings "
-              + fileTypes);
-      if (recursive > 0) {
-        if (recursive > MAX_WEB_DEPTH) {
-          recursive = MAX_WEB_DEPTH;
-          warn("Too large recursion depth for web mode, limiting to " + MAX_WEB_DEPTH + "...");
-        }
-        if (delay < DEFAULT_WEB_DELAY) {
-          warn(
-              "Never crawl an external web site faster than every 10 seconds, your IP will probably be blocked");
-        }
-        info("Entering recursive mode, depth=" + recursive + ", delay=" + delay + "s");
-      }
-      numPagesPosted = postWebPages(args, 0, out);
-      info(numPagesPosted + " web pages indexed.");
-    } catch (URISyntaxException e) {
-      fatal("Wrong URL trying to append /extract to " + solrUrl);
+    if (type != null) {
+      fatal("Specifying content-type with \"-Ddata=web\" is not supported");
     }
+    if (args[0].equals("-")) {
+      // Skip posting url if special param "-" given
+      return;
+    }
+    // Set Extracting handler as default
+    solrUrl = UriBuilder.fromUri(solrUrl).path("/extract").build();
+
+    info("Posting web pages to Solr url " + solrUrl);
+    auto = true;
+    info(
+        "Entering auto mode. Indexing pages with content-types corresponding to file endings "
+            + fileTypes);
+    if (recursive > 0) {
+      if (recursive > MAX_WEB_DEPTH) {
+        recursive = MAX_WEB_DEPTH;
+        warn("Too large recursion depth for web mode, limiting to " + MAX_WEB_DEPTH + "...");
+      }
+      if (delay < DEFAULT_WEB_DELAY) {
+        warn(
+            "Never crawl an external web site faster than every 10 seconds, your IP will probably be blocked");
+      }
+      info("Entering recursive mode, depth=" + recursive + ", delay=" + delay + "s");
+    }
+    numPagesPosted = postWebPages(args, 0, out);
+    info(numPagesPosted + " web pages indexed.");
   }
 
   private void doStdinMode() {
@@ -862,7 +859,7 @@ public class SimplePostTool {
         // TODO: from being interpreted as Solr documents internally
         if (type.equals("application/json") && !FORMAT_SOLR.equals(format)) {
           suffix = "/json/docs";
-          String urlStr = appendUrlPath(solrUrl, suffix).toString();
+          String urlStr = UriBuilder.fromUri(solrUrl).path(suffix).build().toString();
           url = URI.create(urlStr);
         } else if (type.equals("application/xml")
             || type.equals("text/csv")
@@ -871,7 +868,7 @@ public class SimplePostTool {
         } else {
           // SolrCell
           suffix = "/extract";
-          String urlStr = appendUrlPath(solrUrl, suffix).toString();
+          String urlStr = UriBuilder.fromUri(solrUrl).path(suffix).build().toString();
           if (!urlStr.contains("resource.name")) {
             urlStr =
                 appendParam(
@@ -898,8 +895,6 @@ public class SimplePostTool {
               + (mockMode ? " MOCK!" : ""));
       is = new FileInputStream(file);
       postData(is, file.length(), output, type, url);
-    } catch (URISyntaxException e) {
-      warn("Not valid URL");
     } catch (IOException e) {
       warn("Can't open/read file: " + file);
     } finally {
@@ -911,17 +906,6 @@ public class SimplePostTool {
         fatal("IOException while closing file: " + e);
       }
     }
-  }
-
-  /**
-   * Appends to the path of the URI
-   *
-   * @param uri the URI
-   * @param append the path to append
-   * @return the final URI version
-   */
-  protected static URI appendUrlPath(URI uri, String append) throws URISyntaxException {
-    return PostTool.appendUrlPath(uri, append);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -739,7 +739,7 @@ public class SolrCLI implements CLIO {
         hostContext = hostContext.substring(0, hostContext.length() - 1);
       }
       // Only consider URI path component when normalizing hostContext
-      if (urlPath.contains(hostContext)) {
+      if (hostContext != null && !hostContext.isBlank() && urlPath.contains(hostContext)) {
         String newSolrUrl =
             uri.resolve(urlPath.substring(0, urlPath.indexOf(hostContext)) + "/").toString();
         if (logUrlFormatWarning) {

--- a/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/PostToolTest.java
@@ -240,28 +240,6 @@ public class PostToolTest extends SolrCloudTestCase {
   }
 
   @Test
-  public void testAppendUrlPath() {
-    assertEquals(
-        URI.create("http://[ff01::114]/a?foo=bar"),
-        PostTool.appendUrlPath(URI.create("http://[ff01::114]?foo=bar"), "/a"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a?foo=bar"),
-        PostTool.appendUrlPath(URI.create("http://[ff01::114]/?foo=bar"), "/a"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        PostTool.appendUrlPath(URI.create("http://[ff01::114]/a?foo=bar"), "/b"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        PostTool.appendUrlPath(URI.create("http://[ff01::114]/a/?foo=bar"), "/b"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        PostTool.appendUrlPath(URI.create("http://[ff01::114]/a?foo=bar"), "b"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        PostTool.appendUrlPath(URI.create("http://[ff01::114]/a/?foo=bar"), "b"));
-  }
-
-  @Test
   public void testGuessType() {
     File f = new File("foo.doc");
     assertEquals("application/msword", PostTool.guessType(f));

--- a/solr/core/src/test/org/apache/solr/cli/SimplePostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/SimplePostToolTest.java
@@ -156,28 +156,6 @@ public class SimplePostToolTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testAppendUrlPath() throws URISyntaxException {
-    assertEquals(
-        URI.create("http://[ff01::114]/a?foo=bar"),
-        SimplePostTool.appendUrlPath(URI.create("http://[ff01::114]?foo=bar"), "/a"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a?foo=bar"),
-        SimplePostTool.appendUrlPath(URI.create("http://[ff01::114]/?foo=bar"), "/a"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        SimplePostTool.appendUrlPath(URI.create("http://[ff01::114]/a?foo=bar"), "/b"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        SimplePostTool.appendUrlPath(URI.create("http://[ff01::114]/a/?foo=bar"), "/b"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        SimplePostTool.appendUrlPath(URI.create("http://[ff01::114]/a?foo=bar"), "b"));
-    assertEquals(
-        URI.create("http://[ff01::114]/a/b?foo=bar"),
-        SimplePostTool.appendUrlPath(URI.create("http://[ff01::114]/a/?foo=bar"), "b"));
-  }
-
-  @Test
   public void testGuessType() {
     File f = new File("foo.doc");
     assertEquals("application/msword", SimplePostTool.guessType(f));


### PR DESCRIPTION
# Description

This is the continuation of #2778, as it seems there are some special cases that cause URL parsing issues.

# Solution

The changes leverage jakarta's `UriBuilder` to avoid custom logic for URL path concatenation, which seems to cause some issues for cases where path segments like the `hostContext` may be `/`. Additionally, the currently used `SolrCLI#normalizeSolrUrl`is updated to behave differently for the special case where `hostContext` is `/`.

Any usage of `PostTool#appendPath` is replaced to avoid custom concatenation.

# Tests

Since the `appendPath` method is removed, the tests for that method are also removed.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
