### PR TITLE
SOLR-17529: Clean up error message for 9x.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -81,6 +81,8 @@ Bug Fixes
 
 * SOLR-17413: Fixed UpdateLog replay bug that shared thread-unsafe SolrQueryRequest objects across threads (Jason Gerlowski, David Smiley, Houston Putman)
 
+* SOLR-17529: Clean up error message in PostTool when you attempt to post to a basic auth secured Solr.  (Eric Pugh)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/core/src/java/org/apache/solr/cli/PostTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PostTool.java
@@ -1044,8 +1044,7 @@ public class PostTool extends ToolBase {
         warn("IOException while reading response: " + e);
         success = false;
       } catch (GeneralSecurityException e) {
-        warn(
-            "Looks like Solr is secured and would not let us in. Try with another user in '-u' parameter");
+        warn("Looks like Solr is secured and would not let us in.");
       }
     } finally {
       if (urlConnection != null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17529

Misleading error message in the 9x line of Solr.  Fine in 10x!