### PR TITLE
SOLR-17384: Bring ExportTool options in line with the new CLI pattern

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/ExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ExportTool.java
@@ -116,28 +116,48 @@ public class ExportTool extends ToolBase {
             .desc("Name of the collection.")
             .build(),
         Option.builder("out")
+            .deprecated(
+                DeprecatedAttributes.builder()
+                    .setForRemoval(true)
+                    .setSince("9.8")
+                    .setDescription("Use --output instead")
+                    .get())
             .hasArg()
             .argName("PATH")
             .desc(
                 "Path to output the exported data, and optionally the file name, defaults to 'collection-name'.")
             .build(),
-        Option.builder("format")
+        Option.builder()
+            .longOpt("output")
+            .hasArg()
+            .argName("PATH")
+            .desc(
+                "Path to output the exported data, and optionally the file name, defaults to 'collection-name'.")
+            .build(),
+        Option.builder()
+            .longOpt("format")
             .hasArg()
             .argName("FORMAT")
             .desc("Output format for exported docs (json, jsonl or javabin), defaulting to json.")
             .build(),
-        Option.builder("compress").desc("Compress the output.").build(),
-        Option.builder("limit")
+        Option.builder()
+            .longOpt("compress")
+            .desc("Compress the output. Defaults to false.")
+            .build(),
+        Option.builder()
+            .longOpt("limit")
             .hasArg()
             .argName("#")
             .desc("Maximum number of docs to download. Default is 100, use -1 for all docs.")
             .build(),
-        Option.builder("query")
+        Option.builder()
+            .longOpt("query")
             .hasArg()
             .argName("QUERY")
             .desc("A custom query, default is '*:*'.")
             .build(),
-        Option.builder("fields")
+        Option.builder()
+            .longOpt("fields")
             .hasArg()
             .argName("FIELDA,FIELDB")
             .desc("Comma separated list of fields to export. By default all fields are fetched.")
@@ -280,8 +300,11 @@ public class ExportTool extends ToolBase {
     String credentials = cli.getOptionValue(SolrCLI.OPTION_CREDENTIALS.getLongOpt());
     Info info = new MultiThreadedRunner(url, credentials);
     info.query = cli.getOptionValue("query", "*:*");
+
     info.setOutFormat(
-        cli.getOptionValue("out"), cli.getOptionValue("format"), cli.hasOption("compress"));
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli, "output", "out", null),
+        cli.getOptionValue("format"),
+        cli.hasOption("compress"));
     info.fields = cli.getOptionValue("fields");
     info.setLimit(cli.getOptionValue("limit", "100"));
     info.output = super.stdout;

--- a/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
+++ b/solr/core/src/test/org/apache/solr/cli/TestExportTool.java
@@ -249,9 +249,9 @@ public class TestExportTool extends SolrCloudTestCase {
         COLLECTION_NAME,
         "--credentials",
         SecurityJson.USER_PASS,
-        "-out",
+        "--output",
         outFile.getAbsolutePath(),
-        "-verbose"
+        "--verbose"
       };
 
       assertEquals(0, runTool(args));

--- a/solr/packaging/test/test_basic_auth.bats
+++ b/solr/packaging/test/test_basic_auth.bats
@@ -77,7 +77,7 @@ run solr create -c COLL_NAME
   assert_output --partial 'Committed'
   
   # Test export
-  #run solr export -u name:password --solr-url "http://localhost:${SOLR_PORT} --name COLL_NAME" -query "*:*" -out "${BATS_TEST_TMPDIR}/output"
+  #run solr export -u name:password --solr-url "http://localhost:${SOLR_PORT} --name COLL_NAME" -query "*:*" --output "${BATS_TEST_TMPDIR}/output"
   #assert_output --partial 'Export complete'
   
 }

--- a/solr/packaging/test/test_basic_auth.bats
+++ b/solr/packaging/test/test_basic_auth.bats
@@ -77,7 +77,7 @@ run solr create -c COLL_NAME
   assert_output --partial 'Committed'
   
   # Test export
-  #run solr export -u name:password --solr-url "http://localhost:${SOLR_PORT} --name COLL_NAME" -query "*:*" --output "${BATS_TEST_TMPDIR}/output"
+  #run solr export -u name:password --solr-url http://localhost:${SOLR_PORT} --name COLL_NAME --query "*:*" --output "${BATS_TEST_TMPDIR}/output"
   #assert_output --partial 'Export complete'
   
 }

