### PR TITLE
SOLR-17467: Fix Windows start script on 9x and optimize deprecation messages

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -775,7 +775,15 @@ if [ $# -gt 0 ]; then
         -c|--cloud|-cloud)
             SOLR_MODE="solrcloud"
             PASS_TO_RUN_EXAMPLE+=("-c")
+
+            echo -e "Solr will start in SolrCloud mode by default in version 10, and you will no longer need to pass in -c or --cloud flag.\n"
             shift
+        ;;
+        --user-managed)
+          # Allow the user to use the user-managed flag to suppress the warning about th change
+          # of the default mode in v10.
+          SOLR_MODE="user-managed"
+          shift
         ;;
         -d|--dir|-dir|--server-dir)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
@@ -1181,11 +1189,18 @@ if [[ -n "${ZK_HOST:-}" ]]; then
   SOLR_MODE="solrcloud"
 fi
 
+if [[ -z ${SOLR_MODE:-} ]]; then
+  # User has not provided any option for the mode (--cloud/--user-managed), therefore
+  # stay on user-managed mode in 9.x to avoid behavior changing / breaking changes
+  SOLR_MODE="user-managed"
+  # and notify that staying the default option (not providing --user-managed) will affect
+  # future execution
+  echo -e "Solr will start in SolrCloud mode by default in version 10, and you will have to provide --user-managed if you want to stay on the user-managed (aka. standalone) mode.\n"
+fi
+
 if [ "${SOLR_MODE:-}" == 'solrcloud' ]; then
   : "${ZK_CLIENT_TIMEOUT:=30000}"
   CLOUD_MODE_OPTS=("-DzkClientTimeout=$ZK_CLIENT_TIMEOUT")
-
-  echo -e "\nSolr will start in SolrCloud mode by default in version 10, even if no -c or --cloud flag is specified.\n"
   
   if [ -n "${ZK_HOST:-}" ]; then
     CLOUD_MODE_OPTS+=("-DzkHost=$ZK_HOST")
@@ -1218,8 +1233,6 @@ else
     echo -e "\nSolr home directory $SOLR_HOME must contain a solr.xml file!\n"
     exit 1
   fi
-  
-  echo -e "\nSolr will start in SolrCloud mode by default in version 10.  You will need to pass in --user-managed flag to run in User Managed (aka Standalone) mode.\n"
 fi
 
 # Exit if old syntax found

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -50,10 +50,27 @@ teardown() {
 
 }
 
-@test "start provides warning about SolrCloud mode" {
+@test "start warns about SolrCloud mode if no mode specified" {
   run solr start
-  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
-  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10.  You will need to pass in --user-managed flag to run in User Managed (aka Standalone) mode.'
+  # Default behavior should be user-managed mode in Solr 9
+  solr assert --not-cloud http://localhost:${SOLR_PORT} --timeout 5000
+  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10'
+  assert_output --partial 'you will have to provide --user-managed'
+  solr stop
+}
+
+@test "start warns about SolrCloud mode if --cloud used" {
+  run solr start --cloud
+  solr assert --cloud http://localhost:${SOLR_PORT} --timeout 5000
+  assert_output --partial 'Solr will start in SolrCloud mode by default in version 10'
+  assert_output --partial 'you will no longer need to pass in -c or --cloud flag'
+  solr stop
+}
+
+@test "start doesn't warn about SolrCloud mode if --user-managed used" {
+  run solr start --user-managed
+  solr assert --not-cloud http://localhost:${SOLR_PORT} --timeout 5000
+  refute_output --partial 'Solr will start in SolrCloud mode by default in version 10'
   solr stop
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17467

# Description

The Windows start script on 9x behaves differently than on main / 10.0, and fails with the message "mode. was unexpected at this time.". This mesage is coming from the deprecation warnings.

# Solution

The fix moves the deprecation warnings to the dedicated mode setter functions and uses `echo` instead of `@echo`, which probably caused the execution error.

Additionally, this commit adds support for the `--user-managed` mode that allows the user to suppress the deprecation warning by being explicit about the current mode.

# Tests

Existing tests were updated to reflect the updated messages and confirm the behavior for `--user-managed`, `--cloud` and no option (default fallback).

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
