### PR TITLE
SOLR-17528: Match PackageTool use of -y

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -149,6 +149,8 @@ Improvements
   enqueuing with a risk of rejection. Solr will use less resources under stress but to get the most
   of your machine, you may want to increase the thread pool. (David Smiley)
 
+* SOLR-17528: Introduce -y short option to bin/solr start --no-prompt option. Aligns with bin/solr package tool.  (Eric Pugh)
+
 Optimizations
 ---------------------
 * SOLR-14985: Solrj CloudSolrClient with Solr URLs had serious performance regressions (since the

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -94,7 +94,7 @@ public class RunExampleTool extends ToolBase {
   @Override
   public List<Option> getOptions() {
     return List.of(
-        Option.builder()
+        Option.builder("y")
             .longOpt("no-prompt")
             .required(false)
             .desc(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17528


# Description

match how PackageTool works.


# Solution

use `-y` to mean accept all the defaults.
