### PR TITLE
SOLR-17524: Track changes for the whole slew of CLI commands under one umbrella JIRA

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -135,11 +135,9 @@ Improvements
   which may help reduce distributed-search latency in collections with many shards, especially
   when PKI is used between nodes. (Jason Gerlowski)
 
-* SOLR-17382: Deprecate -a and -addlopts in favour of --jvm-opts for passing options into the JVM in bin/solr.   (Eric Pugh, Christos Malliaridis)
-
-* SOLR-17431: Deprecate -p parameter where it doesn't refer to a port in bin/solr. (Eric Pugh, Christos Malliaridis)
-
-* SOLR-17442: Resolve -v flag conflict (version, value, verbose) in bin/solr. (Eric Pugh, Christos Malliaridis)
+* SOLR-17383: Resolved overlapping arguments in the Solr CLI.  Removed duplicative but differing arguments,
+  consolidated use of short form arguments -v to not have differing meanings based on tool.  Provide deprecation warning 
+  in command line when deprecated arguments are used. (Eric Pugh, Christos Malliaridis)
 
 * SOLR-17256: Deprecate SolrRequest `setBasePath` and `getBasePath` methods.  SolrJ users wishing to temporarily
   override an HTTP client's base URL may use `Http2SolrClient.requestWithBaseUrl` instead. (Jason Gerlowski,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17524

I started by listing individual JIRA's and it became a wall of text.  The underlying thing users care about is that stuff changed in the CLI, and you get deprecation warnings ;-).  We have called out (in a separate PR) the biggest changes in the major changes for 10x.  