### PR TITLE
Fix StatusTool related issues on Windows

### DIFF
--- a/gradle/testing/randomization/policies/solr-tests.policy
+++ b/gradle/testing/randomization/policies/solr-tests.policy
@@ -255,7 +255,8 @@ grant {
 
   // Run java
   permission java.io.FilePermission "${java.home}${/}-", "execute";
-  permission java.io.FilePermission "C:\\Windows\\*\\wmic.exe", "execute";
+  // Required by SolrProcessManager on Windows to find Solr processes, used by StatusTool (CLI)
+  permission java.io.FilePermission "<<ALL FILES>>", "execute";
 };
 
 // Grant all permissions to Gradle test runner classes.

--- a/solr/core/src/test/org/apache/solr/cli/SolrProcessManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/SolrProcessManagerTest.java
@@ -85,7 +85,7 @@ public class SolrProcessManagerTest extends SolrTestCase {
     // Get the path to the java executable from the current JVM
     String classPath =
         Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
-            .filter(p -> p.contains("solr/core/build"))
+            .filter(p -> p.contains("solr") && p.contains("core") && p.contains("build"))
             .collect(Collectors.joining(File.pathSeparator));
     ProcessBuilder processBuilder =
         new ProcessBuilder(


### PR DESCRIPTION
# Description

After #2712 the introduced changes were causing file permissions errors on Windows systems.

# Solution

This PR extends the required permissions to all files for Windows, allowing it to run `wmic` without limitations to find and filter processes in the java tests. This permission is not needed when running the `StatusTool` through the CLI, as the Security Manager is not interfering there.

The error returned in test messages mentions:

> access denied ("java.io.FilePermission" "\<\<ALL FILES\>\>" "execute")

#### IMPORTANT: This PR edits the test security policies and grants the execute permission to all files.

# Tests

The PR fixes an issue in the `PATH` filtering logic for determining the classpath on Windows. Since on Windows an escaped backslash (`\\`) is used, path segments are checked individually instead.

Changes should be backported to `branch_9x`.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
