### PR TITLE
SOLR-17383: Fix support for deprecated options in 9x

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/ConfigSetUploadTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ConfigSetUploadTool.java
@@ -110,10 +110,8 @@ public class ConfigSetUploadTool extends ToolBase {
     final String solrInstallDir = System.getProperty("solr.install.dir");
     Path solrInstallDirPath = Paths.get(solrInstallDir);
 
-    String confName =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-name", "confname", null);
-    String confDir =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-dir", "confdir", null);
+    String confName = SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-name", "confname", null);
+    String confDir = SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-dir", "confdir", null);
     try (SolrZkClient zkClient = SolrCLI.getSolrZkClient(cli, zkHost)) {
       echoIfVerbose("\nConnecting to ZooKeeper at " + zkHost + " ...", cli);
 

--- a/solr/core/src/java/org/apache/solr/cli/ConfigSetUploadTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ConfigSetUploadTool.java
@@ -111,11 +111,9 @@ public class ConfigSetUploadTool extends ToolBase {
     Path solrInstallDirPath = Paths.get(solrInstallDir);
 
     String confName =
-        cli.hasOption("conf-name")
-            ? cli.getOptionValue("conf-name")
-            : cli.getOptionValue("confname");
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-name", "confname", null);
     String confDir =
-        cli.hasOption("conf-dir") ? cli.getOptionValue("conf-dir") : cli.getOptionValue("confdir");
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-dir", "confdir", null);
     try (SolrZkClient zkClient = SolrCLI.getSolrZkClient(cli, zkHost)) {
       echoIfVerbose("\nConnecting to ZooKeeper at " + zkHost + " ...", cli);
 
@@ -126,7 +124,7 @@ public class ConfigSetUploadTool extends ToolBase {
           "Uploading "
               + confPath.toAbsolutePath()
               + " for config "
-              + cli.getOptionValue("conf-name")
+              + confName
               + " to ZooKeeper at "
               + zkHost);
       FileTypeMagicUtil.assertConfigSetFolderLegal(confPath);

--- a/solr/core/src/java/org/apache/solr/cli/CreateTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/CreateTool.java
@@ -199,13 +199,12 @@ public class CreateTool extends ToolBase {
 
   protected void createCore(CommandLine cli, SolrClient solrClient) throws Exception {
     String coreName = cli.getOptionValue("name");
-    String solrUrl = cli.getOptionValue("solr-url", SolrCLI.getDefaultSolrUrl());
+    String solrUrl =
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "solr-url", "solrUrl", SolrCLI.getDefaultSolrUrl());
 
     final String solrInstallDir = System.getProperty("solr.install.dir");
     final String confDirName =
-        cli.hasOption("confdir")
-            ? cli.getOptionValue("confdir")
-            : cli.getOptionValue("conf-dir", SolrCLI.DEFAULT_CONFIG_SET);
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
 
     // we allow them to pass a directory instead of a configset name
     Path configsetDir = Paths.get(confDirName);
@@ -286,13 +285,9 @@ public class CreateTool extends ToolBase {
     String collectionName = cli.getOptionValue("name");
     final String solrInstallDir = System.getProperty("solr.install.dir");
     String confName =
-        cli.hasOption("conf-name")
-            ? cli.getOptionValue("conf-name")
-            : cli.getOptionValue("confname");
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-name", "confname", null);
     String confDir =
-        cli.hasOption("confdir")
-            ? cli.getOptionValue("confdir")
-            : cli.getOptionValue("conf-dir", SolrCLI.DEFAULT_CONFIG_SET);
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
     Path solrInstallDirPath = Paths.get(solrInstallDir);
     Path confDirPath = Paths.get(confDir);
     ensureConfDirExists(solrInstallDirPath, confDirPath);
@@ -304,7 +299,8 @@ public class CreateTool extends ToolBase {
           "No live nodes found! Cannot create a collection until "
               + "there is at least 1 live node in the cluster.");
 
-    String solrUrl = cli.getOptionValue("solr-url");
+    String solrUrl =
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "solr-url", "solrUrl", null);
     if (solrUrl == null) {
       String firstLiveNode = liveNodes.iterator().next();
       solrUrl = ZkStateReader.from(cloudSolrClient).getBaseUrlForNodeName(firstLiveNode);
@@ -312,13 +308,12 @@ public class CreateTool extends ToolBase {
 
     // build a URL to create the collection
     int numShards = Integer.parseInt(cli.getOptionValue("shards", String.valueOf(1)));
-    int replicationFactor = 1;
-
-    if (cli.hasOption("replication-factor")) {
-      replicationFactor = Integer.parseInt(cli.getOptionValue("replication-factor"));
-    } else if (cli.hasOption("replicationFactor")) {
-      replicationFactor = Integer.parseInt(cli.getOptionValue("replicationFactor"));
-    }
+    int replicationFactor = Integer.parseInt(
+        SolrCLI.getOptionWithDeprecatedAndDefault(
+            cli,
+            "replication-factor",
+            "replicationFactor",
+            "1"));
 
     boolean configExistsInZk =
         confName != null
@@ -415,15 +410,15 @@ public class CreateTool extends ToolBase {
 
   private void printDefaultConfigsetWarningIfNecessary(CommandLine cli) {
     final String confDirectoryName =
-        cli.hasOption("confdir")
-            ? cli.getOptionValue("confdir")
-            : cli.getOptionValue("conf-dir", SolrCLI.DEFAULT_CONFIG_SET);
-    final String confName = cli.getOptionValue("confname", "");
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
+    final String confName =
+    SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-name", "confname", "");
 
     if (confDirectoryName.equals("_default")
         && (confName.equals("") || confName.equals("_default"))) {
       final String collectionName = cli.getOptionValue("name");
-      final String solrUrl = cli.getOptionValue("solrUrl", SolrCLI.getDefaultSolrUrl());
+      final String solrUrl =
+          SolrCLI.getOptionWithDeprecatedAndDefault(cli , "solr-url", "solrUrl", SolrCLI.getDefaultSolrUrl());
       final String curlCommand =
           String.format(
               Locale.ROOT,

--- a/solr/core/src/java/org/apache/solr/cli/CreateTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/CreateTool.java
@@ -200,11 +200,13 @@ public class CreateTool extends ToolBase {
   protected void createCore(CommandLine cli, SolrClient solrClient) throws Exception {
     String coreName = cli.getOptionValue("name");
     String solrUrl =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "solr-url", "solrUrl", SolrCLI.getDefaultSolrUrl());
+        SolrCLI.getOptionWithDeprecatedAndDefault(
+            cli, "solr-url", "solrUrl", SolrCLI.getDefaultSolrUrl());
 
     final String solrInstallDir = System.getProperty("solr.install.dir");
     final String confDirName =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
+        SolrCLI.getOptionWithDeprecatedAndDefault(
+            cli, "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
 
     // we allow them to pass a directory instead of a configset name
     Path configsetDir = Paths.get(confDirName);
@@ -284,10 +286,10 @@ public class CreateTool extends ToolBase {
 
     String collectionName = cli.getOptionValue("name");
     final String solrInstallDir = System.getProperty("solr.install.dir");
-    String confName =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-name", "confname", null);
+    String confName = SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-name", "confname", null);
     String confDir =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
+        SolrCLI.getOptionWithDeprecatedAndDefault(
+            cli, "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
     Path solrInstallDirPath = Paths.get(solrInstallDir);
     Path confDirPath = Paths.get(confDir);
     ensureConfDirExists(solrInstallDirPath, confDirPath);
@@ -299,8 +301,7 @@ public class CreateTool extends ToolBase {
           "No live nodes found! Cannot create a collection until "
               + "there is at least 1 live node in the cluster.");
 
-    String solrUrl =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "solr-url", "solrUrl", null);
+    String solrUrl = SolrCLI.getOptionWithDeprecatedAndDefault(cli, "solr-url", "solrUrl", null);
     if (solrUrl == null) {
       String firstLiveNode = liveNodes.iterator().next();
       solrUrl = ZkStateReader.from(cloudSolrClient).getBaseUrlForNodeName(firstLiveNode);
@@ -308,12 +309,10 @@ public class CreateTool extends ToolBase {
 
     // build a URL to create the collection
     int numShards = Integer.parseInt(cli.getOptionValue("shards", String.valueOf(1)));
-    int replicationFactor = Integer.parseInt(
-        SolrCLI.getOptionWithDeprecatedAndDefault(
-            cli,
-            "replication-factor",
-            "replicationFactor",
-            "1"));
+    int replicationFactor =
+        Integer.parseInt(
+            SolrCLI.getOptionWithDeprecatedAndDefault(
+                cli, "replication-factor", "replicationFactor", "1"));
 
     boolean configExistsInZk =
         confName != null
@@ -410,15 +409,17 @@ public class CreateTool extends ToolBase {
 
   private void printDefaultConfigsetWarningIfNecessary(CommandLine cli) {
     final String confDirectoryName =
-        SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
+        SolrCLI.getOptionWithDeprecatedAndDefault(
+            cli, "conf-dir", "confdir", SolrCLI.DEFAULT_CONFIG_SET);
     final String confName =
-    SolrCLI.getOptionWithDeprecatedAndDefault(cli , "conf-name", "confname", "");
+        SolrCLI.getOptionWithDeprecatedAndDefault(cli, "conf-name", "confname", "");
 
     if (confDirectoryName.equals("_default")
         && (confName.equals("") || confName.equals("_default"))) {
       final String collectionName = cli.getOptionValue("name");
       final String solrUrl =
-          SolrCLI.getOptionWithDeprecatedAndDefault(cli , "solr-url", "solrUrl", SolrCLI.getDefaultSolrUrl());
+          SolrCLI.getOptionWithDeprecatedAndDefault(
+              cli, "solr-url", "solrUrl", SolrCLI.getDefaultSolrUrl());
       final String curlCommand =
           String.format(
               Locale.ROOT,

--- a/solr/core/src/java/org/apache/solr/cli/PackageTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PackageTool.java
@@ -78,7 +78,8 @@ public class PackageTool extends ToolBase {
       String solrUrl =
           cli.hasOption("solr-url")
               ? cli.getOptionValue("solr-url")
-              : SolrCLI.getOptionWithDeprecatedAndDefault(cli, "solrUrl", "url", SolrCLI.getDefaultSolrUrl());
+              : SolrCLI.getOptionWithDeprecatedAndDefault(
+                  cli, "solrUrl", "url", SolrCLI.getDefaultSolrUrl());
       solrBaseUrl = solrUrl.replaceAll("/solr$", ""); // strip out ending "/solr"
       log.debug("Solr url:{}, solr base url: {}", solrUrl, solrBaseUrl);
 

--- a/solr/core/src/java/org/apache/solr/cli/PackageTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/PackageTool.java
@@ -78,7 +78,7 @@ public class PackageTool extends ToolBase {
       String solrUrl =
           cli.hasOption("solr-url")
               ? cli.getOptionValue("solr-url")
-              : cli.getOptionValue("solrUrl", SolrCLI.getDefaultSolrUrl());
+              : SolrCLI.getOptionWithDeprecatedAndDefault(cli, "solrUrl", "url", SolrCLI.getDefaultSolrUrl());
       solrBaseUrl = solrUrl.replaceAll("/solr$", ""); // strip out ending "/solr"
       log.debug("Solr url:{}, solr base url: {}", solrUrl, solrBaseUrl);
 

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -260,7 +260,7 @@ public class RunExampleTool extends ToolBase {
         "techproducts".equals(exampleName) ? "sample_techproducts_configs" : "_default";
 
     boolean isCloudMode = cli.hasOption('c');
-    String zkHost = SolrCLI.getZkHost(cli);
+    String zkHost = SolrCLI.getOptionWithDeprecatedAndDefault(cli, "z", "zkHost", null);
     int port =
         Integer.parseInt(
             cli.getOptionValue('p', System.getenv().getOrDefault("SOLR_PORT", "8983")));
@@ -511,7 +511,7 @@ public class RunExampleTool extends ToolBase {
     }
 
     // deal with extra args passed to the script to run the example
-    String zkHost = SolrCLI.getZkHost(cli);
+    String zkHost = SolrCLI.getOptionWithDeprecatedAndDefault(cli, "z", "zkHost", null);
 
     // start the first node (most likely with embedded ZK)
     Map<String, Object> nodeStatus =

--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -260,7 +260,7 @@ public class RunExampleTool extends ToolBase {
         "techproducts".equals(exampleName) ? "sample_techproducts_configs" : "_default";
 
     boolean isCloudMode = cli.hasOption('c');
-    String zkHost = cli.getOptionValue('z');
+    String zkHost = SolrCLI.getZkHost(cli);
     int port =
         Integer.parseInt(
             cli.getOptionValue('p', System.getenv().getOrDefault("SOLR_PORT", "8983")));
@@ -511,7 +511,7 @@ public class RunExampleTool extends ToolBase {
     }
 
     // deal with extra args passed to the script to run the example
-    String zkHost = cli.getOptionValue('z');
+    String zkHost = SolrCLI.getZkHost(cli);
 
     // start the first node (most likely with embedded ZK)
     Map<String, Object> nodeStatus =

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -775,8 +775,7 @@ public class SolrCLI implements CLIO {
     }
 
     if (solrUrl == null) {
-      String zkHost =
-          cli.hasOption("zk-host") ? cli.getOptionValue("zk-host") : cli.getOptionValue("zkHost");
+      String zkHost = getOptionWithDeprecatedAndDefault(cli, "zk-host", "zkHost", null);
       if (zkHost == null) {
         solrUrl = SolrCLI.getDefaultSolrUrl();
         CLIO.err(
@@ -838,7 +837,7 @@ public class SolrCLI implements CLIO {
     if (zkHost == null) {
       throw new IllegalStateException(
           "Solr at "
-              + cli.getOptionValue("solrUrl")
+              + getOptionWithDeprecatedAndDefault(cli, "solr-url", "solrUrl", null)
               + " is running in standalone server mode, this command can only be used when running in SolrCloud mode.\n");
     }
     return new SolrZkClient.Builder()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17383

# Description

During the migration of the CLI options some situations do not cover both (old and new) options and therefore compatibility is not granted.

# Solution

This PR focuses on the options listed in `getOptions()` and adds missing checks and reads to places where they should be included.

Note that this PR focuses only on deprecated options and is not relevant for `main`. For `main` see https://github.com/apache/solr/pull/2725 and future PRs that remove deprecated options.

# Tests

No tests modified.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
