### PR TITLE
Actually make collections PRS enabled in tests

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -121,6 +121,9 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
           message.getStr(CollectionStateProps.PER_REPLICA_STATE),
           isPRS);
     }
+    if (isPRS && !message.getBool(CollectionStateProps.PER_REPLICA_STATE, false)) {
+      message = message.plus(CollectionStateProps.PER_REPLICA_STATE, true);
+    }
 
     if (clusterState.hasCollection(collectionName)) {
       throw new SolrException(


### PR DESCRIPTION
Fixes issues with https://github.com/apache/solr/pull/2230, where collections didn't have the PRS flag enabled when the default was enabled.

This does break tests, so it can't be merged without fixing the issues with PRS.