### PR TITLE
SOLR-17515: Always init Http2SolrClient authStore

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/RecoveryZkTestWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/cloud/RecoveryZkTestWithAuth.java
@@ -27,6 +27,7 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudLegacySolrClient;
+import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
@@ -43,6 +44,15 @@ import org.junit.Test;
 public class RecoveryZkTestWithAuth extends SolrCloudTestCase {
   @BeforeClass
   public static void setupCluster() throws Exception {
+    // Periodically mimic the sysprops set by bin/solr when it knows auth is active (see SOLR-17515
+    // for context)
+    if (rarely()) {
+      System.setProperty(
+          HttpClientUtil.SYS_PROP_HTTP_CLIENT_BUILDER_FACTORY,
+          "org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory");
+      System.setProperty("basicauth", SecurityJson.USER_PASS);
+    }
+
     cluster =
         configureCluster(1)
             .addConfig("conf", configset("cloud-minimal"))

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -133,6 +133,8 @@ public class Http2SolrClient extends HttpSolrClientBase {
       if (this.executor == null) {
         this.executor = builder.executor;
       }
+
+      initAuthStoreFromExistingClient(httpClient);
       this.closeClient = false;
     } else {
       this.httpClient = createHttpClient(builder);
@@ -146,6 +148,11 @@ public class Http2SolrClient extends HttpSolrClientBase {
     this.httpClient.setFollowRedirects(Boolean.TRUE.equals(builder.followRedirects));
 
     assert ObjectReleaseTracker.track(this);
+  }
+
+  private void initAuthStoreFromExistingClient(HttpClient httpClient) {
+    assert httpClient.getAuthenticationStore() instanceof AuthenticationStoreHolder;
+    this.authenticationStore = (AuthenticationStoreHolder) httpClient.getAuthenticationStore();
   }
 
   @Deprecated(since = "9.7")

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -151,6 +151,9 @@ public class Http2SolrClient extends HttpSolrClientBase {
   }
 
   private void initAuthStoreFromExistingClient(HttpClient httpClient) {
+    // Since we don't allow users to provide arbitrary Jetty clients, all parameters to this method
+    // must originate from the 'createHttpClient' method, which uses AuthenticationStoreHolder.
+    // Verify this assumption and copy the existing instance to avoid unnecessary wrapping.
     assert httpClient.getAuthenticationStore() instanceof AuthenticationStoreHolder;
     this.authenticationStore = (AuthenticationStoreHolder) httpClient.getAuthenticationStore();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17515


# Description

Prior to this commit, Http2SolrClient only initialized its 'authenticationStore' instance var when creating a fresh Jetty HttpClient.  This causes NPE's later on when client code (e.g. PreemptiveBasicAuthClientBuilderFactory) would attempt to access the object.

# Solution

This commit fixes this by making sure that 'authenticationStore' is initialized when using an existing Jetty client (typically by reusing the AuthenticationStore already used by the client).

# Tests

Strengthens an existing test, RecoveryZkTestWithAuth, by randomizing use of some sysprops helpful for reproducing.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.