### PR TITLE
Ability to run only SolrCloud tests

### DIFF
--- a/help/tests.txt
+++ b/help/tests.txt
@@ -76,6 +76,10 @@ For example, run all solr-core tests annotated as @Nightly:
 
 gradlew -p solr/core test -Ptests.filter=@Nightly
 
+All SolrCloud tests
+
+gradlew test -Ptests.filter=@SolrCloud
+
 Test group filters can be combined into Boolean expressions:
 
 gradlew -p solr/core test -Ptests.filter="default and not(@awaitsfix)"

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
@@ -47,6 +47,7 @@ import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SolrCloud
 public abstract class AbstractDistribZkTestBase extends BaseDistributedSearchTestCase {
 
   private static final String REMOVE_VERSION_FIELD = "remove.version.field";

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MultiSolrCloudTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MultiSolrCloudTestCase.java
@@ -32,6 +32,7 @@ import org.junit.AfterClass;
  * instances, available via the {@code clusterId2cluster} variable. The clusters' shutdown is
  * handled automatically.
  */
+@SolrCloud
 public abstract class MultiSolrCloudTestCase extends SolrTestCaseJ4 {
 
   protected static Map<String, MiniSolrCloudCluster> clusterId2cluster =

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloud.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloud.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.cloud;
+
+import com.carrotsearch.randomizedtesting.annotations.TestGroup;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** Annotation for tests that use SolrCloud. */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@TestGroup(enabled = true, sysProperty = "tests.solrcloud")
+public @interface SolrCloud {}

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
  *   </code>
  * </pre>
  */
+@SolrCloud
 public class SolrCloudTestCase extends SolrTestCaseJ4 {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());


### PR DESCRIPTION
Is this test annotation useful?  Or maybe it's enough to run all tests in org.apache.solr.cloud ?  Albeit not all SolrCloud related tests are in this package!  (SolrJ)