### PR TITLE
Fix release wizard to remove from Solr space before attempting Lucene

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1871,11 +1871,11 @@ groups:
       commands:
       - !Command
         cmd: |
-          svn rm -m "Stop publishing old Solr releases"{% for ver in mirrored_versions_to_delete %}  https://dist.apache.org/repos/dist/release/lucene/solr/{{ ver }}{% endfor %}
-        logfile: svn-rm-solr.log
-        comment: Delete from Lucene dist area
-      - !Command
-        cmd: |
           svn rm -m "Stop publishing old Solr releases"{% for ver in mirrored_versions_to_delete %}  https://dist.apache.org/repos/dist/release/solr/solr/{{ ver }}{% endfor %}
         logfile: svn-rm-solr.log
         comment: Delete from new Solr dist area
+      - !Command
+        cmd: |
+          svn rm -m "Stop publishing old Solr releases"{% for ver in mirrored_versions_to_delete %}  https://dist.apache.org/repos/dist/release/lucene/solr/{{ ver }}{% endfor %}
+        logfile: svn-rm-solr.log
+        comment: Delete from Lucene dist area

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1864,9 +1864,7 @@ groups:
       root_folder: '{{ git_checkout_folder }}'
       commands_text: |
         Run these commands to delete proposed versions from distribution directory.
-        Note, as long as we have some releases (7.x, 8.x) in Lucene dist repo and other
-        releases (9.0 ->) in the Solr dist repo, we may need to delete two places.
-
+        
         WARNING: Validate that the proposal is correct!
       commands:
       - !Command
@@ -1874,8 +1872,3 @@ groups:
           svn rm -m "Stop publishing old Solr releases"{% for ver in mirrored_versions_to_delete %}  https://dist.apache.org/repos/dist/release/solr/solr/{{ ver }}{% endfor %}
         logfile: svn-rm-solr.log
         comment: Delete from new Solr dist area
-      - !Command
-        cmd: |
-          svn rm -m "Stop publishing old Solr releases"{% for ver in mirrored_versions_to_delete %}  https://dist.apache.org/repos/dist/release/lucene/solr/{{ ver }}{% endfor %}
-        logfile: svn-rm-solr.log
-        comment: Delete from Lucene dist area


### PR DESCRIPTION
We should just remove attempting to cleanup the Lucene space once we do the Solr 10.0 release. Right now the wizard fails when it tries to cleanup the Lucene space because the 9x Solr releases are not found there.