### PR TITLE
Improve console output of auth command

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/AuthTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/AuthTool.java
@@ -414,9 +414,8 @@ public class AuthTool extends ToolBase {
         final String successMessage =
             String.format(
                 Locale.ROOT,
-                "Successfully enabled basic auth with username [%s] and password [%s].",
-                username,
-                password);
+                "Successfully enabled basic auth with username [%s].",
+                username);
         echo(successMessage);
         return;
       case "disable":


### PR DESCRIPTION
# Description

The console is currently printing the username and password when the user enables authentication via
```bash
bin/solr auth enable --prompt true
```
This defeats the purpose of a hidden password prompt.

# Solution

Do not print the password when basic authentication is enabled.