--- a/solr/packaging/test/test_export.bats
+++ b/solr/packaging/test/test_export.bats
@@ -30,32 +30,32 @@ teardown() {
 
 @test "Check export command" {
   run solr start -e techproducts
-  run solr export --solr-url http://localhost:${SOLR_PORT} --name techproducts -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output"
+  run solr export --solr-url http://localhost:${SOLR_PORT} --name techproducts --query "*:* -id:test" --output "${BATS_TEST_TMPDIR}/output"
 
   refute_output --partial 'Unrecognized option'
   assert_output --partial 'Export complete'
 
   assert [ -e ${BATS_TEST_TMPDIR}/output.json ]
 
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test"
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c techproducts --query "*:* -id:test"
   assert [ -e techproducts.json ]
   rm techproducts.json
 
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -format javabin
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c techproducts --query "*:* -id:test" --format javabin
   assert [ -e techproducts.javabin ]
   rm techproducts.javabin
 
-  # old pattern of putting a suffix on the out that controlled the format no longer supported ;-).
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}/output.javabin"
+  # old pattern of putting a suffix on the output that controlled the format no longer supported ;-).
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c techproducts --query "*:* -id:test" --output "${BATS_TEST_TMPDIR}/output.javabin"
   assert [ -e ${BATS_TEST_TMPDIR}/output.javabin.json ]
 
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -out "${BATS_TEST_TMPDIR}"
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c techproducts --query "*:* -id:test" --output "${BATS_TEST_TMPDIR}"
   assert [ -e ${BATS_TEST_TMPDIR}/techproducts.json ]
 
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -format jsonl -out "${BATS_TEST_TMPDIR}/output"
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c techproducts --query "*:* -id:test" --format jsonl --output "${BATS_TEST_TMPDIR}/output"
   assert [ -e ${BATS_TEST_TMPDIR}/output.jsonl ]
 
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/techproducts" -query "*:* -id:test" -limit 10 -compress -format jsonl -out "${BATS_TEST_TMPDIR}/output"
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c techproducts --query "*:* -id:test" --limit 10 --compress --format jsonl --output "${BATS_TEST_TMPDIR}/output"
   assert [ -e ${BATS_TEST_TMPDIR}/output.jsonl.gz ]
   assert_output --partial 'Total Docs exported: 10'
 
@@ -64,7 +64,7 @@ teardown() {
 @test "export fails on non cloud mode" {
   run solr start --user-managed
   run solr create -c COLL_NAME
-  run solr export -url "http://localhost:${SOLR_PORT}/solr/COLL_NAME"
+  run solr export --solr-url http://localhost:${SOLR_PORT} -c COLL_NAME
   refute_output --partial 'Export complete'
   assert_output --partial "ERROR: Couldn't initialize a HttpClusterStateProvider"
 }

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -1652,7 +1652,7 @@ Fully-qualified address to a Solr.
 s|Required |Default: none
 |===
 +
-Name of the collection to run a export against.
+Name of the collection to run an export against.
 +
 *Example*: `bin/solr export -c gettingstarted`
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -1634,11 +1634,11 @@ NOTE: The `export` command only works with in a Solr running in cloud mode.
 
 The `bin/solr export` command takes the following parameters:
 
-`--solr-url <url>`::
+`-s <url>` or `--solr-url <url>`::
 +
 [%autowidth,frame=none]
 |===
-s|Required |Default: none
+|Optional |Default: `http://localhost:8983`
 |===
 +
 Fully-qualified address to a Solr.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -1634,16 +1634,27 @@ NOTE: The `export` command only works with in a Solr running in cloud mode.
 
 The `bin/solr export` command takes the following parameters:
 
-`--url <url>`::
+`--solr-url <url>`::
 +
 [%autowidth,frame=none]
 |===
 s|Required |Default: none
 |===
 +
-Fully-qualified address to a collection.
+Fully-qualified address to a Solr.
 +
-*Example*: `--url http://localhost:8983/solr/techproducts`
+*Example*: `--solr-url http://localhost:8983`
+
+`-c <collection>`::
++
+[%autowidth,frame=none]
+|===
+s|Required |Default: none
+|===
++
+Name of the collection to run a export against.
++
+*Example*: `bin/solr export -c gettingstarted`
 
 `--format <format>`::
 +
@@ -1656,7 +1667,7 @@ The file format of the export, `json`, `jsonl`, or `javabin`.
 Choosing `javabin` exports in the native Solr format, and is compact and fast to import.
 `jsonl` is the Json with Lines format, learn more at https://jsonlines.org/.
 
-`--out <path>`::
+`--output <path>`::
 +
 [%autowidth,frame=none]
 |===
@@ -1696,7 +1707,6 @@ The default is `\*:*` which will export all documents.
 Comma separated list of fields to be exported.
 By default all fields are fetched.
 
-
 `--limit <number of documents>`::
 +
 [%autowidth,frame=none]
@@ -1722,13 +1732,13 @@ This parameter is unnecessary if `SOLR_AUTH_TYPE` is defined in `solr.in.sh` or 
 Export all documents from a collection `gettingstarted`:
 
 [source,bash]
-bin/solr export --url http://localhost:8983/solr/gettingstarted --limit -1
+bin/solr export --solr-url http://localhost:8983 -c gettingstarted --limit -1
 
 Export all documents of collection `gettingstarted` into a file called `1MDocs.json.gz` as a compressed JSON file:
 
 [source,bash]
 ----
-bin/solr export --url http://localhost:8983/solr/gettingstarted --limit -1 --format json --compress --out 1MDocs
+bin/solr export --solr-url http://localhost:8983 -c gettingstarted --limit -1 --format json --compress --output 1MDocs
 ----
 
 === Importing Documents into a Collection
@@ -1741,7 +1751,7 @@ First export the documents, making sure to ignore any fields that are populated 
 
 [,console]
 ----
-$ bin/solr export --url http://localhost:8983/solr/gettingstarted --fields id,name,manu,cat,features
+$ bin/solr export --solr-url http://localhost:8983 -c gettingstarted --fields id,name,manu,cat,features
 ----
 
 Create a new collection to import the exported documents into:
@@ -1767,7 +1777,7 @@ $ curl -H 'Content-Type: application/json' -X POST -d @gettingstarted.json 'http
 
 [,console]
 ----
-$ bin/solr export --url http://localhost:8983/solr/gettingstarted --format javabin --fields id,name,manu,cat,features
+$ bin/solr export --solr-url http://localhost:8983 -c gettingstarted --format javabin --fields id,name,manu,cat,features
 $ curl -X POST --header "Content-Type: application/javabin" --data-binary @gettingstarted.javabin 'http://localhost:8983/solr/test_collection/update?commit=true'
 ----
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17384



# Description
Resolve ExportTool option choices

# Solution

Move to -- long opt, deprecate -out in favour of --output.

# Tests

junit and bats
