### PR TITLE
SOLR-17545: Fix alternative jdk testing support

### DIFF
--- a/gradle/testing/alternative-jdk-support.gradle
+++ b/gradle/testing/alternative-jdk-support.gradle
@@ -50,7 +50,7 @@ if (jvmGradle != jvmCurrent) {
       doFirst {
 
         def jvmInfo = { JavaInfo javaInfo ->
-          JvmInstallationMetadata jvmMetadata = jvmDetector.getMetadata(new InstallationLocation(javaInfo.javaHome, "specific path"))
+          JvmInstallationMetadata jvmMetadata = jvmDetector.getMetadata(InstallationLocation.userDefined(javaInfo.javaHome, "specific path"))
           return "${jvmMetadata.languageVersion} (${jvmMetadata.displayName} ${jvmMetadata.runtimeVersion}, home at: ${jvmMetadata.javaHome})"
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17545 / https://github.com/apache/solr/pull/2848 inadvertently broke alternative JDK support that some Jenkins jobs use to run different JDKs. One deprecated use was replaced this replaces the other one.

This now matches what Lucene has - https://github.com/apache/lucene/blob/main/gradle/testing/alternative-jdk-support.gradle#L53