### PR TITLE
SOLR-16427: Enable error-prone PatternMatchingInstanceof rule

### DIFF
--- a/build-tools/missing-doclet/src/main/java/org/apache/lucene/missingdoclet/MissingDoclet.java
+++ b/build-tools/missing-doclet/src/main/java/org/apache/lucene/missingdoclet/MissingDoclet.java
@@ -341,8 +341,7 @@ public class MissingDoclet extends StandardDoclet {
     }
 
     // Check for methods up the types tree.
-    if (element instanceof ExecutableElement) {
-      ExecutableElement thisMethod = (ExecutableElement) element;
+    if (element instanceof ExecutableElement thisMethod) {
       Iterable<Element> superTypes =
           () -> superTypeForInheritDoc(thisMethod.getEnclosingElement()).iterator();
 

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -457,7 +457,7 @@ allprojects { prj ->
             '-Xep:Overrides:WARN',
             // '-Xep:OverridesGuiceInjectableMethod:OFF', // we don't use guice
             '-Xep:ParameterName:WARN',
-            // '-Xep:PatternMatchingInstanceof:WARN', // todo check if useful or comment why not
+            '-Xep:PatternMatchingInstanceof:WARN',
             '-Xep:PreconditionsCheckNotNullRepeated:WARN',
             '-Xep:PrimitiveAtomicReference:WARN',
             '-Xep:ProtectedMembersInFinalClass:WARN',

--- a/solr/benchmark/src/java/org/apache/solr/bench/generators/RandomDataHistogram.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/generators/RandomDataHistogram.java
@@ -436,8 +436,7 @@ public class RandomDataHistogram {
       @Override
       public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Surrogate)) return false;
-        Surrogate surrogate = (Surrogate) o;
+        if (!(o instanceof Surrogate surrogate)) return false;
         return hashCode.equals(surrogate.hashCode)
             && identityHashcode.equals(surrogate.identityHashcode);
       }

--- a/solr/core/src/java/org/apache/solr/api/AnnotatedApi.java
+++ b/solr/core/src/java/org/apache/solr/api/AnnotatedApi.java
@@ -261,8 +261,7 @@ public class AnnotatedApi extends Api implements PermissionNameProvider, Closeab
     }
 
     private void readPayloadType(Type t) {
-      if (t instanceof ParameterizedType) {
-        ParameterizedType typ = (ParameterizedType) t;
+      if (t instanceof ParameterizedType typ) {
         if (typ.getRawType() == PayloadObj.class) {
           isWrappedInPayloadObj = true;
           if (typ.getActualTypeArguments().length == 0) {
@@ -271,8 +270,7 @@ public class AnnotatedApi extends Api implements PermissionNameProvider, Closeab
             return;
           }
           Type t1 = typ.getActualTypeArguments()[0];
-          if (t1 instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) t1;
+          if (t1 instanceof ParameterizedType parameterizedType) {
             parameterClass = (Class<?>) parameterizedType.getRawType();
           } else {
             parameterClass = (Class<?>) typ.getActualTypeArguments()[0];
@@ -345,9 +343,8 @@ public class AnnotatedApi extends Api implements PermissionNameProvider, Closeab
     public boolean equals(Object rhs) {
       if (null == rhs) return false;
       if (this == rhs) return true;
-      if (!(rhs instanceof Cmd)) return false;
+      if (!(rhs instanceof Cmd rhsCast)) return false;
 
-      final Cmd rhsCast = (Cmd) rhs;
       return Objects.equals(command, rhsCast.command)
           && Objects.equals(method, rhsCast.method)
           && Objects.equals(obj, rhsCast.obj)
@@ -373,8 +370,7 @@ public class AnnotatedApi extends Api implements PermissionNameProvider, Closeab
       t = types[2]; // (SolrQueryRequest req, SolrQueryResponse rsp, PayloadObj<PluginMeta>)
     if (types.length == 1) t = types[0]; // (PayloadObj<PluginMeta>)
     if (t != null) {
-      if (t instanceof ParameterizedType) {
-        ParameterizedType typ = (ParameterizedType) t;
+      if (t instanceof ParameterizedType typ) {
         if (typ.getRawType() == PayloadObj.class) {
           t = typ.getActualTypeArguments()[0];
         }

--- a/solr/core/src/java/org/apache/solr/api/ApiBag.java
+++ b/solr/core/src/java/org/apache/solr/api/ApiBag.java
@@ -122,16 +122,14 @@ public class ApiBag {
 
       // If 'o' and 'node.obj' aren't both AnnotatedApi's then we can't aggregate the commands, so
       // fallback to the default behavior
-      if ((!(o instanceof AnnotatedApi)) || (!(node.getObject() instanceof AnnotatedApi))) {
+      if ((!(o instanceof AnnotatedApi beingRegistered))
+          || (!(node.getObject() instanceof AnnotatedApi alreadyRegistered))) {
         super.attachValueToNode(node, o);
         return;
       }
 
-      final AnnotatedApi beingRegistered = (AnnotatedApi) o;
-      final AnnotatedApi alreadyRegistered = (AnnotatedApi) node.getObject();
-      if (alreadyRegistered instanceof CommandAggregatingAnnotatedApi) {
-        final CommandAggregatingAnnotatedApi alreadyRegisteredAsCollapsing =
-            (CommandAggregatingAnnotatedApi) alreadyRegistered;
+      if (alreadyRegistered
+          instanceof CommandAggregatingAnnotatedApi alreadyRegisteredAsCollapsing) {
         alreadyRegisteredAsCollapsing.combineWith(beingRegistered);
       } else {
         final CommandAggregatingAnnotatedApi wrapperApi =
@@ -404,11 +402,10 @@ public class ApiBag {
 
   public static SpecProvider constructSpec(PluginInfo info) {
     Object specObj = info == null ? null : info.attributes.get("spec");
-    if (specObj != null && specObj instanceof Map) {
+    if (specObj != null && specObj instanceof Map<?, ?> map) {
       // Value from Map<String,String> can be a Map because in PluginInfo(String, Map) we assign a
       // Map<String, Object>
       // assert false : "got a map when this should only be Strings";
-      Map<?, ?> map = (Map<?, ?>) specObj;
       return () -> ValidatingJsonMap.getDeepCopy(map, 4, false);
     } else {
       return HANDLER_NAME_SPEC_PROVIDER;

--- a/solr/core/src/java/org/apache/solr/api/ContainerPluginsRegistry.java
+++ b/solr/core/src/java/org/apache/solr/api/ContainerPluginsRegistry.java
@@ -158,8 +158,7 @@ public class ContainerPluginsRegistry implements ClusterPropertiesListener, MapW
 
     @Override
     public boolean equals(Object obj) {
-      if (obj instanceof PluginMetaHolder) {
-        PluginMetaHolder that = (PluginMetaHolder) obj;
+      if (obj instanceof PluginMetaHolder that) {
         return Objects.equals(this.original, that.original);
       }
       return false;
@@ -466,8 +465,7 @@ public class ContainerPluginsRegistry implements ClusterPropertiesListener, MapW
     do {
       Type[] interfaces = klas.getGenericInterfaces();
       for (Type type : interfaces) {
-        if (type instanceof ParameterizedType) {
-          ParameterizedType parameterizedType = (ParameterizedType) type;
+        if (type instanceof ParameterizedType parameterizedType) {
           Type rawType = parameterizedType.getRawType();
           if (rawType == ConfigurablePlugin.class
               ||

--- a/solr/core/src/java/org/apache/solr/cli/ExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ExportTool.java
@@ -363,8 +363,7 @@ public class ExportTool extends ToolBase {
               }
             }
             field = constructDateStr(field);
-            if (field instanceof List) {
-              List<?> list = (List<?>) field;
+            if (field instanceof List<?> list) {
               if (hasdate(list)) {
                 ArrayList<Object> listCopy = new ArrayList<>(list.size());
                 for (Object o : list) listCopy.add(constructDateStr(o));
@@ -443,8 +442,7 @@ public class ExportTool extends ToolBase {
               }
             }
             field = constructDateStr(field);
-            if (field instanceof List) {
-              List<?> list = (List<?>) field;
+            if (field instanceof List<?> list) {
               if (hasdate(list)) {
                 ArrayList<Object> listCopy = new ArrayList<>(list.size());
                 for (Object o : list) listCopy.add(constructDateStr(o));

--- a/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/HealthcheckTool.java
@@ -286,8 +286,7 @@ class ReplicaHealth implements Comparable<ReplicaHealth> {
   public boolean equals(Object obj) {
     if (this == obj) return true;
     if (obj == null) return false;
-    if (!(obj instanceof ReplicaHealth)) return true;
-    ReplicaHealth that = (ReplicaHealth) obj;
+    if (!(obj instanceof ReplicaHealth that)) return true;
     return this.shard.equals(that.shard) && this.isLeader == that.isLeader;
   }
 

--- a/solr/core/src/java/org/apache/solr/cli/StreamTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StreamTool.java
@@ -217,8 +217,7 @@ public class StreamTool extends ToolBase {
 
               Object o = tuple.get(outputHeaders[i]);
               if (o != null) {
-                if (o instanceof List) {
-                  List outfields = (List) o;
+                if (o instanceof List outfields) {
                   outLine.append(listToString(outfields, arrayDelimiter));
                 } else {
                   outLine.append(o);

--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/EmbeddedSolrServer.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/EmbeddedSolrServer.java
@@ -321,8 +321,7 @@ public class EmbeddedSolrServer extends SolrClient {
   /** A list of streams, non-null. */
   private List<ContentStream> getContentStreams(SolrRequest<?> request) throws IOException {
     if (request.getMethod() == SolrRequest.METHOD.GET) return List.of();
-    if (request instanceof ContentStreamUpdateRequest) {
-      final ContentStreamUpdateRequest csur = (ContentStreamUpdateRequest) request;
+    if (request instanceof ContentStreamUpdateRequest csur) {
       final Collection<ContentStream> cs = csur.getContentStreams();
       if (cs != null) return new ArrayList<>(cs);
     }

--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -423,8 +423,7 @@ public class Overseer implements SolrCloseable {
     // Return true whenever the exception thrown by ZkStateWriter is correspond
     // to a invalid state or 'bad' message (in this case, we should remove that message from queue)
     private boolean isBadMessage(Exception e) {
-      if (e instanceof KeeperException) {
-        KeeperException ke = (KeeperException) e;
+      if (e instanceof KeeperException ke) {
         return ke.code() == KeeperException.Code.NONODE
             || ke.code() == KeeperException.Code.NODEEXISTS;
       }

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
@@ -318,8 +318,7 @@ public class OverseerTaskQueue extends ZkDistributedQueue {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof QueueEvent)) return false;
-      QueueEvent other = (QueueEvent) obj;
+      if (!(obj instanceof QueueEvent other)) return false;
       return Objects.equals(id, other.id);
     }
 

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveringCoreTermWatcher.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveringCoreTermWatcher.java
@@ -76,9 +76,8 @@ public class RecoveringCoreTermWatcher implements ZkShardTerms.CoreTermWatcher {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof RecoveringCoreTermWatcher)) return false;
+    if (!(o instanceof RecoveringCoreTermWatcher that)) return false;
 
-    RecoveringCoreTermWatcher that = (RecoveringCoreTermWatcher) o;
     return coreDescriptor.getName().equals(that.coreDescriptor.getName());
   }
 

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -180,8 +180,7 @@ public class ZkController implements Closeable {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof ContextKey)) return false;
-      ContextKey other = (ContextKey) obj;
+      if (!(obj instanceof ContextKey other)) return false;
       return Objects.equals(collection, other.collection)
           && Objects.equals(coreNodeName, other.coreNodeName);
     }
@@ -2833,8 +2832,7 @@ public class ZkController implements Closeable {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof UnloadCoreOnDeletedWatcher)) return false;
-      UnloadCoreOnDeletedWatcher that = (UnloadCoreOnDeletedWatcher) o;
+      if (!(o instanceof UnloadCoreOnDeletedWatcher that)) return false;
       return Objects.equals(coreNodeName, that.coreNodeName)
           && Objects.equals(shard, that.shard)
           && Objects.equals(coreName, that.coreName);

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/MigrateCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/MigrateCmd.java
@@ -101,11 +101,11 @@ public class MigrateCmd implements CollApiCmds.CollectionApiCommand {
           SolrException.ErrorCode.BAD_REQUEST,
           "Unknown target collection: " + sourceCollectionName);
     }
-    if (!(sourceCollection.getRouter() instanceof CompositeIdRouter)) {
+    if (!(sourceCollection.getRouter() instanceof CompositeIdRouter sourceRouter)) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, "Source collection must use a compositeId router");
     }
-    if (!(targetCollection.getRouter() instanceof CompositeIdRouter)) {
+    if (!(targetCollection.getRouter() instanceof CompositeIdRouter targetRouter)) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, "Target collection must use a compositeId router");
     }
@@ -115,8 +115,6 @@ public class MigrateCmd implements CollApiCmds.CollectionApiCommand {
           SolrException.ErrorCode.BAD_REQUEST, "The split.key cannot be null or empty");
     }
 
-    CompositeIdRouter sourceRouter = (CompositeIdRouter) sourceCollection.getRouter();
-    CompositeIdRouter targetRouter = (CompositeIdRouter) targetCollection.getRouter();
     Collection<Slice> sourceSlices =
         sourceRouter.getSearchSlicesSingle(splitKey, null, sourceCollection);
     if (sourceSlices.isEmpty()) {

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/RoutedAlias.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/RoutedAlias.java
@@ -490,8 +490,7 @@ public abstract class RoutedAlias {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof Action)) return false;
-      Action action = (Action) o;
+      if (!(o instanceof Action action)) return false;
       return Objects.equals(sourceAlias, action.sourceAlias)
           && actionType == action.actionType
           && Objects.equals(targetCollection, action.targetCollection);

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -1126,8 +1126,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
         }
       }
     } else if (splitKey != null) {
-      if (router instanceof CompositeIdRouter) {
-        CompositeIdRouter compositeIdRouter = (CompositeIdRouter) router;
+      if (router instanceof CompositeIdRouter compositeIdRouter) {
         List<DocRouter.Range> tmpSubRanges = compositeIdRouter.partitionRangeByKey(splitKey, range);
         if (tmpSubRanges.size() == 1) {
           throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/SliceMutator.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/SliceMutator.java
@@ -62,8 +62,7 @@ public class SliceMutator {
   }
 
   static SolrZkClient getZkClient(SolrCloudManager cloudManager) {
-    if (cloudManager instanceof SolrClientCloudManager) {
-      SolrClientCloudManager manager = (SolrClientCloudManager) cloudManager;
+    if (cloudManager instanceof SolrClientCloudManager manager) {
       return manager.getZkClient();
     } else {
       return null;

--- a/solr/core/src/java/org/apache/solr/cluster/events/impl/ClusterEventProducerFactory.java
+++ b/solr/core/src/java/org/apache/solr/cluster/events/impl/ClusterEventProducerFactory.java
@@ -133,8 +133,7 @@ public class ClusterEventProducerFactory extends ClusterEventProducerBase {
               return;
             }
             Object instance = plugin.getInstance();
-            if (instance instanceof ClusterEventListener) {
-              ClusterEventListener listener = (ClusterEventListener) instance;
+            if (instance instanceof ClusterEventListener listener) {
               clusterEventProducer.registerListener(listener);
             } else if (instance instanceof ClusterEventProducer) {
               if (ClusterEventProducer.PLUGIN_NAME.equals(plugin.getInfo().name)) {
@@ -162,8 +161,7 @@ public class ClusterEventProducerFactory extends ClusterEventProducerBase {
               return;
             }
             Object instance = plugin.getInstance();
-            if (instance instanceof ClusterEventListener) {
-              ClusterEventListener listener = (ClusterEventListener) instance;
+            if (instance instanceof ClusterEventListener listener) {
               clusterEventProducer.unregisterListener(listener);
             } else if (instance instanceof ClusterEventProducer) {
               if (ClusterEventProducer.PLUGIN_NAME.equals(plugin.getInfo().name)) {

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/MetricImpl.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/MetricImpl.java
@@ -115,10 +115,9 @@ public abstract class MetricImpl<T> implements Metric<T> {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof MetricImpl)) {
+    if (!(o instanceof MetricImpl<?> that)) {
       return false;
     }
-    MetricImpl<?> that = (MetricImpl<?>) o;
     return name.equals(that.getName())
         && internalName.equals(that.getInternalName())
         && converter.equals(that.converter);

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/NodeMetricImpl.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/NodeMetricImpl.java
@@ -88,13 +88,12 @@ public class NodeMetricImpl<T> extends MetricImpl<T> implements NodeMetric<T> {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof NodeMetricImpl)) {
+    if (!(o instanceof NodeMetricImpl<?> that)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    NodeMetricImpl<?> that = (NodeMetricImpl<?>) o;
     return registry == that.registry;
   }
 

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/SimpleClusterAbstractionsImpl.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/SimpleClusterAbstractionsImpl.java
@@ -139,10 +139,9 @@ class SimpleClusterAbstractionsImpl {
       if (obj == this) {
         return true;
       }
-      if (!(obj instanceof NodeImpl)) {
+      if (!(obj instanceof NodeImpl other)) {
         return false;
       }
-      NodeImpl other = (NodeImpl) obj;
       return Objects.equals(this.nodeName, other.nodeName);
     }
 
@@ -307,10 +306,9 @@ class SimpleClusterAbstractionsImpl {
       if (obj == this) {
         return true;
       }
-      if (!(obj instanceof ShardImpl)) {
+      if (!(obj instanceof ShardImpl other)) {
         return false;
       }
-      ShardImpl other = (ShardImpl) obj;
       return Objects.equals(this.shardName, other.shardName)
           && Objects.equals(this.collection, other.collection)
           && Objects.equals(this.shardState, other.shardState)
@@ -467,10 +465,9 @@ class SimpleClusterAbstractionsImpl {
       if (obj == this) {
         return true;
       }
-      if (!(obj instanceof ReplicaImpl)) {
+      if (!(obj instanceof ReplicaImpl other)) {
         return false;
       }
-      ReplicaImpl other = (ReplicaImpl) obj;
       return Objects.equals(this.replicaName, other.replicaName)
           && Objects.equals(this.coreName, other.coreName)
           && Objects.equals(this.shard, other.shard)

--- a/solr/core/src/java/org/apache/solr/cluster/placement/plugins/OrderedNodePlacementPlugin.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/OrderedNodePlacementPlugin.java
@@ -555,10 +555,9 @@ public abstract class OrderedNodePlacementPlugin implements PlacementPlugin {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof WeightedNode)) {
+      if (!(o instanceof WeightedNode on)) {
         return false;
       } else {
-        WeightedNode on = (WeightedNode) o;
         if (this.node == null) {
           return on.node == null;
         } else {

--- a/solr/core/src/java/org/apache/solr/core/ClusterSingletons.java
+++ b/solr/core/src/java/org/apache/solr/core/ClusterSingletons.java
@@ -69,8 +69,7 @@ public class ClusterSingletons {
             }
             // register new api
             Object instance = plugin.getInstance();
-            if (instance instanceof ClusterSingleton) {
-              ClusterSingleton singleton = (ClusterSingleton) instance;
+            if (instance instanceof ClusterSingleton singleton) {
               singletonMap.put(singleton.getName(), singleton);
               // check to see if we should immediately start this singleton
               if (isReady() && runSingletons.get()) {
@@ -89,8 +88,7 @@ public class ClusterSingletons {
               return;
             }
             Object instance = plugin.getInstance();
-            if (instance instanceof ClusterSingleton) {
-              ClusterSingleton singleton = (ClusterSingleton) instance;
+            if (instance instanceof ClusterSingleton singleton) {
               singleton.stop();
               singletonMap.remove(singleton.getName());
             }

--- a/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
@@ -193,8 +193,7 @@ public class ConfigOverlay implements MapSerializable {
       if (hierarchy != null) hierarchy.add(part);
       if (obj == null) return null;
       if (i == parts.size() - 1) {
-        if (obj instanceof Map<?, ?>) {
-          Map<?, ?> map = (Map<?, ?>) obj;
+        if (obj instanceof Map<?, ?> map) {
           Object o = map.get(part);
           return checkType(o, isXpath, isAttr);
         }
@@ -209,8 +208,7 @@ public class ConfigOverlay implements MapSerializable {
       new Class<?>[] {String.class, Boolean.class, Integer.class, Float.class};
 
   private static Class<?> checkType(Object o, boolean isXpath, boolean isAttr) {
-    if (o instanceof Long) {
-      Long aLong = (Long) o;
+    if (o instanceof Long aLong) {
       int ten = aLong.intValue() / 10;
       int one = aLong.intValue() % 10;
       if (isXpath && isAttr && one != 0) return null;

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -592,9 +592,8 @@ public class CoreContainer {
   }
 
   private void setupHttpClientForAuthPlugin(Object authcPlugin) {
-    if (authcPlugin instanceof HttpClientBuilderPlugin) {
+    if (authcPlugin instanceof HttpClientBuilderPlugin builderPlugin) {
       // Setup HttpClient for internode communication
-      HttpClientBuilderPlugin builderPlugin = ((HttpClientBuilderPlugin) authcPlugin);
       SolrHttpClientBuilder builder =
           builderPlugin.getHttpClientBuilder(HttpClientUtil.getHttpClientBuilder());
 
@@ -822,8 +821,7 @@ public class CoreContainer {
 
     shardHandlerFactory =
         ShardHandlerFactory.newInstance(cfg.getShardHandlerFactoryPluginInfo(), loader);
-    if (shardHandlerFactory instanceof SolrMetricProducer) {
-      SolrMetricProducer metricProducer = (SolrMetricProducer) shardHandlerFactory;
+    if (shardHandlerFactory instanceof SolrMetricProducer metricProducer) {
       metricProducer.initializeMetrics(solrMetricsContext, "httpShardHandler");
     }
 
@@ -1127,8 +1125,7 @@ public class CoreContainer {
           .forEach(
               handlerName -> {
                 SolrRequestHandler handler = containerHandlers.get(handlerName);
-                if (handler instanceof ClusterSingleton) {
-                  ClusterSingleton singleton = (ClusterSingleton) handler;
+                if (handler instanceof ClusterSingleton singleton) {
                   clusterSingletons.getSingletons().put(singleton.getName(), singleton);
                 }
               });

--- a/solr/core/src/java/org/apache/solr/core/CoreSorter.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreSorter.java
@@ -157,8 +157,7 @@ public class CoreSorter {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof CountsForEachShard)) return false;
-      CountsForEachShard that = (CountsForEachShard) o;
+      if (!(o instanceof CountsForEachShard that)) return false;
       return totalReplicasInDownNodes == that.totalReplicasInDownNodes
           && myReplicas == that.myReplicas
           && totalReplicasInLiveNodes == that.totalReplicasInLiveNodes;

--- a/solr/core/src/java/org/apache/solr/core/PluginBag.java
+++ b/solr/core/src/java/org/apache/solr/core/PluginBag.java
@@ -239,8 +239,7 @@ public class PluginBag<T> implements AutoCloseable {
     if (loadV2ApisIfPresent) {
       if (plugin.isLoaded()) {
         T inst = plugin.get();
-        if (inst instanceof ApiSupport) {
-          ApiSupport apiSupport = (ApiSupport) inst;
+        if (inst instanceof ApiSupport apiSupport) {
           if (registerApi == null) registerApi = apiSupport.registerV2();
           if (disableHandler == null) disableHandler = !apiSupport.registerV1();
 
@@ -366,8 +365,7 @@ public class PluginBag<T> implements AutoCloseable {
 
   private void registerMBean(Object inst, SolrCore core, String pluginKey) {
     if (core == null) return;
-    if (inst instanceof SolrInfoBean) {
-      SolrInfoBean mBean = (SolrInfoBean) inst;
+    if (inst instanceof SolrInfoBean mBean) {
       String name = (inst instanceof SolrRequestHandler) ? pluginKey : mBean.getName();
       core.registerInfoBean(name, mBean);
     }

--- a/solr/core/src/java/org/apache/solr/core/PluginInfo.java
+++ b/solr/core/src/java/org/apache/solr/core/PluginInfo.java
@@ -142,8 +142,7 @@ public class PluginInfo implements MapSerializable {
     for (Map.Entry<String, Object> entry : map.entrySet()) {
       if (NAME.equals(entry.getKey()) || CLASS_NAME.equals(entry.getKey())) continue;
       Object value = entry.getValue();
-      if (value instanceof List) {
-        List<?> list = (List<?>) value;
+      if (value instanceof List<?> list) {
         if (!list.isEmpty() && list.get(0) instanceof Map) { // this is a subcomponent
           for (Object o : list) {
             if (o instanceof Map) o = new NamedList<>((Map) o);
@@ -234,8 +233,7 @@ public class PluginInfo implements MapSerializable {
         Object old = m.get(child.name);
         if (old == null) {
           m.put(child.name, child.toMap(new LinkedHashMap<>()));
-        } else if (old instanceof List) {
-          List list = (List) old;
+        } else if (old instanceof List list) {
           list.add(child.toMap(new LinkedHashMap<>()));
         } else {
           ArrayList l = new ArrayList();

--- a/solr/core/src/java/org/apache/solr/core/QuerySenderListener.java
+++ b/solr/core/src/java/org/apache/solr/core/QuerySenderListener.java
@@ -82,13 +82,11 @@ public class QuerySenderListener extends AbstractSolrEventListener {
           for (int i = 0; i < values.size(); i++) {
             Object o = values.getVal(i);
             SolrDocumentFetcher docFetcher = null;
-            if (o instanceof ResultContext) {
-              ResultContext ctx = (ResultContext) o;
+            if (o instanceof ResultContext ctx) {
               o = ctx.getDocList();
               docFetcher = ctx.getDocFetcher();
             }
-            if (o instanceof DocList) {
-              DocList docs = (DocList) o;
+            if (o instanceof DocList docs) {
               if (docFetcher == null) {
                 docFetcher = newSearcher.getDocFetcher();
               }

--- a/solr/core/src/java/org/apache/solr/core/RequestParams.java
+++ b/solr/core/src/java/org/apache/solr/core/RequestParams.java
@@ -52,8 +52,7 @@ public class RequestParams implements MapSerializable {
     Map<?, ?> paramsets = (Map<?, ?>) data.get(NAME);
     if (paramsets != null) {
       for (Map.Entry<?, ?> e : paramsets.entrySet()) {
-        if (e.getValue() instanceof Map) {
-          Map<?, ?> value = (Map<?, ?>) e.getValue();
+        if (e.getValue() instanceof Map<?, ?> value) {
           this.paramsets.put((String) e.getKey(), createParamSet(value, 0l));
         }
       }
@@ -87,8 +86,7 @@ public class RequestParams implements MapSerializable {
         }
       } else if (entry.getValue() == null) {
         copy.put(entry.getKey(), null);
-      } else if (entry.getValue() instanceof List) {
-        List<?> l = (List<?>) entry.getValue();
+      } else if (entry.getValue() instanceof List<?> l) {
         String[] sarr = new String[l.size()];
         for (int i = 0; i < l.size(); i++) {
           if (l.get(i) != null) sarr[i] = String.valueOf(l.get(i));
@@ -138,8 +136,7 @@ public class RequestParams implements MapSerializable {
 
   public static RequestParams getFreshRequestParams(
       SolrResourceLoader loader, RequestParams requestParams) {
-    if (loader instanceof ZkSolrResourceLoader) {
-      ZkSolrResourceLoader resourceLoader = (ZkSolrResourceLoader) loader;
+    if (loader instanceof ZkSolrResourceLoader resourceLoader) {
       try {
         Stat stat =
             resourceLoader

--- a/solr/core/src/java/org/apache/solr/core/SchemaCodecFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/SchemaCodecFactory.java
@@ -126,8 +126,7 @@ public class SchemaCodecFactory extends CodecFactory implements SolrCoreAware {
           public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
             final SchemaField schemaField = core.getLatestSchema().getFieldOrNull(field);
             FieldType fieldType = (schemaField == null ? null : schemaField.getType());
-            if (fieldType instanceof DenseVectorField) {
-              DenseVectorField vectorType = (DenseVectorField) fieldType;
+            if (fieldType instanceof DenseVectorField vectorType) {
               String knnAlgorithm = vectorType.getKnnAlgorithm();
               if (DenseVectorField.HNSW_ALGORITHM.equals(knnAlgorithm)) {
                 int maxConn = vectorType.getHnswMaxConn();

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -173,14 +173,11 @@ public class SolrConfig implements MapSerializable {
 
     ResourceProvider(InputStream in) throws IOException {
       this.in = in;
-      if (in instanceof ZkSolrResourceLoader.ZkByteArrayInputStream) {
-        ZkSolrResourceLoader.ZkByteArrayInputStream zkin =
-            (ZkSolrResourceLoader.ZkByteArrayInputStream) in;
+      if (in instanceof ZkSolrResourceLoader.ZkByteArrayInputStream zkin) {
         zkVersion = zkin.getStat().getVersion();
         hash = Objects.hash(zkin.getStat().getCtime(), zkVersion, overlay.getVersion());
         this.fileName = zkin.fileName;
-      } else if (in instanceof SolrResourceLoader.SolrFileInputStream) {
-        SolrResourceLoader.SolrFileInputStream sfin = (SolrResourceLoader.SolrFileInputStream) in;
+      } else if (in instanceof SolrResourceLoader.SolrFileInputStream sfin) {
         zkVersion = (int) sfin.getLastModified();
         hash = Objects.hash(sfin.getLastModified(), overlay.getVersion());
       }

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -949,8 +949,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
     } catch (Exception e) {
       // The JVM likes to wrap our helpful SolrExceptions in things like
       // "InvocationTargetException" that have no useful getMessage
-      if (null != e.getCause() && e.getCause() instanceof SolrException) {
-        SolrException inner = (SolrException) e.getCause();
+      if (null != e.getCause() && e.getCause() instanceof SolrException inner) {
         throw inner;
       }
 
@@ -995,8 +994,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
     } catch (Exception e) {
       // The JVM likes to wrap our helpful SolrExceptions in things like
       // "InvocationTargetException" that have no useful getMessage
-      if (null != e.getCause() && e.getCause() instanceof SolrException) {
-        SolrException inner = (SolrException) e.getCause();
+      if (null != e.getCause() && e.getCause() instanceof SolrException inner) {
         throw inner;
       }
 
@@ -3392,8 +3390,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
    * some data so that events are triggered.
    */
   private void registerConfListener() {
-    if (!(resourceLoader instanceof ZkSolrResourceLoader)) return;
-    final ZkSolrResourceLoader zkSolrResourceLoader = (ZkSolrResourceLoader) resourceLoader;
+    if (!(resourceLoader instanceof ZkSolrResourceLoader zkSolrResourceLoader)) return;
     if (zkSolrResourceLoader != null)
       zkSolrResourceLoader
           .getZkController()
@@ -3413,8 +3410,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
         zkSolrResourceLoader.getConfigSetZkPath() + "/" + core.getSolrConfig().getName();
     String schemaRes = null;
     if (core.getLatestSchema().isMutable()
-        && core.getLatestSchema() instanceof ManagedIndexSchema) {
-      ManagedIndexSchema mis = (ManagedIndexSchema) core.getLatestSchema();
+        && core.getLatestSchema() instanceof ManagedIndexSchema mis) {
       schemaRes = mis.getResourceName();
     }
     final String managedSchemaResourcePath =

--- a/solr/core/src/java/org/apache/solr/core/SolrDeletionPolicy.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrDeletionPolicy.java
@@ -113,8 +113,7 @@ public class SolrDeletionPolicy extends IndexDeletionPolicy implements NamedList
 
     protected void appendDetails(StringBuilder sb, IndexCommit c) {
       Directory dir = c.getDirectory();
-      if (dir instanceof FSDirectory) {
-        FSDirectory fsd = (FSDirectory) dir;
+      if (dir instanceof FSDirectory fsd) {
         sb.append("dir=").append(fsd.getDirectory());
       } else {
         sb.append("dir=").append(dir);
@@ -198,8 +197,7 @@ public class SolrDeletionPolicy extends IndexDeletionPolicy implements NamedList
 
     // For anything persistent, make something that will
     // be the same, regardless of the Directory instance.
-    if (dir instanceof FSDirectory) {
-      FSDirectory fsd = (FSDirectory) dir;
+    if (dir instanceof FSDirectory fsd) {
       File fdir = fsd.getDirectory().toFile();
       sb.append(fdir.getPath());
     } else {

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -760,8 +760,7 @@ public class SolrXmlConfig {
   }
 
   private static Object decodeNullValue(Object o) {
-    if (o instanceof String) { // check if it's a JSON object
-      String str = (String) o;
+    if (o instanceof String str) { // check if it's a JSON object
       if (!str.isBlank() && (str.startsWith("{") || str.startsWith("["))) {
         try {
           o = Utils.fromJSONString((String) o);

--- a/solr/core/src/java/org/apache/solr/core/backup/BackupId.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/BackupId.java
@@ -62,8 +62,7 @@ public class BackupId implements Comparable<BackupId> {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof BackupId)) return false;
-    BackupId backupId = (BackupId) o;
+    if (!(o instanceof BackupId backupId)) return false;
     return id == backupId.id;
   }
 

--- a/solr/core/src/java/org/apache/solr/core/backup/Checksum.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/Checksum.java
@@ -32,9 +32,8 @@ public class Checksum {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof Checksum)) return false;
-    Checksum checksum = (Checksum) o;
-    return size == checksum.size && this.checksum == checksum.checksum;
+    if (!(o instanceof Checksum cs)) return false;
+    return size == cs.size && this.checksum == cs.checksum;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepositoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepositoryFactory.java
@@ -76,8 +76,7 @@ public class BackupRepositoryFactory {
     BackupRepository backupRepository = loader.newInstance(repo.className, BackupRepository.class);
     backupRepository.init(repo.initArgs);
 
-    if (backupRepository instanceof DelegatingBackupRepository) {
-      DelegatingBackupRepository delegatingRepo = (DelegatingBackupRepository) backupRepository;
+    if (backupRepository instanceof DelegatingBackupRepository delegatingRepo) {
       String delegateName = (String) repo.initArgs.get(PARAM_DELEGATE_REPOSITORY_NAME);
       if (delegateName == null) {
         throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/filestore/FileStoreAPI.java
+++ b/solr/core/src/java/org/apache/solr/filestore/FileStoreAPI.java
@@ -57,8 +57,7 @@ public class FileStoreAPI {
 
     @Override
     public boolean equals(Object that) {
-      if (that instanceof MetaData) {
-        MetaData metaData = (MetaData) that;
+      if (that instanceof MetaData metaData) {
         return Objects.equals(sha512, metaData.sha512)
             && Objects.equals(signatures, metaData.signatures)
             && Objects.equals(otherAttribs, metaData.otherAttribs);

--- a/solr/core/src/java/org/apache/solr/handler/AnalysisRequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/AnalysisRequestHandlerBase.java
@@ -305,8 +305,7 @@ public abstract class AnalysisRequestHandlerBase extends RequestHandlerBase {
                 k = ATTRIBUTE_MAPPING.get(k);
               }
 
-              if (value instanceof BytesRef) {
-                final BytesRef p = (BytesRef) value;
+              if (value instanceof BytesRef p) {
                 value = p.toString();
               }
 

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -382,8 +382,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
         for (BooleanClause clause : boostedQuery) {
           Query q = clause.getQuery();
           float originalBoost = 1f;
-          if (q instanceof BoostQuery) {
-            BoostQuery bq = (BoostQuery) q;
+          if (q instanceof BoostQuery bq) {
             q = bq.getQuery();
             originalBoost = bq.getBoost();
           }
@@ -481,8 +480,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
         }
         Query q = o.getQuery();
         float boost = 1f;
-        if (q instanceof BoostQuery) {
-          BoostQuery bq = (BoostQuery) q;
+        if (q instanceof BoostQuery bq) {
           q = bq.getQuery();
           boost = bq.getBoost();
         }

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1314,8 +1314,7 @@ public class ReplicationHandler extends RequestHandlerBase
       if (replicateOnOptimize) {
         IndexDeletionPolicyWrapper wrapper = core.getDeletionPolicy();
         IndexDeletionPolicy policy = wrapper == null ? null : wrapper.getWrappedDeletionPolicy();
-        if (policy instanceof SolrDeletionPolicy) {
-          SolrDeletionPolicy solrPolicy = (SolrDeletionPolicy) policy;
+        if (policy instanceof SolrDeletionPolicy solrPolicy) {
           if (solrPolicy.getMaxOptimizedCommitsToKeep() < 1) {
             solrPolicy.setMaxOptimizedCommitsToKeep(1);
           }

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -285,8 +285,7 @@ public abstract class RequestHandlerBase
 
   public static void processErrorMetricsOnException(Exception e, HandlerMetrics metrics) {
     boolean isClientError = false;
-    if (e instanceof SolrException) {
-      final SolrException se = (SolrException) e;
+    if (e instanceof SolrException se) {
       if (se.code() == SolrException.ErrorCode.CONFLICT.code) {
         return;
       } else if (se.code() >= 400 && se.code() < 500) {

--- a/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
@@ -501,8 +501,7 @@ public class SolrConfigHandler extends RequestHandlerBase
       }
 
       SolrResourceLoader loader = req.getCore().getResourceLoader();
-      if (loader instanceof ZkSolrResourceLoader) {
-        ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
+      if (loader instanceof ZkSolrResourceLoader zkLoader) {
         if (ops.isEmpty()) {
           ZkController.touchConfDir(zkLoader);
         } else {

--- a/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/StreamHandler.java
@@ -240,8 +240,7 @@ public class StreamHandler extends RequestHandlerBase
       rsp.add("explanation", tupleStream.toExplanation(this.streamFactory));
     }
 
-    if (tupleStream instanceof DaemonStream) {
-      DaemonStream daemonStream = (DaemonStream) tupleStream;
+    if (tupleStream instanceof DaemonStream daemonStream) {
       if (daemons.containsKey(daemonStream.getId())) {
         daemons.remove(daemonStream.getId()).close();
       }

--- a/solr/core/src/java/org/apache/solr/handler/admin/IndexSizeEstimator.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/IndexSizeEstimator.java
@@ -276,13 +276,11 @@ public class IndexSizeEstimator {
   private void convert(Map<String, Object> result) {
     for (Map.Entry<String, Object> entry : result.entrySet()) {
       Object value = entry.getValue();
-      if (value instanceof ItemPriorityQueue) {
-        ItemPriorityQueue queue = (ItemPriorityQueue) value;
+      if (value instanceof ItemPriorityQueue queue) {
         Map<String, Object> map = new LinkedHashMap<>();
         queue.toMap(map);
         entry.setValue(map);
-      } else if (value instanceof MapWriterSummaryStatistics) {
-        MapWriterSummaryStatistics stats = (MapWriterSummaryStatistics) value;
+      } else if (value instanceof MapWriterSummaryStatistics stats) {
         Map<String, Object> map = new LinkedHashMap<>();
         stats.toMap(map);
         entry.setValue(map);
@@ -308,8 +306,7 @@ public class IndexSizeEstimator {
                     ((Map<String, Object>) perField)
                         .forEach(
                             (k, val) -> {
-                              if (val instanceof SummaryStatistics) {
-                                SummaryStatistics stats = (SummaryStatistics) val;
+                              if (val instanceof SummaryStatistics stats) {
                                 if (k.startsWith("lengths")) {
                                   AtomicLong total =
                                       (AtomicLong)
@@ -596,8 +593,7 @@ public class IndexSizeEstimator {
       LeafReader leafReader = context.reader();
       EstimatingVisitor visitor = new EstimatingVisitor(stats, topN, maxLength, samplingStep);
       Bits liveDocs = leafReader.getLiveDocs();
-      if (leafReader instanceof CodecReader) {
-        CodecReader codecReader = (CodecReader) leafReader;
+      if (leafReader instanceof CodecReader codecReader) {
         StoredFieldsReader storedFieldsReader = codecReader.getFieldsReader();
         // this instance may be faster for a full sequential pass
         StoredFieldsReader mergeInstance = storedFieldsReader.getMergeInstance();

--- a/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
@@ -547,9 +547,7 @@ public class LukeRequestHandler extends RequestHandlerBase {
   private static SimpleOrderedMap<Object> getAnalyzerInfo(Analyzer analyzer) {
     SimpleOrderedMap<Object> aninfo = new SimpleOrderedMap<>();
     aninfo.add("className", analyzer.getClass().getName());
-    if (analyzer instanceof TokenizerChain) {
-
-      TokenizerChain tchain = (TokenizerChain) analyzer;
+    if (analyzer instanceof TokenizerChain tchain) {
 
       CharFilterFactory[] cfiltfacs = tchain.getCharFilterFactories();
       if (0 < cfiltfacs.length) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -237,8 +237,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
     for (LeafReaderContext lrc : leafContexts) {
       LeafReader leafReader = lrc.reader();
       leafReader = FilterLeafReader.unwrap(leafReader);
-      if (leafReader instanceof SegmentReader) {
-        SegmentReader sr = (SegmentReader) leafReader;
+      if (leafReader instanceof SegmentReader sr) {
         if (sr.getSegmentInfo().info.equals(segmentCommitInfo.info)) {
           seg = sr;
           break;

--- a/solr/core/src/java/org/apache/solr/handler/admin/SplitOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SplitOp.java
@@ -158,8 +158,7 @@ class SplitOp implements CoreAdminHandler.CoreAdminOp {
         }
         Object routerObj =
             collection.get(CollectionStateProps.DOC_ROUTER); // for back-compat with Solr 4.4
-        if (routerObj instanceof Map) {
-          Map<?, ?> routerProps = (Map<?, ?>) routerObj;
+        if (routerObj instanceof Map<?, ?> routerProps) {
           routeFieldName = (String) routerProps.get("field");
         }
       }
@@ -275,8 +274,7 @@ class SplitOp implements CoreAdminHandler.CoreAdminOp {
 
         Object routerObj =
             collection.get(CollectionStateProps.DOC_ROUTER); // for back-compat with Solr 4.4
-        if (routerObj instanceof Map) {
-          Map<?, ?> routerProps = (Map<?, ?>) routerObj;
+        if (routerObj instanceof Map<?, ?> routerProps) {
           routeFieldName = (String) routerProps.get("field");
         }
         if (routeFieldName == null) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -336,8 +336,7 @@ public class SystemInfoHandler extends RequestHandlerBase {
       // Mapped roles for this principal
       @SuppressWarnings("resource")
       AuthorizationPlugin auth = cc == null ? null : cc.getAuthorizationPlugin();
-      if (auth instanceof RuleBasedAuthorizationPluginBase) {
-        RuleBasedAuthorizationPluginBase rbap = (RuleBasedAuthorizationPluginBase) auth;
+      if (auth instanceof RuleBasedAuthorizationPluginBase rbap) {
         Set<String> roles = rbap.getUserRoles(req.getUserPrincipal());
         info.add("roles", roles);
         if (roles == null) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/GetSchema.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/GetSchema.java
@@ -110,8 +110,7 @@ public class GetSchema extends JerseyResource implements GetSchemaApi {
     final SchemaZkVersionResponse response =
         instantiateJerseyResponse(SchemaZkVersionResponse.class);
     int zkVersion = -1;
-    if (solrCore.getLatestSchema() instanceof ManagedIndexSchema) {
-      ManagedIndexSchema managed = (ManagedIndexSchema) solrCore.getLatestSchema();
+    if (solrCore.getLatestSchema() instanceof ManagedIndexSchema managed) {
       zkVersion = managed.getSchemaZkVersion();
       if (refreshIfBelowVersion != -1 && zkVersion < refreshIfBelowVersion) {
         log.info(

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/GetSchemaField.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/GetSchemaField.java
@@ -193,8 +193,7 @@ public class GetSchemaField extends JerseyResource implements GetSchemaApi.Field
     String camelCaseRealName = IndexSchema.nameMapping.get(realName);
     Map<String, Object> propertyValues = indexSchema.getNamedPropertyValues(realName, params);
     Object o = propertyValues.get(camelCaseRealName);
-    if (o instanceof List) {
-      List<?> list = (List<?>) o;
+    if (o instanceof List<?> list) {
       for (Object obj : list) {
         if (obj instanceof SimpleOrderedMap) {
           SimpleOrderedMap<Object> fieldInfo = (SimpleOrderedMap<Object>) obj;
@@ -216,8 +215,7 @@ public class GetSchemaField extends JerseyResource implements GetSchemaApi.Field
    * the response
    */
   private void insertPackageInfo(Object o) {
-    if (o instanceof List) {
-      List<?> l = (List<?>) o;
+    if (o instanceof List<?> l) {
       for (Object o1 : l) {
         if (o1 instanceof NamedList || o1 instanceof List) insertPackageInfo(o1);
       }
@@ -230,8 +228,7 @@ public class GetSchemaField extends JerseyResource implements GetSchemaApi.Field
             if (v instanceof NamedList || v instanceof List) insertPackageInfo(v);
           });
       Object v = nl.get("class");
-      if (v instanceof String) {
-        String klas = (String) v;
+      if (v instanceof String klas) {
         PluginInfo.ClassName parsedClassName = new PluginInfo.ClassName(klas);
         if (parsedClassName.pkg != null) {
           SolrClassLoader solrClassLoader = indexSchema.getSolrClassLoader();

--- a/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
@@ -338,9 +338,8 @@ public class DebugComponent extends SearchComponent {
       }
     }
 
-    if (source instanceof NamedList && dest instanceof NamedList) {
+    if (source instanceof NamedList<?> sl && dest instanceof NamedList) {
       NamedList<Object> tmp = new NamedList<>();
-      NamedList<?> sl = (NamedList<?>) source;
       @SuppressWarnings("unchecked")
       NamedList<Object> dl = (NamedList<Object>) dest;
       for (int i = 0; i < sl.size(); i++) {

--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -144,9 +144,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       if (filters != null) {
         int cost = Integer.MAX_VALUE;
         for (Query q : filters) {
-          if (q instanceof CollapsingQParserPlugin.CollapsingPostFilter) {
-            CollapsingQParserPlugin.CollapsingPostFilter cp =
-                (CollapsingQParserPlugin.CollapsingPostFilter) q;
+          if (q instanceof CollapsingQParserPlugin.CollapsingPostFilter cp) {
             // if there are multiple collapse pick the low cost one
             // if cost are equal then first one is picked
             if (cp.getCost() < cost) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -195,8 +195,7 @@ public class QueryComponent extends SearchComponent {
       if (rankQueryString != null) {
         QParser rqparser = QParser.getParser(rankQueryString, req);
         Query rq = rqparser.getQuery();
-        if (rq instanceof RankQuery) {
-          RankQuery rankQuery = (RankQuery) rq;
+        if (rq instanceof RankQuery rankQuery) {
           rb.setRankQuery(rankQuery);
           MergeStrategy mergeStrategy = rankQuery.getMergeStrategy();
           if (mergeStrategy != null) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryElevationComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryElevationComponent.java
@@ -1117,10 +1117,9 @@ public class QueryElevationComponent extends SearchComponent implements SolrCore
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof ElevatingQuery)) {
+      if (!(o instanceof ElevatingQuery eq)) {
         return false;
       }
-      ElevatingQuery eq = (ElevatingQuery) o;
       return queryString.equals(eq.queryString) && subsetMatch == eq.subsetMatch;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -879,8 +879,7 @@ public class RealTimeGetComponent extends SearchComponent {
         if ((!sf.hasDocValues() && !sf.stored()) || schema.isCopyFieldTarget(sf)) continue;
       }
       for (Object val : doc.getFieldValues(fname)) {
-        if (val instanceof IndexableField) {
-          IndexableField f = (IndexableField) val;
+        if (val instanceof IndexableField f) {
           // materialize:
           if (sf != null) {
             val = sf.getType().toObject(f); // object or external string?

--- a/solr/core/src/java/org/apache/solr/handler/component/ShardDoc.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ShardDoc.java
@@ -61,9 +61,8 @@ public class ShardDoc extends FieldDoc {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ShardDoc)) return false;
+    if (!(o instanceof ShardDoc shardDoc)) return false;
 
-    ShardDoc shardDoc = (ShardDoc) o;
     return Objects.equals(id, shardDoc.id);
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/StatsField.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/StatsField.java
@@ -405,8 +405,7 @@ public class StatsField {
       // tagMap has entries of List<String,List<QParser>>, but subject to change in the future
       if (!(olst instanceof Collection)) continue;
       for (Object o : (Collection<?>) olst) {
-        if (!(o instanceof QParser)) continue;
-        QParser qp = (QParser) o;
+        if (!(o instanceof QParser qp)) continue;
         try {
           excludeSet.put(qp.getQuery(), Boolean.TRUE);
         } catch (SyntaxError e) {

--- a/solr/core/src/java/org/apache/solr/handler/designer/DefaultSchemaSuggester.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/DefaultSchemaSuggester.java
@@ -275,11 +275,10 @@ public class DefaultSchemaSuggester implements SchemaSuggester {
     int maxLength = -1;
     int maxTerms = -1;
     for (Object next : values) {
-      if (!(next instanceof String)) {
+      if (!(next instanceof String cs)) {
         return false;
       }
 
-      String cs = (String) next;
       int len = cs.length();
       if (len > maxLength) {
         maxLength = len;

--- a/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerConfigSetHelper.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerConfigSetHelper.java
@@ -324,8 +324,7 @@ class SchemaDesignerConfigSetHelper implements SchemaDesignerConstants {
     // nice, the json for this field looks like
     // "synonymQueryStyle":
     // "org.apache.solr.parser.SolrQueryParserBase$SynonymQueryStyle:AS_SAME_TERM"
-    if (typeAttrs.get("synonymQueryStyle") instanceof String) {
-      String synonymQueryStyle = (String) typeAttrs.get("synonymQueryStyle");
+    if (typeAttrs.get("synonymQueryStyle") instanceof String synonymQueryStyle) {
       if (synonymQueryStyle.lastIndexOf(':') != -1) {
         typeAttrs.put(
             "synonymQueryStyle",

--- a/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerSettings.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerSettings.java
@@ -144,8 +144,7 @@ class SchemaDesignerSettings implements SchemaDesignerConstants {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof SchemaDesignerSettings)) return false;
-    SchemaDesignerSettings that = (SchemaDesignerSettings) o;
+    if (!(o instanceof SchemaDesignerSettings that)) return false;
     return isDisabled == that.isDisabled
         && dynamicFieldsEnabled == that.dynamicFieldsEnabled
         && nestedDocsEnabled == that.nestedDocsEnabled

--- a/solr/core/src/java/org/apache/solr/handler/loader/JavabinLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/JavabinLoader.java
@@ -164,9 +164,8 @@ public class JavabinLoader extends ContentStreamLoader {
                 params = ((NamedList) o).toSolrParams();
               } else {
                 try {
-                  if (o instanceof byte[]) {
+                  if (o instanceof byte[] buf) {
                     if (params != null) req.setParams(params);
-                    byte[] buf = (byte[]) o;
                     contentStreamLoader.load(
                         req, rsp, new ContentStreamBase.ByteArrayStream(buf, null), processor);
                   } else {

--- a/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
@@ -92,8 +92,7 @@ public class JsonLoader extends ContentStreamLoader {
     SolrInputDocument result = new SolrInputDocument();
     for (Map.Entry<String, Object> e : m.entrySet()) {
       if (mapEntryIsChildDoc(e.getValue())) { // parse child documents
-        if (e.getValue() instanceof List) {
-          List<?> value = (List<?>) e.getValue();
+        if (e.getValue() instanceof List<?> value) {
           for (Object o : value) {
             if (o instanceof Map) {
               // retain the value as a list, even if the list contains a single value.
@@ -114,8 +113,7 @@ public class JsonLoader extends ContentStreamLoader {
   }
 
   private static boolean mapEntryIsChildDoc(Object val) {
-    if (val instanceof List) {
-      List<?> listVal = (List<?>) val;
+    if (val instanceof List<?> listVal) {
       if (listVal.size() == 0) return false;
       return listVal.get(0) instanceof Map;
     }
@@ -297,9 +295,8 @@ public class JsonLoader extends ContentStreamLoader {
     private Map<String, Object> getDocMap(
         Map<String, Object> record, JSONParser parser, String srcField, boolean mapUniqueKeyOnly) {
       Map<String, Object> result = mapUniqueKeyOnly ? record : new LinkedHashMap<>(record);
-      if (srcField != null && parser instanceof RecordingJSONParser) {
+      if (srcField != null && parser instanceof RecordingJSONParser rjp) {
         // if srcFIeld specified extract it out first
-        RecordingJSONParser rjp = (RecordingJSONParser) parser;
         result.put(srcField, rjp.getBuf());
         rjp.resetBuf();
       }

--- a/solr/core/src/java/org/apache/solr/handler/tagger/TaggerRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/tagger/TaggerRequestHandler.java
@@ -351,8 +351,7 @@ public class TaggerRequestHandler extends RequestHandlerBase {
   private boolean fieldHasIndexedStopFilter(String field, SolrQueryRequest req) {
     FieldType fieldType = req.getSchema().getFieldType(field);
     Analyzer analyzer = fieldType.getIndexAnalyzer(); // index analyzer
-    if (analyzer instanceof TokenizerChain) {
-      TokenizerChain tokenizerChain = (TokenizerChain) analyzer;
+    if (analyzer instanceof TokenizerChain tokenizerChain) {
       TokenFilterFactory[] tokenFilterFactories = tokenizerChain.getTokenFilterFactories();
       for (TokenFilterFactory tokenFilterFactory : tokenFilterFactories) {
         if (tokenFilterFactory instanceof StopFilterFactory) return true;

--- a/solr/core/src/java/org/apache/solr/jersey/CatchAllExceptionMapper.java
+++ b/solr/core/src/java/org/apache/solr/jersey/CatchAllExceptionMapper.java
@@ -65,8 +65,7 @@ public class CatchAllExceptionMapper implements ExceptionMapper<Exception> {
         (SolrQueryResponse) containerRequestContext.getProperty(SOLR_QUERY_RESPONSE);
     final SolrQueryRequest solrQueryRequest =
         (SolrQueryRequest) containerRequestContext.getProperty(SOLR_QUERY_REQUEST);
-    if (exception instanceof WebApplicationException) {
-      final WebApplicationException wae = (WebApplicationException) exception;
+    if (exception instanceof WebApplicationException wae) {
       final SolrException solrException =
           new SolrException(getErrorCode(wae.getResponse().getStatus()), wae.getMessage());
       solrQueryResponse.setException(solrException);

--- a/solr/core/src/java/org/apache/solr/legacy/BBoxStrategy.java
+++ b/solr/core/src/java/org/apache/solr/legacy/BBoxStrategy.java
@@ -177,13 +177,12 @@ public class BBoxStrategy extends SpatialStrategy {
       numQuads++;
     }
     if (fieldType.indexOptions() != IndexOptions.NONE
-        && fieldType instanceof LegacyFieldType
-        && ((LegacyFieldType) fieldType).numericType() != null) {
+        && fieldType instanceof LegacyFieldType legacyType
+        && legacyType.numericType() != null) {
       if (hasPointVals) {
         throw new IllegalArgumentException(
             "pointValues and LegacyNumericType are mutually exclusive");
       }
-      final LegacyFieldType legacyType = (LegacyFieldType) fieldType;
       if (legacyType.numericType() != LegacyNumericType.DOUBLE) {
         throw new IllegalArgumentException(
             getClass() + " does not support " + legacyType.numericType());
@@ -302,10 +301,9 @@ public class BBoxStrategy extends SpatialStrategy {
   @Override
   public Query makeQuery(SpatialArgs args) {
     Shape shape = args.getShape();
-    if (!(shape instanceof Rectangle))
+    if (!(shape instanceof Rectangle bbox))
       throw new UnsupportedOperationException("Can only query by Rectangle, not " + shape);
 
-    Rectangle bbox = (Rectangle) shape;
     Query spatial;
 
     // Useful for understanding Relations:

--- a/solr/core/src/java/org/apache/solr/legacy/BBoxValueSource.java
+++ b/solr/core/src/java/org/apache/solr/legacy/BBoxValueSource.java
@@ -88,9 +88,7 @@ class BBoxValueSource extends ShapeValuesSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof BBoxValueSource)) return false;
-
-    BBoxValueSource that = (BBoxValueSource) o;
+    if (!(o instanceof BBoxValueSource that)) return false;
 
     return strategy.equals(that.strategy);
   }

--- a/solr/core/src/java/org/apache/solr/legacy/LegacyFieldType.java
+++ b/solr/core/src/java/org/apache/solr/legacy/LegacyFieldType.java
@@ -114,8 +114,7 @@ public final class LegacyFieldType extends FieldType {
     if (!super.equals(obj)) {
       return false;
     }
-    if (!(obj instanceof LegacyFieldType)) return false;
-    LegacyFieldType other = (LegacyFieldType) obj;
+    if (!(obj instanceof LegacyFieldType other)) return false;
     if (numericPrecisionStep != other.numericPrecisionStep) return false;
     return numericType == other.numericType;
   }

--- a/solr/core/src/java/org/apache/solr/legacy/LegacyNumericRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/legacy/LegacyNumericRangeQuery.java
@@ -422,8 +422,7 @@ public final class LegacyNumericRangeQuery<T extends Number> extends MultiTermQu
   public final boolean equals(final Object o) {
     if (o == this) return true;
     if (!super.equals(o)) return false;
-    if (o instanceof LegacyNumericRangeQuery) {
-      final LegacyNumericRangeQuery<?> q = (LegacyNumericRangeQuery<?>) o;
+    if (o instanceof LegacyNumericRangeQuery<?> q) {
       return Objects.equals(q.min, min)
           && Objects.equals(q.max, max)
           && minInclusive == q.minInclusive

--- a/solr/core/src/java/org/apache/solr/legacy/LegacyNumericTokenStream.java
+++ b/solr/core/src/java/org/apache/solr/legacy/LegacyNumericTokenStream.java
@@ -254,8 +254,7 @@ public final class LegacyNumericTokenStream extends TokenStream {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof LegacyNumericTermAttributeImpl)) return false;
-      LegacyNumericTermAttributeImpl other = (LegacyNumericTermAttributeImpl) obj;
+      if (!(obj instanceof LegacyNumericTermAttributeImpl other)) return false;
       if (precisionStep != other.precisionStep) return false;
       if (shift != other.shift) return false;
       if (value != other.value) return false;

--- a/solr/core/src/java/org/apache/solr/metrics/AggregateMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/AggregateMetric.java
@@ -90,10 +90,9 @@ public class AggregateMetric implements Metric {
     }
     Double res = null;
     for (Update u : values.values()) {
-      if (!(u.value instanceof Number)) {
+      if (!(u.value instanceof Number n)) {
         continue;
       }
-      Number n = (Number) u.value;
       if (res == null) {
         res = n.doubleValue();
         continue;
@@ -114,10 +113,9 @@ public class AggregateMetric implements Metric {
     }
     Double res = null;
     for (Update u : values.values()) {
-      if (!(u.value instanceof Number)) {
+      if (!(u.value instanceof Number n)) {
         continue;
       }
-      Number n = (Number) u.value;
       if (res == null) {
         res = n.doubleValue();
         continue;
@@ -138,10 +136,9 @@ public class AggregateMetric implements Metric {
     }
     double total = 0;
     for (Update u : values.values()) {
-      if (!(u.value instanceof Number)) {
+      if (!(u.value instanceof Number n)) {
         continue;
       }
-      Number n = (Number) u.value;
       total += n.doubleValue();
     }
     return total / values.size();
@@ -156,11 +153,10 @@ public class AggregateMetric implements Metric {
     double sum = 0;
     int count = 0;
     for (Update u : values.values()) {
-      if (!(u.value instanceof Number)) {
+      if (!(u.value instanceof Number n)) {
         continue;
       }
       count++;
-      Number n = (Number) u.value;
       final double diff = n.doubleValue() - mean;
       sum += diff * diff;
     }
@@ -177,10 +173,9 @@ public class AggregateMetric implements Metric {
     }
     double res = 0;
     for (Update u : values.values()) {
-      if (!(u.value instanceof Number)) {
+      if (!(u.value instanceof Number n)) {
         continue;
       }
-      Number n = (Number) u.value;
       res += n.doubleValue();
     }
     return res;

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricInfo.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricInfo.java
@@ -94,9 +94,8 @@ public final class SolrMetricInfo {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof SolrMetricInfo)) return false;
+    if (!(o instanceof SolrMetricInfo that)) return false;
 
-    SolrMetricInfo that = (SolrMetricInfo) o;
     return Objects.equals(name, that.name)
         && Objects.equals(scope, that.scope)
         && category == that.category;

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -835,8 +835,7 @@ public class SolrMetricManager {
     AtomicInteger removed = new AtomicInteger();
     registry.removeMatching(
         (name, metric) -> {
-          if (metric instanceof GaugeWrapper) {
-            GaugeWrapper<?> wrapper = (GaugeWrapper<?>) metric;
+          if (metric instanceof GaugeWrapper<?> wrapper) {
             boolean toRemove = wrapper.getTag().contains(tagSegment);
             if (toRemove) {
               removed.incrementAndGet();

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
@@ -140,8 +140,7 @@ public abstract class SolrPrometheusFormatter {
       GaugeSnapshot.GaugeDataPointSnapshot dataPoint =
           createGaugeDatapoint(((Number) dropwizardMetric).doubleValue(), labels);
       collectGaugeDatapoint(metricName, dataPoint);
-    } else if (dropwizardMetric instanceof HashMap) {
-      HashMap<?, ?> itemsMap = (HashMap<?, ?>) dropwizardMetric;
+    } else if (dropwizardMetric instanceof HashMap<?, ?> itemsMap) {
       for (Object item : itemsMap.keySet()) {
         if (itemsMap.get(item) instanceof Number) {
           GaugeSnapshot.GaugeDataPointSnapshot dataPoint =

--- a/solr/core/src/java/org/apache/solr/metrics/reporters/jmx/JmxMetricsReporter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/reporters/jmx/JmxMetricsReporter.java
@@ -580,8 +580,7 @@ public class JmxMetricsReporter implements Reporter, Closeable {
         if (filter.matches(name, gauge)) {
           final ObjectName objectName = createName("gauges", name);
           if (gauge instanceof SolrMetricManager.GaugeWrapper
-              && ((SolrMetricManager.GaugeWrapper<?>) gauge).getGauge() instanceof MetricsMap) {
-            MetricsMap mm = (MetricsMap) ((SolrMetricManager.GaugeWrapper<?>) gauge).getGauge();
+              && ((SolrMetricManager.GaugeWrapper<?>) gauge).getGauge() instanceof MetricsMap mm) {
             mm.setAttribute(new Attribute(INSTANCE_TAG, tag));
             // don't wrap it in a JmxGauge, it already supports all necessary JMX attributes
             registerMBean(mm, objectName);

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -549,8 +549,7 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
     // only set slop of the phrase query was a result of this parser
     // and not a sub-parser.
     if (subQParser == null) {
-      if (query instanceof PhraseQuery) {
-        PhraseQuery pq = (PhraseQuery) query;
+      if (query instanceof PhraseQuery pq) {
         Term[] terms = pq.getTerms();
         int[] positions = pq.getPositions();
         PhraseQuery.Builder builder = new PhraseQuery.Builder();
@@ -559,8 +558,7 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
         }
         builder.setSlop(slop);
         query = builder.build();
-      } else if (query instanceof MultiPhraseQuery) {
-        MultiPhraseQuery mpq = (MultiPhraseQuery) query;
+      } else if (query instanceof MultiPhraseQuery mpq) {
 
         if (slop != mpq.getSlop()) {
           query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
@@ -1011,9 +1009,8 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
     }
 
     Analyzer a = fieldType.getIndexAnalyzer();
-    if (a instanceof TokenizerChain) {
+    if (a instanceof TokenizerChain tc) {
       // examine the indexing analysis chain if it supports leading wildcards
-      TokenizerChain tc = (TokenizerChain) a;
       TokenFilterFactory[] factories = tc.getTokenFilterFactories();
       for (TokenFilterFactory factory : factories) {
         if (factory instanceof ReversedWildcardFilterFactory) {
@@ -1053,8 +1050,7 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
   // Create a "normal" query from a RawQuery (or just return the current query if it's not raw)
   Query rawToNormal(Query q) {
     Query normal = q;
-    if (q instanceof RawQuery) {
-      RawQuery rawq = (RawQuery) q;
+    if (q instanceof RawQuery rawq) {
       if (rawq.sfield.getType().isTokenized()) {
         normal =
             rawq.sfield.getType().getFieldQuery(parser, rawq.sfield, rawq.getJoinedExternalVal());

--- a/solr/core/src/java/org/apache/solr/pkg/PackageAPI.java
+++ b/solr/core/src/java/org/apache/solr/pkg/PackageAPI.java
@@ -198,8 +198,7 @@ public class PackageAPI {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj instanceof PkgVersion) {
-        PkgVersion that = (PkgVersion) obj;
+      if (obj instanceof PkgVersion that) {
         return Objects.equals(this.version, that.version) && Objects.equals(this.files, that.files);
       }
       return false;

--- a/solr/core/src/java/org/apache/solr/pkg/PackagePluginHolder.java
+++ b/solr/core/src/java/org/apache/solr/pkg/PackagePluginHolder.java
@@ -146,8 +146,7 @@ public class PackagePluginHolder<T> extends PluginBag.PluginHolder<T> {
     handleAwareCallbacks(newest.getLoader(), instance, core);
     T old = inst;
     inst = (T) instance;
-    if (old instanceof AutoCloseable) {
-      AutoCloseable closeable = (AutoCloseable) old;
+    if (old instanceof AutoCloseable closeable) {
       try {
         closeable.close();
       } catch (Exception e) {
@@ -158,8 +157,7 @@ public class PackagePluginHolder<T> extends PluginBag.PluginHolder<T> {
   }
 
   private void handleAwareCallbacks(SolrResourceLoader loader, Object instance, SolrCore core) {
-    if (instance instanceof SolrCoreAware) {
-      SolrCoreAware coreAware = (SolrCoreAware) instance;
+    if (instance instanceof SolrCoreAware coreAware) {
       if (!core.getResourceLoader().addToCoreAware(coreAware)) {
         coreAware.inform(core);
       }

--- a/solr/core/src/java/org/apache/solr/query/FilterQuery.java
+++ b/solr/core/src/java/org/apache/solr/query/FilterQuery.java
@@ -85,8 +85,7 @@ public class FilterQuery extends ExtendedQueryBase {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof FilterQuery)) return false;
-    FilterQuery fq = (FilterQuery) obj;
+    if (!(obj instanceof FilterQuery fq)) return false;
     return this.q.equals(fq.q);
   }
 
@@ -119,13 +118,12 @@ public class FilterQuery extends ExtendedQueryBase {
       throws IOException {
     // SolrRequestInfo reqInfo = SolrRequestInfo.getRequestInfo();
 
-    if (!(searcher instanceof SolrIndexSearcher)) {
+    if (!(searcher instanceof SolrIndexSearcher solrSearcher)) {
       // delete-by-query won't have SolrIndexSearcher
       // note: CSQ has some optimizations so we wrap it even though unnecessary given 0 boost
       return new ConstantScoreQuery(q).createWeight(searcher, scoreMode, 0f);
     }
 
-    SolrIndexSearcher solrSearcher = (SolrIndexSearcher) searcher;
     DocSet docs = solrSearcher.getDocSet(q);
     // reqInfo.addCloseHook(docs);  // needed for off-heap refcounting
 

--- a/solr/core/src/java/org/apache/solr/query/SolrRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/query/SolrRangeQuery.java
@@ -115,10 +115,9 @@ public final class SolrRangeQuery extends ExtendedQueryBase implements DocSetPro
     if (this == obj) {
       return true;
     }
-    if (!(obj instanceof SolrRangeQuery)) {
+    if (!(obj instanceof SolrRangeQuery other)) {
       return false;
     }
-    SolrRangeQuery other = (SolrRangeQuery) obj;
 
     return (this.flags == other.flags)
         && (this.field.equals(other.field))

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -234,8 +234,7 @@ public class SimpleFacets {
       // tagMap has entries of List<String,List<QParser>>, but subject to change in the future
       if (!(olst instanceof Collection)) continue;
       for (Object o : (Collection<?>) olst) {
-        if (!(o instanceof QParser)) continue;
-        QParser qp = (QParser) o;
+        if (!(o instanceof QParser qp)) continue;
         excludeSet.put(qp.getQuery(), Boolean.TRUE);
       }
     }
@@ -1292,8 +1291,7 @@ public class SimpleFacets {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof CountPair)) return false;
-      CountPair<?, ?> that = (CountPair<?, ?>) o;
+      if (!(o instanceof CountPair<?, ?> that)) return false;
       return (this.key.equals(that.key) && this.val.equals(that.val));
     }
 

--- a/solr/core/src/java/org/apache/solr/request/json/JsonQueryConverter.java
+++ b/solr/core/src/java/org/apache/solr/request/json/JsonQueryConverter.java
@@ -145,14 +145,13 @@ class JsonQueryConverter {
       } else {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
           String key = entry.getKey();
-          if (entry.getValue() instanceof List) {
+          if (entry.getValue() instanceof List<?> l) {
             if (key.equals("query")) {
               throw new SolrException(
                   SolrException.ErrorCode.BAD_REQUEST,
                   "Error when parsing json query, value of query field should not be a list, found : "
                       + entry.getValue());
             }
-            List<?> l = (List<?>) entry.getValue();
             for (Object subVal : l) {
               builder.append(key).append("=");
               buildLocalParams(builder, subVal, true, additionalParams);

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -363,8 +363,7 @@ public class RequestUtil {
 
         if (val == null) {
           params.remove(key);
-        } else if (val instanceof List) {
-          List<?> lst = (List<?>) val;
+        } else if (val instanceof List<?> lst) {
           String[] vals = new String[lst.size()];
           for (int i = 0; i < vals.length; i++) {
             vals[i] = lst.get(i).toString();

--- a/solr/core/src/java/org/apache/solr/response/BinaryResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/BinaryResponseWriter.java
@@ -83,9 +83,8 @@ public class BinaryResponseWriter implements BinaryQueryResponseWriter {
 
     @Override
     public Object resolve(Object o, JavaBinCodec codec) throws IOException {
-      if (o instanceof ResultContext) {
+      if (o instanceof ResultContext res) {
         ReturnFields orig = returnFields;
-        ResultContext res = (ResultContext) o;
         if (res.getReturnFields() != null) {
           returnFields = res.getReturnFields();
         }
@@ -111,10 +110,9 @@ public class BinaryResponseWriter implements BinaryQueryResponseWriter {
         writeResults(ctx, codec);
         return null; // null means we completely handled it
       }
-      if (o instanceof IndexableField) {
+      if (o instanceof IndexableField f) {
         if (schema == null) schema = solrQueryRequest.getSchema();
 
-        IndexableField f = (IndexableField) o;
         SchemaField sf = schema.getFieldOrNull(f.name());
         try {
           o = DocsStreamer.getValue(sf, f);
@@ -262,8 +260,7 @@ public class BinaryResponseWriter implements BinaryQueryResponseWriter {
     @Override
     public Object getFirstValue(String name) {
       Object v = _fields.get(name);
-      if (v == null || !(v instanceof Collection)) return convertCharSeq(v);
-      Collection<?> c = (Collection<?>) v;
+      if (v == null || !(v instanceof Collection<?> c)) return convertCharSeq(v);
       if (c.size() > 0) {
         return convertCharSeq(c.iterator().next());
       }

--- a/solr/core/src/java/org/apache/solr/response/CSVResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/CSVResponseWriter.java
@@ -419,8 +419,7 @@ class CSVWriter extends TabularResponseWriter {
 
       } else {
         // normalize to first value
-        if (val instanceof Collection) {
-          Collection<?> values = (Collection<?>) val;
+        if (val instanceof Collection<?> values) {
           val = values.iterator().next();
         }
         // if field is polyfield, use the multi-valued printer to apply appropriate escaping

--- a/solr/core/src/java/org/apache/solr/response/GraphMLResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/GraphMLResponseWriter.java
@@ -46,8 +46,7 @@ public class GraphMLResponseWriter implements QueryResponseWriter {
 
     TupleStream stream = (TupleStream) req.getContext().get("stream");
 
-    if (stream instanceof GraphHandler.DummyErrorStream) {
-      GraphHandler.DummyErrorStream d = (GraphHandler.DummyErrorStream) stream;
+    if (stream instanceof GraphHandler.DummyErrorStream d) {
       Exception e = d.getException();
       e.printStackTrace(new PrintWriter(writer));
       return;

--- a/solr/core/src/java/org/apache/solr/response/QueryResponseWriterUtil.java
+++ b/solr/core/src/java/org/apache/solr/response/QueryResponseWriterUtil.java
@@ -49,13 +49,11 @@ public final class QueryResponseWriterUtil {
       String contentType)
       throws IOException {
 
-    if (responseWriter instanceof JacksonJsonWriter) {
-      JacksonJsonWriter binWriter = (JacksonJsonWriter) responseWriter;
+    if (responseWriter instanceof JacksonJsonWriter binWriter) {
       BufferedOutputStream bos = new BufferedOutputStream(new NonFlushingStream(outputStream));
       binWriter.write(bos, solrRequest, solrResponse);
       bos.flush();
-    } else if (responseWriter instanceof BinaryQueryResponseWriter) {
-      BinaryQueryResponseWriter binWriter = (BinaryQueryResponseWriter) responseWriter;
+    } else if (responseWriter instanceof BinaryQueryResponseWriter binWriter) {
       binWriter.write(outputStream, solrRequest, solrResponse);
     } else {
       OutputStream out = new NonFlushingStream(outputStream);

--- a/solr/core/src/java/org/apache/solr/response/RawResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/RawResponseWriter.java
@@ -98,9 +98,8 @@ public class RawResponseWriter implements BinaryQueryResponseWriter {
   public void write(Writer writer, SolrQueryRequest request, SolrQueryResponse response)
       throws IOException {
     Object obj = response.getValues().get(CONTENT);
-    if (obj != null && (obj instanceof ContentStream)) {
+    if (obj != null && (obj instanceof ContentStream content)) {
       // copy the contents to the writer...
-      ContentStream content = (ContentStream) obj;
       try (Reader reader = content.getReader()) {
         reader.transferTo(writer);
       }
@@ -113,14 +112,12 @@ public class RawResponseWriter implements BinaryQueryResponseWriter {
   public void write(OutputStream out, SolrQueryRequest request, SolrQueryResponse response)
       throws IOException {
     Object obj = response.getValues().get(CONTENT);
-    if (obj != null && (obj instanceof ContentStream)) {
+    if (obj != null && (obj instanceof ContentStream content)) {
       // copy the contents to the writer...
-      ContentStream content = (ContentStream) obj;
       try (InputStream in = content.getStream()) {
         in.transferTo(out);
       }
-    } else if (obj != null && (obj instanceof SolrCore.RawWriter)) {
-      final var rawWriter = (SolrCore.RawWriter) obj;
+    } else if (obj != null && (obj instanceof SolrCore.RawWriter rawWriter)) {
       rawWriter.write(out);
       if (rawWriter instanceof Closeable) ((Closeable) rawWriter).close();
     } else {

--- a/solr/core/src/java/org/apache/solr/response/TextResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/TextResponseWriter.java
@@ -176,8 +176,7 @@ public abstract class TextResponseWriter implements TextWriter {
       return;
     }
 
-    if (val instanceof IndexableField) {
-      IndexableField f = (IndexableField) val;
+    if (val instanceof IndexableField f) {
       SchemaField sf = schema.getFieldOrNull(f.name());
       if (sf != null) {
         sf.getType().write(raw ? rawShim : this, name, f);
@@ -206,8 +205,7 @@ public abstract class TextResponseWriter implements TextWriter {
       // restricts the fields to write...?
     } else if (val instanceof SolrDocumentList) {
       writeSolrDocumentList(name, (SolrDocumentList) val, returnFields);
-    } else if (val instanceof BytesRef) {
-      BytesRef arr = (BytesRef) val;
+    } else if (val instanceof BytesRef arr) {
       writeByteArr(name, arr.bytes, arr.offset, arr.length);
     } else {
       TextWriter.super.writeVal(name, val, raw);

--- a/solr/core/src/java/org/apache/solr/response/transform/BaseEditorialTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/BaseEditorialTransformer.java
@@ -59,8 +59,7 @@ public abstract class BaseEditorialTransformer extends DocTransformer {
 
   protected BytesRef getKey(SolrDocument doc) {
     Object obj = doc.get(idFieldName);
-    if (obj instanceof IndexableField) {
-      IndexableField f = (IndexableField) obj;
+    if (obj instanceof IndexableField f) {
       BytesRefBuilder bytesRefBuilder = new BytesRefBuilder();
       Number n = f.numericValue();
       if (n != null) {

--- a/solr/core/src/java/org/apache/solr/response/transform/GeoTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/GeoTransformerFactory.java
@@ -95,7 +95,7 @@ public class GeoTransformerFactory extends TransformerFactory
           ErrorCode.BAD_REQUEST,
           this.getClass().getSimpleName() + " using unknown field: " + fname);
     }
-    if (!(sf.getType() instanceof AbstractSpatialFieldType)) {
+    if (!(sf.getType() instanceof AbstractSpatialFieldType<?> sdv)) {
       throw new SolrException(
           ErrorCode.BAD_REQUEST,
           "GeoTransformer requested non-spatial field: "
@@ -111,7 +111,6 @@ public class GeoTransformerFactory extends TransformerFactory
     updater.display_error = display + "_error";
 
     final ShapeValuesSource shapes;
-    AbstractSpatialFieldType<?> sdv = (AbstractSpatialFieldType<?>) sf.getType();
     SpatialStrategy strategy = sdv.getStrategy(fname);
     if (strategy instanceof CompositeSpatialStrategy) {
       shapes = ((CompositeSpatialStrategy) strategy).getGeometryStrategy().makeShapeValueSource();

--- a/solr/core/src/java/org/apache/solr/response/transform/SubQueryAugmenterFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/SubQueryAugmenterFactory.java
@@ -274,8 +274,7 @@ class SubQueryAugmenter extends DocTransformer {
 
     private String convertFieldValue(Object val) {
 
-      if (val instanceof IndexableField) {
-        IndexableField f = (IndexableField) val;
+      if (val instanceof IndexableField f) {
         return f.stringValue();
       }
       return val.toString();

--- a/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymFilterFactory.java
@@ -221,8 +221,7 @@ public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
         Set<String> output = cpsm.mappings.get(origTerm);
 
         Object val = jsonMap.get(origTerm); // IMPORTANT: use the original
-        if (val instanceof String) {
-          String strVal = (String) val;
+        if (val instanceof String strVal) {
 
           if (output == null) {
             output = new TreeSet<>();

--- a/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymGraphFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymGraphFilterFactory.java
@@ -217,8 +217,7 @@ public class ManagedSynonymGraphFilterFactory extends BaseManagedTokenFilterFact
         Set<String> output = cpsm.mappings.get(origTerm);
 
         Object val = jsonMap.get(origTerm); // IMPORTANT: use the original
-        if (val instanceof String) {
-          String strVal = (String) val;
+        if (val instanceof String strVal) {
 
           if (output == null) {
             output = new TreeSet<>();

--- a/solr/core/src/java/org/apache/solr/schema/BinaryField.java
+++ b/solr/core/src/java/org/apache/solr/schema/BinaryField.java
@@ -112,8 +112,7 @@ public class BinaryField extends FieldType {
     if (val instanceof byte[]) {
       buf = (byte[]) val;
       len = buf.length;
-    } else if (val instanceof ByteBuffer && ((ByteBuffer) val).hasArray()) {
-      ByteBuffer byteBuf = (ByteBuffer) val;
+    } else if (val instanceof ByteBuffer byteBuf && byteBuf.hasArray()) {
       buf = byteBuf.array();
       offset = byteBuf.arrayOffset() + byteBuf.position();
       len = byteBuf.limit() - byteBuf.position();
@@ -156,8 +155,7 @@ public class BinaryField extends FieldType {
   public Object toNativeType(Object val) {
     if (val instanceof byte[]) {
       return ByteBuffer.wrap((byte[]) val);
-    } else if (val instanceof CharSequence) {
-      final CharSequence valAsCharSequence = (CharSequence) val;
+    } else if (val instanceof CharSequence valAsCharSequence) {
       return ByteBuffer.wrap(Base64.getDecoder().decode(valAsCharSequence.toString()));
     }
     return super.toNativeType(val);

--- a/solr/core/src/java/org/apache/solr/schema/CurrencyFieldType.java
+++ b/solr/core/src/java/org/apache/solr/schema/CurrencyFieldType.java
@@ -515,9 +515,7 @@ public class CurrencyFieldType extends FieldType implements SchemaAware, Resourc
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof ConvertedCurrencyValueSource)) return false;
-
-      ConvertedCurrencyValueSource that = (ConvertedCurrencyValueSource) o;
+      if (!(o instanceof ConvertedCurrencyValueSource that)) return false;
 
       return Objects.equals(source, that.source)
           && (rate == that.rate)
@@ -728,9 +726,7 @@ public class CurrencyFieldType extends FieldType implements SchemaAware, Resourc
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof RawCurrencyValueSource)) return false;
-
-      RawCurrencyValueSource that = (RawCurrencyValueSource) o;
+      if (!(o instanceof RawCurrencyValueSource that)) return false;
 
       return Objects.equals(amountValues, that.amountValues)
           && Objects.equals(currencyValues, that.currencyValues)

--- a/solr/core/src/java/org/apache/solr/schema/DateRangeField.java
+++ b/solr/core/src/java/org/apache/solr/schema/DateRangeField.java
@@ -75,8 +75,7 @@ public class DateRangeField
   protected String getStoredValue(Shape shape, String shapeStr) {
     // even if shapeStr is set, it might have included some dateMath, so see if we can resolve it
     // first:
-    if (shape instanceof UnitNRShape) {
-      UnitNRShape unitShape = (UnitNRShape) shape;
+    if (shape instanceof UnitNRShape unitShape) {
       if (unitShape.getLevel() == tree.getMaxLevels()) {
         // fully precise date. We can be fully compatible with DatePointField (incl. 'Z')
         return shape.toString() + 'Z';

--- a/solr/core/src/java/org/apache/solr/schema/ExternalFileFieldReloader.java
+++ b/solr/core/src/java/org/apache/solr/schema/ExternalFileFieldReloader.java
@@ -79,8 +79,7 @@ public class ExternalFileFieldReloader extends AbstractSolrEventListener {
     fieldSources.clear();
     for (SchemaField field : schema.getFields().values()) {
       FieldType type = field.getType();
-      if (type instanceof ExternalFileField) {
-        ExternalFileField eff = (ExternalFileField) type;
+      if (type instanceof ExternalFileField eff) {
         fieldSources.add(eff.getFileFloatSource(field, datadir));
         if (log.isInfoEnabled()) {
           log.info("Adding ExternalFileFieldReloader listener for field {}", field.getName());

--- a/solr/core/src/java/org/apache/solr/schema/FieldType.java
+++ b/solr/core/src/java/org/apache/solr/schema/FieldType.java
@@ -1311,9 +1311,8 @@ public abstract class FieldType extends FieldProperties {
   protected static SimpleOrderedMap<Object> getAnalyzerProperties(Analyzer analyzer) {
     SimpleOrderedMap<Object> analyzerProps = new SimpleOrderedMap<>();
 
-    if (analyzer instanceof TokenizerChain) {
+    if (analyzer instanceof TokenizerChain tokenizerChain) {
       Map<String, String> factoryArgs;
-      TokenizerChain tokenizerChain = (TokenizerChain) analyzer;
       CharFilterFactory[] charFilterFactories = tokenizerChain.getCharFilterFactories();
       if (0 < charFilterFactories.length) {
         List<SimpleOrderedMap<Object>> charFilterProps = new ArrayList<>();

--- a/solr/core/src/java/org/apache/solr/schema/FileExchangeRateProvider.java
+++ b/solr/core/src/java/org/apache/solr/schema/FileExchangeRateProvider.java
@@ -132,9 +132,7 @@ public class FileExchangeRateProvider implements ExchangeRateProvider {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof FileExchangeRateProvider)) return false;
-
-    FileExchangeRateProvider that = (FileExchangeRateProvider) o;
+    if (!(o instanceof FileExchangeRateProvider that)) return false;
 
     return Objects.equals(rates, that.rates);
   }

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
@@ -2017,8 +2017,7 @@ public class IndexSchema {
       informResourceLoaderAwareObjectsInChain((TokenizerChain) queryAnalyzer);
 
     // if fieldType is a TextField, it might have a multi-term analyzer
-    if (fieldType instanceof TextField) {
-      TextField textFieldType = (TextField) fieldType;
+    if (fieldType instanceof TextField textFieldType) {
       Analyzer multiTermAnalyzer = textFieldType.getMultiTermAnalyzer();
       if (multiTermAnalyzer != null
           && multiTermAnalyzer != indexAnalyzer

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchemaFactory.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchemaFactory.java
@@ -168,8 +168,7 @@ public abstract class IndexSchemaFactory implements NamedListInitializedPlugin {
               return c.get();
             };
 
-    if (loader instanceof ZkSolrResourceLoader) {
-      ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
+    if (loader instanceof ZkSolrResourceLoader zkLoader) {
       ObjectCache objectCache = objectCacheSupplier.get();
       if (objectCache == null) return cfgLoader.get();
       Map<String, VersionedConfig> confCache =

--- a/solr/core/src/java/org/apache/solr/schema/LatLonPointSpatialField.java
+++ b/solr/core/src/java/org/apache/solr/schema/LatLonPointSpatialField.java
@@ -138,12 +138,11 @@ public class LatLonPointSpatialField
 
     @Override
     public Field[] createIndexableFields(Shape shape) {
-      if (!(shape instanceof Point)) {
+      if (!(shape instanceof Point point)) {
         throw new SolrException(
             SolrException.ErrorCode.BAD_REQUEST,
             getClass().getSimpleName() + " only supports indexing points; got: " + shape);
       }
-      Point point = (Point) shape;
 
       int fieldsLen = (indexed ? 1 : 0) + (docValues ? 1 : 0);
       Field[] fields = new Field[fieldsLen];
@@ -179,17 +178,14 @@ public class LatLonPointSpatialField
     // Uses LatLonPoint
     protected Query makeQueryFromIndex(Shape shape) {
       // note: latitude then longitude order for LLP's methods
-      if (shape instanceof Circle) {
-        Circle circle = (Circle) shape;
+      if (shape instanceof Circle circle) {
         double radiusMeters = circle.getRadius() * DistanceUtils.DEG_TO_KM * 1000;
         return LatLonPoint.newDistanceQuery(
             getFieldName(), circle.getCenter().getY(), circle.getCenter().getX(), radiusMeters);
-      } else if (shape instanceof Rectangle) {
-        Rectangle rect = (Rectangle) shape;
+      } else if (shape instanceof Rectangle rect) {
         return LatLonPoint.newBoxQuery(
             getFieldName(), rect.getMinY(), rect.getMaxY(), rect.getMinX(), rect.getMaxX());
-      } else if (shape instanceof Point) {
-        Point point = (Point) shape;
+      } else if (shape instanceof Point point) {
         return LatLonPoint.newDistanceQuery(getFieldName(), point.getY(), point.getX(), 0);
       } else {
         throw new UnsupportedOperationException(
@@ -204,17 +200,14 @@ public class LatLonPointSpatialField
     // Uses DocValuesField  (otherwise identical to above)
     protected Query makeQueryFromDocValues(Shape shape) {
       // note: latitude then longitude order for LLP's methods
-      if (shape instanceof Circle) {
-        Circle circle = (Circle) shape;
+      if (shape instanceof Circle circle) {
         double radiusMeters = circle.getRadius() * DistanceUtils.DEG_TO_KM * 1000;
         return LatLonDocValuesField.newSlowDistanceQuery(
             getFieldName(), circle.getCenter().getY(), circle.getCenter().getX(), radiusMeters);
-      } else if (shape instanceof Rectangle) {
-        Rectangle rect = (Rectangle) shape;
+      } else if (shape instanceof Rectangle rect) {
         return LatLonDocValuesField.newSlowBoxQuery(
             getFieldName(), rect.getMinY(), rect.getMaxY(), rect.getMinX(), rect.getMaxX());
-      } else if (shape instanceof Point) {
-        Point point = (Point) shape;
+      } else if (shape instanceof Point point) {
         return LatLonDocValuesField.newSlowDistanceQuery(
             getFieldName(), point.getY(), point.getX(), 0);
       } else {
@@ -258,8 +251,7 @@ public class LatLonPointSpatialField
       @Override
       public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DistanceSortValueSource)) return false;
-        DistanceSortValueSource that = (DistanceSortValueSource) o;
+        if (!(o instanceof DistanceSortValueSource that)) return false;
         return Double.compare(that.multiplier, multiplier) == 0
             && Objects.equals(fieldName, that.fieldName)
             && Objects.equals(queryPoint, that.queryPoint);

--- a/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchemaFactory.java
+++ b/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchemaFactory.java
@@ -209,12 +209,11 @@ public class ManagedIndexSchemaFactory extends IndexSchemaFactory implements Sol
       }
 
       int schemaZkVersion = -1;
-      if (!(loader instanceof ZkSolrResourceLoader)) {
+      if (!(loader instanceof ZkSolrResourceLoader zkLoader)) {
         Entry<String, InputStream> localSchemaInput = readSchemaLocally();
         loadedResource = localSchemaInput.getKey();
         schemaInputStream = localSchemaInput.getValue();
       } else { // ZooKeeper
-        final ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
         final SolrZkClient zkClient = zkLoader.getZkController().getZkClient();
         final String managedSchemaPath = lookupZKManagedSchemaPath();
         managedSchemaResourceName =
@@ -347,8 +346,7 @@ public class ManagedIndexSchemaFactory extends IndexSchemaFactory implements Sol
     if (!resourceName.equals(managedSchemaResourceName)) {
       boolean exists = false;
       SolrResourceLoader loader = config.getResourceLoader();
-      if (loader instanceof ZkSolrResourceLoader) {
-        ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
+      if (loader instanceof ZkSolrResourceLoader zkLoader) {
         String nonManagedSchemaPath = zkLoader.getConfigSetZkPath() + "/" + resourceName;
         try {
           exists = zkLoader.getZkController().pathExists(nonManagedSchemaPath);
@@ -544,9 +542,8 @@ public class ManagedIndexSchemaFactory extends IndexSchemaFactory implements Sol
   @Override
   public void inform(SolrCore core) {
     this.core = core;
-    if (loader instanceof ZkSolrResourceLoader) {
+    if (loader instanceof ZkSolrResourceLoader zkLoader) {
       this.zkIndexSchemaReader = new ZkIndexSchemaReader(this, core);
-      ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
       zkLoader.setZkIndexSchemaReader(this.zkIndexSchemaReader);
       try {
         zkIndexSchemaReader.refreshSchemaFromZk(-1); // update immediately if newer is available

--- a/solr/core/src/java/org/apache/solr/schema/OpenExchangeRatesOrgProvider.java
+++ b/solr/core/src/java/org/apache/solr/schema/OpenExchangeRatesOrgProvider.java
@@ -122,9 +122,8 @@ public class OpenExchangeRatesOrgProvider implements ExchangeRateProvider {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof OpenExchangeRatesOrgProvider)) return false;
+    if (!(o instanceof OpenExchangeRatesOrgProvider that)) return false;
 
-    OpenExchangeRatesOrgProvider that = (OpenExchangeRatesOrgProvider) o;
     return Objects.equals(rates, that.rates);
   }
 

--- a/solr/core/src/java/org/apache/solr/schema/RandomSortField.java
+++ b/solr/core/src/java/org/apache/solr/schema/RandomSortField.java
@@ -192,8 +192,7 @@ public class RandomSortField extends FieldType {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof RandomValueSource)) return false;
-      RandomValueSource other = (RandomValueSource) o;
+      if (!(o instanceof RandomValueSource other)) return false;
       return this.field.equals(other.field);
     }
 

--- a/solr/core/src/java/org/apache/solr/schema/RptWithGeometrySpatialField.java
+++ b/solr/core/src/java/org/apache/solr/schema/RptWithGeometrySpatialField.java
@@ -134,9 +134,8 @@ public class RptWithGeometrySpatialField
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof CachingShapeValuesource)) return false;
+      if (!(o instanceof CachingShapeValuesource that)) return false;
 
-      CachingShapeValuesource that = (CachingShapeValuesource) o;
       return Objects.equals(targetValueSource, that.targetValueSource)
           && Objects.equals(fieldName, that.fieldName);
     }
@@ -217,9 +216,7 @@ public class RptWithGeometrySpatialField
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof PerSegCacheKey)) return false;
-
-      PerSegCacheKey that = (PerSegCacheKey) o;
+      if (!(o instanceof PerSegCacheKey that)) return false;
 
       if (docId != that.docId) return false;
 

--- a/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
+++ b/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
@@ -120,8 +120,7 @@ public class SchemaManager {
         errors = CommandOperation.captureErrors(operations);
         if (!errors.isEmpty()) break;
         SolrResourceLoader loader = req.getCore().getResourceLoader();
-        if (loader instanceof ZkSolrResourceLoader) {
-          ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
+        if (loader instanceof ZkSolrResourceLoader zkLoader) {
           StringWriter sw = new StringWriter();
           try {
             managedIndexSchema.persist(sw);
@@ -484,8 +483,7 @@ public class SchemaManager {
 
     SolrResourceLoader resourceLoader = core.getResourceLoader();
     String schemaResourceName = core.getLatestSchema().getResourceName();
-    if (resourceLoader instanceof ZkSolrResourceLoader) {
-      final ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) resourceLoader;
+    if (resourceLoader instanceof ZkSolrResourceLoader zkLoader) {
       SolrZkClient zkClient = zkLoader.getZkController().getZkClient();
       String managedSchemaPath = zkLoader.getConfigSetZkPath() + "/" + schemaResourceName;
       try {

--- a/solr/core/src/java/org/apache/solr/schema/SortableTextField.java
+++ b/solr/core/src/java/org/apache/solr/schema/SortableTextField.java
@@ -101,8 +101,7 @@ public class SortableTextField extends TextField {
     if (!field.hasDocValues()) {
       return Collections.singletonList(f);
     }
-    if (value instanceof ByteArrayUtf8CharSequence) {
-      ByteArrayUtf8CharSequence utf8 = (ByteArrayUtf8CharSequence) value;
+    if (value instanceof ByteArrayUtf8CharSequence utf8) {
       if (utf8.size() < maxCharsForDocValues) {
         BytesRef bytes = new BytesRef(utf8.getBuf(), utf8.offset(), utf8.size());
         return getIndexableFields(field, f, bytes);

--- a/solr/core/src/java/org/apache/solr/schema/StrField.java
+++ b/solr/core/src/java/org/apache/solr/schema/StrField.java
@@ -69,8 +69,7 @@ public class StrField extends PrimitiveFieldType {
   }
 
   public static BytesRef getBytesRef(Object value) {
-    if (value instanceof ByteArrayUtf8CharSequence) {
-      ByteArrayUtf8CharSequence utf8 = (ByteArrayUtf8CharSequence) value;
+    if (value instanceof ByteArrayUtf8CharSequence utf8) {
       return new BytesRef(utf8.getBuf(), utf8.offset(), utf8.size());
     } else return new BytesRef(value.toString());
   }

--- a/solr/core/src/java/org/apache/solr/schema/TrieField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieField.java
@@ -697,8 +697,7 @@ public class TrieField extends NumericFieldType {
    * prefix of the main value of a trie field that indexes multiple precisions per value.
    */
   public static String getMainValuePrefix(org.apache.solr.schema.FieldType ft) {
-    if (ft instanceof TrieField) {
-      final TrieField trie = (TrieField) ft;
+    if (ft instanceof TrieField trie) {
       if (trie.precisionStep == Integer.MAX_VALUE) return null;
       switch (trie.type) {
         case INTEGER:

--- a/solr/core/src/java/org/apache/solr/schema/ZkIndexSchemaReader.java
+++ b/solr/core/src/java/org/apache/solr/schema/ZkIndexSchemaReader.java
@@ -257,8 +257,7 @@ public class ZkIndexSchemaReader implements OnReconnect {
   public boolean equals(Object other) {
     if (other == null) return false;
     if (other == this) return true;
-    if (!(other instanceof ZkIndexSchemaReader)) return false;
-    ZkIndexSchemaReader that = (ZkIndexSchemaReader) other;
+    if (!(other instanceof ZkIndexSchemaReader that)) return false;
     return this.managedSchemaPath.equals(that.managedSchemaPath)
         && this.uniqueCoreId.equals(that.uniqueCoreId);
   }

--- a/solr/core/src/java/org/apache/solr/search/BitDocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/BitDocSet.java
@@ -224,8 +224,7 @@ public class BitDocSet extends DocSet {
   @Override
   public DocSet union(DocSet other) {
     FixedBitSet newbits = bits.clone();
-    if (other instanceof BitDocSet) {
-      BitDocSet otherDocSet = (BitDocSet) other;
+    if (other instanceof BitDocSet otherDocSet) {
       newbits = FixedBitSet.ensureCapacity(newbits, otherDocSet.bits.length());
       newbits.or(otherDocSet.bits);
     } else {

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -249,8 +249,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
 
     @Override
     public boolean equals(final Object other) {
-      if (other instanceof GroupHeadSelector) {
-        final GroupHeadSelector that = (GroupHeadSelector) other;
+      if (other instanceof GroupHeadSelector that) {
         return (this.type == that.type) && this.selectorText.equals(that.selectorText);
       }
       return false;

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -151,8 +151,7 @@ public class DisMaxQParser extends QParser {
       if (1 == boostQueries.size() && 1 == boostParams.length) {
         /* legacy logic */
         Query f = boostQueries.get(0);
-        while (f instanceof BoostQuery) {
-          BoostQuery bq = (BoostQuery) f;
+        while (f instanceof BoostQuery bq) {
           if (bq.getBoost() == 1f) {
             f = bq.getQuery();
           } else {

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -1236,8 +1236,7 @@ public class ExtendedDismaxQParser extends QParser {
               subs.clear();
               // Make a dismax query for each clause position in the boolean per-field queries.
               for (int n = 0; n < lst.size(); ++n) {
-                if (lst.get(n) instanceof BoostQuery) {
-                  BoostQuery boostQuery = (BoostQuery) lst.get(n);
+                if (lst.get(n) instanceof BoostQuery boostQuery) {
                   BooleanQuery booleanQuery = (BooleanQuery) boostQuery.getQuery();
                   subs.add(
                       new BoostQuery(
@@ -1440,8 +1439,7 @@ public class ExtendedDismaxQParser extends QParser {
                 BooleanQuery bq = (BooleanQuery) query;
                 query = SolrPluginUtils.setMinShouldMatch(bq, minShouldMatch, false);
               }
-            } else if (query instanceof PhraseQuery) {
-              PhraseQuery pq = (PhraseQuery) query;
+            } else if (query instanceof PhraseQuery pq) {
               if (minClauseSize > 1 && pq.getTerms().length < minClauseSize) return null;
               PhraseQuery.Builder builder = new PhraseQuery.Builder();
               Term[] terms = pq.getTerms();
@@ -1451,8 +1449,7 @@ public class ExtendedDismaxQParser extends QParser {
               }
               builder.setSlop(slop);
               query = builder.build();
-            } else if (query instanceof MultiPhraseQuery) {
-              MultiPhraseQuery mpq = (MultiPhraseQuery) query;
+            } else if (query instanceof MultiPhraseQuery mpq) {
               if (minClauseSize > 1 && mpq.getTermArrays().length < minClauseSize) return null;
               if (slop != mpq.getSlop()) {
                 query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
@@ -1485,16 +1482,14 @@ public class ExtendedDismaxQParser extends QParser {
     private Analyzer noStopwordFilterAnalyzer(String fieldName) {
       FieldType ft = parser.getReq().getSchema().getFieldType(fieldName);
       Analyzer qa = ft.getQueryAnalyzer();
-      if (!(qa instanceof TokenizerChain)) {
+      if (!(qa instanceof TokenizerChain tcq)) {
         return qa;
       }
 
-      TokenizerChain tcq = (TokenizerChain) qa;
       Analyzer ia = ft.getIndexAnalyzer();
-      if (ia == qa || !(ia instanceof TokenizerChain)) {
+      if (ia == qa || !(ia instanceof TokenizerChain tci)) {
         return qa;
       }
-      TokenizerChain tci = (TokenizerChain) ia;
 
       // make sure that there isn't a stop filter in the indexer
       for (TokenFilterFactory tf : tci.getTokenFilterFactories()) {

--- a/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
@@ -221,9 +221,8 @@ public class FloatPayloadValueSource extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof FloatPayloadValueSource)) return false;
+    if (!(o instanceof FloatPayloadValueSource that)) return false;
 
-    FloatPayloadValueSource that = (FloatPayloadValueSource) o;
     return Objects.equals(indexedField, that.indexedField)
         && Objects.equals(indexedBytes, that.indexedBytes)
         && Objects.equals(decoder, that.decoder)

--- a/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
@@ -424,8 +424,7 @@ public class FunctionQParser extends QParser {
         valueSource = new FieldNameValueSource(val);
       } else {
         QParser subParser = subQuery(val, "func");
-        if (subParser instanceof FunctionQParser) {
-          FunctionQParser subFunc = (FunctionQParser) subParser;
+        if (subParser instanceof FunctionQParser subFunc) {
           subFunc.setParseMultipleSources(true);
           subFunc.setFlags(flags);
         }

--- a/solr/core/src/java/org/apache/solr/search/HashQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/HashQParserPlugin.java
@@ -193,8 +193,7 @@ public class HashQParserPlugin extends QParserPlugin {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof HashCodeValuesSource)) return false;
-      HashCodeValuesSource that = (HashCodeValuesSource) o;
+      if (!(o instanceof HashCodeValuesSource that)) return false;
       return Arrays.equals(fields, that.fields);
     }
 
@@ -240,8 +239,7 @@ public class HashQParserPlugin extends QParserPlugin {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof HashPartitionPredicate)) return false;
-      HashPartitionPredicate that = (HashPartitionPredicate) o;
+      if (!(o instanceof HashPartitionPredicate that)) return false;
       return workers == that.workers && worker == that.worker;
     }
 

--- a/solr/core/src/java/org/apache/solr/search/IGainTermsQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/IGainTermsQParserPlugin.java
@@ -230,8 +230,7 @@ public class IGainTermsQParserPlugin extends QParserPlugin {
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof TermWithScore)) return false;
-      TermWithScore other = (TermWithScore) obj;
+      if (!(obj instanceof TermWithScore other)) return false;
       return Objects.equals(this.term, other.term);
     }
 

--- a/solr/core/src/java/org/apache/solr/search/MaxScoreQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/MaxScoreQParser.java
@@ -54,8 +54,7 @@ public class MaxScoreQParser extends LuceneQParser {
   public Query parse() throws SyntaxError {
     Query q = super.parse();
     float boost = 1f;
-    if (q instanceof BoostQuery) {
-      BoostQuery bq = (BoostQuery) q;
+    if (q instanceof BoostQuery bq) {
       boost = bq.getBoost();
       q = bq.getQuery();
     }

--- a/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
@@ -280,8 +280,7 @@ public class MultiThreadedSearcher {
     public Object reduce(Collection collectors) throws IOException {
       final FixedBitSet reduced = new FixedBitSet(maxDoc);
       for (Object collector : collectors) {
-        if (collector instanceof FixedBitSetCollector) {
-          FixedBitSetCollector fixedBitSetCollector = (FixedBitSetCollector) collector;
+        if (collector instanceof FixedBitSetCollector fixedBitSetCollector) {
           fixedBitSetCollector.update(reduced);
         }
       }

--- a/solr/core/src/java/org/apache/solr/search/MutableBitDocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/MutableBitDocSet.java
@@ -50,8 +50,7 @@ class MutableBitDocSet extends BitDocSet {
    * @return Unwrapped DocSet that is not mutable
    */
   public static DocSet unwrapIfMutable(DocSet docSet) {
-    if (docSet instanceof MutableBitDocSet) {
-      MutableBitDocSet mutableBitDocSet = (MutableBitDocSet) docSet;
+    if (docSet instanceof MutableBitDocSet mutableBitDocSet) {
       // don't call size() since we just want to pass through the size
       // instead of computing it if it was already computed
       return new BitDocSet(mutableBitDocSet.getBits(), mutableBitDocSet.size);

--- a/solr/core/src/java/org/apache/solr/search/QueryParsing.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryParsing.java
@@ -230,13 +230,11 @@ public class QueryParsing {
     // clear the boosted / is clause flags for recursion
     int subflag = flags & ~(FLAG_BOOSTED | FLAG_IS_CLAUSE);
 
-    if (query instanceof TermQuery) {
-      TermQuery q = (TermQuery) query;
+    if (query instanceof TermQuery q) {
       Term t = q.getTerm();
       FieldType ft = writeFieldName(t.field(), schema, out, flags);
       writeFieldVal(t.bytes(), ft, out, flags);
-    } else if (query instanceof TermRangeQuery) {
-      TermRangeQuery q = (TermRangeQuery) query;
+    } else if (query instanceof TermRangeQuery q) {
       String fname = q.getField();
       FieldType ft = writeFieldName(fname, schema, out, flags);
       out.append(q.includesLower() ? '[' : '{');
@@ -257,8 +255,7 @@ public class QueryParsing {
       }
 
       out.append(q.includesUpper() ? ']' : '}');
-    } else if (query instanceof LegacyNumericRangeQuery) {
-      LegacyNumericRangeQuery<?> q = (LegacyNumericRangeQuery<?>) query;
+    } else if (query instanceof LegacyNumericRangeQuery<?> q) {
       String fname = q.getField();
       FieldType ft = writeFieldName(fname, schema, out, flags);
       out.append(q.includesMin() ? '[' : '{');
@@ -279,8 +276,7 @@ public class QueryParsing {
       }
 
       out.append(q.includesMax() ? ']' : '}');
-    } else if (query instanceof BooleanQuery) {
-      BooleanQuery q = (BooleanQuery) query;
+    } else if (query instanceof BooleanQuery q) {
       boolean needParens = false;
 
       if (q.getMinimumNumberShouldMatch() != 0 || (flags & (FLAG_IS_CLAUSE | FLAG_BOOSTED)) != 0) {
@@ -315,8 +311,7 @@ public class QueryParsing {
         out.append(Integer.toString(q.getMinimumNumberShouldMatch()));
       }
 
-    } else if (query instanceof PrefixQuery) {
-      PrefixQuery q = (PrefixQuery) query;
+    } else if (query instanceof PrefixQuery q) {
       Term prefix = q.getPrefix();
       FieldType ft = writeFieldName(prefix.field(), schema, out, flags);
       out.append(prefix.text());
@@ -327,12 +322,10 @@ public class QueryParsing {
       out.append(query.toString());
     } else if (query instanceof ConstantScoreQuery) {
       out.append(query.toString());
-    } else if (query instanceof WrappedQuery) {
-      WrappedQuery q = (WrappedQuery) query;
+    } else if (query instanceof WrappedQuery q) {
       out.append(q.getOptions());
       toString(q.getWrappedQuery(), schema, out, subflag);
-    } else if (query instanceof BoostQuery) {
-      BoostQuery q = (BoostQuery) query;
+    } else if (query instanceof BoostQuery q) {
       toString(q.getQuery(), schema, out, subflag | FLAG_BOOSTED);
       out.append('^');
       out.append(Float.toString(q.getBoost()));

--- a/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
@@ -110,8 +110,7 @@ public final class QueryResultKey implements Accountable {
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;
-    if (!(o instanceof QueryResultKey)) return false;
-    QueryResultKey other = (QueryResultKey) o;
+    if (!(o instanceof QueryResultKey other)) return false;
 
     // fast check of the whole hash code... most hash tables will only use
     // some of the bits, so if this is a hash collision, it's still likely

--- a/solr/core/src/java/org/apache/solr/search/QueryUtils.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryUtils.java
@@ -44,8 +44,7 @@ public class QueryUtils {
 
   /** return true if this query has no positive components */
   public static boolean isNegative(Query q) {
-    if (!(q instanceof BooleanQuery)) return false;
-    BooleanQuery bq = (BooleanQuery) q;
+    if (!(q instanceof BooleanQuery bq)) return false;
     Collection<BooleanClause> clauses = bq.clauses();
     if (clauses.size() == 0) return false;
     for (BooleanClause clause : clauses) {
@@ -140,8 +139,7 @@ public class QueryUtils {
    * @return Absolute version of the Query
    */
   public static Query getAbs(Query q) {
-    if (q instanceof BoostQuery) {
-      BoostQuery bq = (BoostQuery) q;
+    if (q instanceof BoostQuery bq) {
       Query subQ = bq.getQuery();
       Query absSubQ = getAbs(subQ);
       if (absSubQ.equals(subQ)) return q;
@@ -155,8 +153,7 @@ public class QueryUtils {
       return new WrappedQuery(absSubQ);
     }
 
-    if (!(q instanceof BooleanQuery)) return q;
-    BooleanQuery bq = (BooleanQuery) q;
+    if (!(q instanceof BooleanQuery bq)) return q;
 
     Collection<BooleanClause> clauses = bq.clauses();
     if (clauses.size() == 0) return q;
@@ -198,8 +195,7 @@ public class QueryUtils {
    */
   public static Query fixNegativeQuery(Query q) {
     float boost = 1f;
-    if (q instanceof BoostQuery) {
-      BoostQuery bq = (BoostQuery) q;
+    if (q instanceof BoostQuery bq) {
       boost = bq.getBoost();
       q = bq.getQuery();
     }
@@ -326,8 +322,7 @@ public class QueryUtils {
       Object tagVal = tagMap.get(tagName);
       if (!(tagVal instanceof Collection)) continue;
       for (Object obj : (Collection<?>) tagVal) {
-        if (!(obj instanceof QParser)) continue;
-        QParser qParser = (QParser) obj;
+        if (!(obj instanceof QParser qParser)) continue;
         Query query;
         try {
           query = qParser.getQuery();

--- a/solr/core/src/java/org/apache/solr/search/ReRankScaler.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankScaler.java
@@ -84,8 +84,7 @@ public class ReRankScaler {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof ReRankScaler) {
-      ReRankScaler _reRankScaler = (ReRankScaler) o;
+    if (o instanceof ReRankScaler _reRankScaler) {
       if (mainQueryMin == _reRankScaler.mainQueryMin
           && mainQueryMax == _reRankScaler.mainQueryMax
           && reRankQueryMin == _reRankScaler.reRankQueryMin

--- a/solr/core/src/java/org/apache/solr/search/SignificantTermsQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SignificantTermsQParserPlugin.java
@@ -291,8 +291,7 @@ public class SignificantTermsQParserPlugin extends QParserPlugin {
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof TermWithScore)) return false;
-      TermWithScore other = (TermWithScore) obj;
+      if (!(obj instanceof TermWithScore other)) return false;
       return Objects.equals(this.term, other.term);
     }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1230,8 +1230,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     int end = 0; // size of "sets" and "neg"; parallel arrays
 
     for (Query q : queries) {
-      if (q instanceof ExtendedQuery) {
-        ExtendedQuery eq = (ExtendedQuery) q;
+      if (q instanceof ExtendedQuery eq) {
         if (!eq.getCache()) {
           if (eq.getCost() >= 100 && eq instanceof PostFilter) {
             if (postFilters == null) postFilters = new ArrayList<>(sets.length - end);
@@ -1608,8 +1607,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
     int flags = cmd.getFlags();
     Query q = cmd.getQuery();
-    if (q instanceof ExtendedQuery) {
-      ExtendedQuery eq = (ExtendedQuery) q;
+    if (q instanceof ExtendedQuery eq) {
       if (!eq.getCache()) {
         flags |= (NO_CHECK_QCACHE | NO_SET_QCACHE | NO_CHECK_FILTERCACHE);
       }
@@ -1858,8 +1856,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       throws IOException {
     int minNumFound = cmd.getMinExactCount();
     Query q = cmd.getQuery();
-    if (q instanceof RankQuery) {
-      RankQuery rq = (RankQuery) q;
+    if (q instanceof RankQuery rq) {
       return rq.getTopDocsCollector(len, cmd, this);
     }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
@@ -381,8 +381,7 @@ public class SolrReturnFields extends ReturnFields {
         ValueSource vs = null;
 
         try {
-          if (parser instanceof FunctionQParser) {
-            FunctionQParser fparser = (FunctionQParser) parser;
+          if (parser instanceof FunctionQParser fparser) {
             fparser.setParseMultipleSources(false);
             fparser.setParseToEnd(false);
 

--- a/solr/core/src/java/org/apache/solr/search/SortSpecParsing.java
+++ b/solr/core/src/java/org/apache/solr/search/SortSpecParsing.java
@@ -115,8 +115,7 @@ public class SortSpecParsing {
           QParser parser = QParser.getParser(funcStr, FunctionQParserPlugin.NAME, optionalReq);
           Query q = null;
           try {
-            if (parser instanceof FunctionQParser) {
-              FunctionQParser fparser = (FunctionQParser) parser;
+            if (parser instanceof FunctionQParser fparser) {
               fparser.setParseMultipleSources(false);
               fparser.setParseToEnd(false);
 

--- a/solr/core/src/java/org/apache/solr/search/SpatialFilterQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/SpatialFilterQParser.java
@@ -73,8 +73,7 @@ public class SpatialFilterQParser extends QParser {
       SchemaField sf = req.getSchema().getField(fields[0]);
       FieldType type = sf.getType();
 
-      if (type instanceof SpatialQueryable) {
-        SpatialQueryable queryable = ((SpatialQueryable) type);
+      if (type instanceof SpatialQueryable queryable) {
         double radius =
             localParams.getDouble(SpatialParams.SPHERE_RADIUS, queryable.getSphereRadius());
         SpatialOptions opts = new SpatialOptions(pointStr, dist, sf, measStr, radius);

--- a/solr/core/src/java/org/apache/solr/search/TopLevelJoinQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/TopLevelJoinQuery.java
@@ -56,14 +56,13 @@ public class TopLevelJoinQuery extends JoinQuery {
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
-    if (!(searcher instanceof SolrIndexSearcher)) {
+    if (!(searcher instanceof SolrIndexSearcher solrSearcher)) {
       log.debug(
           "Falling back to JoinQueryWeight because searcher [{}] is not the required SolrIndexSearcher",
           searcher);
       return super.createWeight(searcher, scoreMode, boost);
     }
 
-    final SolrIndexSearcher solrSearcher = (SolrIndexSearcher) searcher;
     final JoinQueryWeight weight =
         new JoinQueryWeight(solrSearcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
     final SolrIndexSearcher fromSearcher = weight.fromSearcher;

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -541,12 +541,11 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
 
             String fieldName = fp.parseArg();
             SchemaField f = fp.getReq().getSchema().getField(fieldName);
-            if (!(f.getType() instanceof CurrencyFieldType)) {
+            if (!(f.getType() instanceof CurrencyFieldType ft)) {
               throw new SolrException(
                   SolrException.ErrorCode.BAD_REQUEST,
                   "Currency function input must be the name of a CurrencyFieldType: " + fieldName);
             }
-            CurrencyFieldType ft = (CurrencyFieldType) f.getType();
             String code = fp.hasMoreArguments() ? fp.parseArg() : null;
             return ft.getConvertedValueSource(code, ft.getValueSource(f, fp));
           }
@@ -1606,8 +1605,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof LongConstValueSource)) return false;
-      LongConstValueSource other = (LongConstValueSource) o;
+      if (!(o instanceof LongConstValueSource other)) return false;
       return this.constant == other.constant;
     }
 
@@ -1759,8 +1757,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
 
       @Override
       public boolean equals(Object o) {
-        if (!(o instanceof Function)) return false;
-        Function other = (Function) o;
+        if (!(o instanceof Function other)) return false;
         return this.a.equals(other.a) && this.b.equals(other.b);
       }
     }
@@ -1799,8 +1796,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof BoolConstValueSource)) return false;
-      BoolConstValueSource other = (BoolConstValueSource) o;
+      if (!(o instanceof BoolConstValueSource other)) return false;
       return this.constant == other.constant;
     }
 

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessor.java
@@ -895,8 +895,8 @@ abstract class FacetFieldProcessor extends FacetProcessor<FacetField> {
    * @see SweepingCountSlotAcc
    */
   protected boolean registerSweepingAccIfSupportedByCollectAcc() {
-    if (countAcc instanceof SweepingCountSlotAcc && collectAcc instanceof SweepableSlotAcc) {
-      final SweepingCountSlotAcc sweepingCountAcc = (SweepingCountSlotAcc) countAcc;
+    if (countAcc instanceof SweepingCountSlotAcc sweepingCountAcc
+        && collectAcc instanceof SweepableSlotAcc) {
       collectAcc = ((SweepableSlotAcc<?>) collectAcc).registerSweepingAccs(sweepingCountAcc);
       if (allBucketsAcc != null) {
         allBucketsAcc.collectAcc = collectAcc;

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayDV.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayDV.java
@@ -225,9 +225,7 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
 
     // calculate segment-local counts
     int doc;
-    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter) {
-      FieldCacheImpl.SortedDocValuesImpl.Iter fc =
-          (FieldCacheImpl.SortedDocValuesImpl.Iter) singleDv;
+    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter fc) {
       while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
         final int segOrd = fc.getOrd(doc);
         if (segOrd >= 0) {
@@ -340,10 +338,8 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
       throws IOException {
     final SegCountGlobal segCounter = getSegCountGlobal(disi, singleDv);
     int doc;
-    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter) {
+    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter fc) {
 
-      FieldCacheImpl.SortedDocValuesImpl.Iter fc =
-          (FieldCacheImpl.SortedDocValuesImpl.Iter) singleDv;
       while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
         int segOrd = fc.getOrd(doc);
         if (segOrd < 0) continue;

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByHashDV.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByHashDV.java
@@ -369,9 +369,7 @@ class FacetFieldProcessorByHashDV extends FacetFieldProcessor {
             @Override
             protected void doSetNextReader(LeafReaderContext ctx) throws IOException {
               setNextReaderFirstPhase(ctx);
-              if (globalDocValues instanceof MultiDocValues.MultiSortedDocValues) {
-                MultiDocValues.MultiSortedDocValues multiDocValues =
-                    (MultiDocValues.MultiSortedDocValues) globalDocValues;
+              if (globalDocValues instanceof MultiDocValues.MultiSortedDocValues multiDocValues) {
                 docValues = multiDocValues.values[ctx.ord];
                 toGlobal = multiDocValues.mapping.getGlobalOrds(ctx.ord);
               }

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetHeatmap.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetHeatmap.java
@@ -129,13 +129,10 @@ public class FacetHeatmap extends FacetRequest {
       final DistanceUnits distanceUnits;
       // note: the two instanceof conditions is not ideal, versus one. If we start needing to add
       // more then refactor.
-      if ((type instanceof AbstractSpatialPrefixTreeFieldType)) {
-        AbstractSpatialPrefixTreeFieldType<?> rptType =
-            (AbstractSpatialPrefixTreeFieldType<?>) type;
+      if ((type instanceof AbstractSpatialPrefixTreeFieldType<?> rptType)) {
         strategy = rptType.getStrategy(fieldName);
         distanceUnits = rptType.getDistanceUnits();
-      } else if (type instanceof RptWithGeometrySpatialField) {
-        RptWithGeometrySpatialField rptSdvType = (RptWithGeometrySpatialField) type;
+      } else if (type instanceof RptWithGeometrySpatialField rptSdvType) {
         strategy = rptSdvType.getStrategy(fieldName).getIndexStrategy();
         distanceUnits = rptSdvType.getDistanceUnits();
       } else {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetParser.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetParser.java
@@ -612,8 +612,7 @@ abstract class FacetParser<T extends FacetRequest> {
 
       FacetRequest.FacetSort facetSort = null;
 
-      if (sort instanceof String) {
-        String sortStr = (String) sort;
+      if (sort instanceof String sortStr) {
         if (sortStr.endsWith(" asc")) {
           facetSort =
               new FacetRequest.FacetSort(

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRangeProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRangeProcessor.java
@@ -297,12 +297,11 @@ class FacetRangeProcessor extends FacetProcessor<FacetRange> {
    * @return list of {@link Range}
    */
   private List<Range> parseRanges(Object input) {
-    if (!(input instanceof List)) {
+    if (!(input instanceof List<?> intervals)) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST,
           "Expected List for ranges but got " + input.getClass().getSimpleName() + " = " + input);
     }
-    List<?> intervals = (List<?>) input;
     List<Range> ranges = new ArrayList<>();
     for (Object obj : intervals) {
       if (!(obj instanceof Map)) {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
@@ -61,8 +61,7 @@ public abstract class FacetRequest {
 
     @Override
     public boolean equals(Object other) {
-      if (other instanceof FacetSort) {
-        final FacetSort that = (FacetSort) other;
+      if (other instanceof FacetSort that) {
         return this.sortVariable.equals(that.sortVariable)
             && this.sortDirection.equals(that.sortDirection);
       }

--- a/solr/core/src/java/org/apache/solr/search/facet/FieldUtil.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FieldUtil.java
@@ -84,9 +84,7 @@ public class FieldUtil {
   public static void visitOrds(SortedDocValues singleDv, DocIdSetIterator disi, OrdFunc ordFunc)
       throws IOException {
     int doc;
-    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter) {
-      FieldCacheImpl.SortedDocValuesImpl.Iter fc =
-          (FieldCacheImpl.SortedDocValuesImpl.Iter) singleDv;
+    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter fc) {
       while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
         ordFunc.handleOrd(doc, fc.getOrd(doc));
       }
@@ -102,9 +100,7 @@ public class FieldUtil {
   }
 
   public static OrdValues getOrdValues(SortedDocValues singleDv, DocIdSetIterator disi) {
-    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter) {
-      FieldCacheImpl.SortedDocValuesImpl.Iter fc =
-          (FieldCacheImpl.SortedDocValuesImpl.Iter) singleDv;
+    if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter fc) {
       return new FCOrdValues(fc, disi);
     }
     return new DVOrdValues(singleDv, disi);

--- a/solr/core/src/java/org/apache/solr/search/facet/PercentileAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/PercentileAgg.java
@@ -86,8 +86,7 @@ public class PercentileAgg extends SimpleAggValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof PercentileAgg)) return false;
-    PercentileAgg other = (PercentileAgg) o;
+    if (!(o instanceof PercentileAgg other)) return false;
     return this.arg.equals(other.arg) && this.percentiles.equals(other.percentiles);
   }
 

--- a/solr/core/src/java/org/apache/solr/search/facet/RelatednessAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/RelatednessAgg.java
@@ -118,10 +118,9 @@ public class RelatednessAgg extends AggValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof RelatednessAgg)) {
+    if (!(o instanceof RelatednessAgg that)) {
       return false;
     }
-    RelatednessAgg that = (RelatednessAgg) o;
     return Objects.equals(fgQ, that.fgQ)
         && Objects.equals(bgQ, that.bgQ)
         && min_pop == that.min_pop;
@@ -571,10 +570,9 @@ public class RelatednessAgg extends AggValueSource {
 
     @Override
     public boolean equals(Object other) {
-      if (!(other instanceof BucketData)) {
+      if (!(other instanceof BucketData that)) {
         return false;
       }
-      BucketData that = (BucketData) other;
       // we will most certainly be compared to other buckets of the same Agg instance, so compare
       // counts first
       return this.implied == that.implied

--- a/solr/core/src/java/org/apache/solr/search/function/DualDoubleFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/DualDoubleFunction.java
@@ -98,8 +98,7 @@ public abstract class DualDoubleFunction extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof DualDoubleFunction)) return false;
-    DualDoubleFunction other = (DualDoubleFunction) o;
+    if (!(o instanceof DualDoubleFunction other)) return false;
     return Objects.equals(this.a, other.a) && Objects.equals(this.b, other.b);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -109,8 +109,7 @@ public class FileFloatSource extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof FileFloatSource)) return false;
-    FileFloatSource other = (FileFloatSource) o;
+    if (!(o instanceof FileFloatSource other)) return false;
     return this.field.getName().equals(other.field.getName())
         && this.keyField.getName().equals(other.keyField.getName())
         && this.defVal == other.defVal
@@ -242,8 +241,7 @@ public class FileFloatSource extends ValueSource {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof Entry)) return false;
-      Entry other = (Entry) o;
+      if (!(o instanceof Entry other)) return false;
       return ffs.equals(other.ffs);
     }
 

--- a/solr/core/src/java/org/apache/solr/search/function/MultiStringFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/MultiStringFunction.java
@@ -134,8 +134,7 @@ public abstract class MultiStringFunction extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof MultiStringFunction)) return false;
-    MultiStringFunction other = (MultiStringFunction) o;
+    if (!(o instanceof MultiStringFunction other)) return false;
     return Objects.equals(this.name(), other.name()) && Arrays.equals(this.sources, other.sources);
   }
 

--- a/solr/core/src/java/org/apache/solr/search/function/OrdFieldSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/OrdFieldSource.java
@@ -73,9 +73,7 @@ public class OrdFieldSource extends ValueSource {
     final int off = readerContext.docBase;
     final LeafReader r;
     Object o = context.get("searcher");
-    if (o instanceof SolrIndexSearcher) {
-      @SuppressWarnings("resource")
-      final SolrIndexSearcher is = (SolrIndexSearcher) o;
+    if (o instanceof @SuppressWarnings("resource") SolrIndexSearcher is) {
       SchemaField sf = is.getSchema().getFieldOrNull(field);
       if (sf != null && sf.getType().isPointField()) {
         throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/search/function/ReverseOrdFieldSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/ReverseOrdFieldSource.java
@@ -71,9 +71,7 @@ public class ReverseOrdFieldSource extends ValueSource {
     final int off = readerContext.docBase;
     final LeafReader r;
     Object o = context.get("searcher");
-    if (o instanceof SolrIndexSearcher) {
-      @SuppressWarnings("resource")
-      final SolrIndexSearcher is = (SolrIndexSearcher) o;
+    if (o instanceof @SuppressWarnings("resource") SolrIndexSearcher is) {
       SchemaField sf = is.getSchema().getFieldOrNull(field);
       if (sf != null && sf.getType().isPointField()) {
         throw new SolrException(
@@ -122,8 +120,7 @@ public class ReverseOrdFieldSource extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof ReverseOrdFieldSource)) return false;
-    ReverseOrdFieldSource other = (ReverseOrdFieldSource) o;
+    if (!(o instanceof ReverseOrdFieldSource other)) return false;
     return this.field.equals(other.field);
   }
 

--- a/solr/core/src/java/org/apache/solr/search/function/ValueSourceRangeFilter.java
+++ b/solr/core/src/java/org/apache/solr/search/function/ValueSourceRangeFilter.java
@@ -147,9 +147,8 @@ public class ValueSourceRangeFilter extends Query {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ValueSourceRangeFilter)) return false;
+    if (!(o instanceof ValueSourceRangeFilter other)) return false;
 
-    ValueSourceRangeFilter other = (ValueSourceRangeFilter) o;
     return Objects.equals(this.valueSource, other.valueSource)
         && this.includeLower == other.includeLower
         && this.includeUpper == other.includeUpper

--- a/solr/core/src/java/org/apache/solr/search/function/distance/GeoDistValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/GeoDistValueSourceParser.java
@@ -227,8 +227,7 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
       throws SyntaxError {
     SchemaField sf = fp.getReq().getSchema().getField(sfield);
     FieldType type = sf.getType();
-    if (type instanceof AbstractSpatialFieldType) {
-      AbstractSpatialFieldType<?> asft = (AbstractSpatialFieldType<?>) type;
+    if (type instanceof AbstractSpatialFieldType<?> asft) {
       return new SpatialStrategyMultiValueSource(asft.getStrategy(sfield), asft.getDistanceUnits());
     }
     ValueSource vs = type.getValueSource(sf, fp);

--- a/solr/core/src/java/org/apache/solr/search/function/distance/GeohashFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/GeohashFunction.java
@@ -70,9 +70,7 @@ public class GeohashFunction extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof GeohashFunction)) return false;
-
-    GeohashFunction that = (GeohashFunction) o;
+    if (!(o instanceof GeohashFunction that)) return false;
 
     if (!lat.equals(that.lat)) return false;
     if (!lon.equals(that.lon)) return false;

--- a/solr/core/src/java/org/apache/solr/search/function/distance/GeohashHaversineFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/GeohashHaversineFunction.java
@@ -105,8 +105,7 @@ public class GeohashHaversineFunction extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeohashHaversineFunction)) return false;
-    GeohashHaversineFunction other = (GeohashHaversineFunction) o;
+    if (!(o instanceof GeohashHaversineFunction other)) return false;
     return Objects.equals(this.name(), other.name())
         && Objects.equals(geoHash1, other.geoHash1)
         && Objects.equals(geoHash2, other.geoHash2)

--- a/solr/core/src/java/org/apache/solr/search/function/distance/HaversineConstFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/HaversineConstFunction.java
@@ -99,8 +99,7 @@ public class HaversineConstFunction extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof HaversineConstFunction)) return false;
-    HaversineConstFunction other = (HaversineConstFunction) o;
+    if (!(o instanceof HaversineConstFunction other)) return false;
     return this.latCenter == other.latCenter
         && this.lonCenter == other.lonCenter
         && this.p2.equals(other.p2);

--- a/solr/core/src/java/org/apache/solr/search/function/distance/HaversineFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/HaversineFunction.java
@@ -124,8 +124,7 @@ public class HaversineFunction extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof HaversineFunction)) return false;
-    HaversineFunction other = (HaversineFunction) o;
+    if (!(o instanceof HaversineFunction other)) return false;
     return Objects.equals(this.name(), other.name())
         && Objects.equals(p1, other.p1)
         && Objects.equals(p2, other.p2)

--- a/solr/core/src/java/org/apache/solr/search/function/distance/SquaredEuclideanFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/SquaredEuclideanFunction.java
@@ -54,10 +54,8 @@ public class SquaredEuclideanFunction extends VectorDistanceFunction {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof SquaredEuclideanFunction)) return false;
+    if (!(o instanceof SquaredEuclideanFunction that)) return false;
     if (!super.equals(o)) return false;
-
-    SquaredEuclideanFunction that = (SquaredEuclideanFunction) o;
 
     if (!name.equals(that.name)) return false;
 

--- a/solr/core/src/java/org/apache/solr/search/function/distance/StringDistanceFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/StringDistanceFunction.java
@@ -86,9 +86,7 @@ public class StringDistanceFunction extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof StringDistanceFunction)) return false;
-
-    StringDistanceFunction that = (StringDistanceFunction) o;
+    if (!(o instanceof StringDistanceFunction that)) return false;
 
     if (!dist.equals(that.dist)) return false;
     if (!str1.equals(that.str1)) return false;

--- a/solr/core/src/java/org/apache/solr/search/function/distance/VectorDistanceFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/VectorDistanceFunction.java
@@ -184,9 +184,7 @@ public class VectorDistanceFunction extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof VectorDistanceFunction)) return false;
-
-    VectorDistanceFunction that = (VectorDistanceFunction) o;
+    if (!(o instanceof VectorDistanceFunction that)) return false;
 
     if (Float.compare(that.power, power) != 0) return false;
     if (!source1.equals(that.source1)) return false;

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -57,8 +57,7 @@ public class SearchGroupsResultTransformer
     final NamedList<NamedList<Object>> result = new NamedList<>(data.size());
     for (Command<?> command : data) {
       final NamedList<Object> commandResult = new NamedList<>(2);
-      if (command instanceof SearchGroupsFieldCommand) {
-        SearchGroupsFieldCommand fieldCommand = (SearchGroupsFieldCommand) command;
+      if (command instanceof SearchGroupsFieldCommand fieldCommand) {
         final SearchGroupsFieldCommandResult fieldCommandResult = fieldCommand.result();
         final Collection<SearchGroup<BytesRef>> searchGroups = fieldCommandResult.getSearchGroups();
         if (searchGroups != null) {

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/TopGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/TopGroupsResultTransformer.java
@@ -72,12 +72,10 @@ public class TopGroupsResultTransformer
     final IndexSchema schema = rb.req.getSearcher().getSchema();
     for (Command<?> command : data) {
       NamedList<Object> commandResult;
-      if (command instanceof TopGroupsFieldCommand) {
-        TopGroupsFieldCommand fieldCommand = (TopGroupsFieldCommand) command;
+      if (command instanceof TopGroupsFieldCommand fieldCommand) {
         SchemaField groupField = schema.getField(fieldCommand.getKey());
         commandResult = serializeTopGroups(fieldCommand.result(), groupField);
-      } else if (command instanceof QueryCommand) {
-        QueryCommand queryCommand = (QueryCommand) command;
+      } else if (command instanceof QueryCommand queryCommand) {
         commandResult = serializeTopDocs(queryCommand.result());
       } else {
         commandResult = null;
@@ -241,11 +239,10 @@ public class TopGroupsResultTransformer
         if (!Float.isNaN(searchGroup.scoreDocs[i].score)) {
           document.add("score", searchGroup.scoreDocs[i].score);
         }
-        if (!(searchGroup.scoreDocs[i] instanceof FieldDoc)) {
+        if (!(searchGroup.scoreDocs[i] instanceof FieldDoc fieldDoc)) {
           continue; // thus don't add sortValues below
         }
 
-        FieldDoc fieldDoc = (FieldDoc) searchGroup.scoreDocs[i];
         Object[] convertedSortValues = new Object[fieldDoc.fields.length];
         for (int j = 0; j < fieldDoc.fields.length; j++) {
           Object sortValue = fieldDoc.fields[j];
@@ -304,11 +301,10 @@ public class TopGroupsResultTransformer
       if (!Float.isNaN(scoreDoc.score)) {
         document.add("score", scoreDoc.score);
       }
-      if (!(scoreDoc instanceof FieldDoc)) {
+      if (!(scoreDoc instanceof FieldDoc fieldDoc)) {
         continue; // thus don't add sortValues below
       }
 
-      FieldDoc fieldDoc = (FieldDoc) scoreDoc;
       Object[] convertedSortValues = new Object[fieldDoc.fields.length];
       for (int j = 0; j < fieldDoc.fields.length; j++) {
         Object sortValue = fieldDoc.fields[j];

--- a/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/MainEndResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/MainEndResultTransformer.java
@@ -72,8 +72,7 @@ public class MainEndResultTransformer implements EndResultTransformer {
         docList.setMaxScore(maxScore);
       }
       rb.rsp.addResponse(docList);
-    } else if (value instanceof QueryCommandResult) {
-      QueryCommandResult queryCommandResult = (QueryCommandResult) value;
+    } else if (value instanceof QueryCommandResult queryCommandResult) {
       SolrDocumentList docList = new SolrDocumentList();
       TopDocs topDocs = queryCommandResult.getTopDocs();
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/SimpleEndResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/SimpleEndResultTransformer.java
@@ -70,8 +70,7 @@ public class SimpleEndResultTransformer implements EndResultTransformer {
         }
         command.add("doclist", docList);
         commands.add(entry.getKey(), command);
-      } else if (value instanceof QueryCommandResult) {
-        QueryCommandResult queryCommandResult = (QueryCommandResult) value;
+      } else if (value instanceof QueryCommandResult queryCommandResult) {
         NamedList<Object> command = new SimpleOrderedMap<>();
         command.add("matches", queryCommandResult.getMatches());
 

--- a/solr/core/src/java/org/apache/solr/search/join/ChildFieldValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/ChildFieldValueSourceParser.java
@@ -100,8 +100,7 @@ public class ChildFieldValueSourceParser extends ValueSourceParser {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof BlockJoinSortFieldValueSource)) return false;
-      BlockJoinSortFieldValueSource other = (BlockJoinSortFieldValueSource) obj;
+      if (!(obj instanceof BlockJoinSortFieldValueSource other)) return false;
       return Objects.equals(childField, other.childField)
           && Objects.equals(childFilter, other.childFilter)
           && Objects.equals(parentFilter, other.parentFilter);

--- a/solr/core/src/java/org/apache/solr/search/join/FiltersQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/FiltersQParser.java
@@ -133,8 +133,7 @@ public class FiltersQParser extends QParser {
       // tagMap has entries of List<String,List<QParser>>, but subject to change in the future
       if (!(olst instanceof Collection)) continue;
       for (Object o : (Collection<?>) olst) {
-        if (!(o instanceof QParser)) continue;
-        QParser qp = (QParser) o;
+        if (!(o instanceof QParser qp)) continue;
         excludeSet.put(qp, Boolean.TRUE);
       }
     }

--- a/solr/core/src/java/org/apache/solr/search/join/ScoreJoinQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/join/ScoreJoinQParserPlugin.java
@@ -154,8 +154,7 @@ public class ScoreJoinQParserPlugin extends QParserPlugin {
     public boolean equals(Object obj) {
       if (this == obj) return true;
       if (!super.equals(obj)) return false;
-      if (!(obj instanceof OtherCoreJoinQuery)) return false;
-      OtherCoreJoinQuery other = (OtherCoreJoinQuery) obj;
+      if (!(obj instanceof OtherCoreJoinQuery other)) return false;
       return (fromCoreOpenTime == other.fromCoreOpenTime)
           && Objects.equals(fromIndex, other.fromIndex);
     }

--- a/solr/core/src/java/org/apache/solr/search/mlt/AbstractMLTQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/mlt/AbstractMLTQParser.java
@@ -138,8 +138,7 @@ abstract class AbstractMLTQParser extends QParser {
       for (BooleanClause clause : rawMLTQuery) {
         Query q = clause.getQuery();
         float originalBoost = 1f;
-        if (q instanceof BoostQuery) {
-          BoostQuery bq = (BoostQuery) q;
+        if (q instanceof BoostQuery bq) {
           q = bq.getQuery();
           originalBoost = bq.getBoost();
         }

--- a/solr/core/src/java/org/apache/solr/security/BasicAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/BasicAuthPlugin.java
@@ -102,8 +102,7 @@ public class BasicAuthPlugin extends AuthenticationPlugin
       }
     }
     if (!CommandOperation.captureErrors(commands).isEmpty()) return null;
-    if (authenticationProvider instanceof ConfigEditablePlugin) {
-      ConfigEditablePlugin editablePlugin = (ConfigEditablePlugin) authenticationProvider;
+    if (authenticationProvider instanceof ConfigEditablePlugin editablePlugin) {
       return editablePlugin.edit(latestConf, commands);
     }
     throw new SolrException(ErrorCode.BAD_REQUEST, "This cannot be edited");
@@ -223,11 +222,8 @@ public class BasicAuthPlugin extends AuthenticationPlugin
   @Override
   protected boolean interceptInternodeRequest(HttpRequest httpRequest, HttpContext httpContext) {
     if (forwardCredentials) {
-      if (httpContext instanceof HttpClientContext) {
-        HttpClientContext httpClientContext = (HttpClientContext) httpContext;
-        if (httpClientContext.getUserToken() instanceof BasicAuthUserPrincipal) {
-          BasicAuthUserPrincipal principal =
-              (BasicAuthUserPrincipal) httpClientContext.getUserToken();
+      if (httpContext instanceof HttpClientContext httpClientContext) {
+        if (httpClientContext.getUserToken() instanceof BasicAuthUserPrincipal principal) {
           String userPassBase64 =
               Base64.getEncoder()
                   .encodeToString(
@@ -245,8 +241,7 @@ public class BasicAuthPlugin extends AuthenticationPlugin
   protected boolean interceptInternodeRequest(Request request) {
     if (forwardCredentials) {
       Object userToken = request.getAttributes().get(Http2SolrClient.REQ_PRINCIPAL_KEY);
-      if (userToken instanceof BasicAuthUserPrincipal) {
-        BasicAuthUserPrincipal principal = (BasicAuthUserPrincipal) userToken;
+      if (userToken instanceof BasicAuthUserPrincipal principal) {
         String userPassBase64 =
             Base64.getEncoder()
                 .encodeToString(
@@ -311,8 +306,7 @@ public class BasicAuthPlugin extends AuthenticationPlugin
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof BasicAuthUserPrincipal)) return false;
-      BasicAuthUserPrincipal that = (BasicAuthUserPrincipal) o;
+      if (!(o instanceof BasicAuthUserPrincipal that)) return false;
       return Objects.equals(username, that.username) && Objects.equals(password, that.password);
     }
 

--- a/solr/core/src/java/org/apache/solr/security/Permission.java
+++ b/solr/core/src/java/org/apache/solr/security/Permission.java
@@ -148,8 +148,7 @@ class Permission {
       }
       return null;
     }
-    if (val instanceof Collection) {
-      Collection<?> list = (Collection<?>) val;
+    if (val instanceof Collection<?> list) {
       for (Object o : list) result.add(String.valueOf(o));
     } else if (val instanceof String) {
       result.add((String) val);

--- a/solr/core/src/java/org/apache/solr/security/RuleBasedAuthorizationPluginBase.java
+++ b/solr/core/src/java/org/apache/solr/security/RuleBasedAuthorizationPluginBase.java
@@ -216,7 +216,7 @@ public abstract class RuleBasedAuthorizationPluginBase
     if (predefinedPermission.wellknownName == PermissionNameProvider.Name.ALL) {
       log.trace("'ALL' perm applies to all requests; perm applies.");
       return true; // 'ALL' applies to everything!
-    } else if (!(context.getHandler() instanceof PermissionNameProvider)) {
+    } else if (!(context.getHandler() instanceof PermissionNameProvider handler)) {
       // TODO: Is this code path needed anymore, now that all handlers implement the interface?
       // context.getHandler returns Object and is not documented
       if (log.isTraceEnabled()) {
@@ -227,7 +227,6 @@ public abstract class RuleBasedAuthorizationPluginBase
       // We're not 'ALL', and the handler isn't associated with any other predefined permissions
       return false;
     } else {
-      PermissionNameProvider handler = (PermissionNameProvider) context.getHandler();
       PermissionNameProvider.Name permissionName = handler.getPermissionName(context);
 
       boolean applies =

--- a/solr/core/src/java/org/apache/solr/servlet/ResponseUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ResponseUtils.java
@@ -68,8 +68,7 @@ public class ResponseUtils {
   public static int getErrorInfo(
       Throwable ex, NamedList<Object> info, Logger log, boolean hideTrace) {
     int code = 500;
-    if (ex instanceof SolrException) {
-      SolrException solrExc = (SolrException) ex;
+    if (ex instanceof SolrException solrExc) {
       code = solrExc.code();
       NamedList<String> errorMetadata = solrExc.getMetadata();
       if (errorMetadata == null) {
@@ -79,8 +78,7 @@ public class ResponseUtils {
       errorMetadata.add(
           ErrorInfo.ROOT_ERROR_CLASS, SolrException.getRootCause(ex).getClass().getName());
       info.add("metadata", errorMetadata);
-      if (ex instanceof ApiBag.ExceptionWithErrObject) {
-        ApiBag.ExceptionWithErrObject exception = (ApiBag.ExceptionWithErrObject) ex;
+      if (ex instanceof ApiBag.ExceptionWithErrObject exception) {
         info.add("details", exception.getErrs());
       }
     }
@@ -142,14 +140,12 @@ public class ResponseUtils {
   public static ErrorInfo getTypedErrorInfo(Throwable ex, Logger log, boolean hideTrace) {
     final ErrorInfo errorInfo = new ErrorInfo();
     int code = 500;
-    if (ex instanceof SolrException) {
-      SolrException solrExc = (SolrException) ex;
+    if (ex instanceof SolrException solrExc) {
       code = solrExc.code();
       errorInfo.metadata = new ErrorInfo.ErrorMetadata();
       errorInfo.metadata.errorClass = ex.getClass().getName();
       errorInfo.metadata.rootErrorClass = SolrException.getRootCause(ex).getClass().getName();
-      if (ex instanceof ApiBag.ExceptionWithErrObject) {
-        ApiBag.ExceptionWithErrObject exception = (ApiBag.ExceptionWithErrObject) ex;
+      if (ex instanceof ApiBag.ExceptionWithErrObject exception) {
         errorInfo.details = exception.getErrs();
       }
     }

--- a/solr/core/src/java/org/apache/solr/spelling/PossibilityIterator.java
+++ b/solr/core/src/java/org/apache/solr/spelling/PossibilityIterator.java
@@ -363,8 +363,7 @@ public class PossibilityIterator implements Iterator<PossibilityIterator.RankedS
     public boolean equals(Object obj) {
       if (this == obj) return true;
       if (obj == null) return false;
-      if (!(obj instanceof RankedSpellPossibility)) return false;
-      RankedSpellPossibility other = (RankedSpellPossibility) obj;
+      if (!(obj instanceof RankedSpellPossibility other)) return false;
       return Objects.equals(corrections, other.corrections);
     }
 

--- a/solr/core/src/java/org/apache/solr/spelling/ResultEntry.java
+++ b/solr/core/src/java/org/apache/solr/spelling/ResultEntry.java
@@ -42,8 +42,7 @@ public class ResultEntry {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (!(obj instanceof ResultEntry)) return false;
-    ResultEntry other = (ResultEntry) obj;
+    if (!(obj instanceof ResultEntry other)) return false;
     return freq == other.freq
         && Objects.equals(suggestion, other.suggestion)
         && Objects.equals(token, other.token);

--- a/solr/core/src/java/org/apache/solr/spelling/Token.java
+++ b/solr/core/src/java/org/apache/solr/spelling/Token.java
@@ -132,9 +132,8 @@ public class Token extends PackedTokenAttributeImpl implements FlagsAttribute, P
   @Override
   public boolean equals(Object obj) {
     if (obj == this) return true;
-    if (!(obj instanceof Token)) return false;
+    if (!(obj instanceof Token other)) return false;
 
-    final Token other = (Token) obj;
     return (flags == other.flags && (Objects.equals(payload, other.payload)) && super.equals(obj));
   }
 

--- a/solr/core/src/java/org/apache/solr/uninverting/FieldCacheImpl.java
+++ b/solr/core/src/java/org/apache/solr/uninverting/FieldCacheImpl.java
@@ -225,8 +225,7 @@ public class FieldCacheImpl implements FieldCache {
     /** Two of these are equal iff they reference the same field and type. */
     @Override
     public boolean equals(Object o) {
-      if (o instanceof CacheKey) {
-        CacheKey other = (CacheKey) o;
+      if (o instanceof CacheKey other) {
         if (other.field.equals(field)) {
           if (other.custom == null) {
             if (custom == null) return true;

--- a/solr/core/src/java/org/apache/solr/update/PeerSync.java
+++ b/solr/core/src/java/org/apache/solr/update/PeerSync.java
@@ -603,11 +603,8 @@ public class PeerSync implements SolrMetricProducer {
     // comparator that sorts update records by absolute value of version, putting lowest first
     private static final Comparator<Object> updateRecordComparator =
         (o1, o2) -> {
-          if (!(o1 instanceof List)) return 1;
-          if (!(o2 instanceof List)) return -1;
-
-          List<?> lst1 = (List<?>) o1;
-          List<?> lst2 = (List<?>) o2;
+          if (!(o1 instanceof List<?> lst1)) return 1;
+          if (!(o2 instanceof List<?> lst2)) return -1;
 
           long l1 = Math.abs((Long) lst1.get(1));
           long l2 = Math.abs((Long) lst2.get(1));

--- a/solr/core/src/java/org/apache/solr/update/SolrCmdDistributor.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrCmdDistributor.java
@@ -617,8 +617,7 @@ public class SolrCmdDistributor implements Closeable {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof StdNode)) return false;
-      StdNode other = (StdNode) obj;
+      if (!(obj instanceof StdNode other)) return false;
       return (this.retry == other.retry)
           && (this.maxRetries == other.maxRetries)
           && Objects.equals(this.nodeProps.getBaseUrl(), other.nodeProps.getBaseUrl())
@@ -700,8 +699,7 @@ public class SolrCmdDistributor implements Closeable {
     public boolean equals(Object obj) {
       if (this == obj) return true;
       if (!super.equals(obj)) return false;
-      if (!(obj instanceof ForwardNode)) return false;
-      ForwardNode other = (ForwardNode) obj;
+      if (!(obj instanceof ForwardNode other)) return false;
       return Objects.equals(nodeProps.getCoreUrl(), other.nodeProps.getCoreUrl());
     }
   }

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexSplitter.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexSplitter.java
@@ -633,10 +633,9 @@ public class SolrIndexSplitter {
       if (this == obj) {
         return true;
       }
-      if (!(obj instanceof SplittingQuery)) {
+      if (!(obj instanceof SplittingQuery q)) {
         return false;
       }
-      SplittingQuery q = (SplittingQuery) obj;
       return partition == q.partition;
     }
 

--- a/solr/core/src/java/org/apache/solr/update/TransactionLog.java
+++ b/solr/core/src/java/org/apache/solr/update/TransactionLog.java
@@ -93,8 +93,7 @@ public class TransactionLog implements Closeable {
       new JavaBinCodec.ObjectResolver() {
         @Override
         public Object resolve(Object o, JavaBinCodec codec) throws IOException {
-          if (o instanceof BytesRef) {
-            BytesRef br = (BytesRef) o;
+          if (o instanceof BytesRef br) {
             codec.writeByteArray(br.bytes, br.offset, br.length);
             return null;
           }
@@ -161,8 +160,7 @@ public class TransactionLog implements Closeable {
 
     @Override
     public boolean writePrimitive(Object val) throws IOException {
-      if (val instanceof java.util.UUID) {
-        java.util.UUID uuid = (java.util.UUID) val;
+      if (val instanceof java.util.UUID uuid) {
         daos.writeByte(UUID);
         daos.writeLong(uuid.getMostSignificantBits());
         daos.writeLong(uuid.getLeastSignificantBits());

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -1215,8 +1215,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
                 lookupVersion);
           }
 
-          if (obj != null && obj instanceof List) {
-            List<?> tmpEntry = (List<?>) obj;
+          if (obj != null && obj instanceof List<?> tmpEntry) {
             if (tmpEntry.size() >= 2
                 &&
                 // why not Objects.equals(lookupVersion, tmpEntry.get())?

--- a/solr/core/src/java/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactory.java
@@ -191,11 +191,10 @@ public class AddSchemaFieldsUpdateProcessorFactory extends UpdateRequestProcesso
         throw new SolrException(
             SERVER_ERROR, "'" + TYPE_MAPPING_PARAM + "' init param cannot be null");
       }
-      if (!(typeMappingObj instanceof NamedList)) {
+      if (!(typeMappingObj instanceof NamedList<?> typeMappingNamedList)) {
         throw new SolrException(
             SERVER_ERROR, "'" + TYPE_MAPPING_PARAM + "' init param must be a <lst>");
       }
-      NamedList<?> typeMappingNamedList = (NamedList<?>) typeMappingObj;
 
       Object fieldTypeObj = typeMappingNamedList.remove(FIELD_TYPE_PARAM);
       if (null == fieldTypeObj) {
@@ -256,11 +255,10 @@ public class AddSchemaFieldsUpdateProcessorFactory extends UpdateRequestProcesso
       Collection<CopyFieldDef> copyFieldDefs = new ArrayList<>();
       while (typeMappingNamedList.get(COPY_FIELD_PARAM) != null) {
         Object copyFieldObj = typeMappingNamedList.remove(COPY_FIELD_PARAM);
-        if (!(copyFieldObj instanceof NamedList)) {
+        if (!(copyFieldObj instanceof NamedList<?> copyFieldNamedList)) {
           throw new SolrException(
               SERVER_ERROR, "'" + COPY_FIELD_PARAM + "' init param must be a <lst>");
         }
-        NamedList<?> copyFieldNamedList = (NamedList<?>) copyFieldObj;
         // dest
         Object destObj = copyFieldNamedList.remove(DEST_PARAM);
         if (null == destObj) {

--- a/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java
@@ -587,11 +587,10 @@ public class AtomicUpdateDocumentMerger {
 
       // behavior similar to doAdd/doSet
       Object resObj = getNativeFieldValue(sf.getName(), fieldVal);
-      if (!(resObj instanceof Number)) {
+      if (!(resObj instanceof Number result)) {
         throw new SolrException(
             ErrorCode.BAD_REQUEST, "Invalid input '" + resObj + "' for field " + sf.getName());
       }
-      Number result = (Number) resObj;
       if (oldVal instanceof Long) {
         result = ((Long) oldVal).longValue() + result.longValue();
       } else if (oldVal instanceof Float) {
@@ -691,10 +690,9 @@ public class AtomicUpdateDocumentMerger {
   }
 
   private static boolean isChildDoc(Object obj) {
-    if (!(obj instanceof Collection)) {
+    if (!(obj instanceof Collection<?> objValues)) {
       return obj instanceof SolrDocumentBase;
     }
-    Collection<?> objValues = (Collection<?>) obj;
     if (objValues.size() == 0) {
       return false;
     }

--- a/solr/core/src/java/org/apache/solr/update/processor/CloneFieldUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/CloneFieldUpdateProcessorFactory.java
@@ -349,11 +349,10 @@ public class CloneFieldUpdateProcessorFactory extends UpdateRequestProcessorFact
             throw new SolrException(
                 SERVER_ERROR, "Init param '" + SOURCE_PARAM + "' child 'exclude' can not be null");
           }
-          if (!(excObj instanceof NamedList)) {
+          if (!(excObj instanceof NamedList<?> exc)) {
             throw new SolrException(
                 SERVER_ERROR, "Init param '" + SOURCE_PARAM + "' child 'exclude' must be <lst/>");
           }
-          NamedList<?> exc = (NamedList<?>) excObj;
           srcExclusions.add(parseSelectorParams(exc));
           if (0 < exc.size()) {
             throw new SolrException(
@@ -400,8 +399,7 @@ public class CloneFieldUpdateProcessorFactory extends UpdateRequestProcessorFact
               + "for CloneFieldUpdateProcessorFactory for further details.");
     }
 
-    if (d instanceof NamedList) {
-      NamedList<?> destList = (NamedList<?>) d;
+    if (d instanceof NamedList<?> destList) {
 
       Object patt = destList.remove(PATTERN_PARAM);
       Object replacement = destList.remove(REPLACEMENT_PARAM);

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -1229,8 +1229,7 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
       // create a merged copy of the metadata from all wrapped exceptions
       NamedList<String> metadata = new NamedList<>();
       for (SolrError error : errors) {
-        if (error.e instanceof SolrException) {
-          SolrException e = (SolrException) error.e;
+        if (error.e instanceof SolrException e) {
           NamedList<String> eMeta = e.getMetadata();
           if (null != eMeta) {
             metadata.addAll(eMeta);

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -680,11 +680,9 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
   @Override
   void setupRequest(UpdateCommand cmd) {
     zkCheck(cmd);
-    if (cmd instanceof AddUpdateCommand) {
-      AddUpdateCommand acmd = (AddUpdateCommand) cmd;
+    if (cmd instanceof AddUpdateCommand acmd) {
       nodes = setupRequest(acmd.getIndexedIdStr(), acmd.getSolrInputDocument(), null, cmd);
-    } else if (cmd instanceof DeleteUpdateCommand) {
-      DeleteUpdateCommand dcmd = (DeleteUpdateCommand) cmd;
+    } else if (cmd instanceof DeleteUpdateCommand dcmd) {
       nodes =
           setupRequest(
               dcmd.getId(),
@@ -975,8 +973,7 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
       ClusterState cstate, DocCollection coll, String id, SolrInputDocument doc) {
     DocRouter router = coll.getRouter();
     List<SolrCmdDistributor.Node> nodes = null;
-    if (router instanceof CompositeIdRouter) {
-      CompositeIdRouter compositeIdRouter = (CompositeIdRouter) router;
+    if (router instanceof CompositeIdRouter compositeIdRouter) {
       String myShardId = cloudDesc.getShardId();
       Slice slice = coll.getSlice(myShardId);
       Map<String, RoutingRule> routingRules = slice.getRoutingRules();
@@ -1248,8 +1245,7 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
       String collection = null;
       String shardId = null;
 
-      if (error.req.node instanceof SolrCmdDistributor.StdNode) {
-        SolrCmdDistributor.StdNode stdNode = (SolrCmdDistributor.StdNode) error.req.node;
+      if (error.req.node instanceof SolrCmdDistributor.StdNode stdNode) {
         collection = stdNode.getCollection();
         shardId = stdNode.getShardId();
 

--- a/solr/core/src/java/org/apache/solr/update/processor/FieldMutatingUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/FieldMutatingUpdateProcessorFactory.java
@@ -165,11 +165,10 @@ public abstract class FieldMutatingUpdateProcessorFactory extends UpdateRequestP
         throw new SolrException(
             SolrException.ErrorCode.SERVER_ERROR, "'exclude' init param can not be null");
       }
-      if (!(excObj instanceof NamedList)) {
+      if (!(excObj instanceof NamedList<?> exc)) {
         throw new SolrException(
             SolrException.ErrorCode.SERVER_ERROR, "'exclude' init param must be <lst/>");
       }
-      NamedList<?> exc = (NamedList<?>) excObj;
       exclusions.add(parseSelectorParams(exc));
       if (0 < exc.size()) {
         throw new SolrException(

--- a/solr/core/src/java/org/apache/solr/update/processor/HTMLStripFieldUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/HTMLStripFieldUpdateProcessorFactory.java
@@ -59,8 +59,7 @@ public final class HTMLStripFieldUpdateProcessorFactory
         getSelector(),
         next,
         src -> {
-          if (src instanceof CharSequence) {
-            CharSequence s = (CharSequence) src;
+          if (src instanceof CharSequence s) {
             StringWriter result = new StringWriter(s.length());
             try (Reader in = new HTMLStripCharFilter(new StringReader(s.toString()))) {
               in.transferTo(result);

--- a/solr/core/src/java/org/apache/solr/update/processor/LastFieldValueUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/LastFieldValueUpdateProcessorFactory.java
@@ -53,9 +53,8 @@ public final class LastFieldValueUpdateProcessorFactory
 
     T result = null;
 
-    if (values instanceof List) {
+    if (values instanceof List<T> l) {
       // optimize index lookup
-      List<T> l = (List<T>) values;
       result = l.get(l.size() - 1);
     } else if (values instanceof SortedSet) {
       // optimize tail lookup

--- a/solr/core/src/java/org/apache/solr/update/processor/NestedUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/NestedUpdateProcessorFactory.java
@@ -85,7 +85,7 @@ public class NestedUpdateProcessorFactory extends UpdateRequestProcessorFactory 
         int childNum = 0;
         boolean isSingleVal = !(field.getValue() instanceof Collection);
         for (Object val : field) {
-          if (!(val instanceof SolrInputDocument)) {
+          if (!(val instanceof SolrInputDocument cDoc)) {
             // either all collection items are child docs or none are.
             break;
           }
@@ -101,7 +101,6 @@ public class NestedUpdateProcessorFactory extends UpdateRequestProcessorFactory 
                     + "' , which is reserved for the nested URP");
           }
           final String sChildNum = isSingleVal ? SINGULAR_VALUE_CHAR : String.valueOf(childNum);
-          SolrInputDocument cDoc = (SolrInputDocument) val;
           if (!cDoc.containsKey(uniqueKeyFieldName)) {
             String parentDocId = doc.getField(uniqueKeyFieldName).getFirstValue().toString();
             cDoc.setField(

--- a/solr/core/src/java/org/apache/solr/update/processor/RegexReplaceProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/RegexReplaceProcessorFactory.java
@@ -120,8 +120,7 @@ public final class RegexReplaceProcessorFactory extends FieldMutatingUpdateProce
         getSelector(),
         next,
         src -> {
-          if (src instanceof CharSequence) {
-            CharSequence txt = (CharSequence) src;
+          if (src instanceof CharSequence txt) {
             return pattern.matcher(txt).replaceAll(replacement);
           }
           return src;

--- a/solr/core/src/java/org/apache/solr/update/processor/TolerantUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/TolerantUpdateProcessor.java
@@ -238,11 +238,10 @@ public class TolerantUpdateProcessor extends UpdateRequestProcessor {
         //
         // instead we trust the metadata that the TolerantUpdateProcessor running on the remote node
         // added to the exception when it failed.
-        if (!(error.e instanceof SolrException)) {
+        if (!(error.e instanceof SolrException remoteErr)) {
           log.error("async update exception is not SolrException, no metadata to process", error.e);
           continue;
         }
-        SolrException remoteErr = (SolrException) error.e;
         NamedList<String> remoteErrMetadata = remoteErr.getMetadata();
 
         if (null == remoteErrMetadata) {

--- a/solr/core/src/java/org/apache/solr/update/processor/TruncateFieldUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/TruncateFieldUpdateProcessorFactory.java
@@ -89,8 +89,7 @@ public final class TruncateFieldUpdateProcessorFactory extends FieldMutatingUpda
         getSelector(),
         next,
         src -> {
-          if (src instanceof CharSequence) {
-            CharSequence s = (CharSequence) src;
+          if (src instanceof CharSequence s) {
             if (maxLength < s.length()) {
               return s.subSequence(0, maxLength);
             }

--- a/solr/core/src/java/org/apache/solr/update/processor/UpdateRequestProcessorChain.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpdateRequestProcessorChain.java
@@ -348,8 +348,7 @@ public final class UpdateRequestProcessorChain implements PluginInfoInitialized 
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof ProcessorInfo)) return false;
-      ProcessorInfo that = (ProcessorInfo) obj;
+      if (!(obj instanceof ProcessorInfo that)) return false;
 
       return Objects.equals(this.processor, that.processor)
           && Objects.equals(this.postProcessor, that.postProcessor);

--- a/solr/core/src/java/org/apache/solr/util/PayloadUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/PayloadUtils.java
@@ -50,10 +50,9 @@ public class PayloadUtils {
     // component that encodes payloads as floats
     String encoder = null;
     Analyzer a = fieldType.getIndexAnalyzer();
-    if (a instanceof TokenizerChain) {
+    if (a instanceof TokenizerChain tc) {
       // examine the indexing analysis chain for DelimitedPayloadTokenFilterFactory or
       // NumericPayloadTokenFilterFactory
-      TokenizerChain tc = (TokenizerChain) a;
       TokenFilterFactory[] factories = tc.getTokenFilterFactories();
       for (TokenFilterFactory factory : factories) {
         if (factory instanceof DelimitedPayloadTokenFilterFactory) {

--- a/solr/core/src/java/org/apache/solr/util/SolrJacksonAnnotationInspector.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrJacksonAnnotationInspector.java
@@ -52,8 +52,7 @@ public class SolrJacksonAnnotationInspector extends AnnotationIntrospector {
 
   @Override
   public PropertyName findNameForSerialization(Annotated a) {
-    if (a instanceof AnnotatedMethod) {
-      AnnotatedMethod am = (AnnotatedMethod) a;
+    if (a instanceof AnnotatedMethod am) {
       JsonProperty prop = am.getAnnotation(JsonProperty.class);
       if (prop == null) return null;
       if (prop.value().isEmpty()) {
@@ -62,8 +61,7 @@ public class SolrJacksonAnnotationInspector extends AnnotationIntrospector {
         return new PropertyName(prop.value());
       }
     }
-    if (a instanceof AnnotatedField) {
-      AnnotatedField af = (AnnotatedField) a;
+    if (a instanceof AnnotatedField af) {
       JsonProperty prop = af.getAnnotation(JsonProperty.class);
       if (prop == null) return null;
       return prop.value().isEmpty()

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -712,8 +712,7 @@ public class SolrPluginUtils {
 
       Query cq = clause.getQuery();
       float boost = fromBoost;
-      while (cq instanceof BoostQuery) {
-        BoostQuery bq = (BoostQuery) cq;
+      while (cq instanceof BoostQuery bq) {
         cq = bq.getQuery();
         boost *= bq.getBoost();
       }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
@@ -118,9 +118,7 @@ public class CPUCircuitBreaker extends CircuitBreaker implements SolrCoreAware {
       return -1.0;
     }
 
-    if (metric instanceof Gauge) {
-      @SuppressWarnings({"rawtypes"})
-      Gauge gauge = (Gauge) metric;
+    if (metric instanceof Gauge<?> gauge) {
       // unwrap if needed
       if (gauge instanceof SolrMetricManager.GaugeWrapper) {
         gauge = ((SolrMetricManager.GaugeWrapper) gauge).getGauge();

--- a/solr/core/src/java/org/apache/solr/util/stats/InstrumentedHttpRequestExecutor.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/InstrumentedHttpRequestExecutor.java
@@ -49,8 +49,7 @@ public class InstrumentedHttpRequestExecutor extends HttpRequestExecutor
         try {
           final RequestLine requestLine = request.getRequestLine();
           String schemeHostPort = null;
-          if (request instanceof HttpRequestWrapper) {
-            HttpRequestWrapper wrapper = (HttpRequestWrapper) request;
+          if (request instanceof HttpRequestWrapper wrapper) {
             if (wrapper.getTarget() != null) {
               schemeHostPort =
                   wrapper.getTarget().getSchemeName()
@@ -80,8 +79,7 @@ public class InstrumentedHttpRequestExecutor extends HttpRequestExecutor
         try {
           final RequestLine requestLine = request.getRequestLine();
           String schemeHostPort = null;
-          if (request instanceof HttpRequestWrapper) {
-            HttpRequestWrapper wrapper = (HttpRequestWrapper) request;
+          if (request instanceof HttpRequestWrapper wrapper) {
             if (wrapper.getTarget() != null) {
               schemeHostPort =
                   wrapper.getTarget().getSchemeName()

--- a/solr/core/src/java/org/apache/solr/util/stats/MetricUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/MetricUtils.java
@@ -192,8 +192,7 @@ public class MetricUtils {
             doc.addField(key, v);
           }
         };
-    if (o instanceof MapWriter) {
-      MapWriter writer = (MapWriter) o;
+    if (o instanceof MapWriter writer) {
       writer._forEachEntry(consumer);
     } else if (o instanceof Map) {
       @SuppressWarnings({"unchecked"})
@@ -201,8 +200,7 @@ public class MetricUtils {
       for (Map.Entry<String, Object> entry : map.entrySet()) {
         consumer.accept(entry.getKey(), entry.getValue());
       }
-    } else if (o instanceof IteratorWriter) {
-      IteratorWriter writer = (IteratorWriter) o;
+    } else if (o instanceof IteratorWriter writer) {
       final String name = prefix != null ? prefix : "value";
       try {
         writer.writeIter(
@@ -348,11 +346,9 @@ public class MetricUtils {
       boolean simple,
       String separator,
       BiConsumer<String, Object> consumer) {
-    if (metric instanceof Counter) {
-      Counter counter = (Counter) metric;
+    if (metric instanceof Counter counter) {
       convertCounter(n, counter, propertyFilter, compact, consumer);
-    } else if (metric instanceof Gauge) {
-      Gauge<?> gauge = (Gauge<?>) metric;
+    } else if (metric instanceof Gauge<?> gauge) {
       // unwrap if needed
       if (gauge instanceof SolrMetricManager.GaugeWrapper) {
         gauge = ((SolrMetricManager.GaugeWrapper<?>) gauge).getGauge();
@@ -372,11 +368,9 @@ public class MetricUtils {
           throw ie;
         }
       }
-    } else if (metric instanceof Meter) {
-      Meter meter = (Meter) metric;
+    } else if (metric instanceof Meter meter) {
       convertMeter(n, meter, propertyFilter, simple, separator, consumer);
-    } else if (metric instanceof Timer) {
-      Timer timer = (Timer) metric;
+    } else if (metric instanceof Timer timer) {
       convertTimer(n, timer, propertyFilter, skipHistograms, simple, separator, consumer);
     } else if (metric instanceof Histogram) {
       if (!skipHistograms) {

--- a/solr/core/src/java/org/apache/solr/util/vector/DenseVectorParser.java
+++ b/solr/core/src/java/org/apache/solr/util/vector/DenseVectorParser.java
@@ -51,11 +51,10 @@ public abstract class DenseVectorParser {
   }
 
   protected void parseIndexVector() {
-    if (!(inputValue instanceof List)) {
+    if (!(inputValue instanceof List<?> inputVector)) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, "incorrect vector format. " + errorMessage());
     }
-    List<?> inputVector = (List<?>) inputValue;
     checkVectorDimension(inputVector.size());
     if (inputVector.get(0) instanceof CharSequence) {
       for (int i = 0; i < dimension; i++) {

--- a/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
@@ -1139,8 +1139,7 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
               "stat should be a Number: " + s + " -> " + svals.get(s).getClass(),
               svals.get(s) instanceof Number);
           // some loose assertions since we're iterating over various stats
-          if (svals.get(s) instanceof Double) {
-            Double val = (Double) svals.get(s);
+          if (svals.get(s) instanceof Double val) {
             assertFalse("stat shouldn't be NaN: " + s, val.isNaN());
             assertFalse("stat shouldn't be Inf: " + s, val.isInfinite());
             assertNotEquals("stat shouldn't be 0: " + s, 0.0D, val, 0.0);

--- a/solr/core/src/test/org/apache/solr/TestTrie.java
+++ b/solr/core/src/test/org/apache/solr/TestTrie.java
@@ -444,8 +444,7 @@ public class TestTrie extends SolrTestCaseJ4 {
 
   private void checkPrecisionSteps(String fieldType) {
     FieldType type = h.getCore().getLatestSchema().getFieldType(fieldType);
-    if (type instanceof TrieField) {
-      TrieField field = (TrieField) type;
+    if (type instanceof TrieField field) {
       assertTrue(field.getPrecisionStep() > 0 && field.getPrecisionStep() < 64);
     }
   }

--- a/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
@@ -384,8 +384,7 @@ public class DistribDocExpirationUpdateProcessorTest extends SolrCloudTestCase {
 
     @Override
     public boolean equals(Object other) {
-      if (other instanceof ReplicaData) {
-        ReplicaData that = (ReplicaData) other;
+      if (other instanceof ReplicaData that) {
         return this.shardName.equals(that.shardName)
             && this.coreName.equals(that.coreName)
             && (this.indexVersion == that.indexVersion)

--- a/solr/core/src/test/org/apache/solr/cloud/TestOnReconnectListenerSupport.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestOnReconnectListenerSupport.java
@@ -85,8 +85,7 @@ public class TestOnReconnectListenerSupport extends AbstractFullDistribZkTestBas
     assertNotNull("ZkController returned null OnReconnect listeners", listeners);
     ZkIndexSchemaReader expectedListener = null;
     for (OnReconnect listener : listeners) {
-      if (listener instanceof ZkIndexSchemaReader) {
-        ZkIndexSchemaReader reader = (ZkIndexSchemaReader) listener;
+      if (listener instanceof ZkIndexSchemaReader reader) {
         if (leaderCoreId.equals(reader.getUniqueCoreId())) {
           expectedListener = reader;
           break;
@@ -122,8 +121,7 @@ public class TestOnReconnectListenerSupport extends AbstractFullDistribZkTestBas
 
     expectedListener = null; // reset
     for (OnReconnect listener : listeners) {
-      if (listener instanceof ZkIndexSchemaReader) {
-        ZkIndexSchemaReader reader = (ZkIndexSchemaReader) listener;
+      if (listener instanceof ZkIndexSchemaReader reader) {
         if (leaderCoreId.equals(reader.getUniqueCoreId())) {
           fail(
               "Previous core "
@@ -153,8 +151,7 @@ public class TestOnReconnectListenerSupport extends AbstractFullDistribZkTestBas
 
     listeners = zkController.getCurrentOnReconnectListeners();
     for (OnReconnect listener : listeners) {
-      if (listener instanceof ZkIndexSchemaReader) {
-        ZkIndexSchemaReader reader = (ZkIndexSchemaReader) listener;
+      if (listener instanceof ZkIndexSchemaReader reader) {
         if (reloadedLeaderCoreId.equals(reader.getUniqueCoreId())) {
           fail(
               "Previous core "

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -1320,8 +1320,7 @@ public class ShardSplitTest extends BasicDistributedZkTest {
 
   public static int getHashRangeIdx(DocRouter router, List<DocRouter.Range> ranges, String id) {
     int hash = 0;
-    if (router instanceof HashBasedRouter) {
-      HashBasedRouter hashBasedRouter = (HashBasedRouter) router;
+    if (router instanceof HashBasedRouter hashBasedRouter) {
       hash = hashBasedRouter.sliceHash(id, null, null, null);
     }
     for (int i = 0; i < ranges.size(); i++) {

--- a/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
@@ -732,9 +732,7 @@ public class TestSolrConfigHandler extends RestTestBase {
       }
       Object actual = Utils.getObjectByPath(m, false, jsonPath);
 
-      if (expected instanceof ValidatingJsonMap.PredicateWithErrMsg) {
-        ValidatingJsonMap.PredicateWithErrMsg predicate =
-            (ValidatingJsonMap.PredicateWithErrMsg) expected;
+      if (expected instanceof ValidatingJsonMap.PredicateWithErrMsg predicate) {
         if (predicate.test(actual) == null) {
           success = true;
           break;
@@ -982,8 +980,7 @@ public class TestSolrConfigHandler extends RestTestBase {
             new ValidatingJsonMap.PredicateWithErrMsg<>() {
               @Override
               public String test(Object o) {
-                if (o instanceof Map) {
-                  Map<?, ?> m = (Map<?, ?>) o;
+                if (o instanceof Map<?, ?> m) {
                   if ("part1_Value".equals(m.get("part1")) && "part2_Value".equals(m.get("part2")))
                     return null;
                 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/TestApiFramework.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/TestApiFramework.java
@@ -323,8 +323,7 @@ public class TestApiFramework extends SolrTestCaseJ4 {
     } else {
       api = V2HttpCall.getApiInfo(mockCC.getRequestHandlers(), fullPath, "GET", fullPath, parts);
       if (api == null) api = new CompositeApi(null);
-      if (api instanceof CompositeApi) {
-        CompositeApi compositeApi = (CompositeApi) api;
+      if (api instanceof CompositeApi compositeApi) {
         api = V2HttpCall.getApiInfo(reqHandlers, path, "GET", fullPath, parts);
         compositeApi.add(api);
         api = compositeApi;

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallTest.java
@@ -2523,8 +2523,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
     public boolean equals(Object obj) {
       if (this == obj) return true;
       if (obj == null) return false;
-      if (!(obj instanceof PivotField)) return false;
-      PivotField other = (PivotField) obj;
+      if (!(obj instanceof PivotField other)) return false;
       if (getCount() != other.getCount()) return false;
       if (getField() == null) {
         if (other.getField() != null) return false;
@@ -2595,8 +2594,7 @@ public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCas
     @Override
     public boolean equals(Object o) {
       boolean equal = false;
-      if (o instanceof ArrayList) {
-        List<?> otherList = (List<?>) o;
+      if (o instanceof List<?> otherList) {
         if (size() == otherList.size()) {
           equal = true;
           for (Object objectInOtherList : otherList) {

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
@@ -241,8 +241,7 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof TestTag)) return false;
-      TestTag that = (TestTag) obj;
+      if (!(obj instanceof TestTag that)) return false;
       return this.startOffset == that.startOffset
           && this.endOffset == that.endOffset
           && Objects.equals(this.docName, that.docName);

--- a/solr/core/src/test/org/apache/solr/request/TestWriterPerf.java
+++ b/solr/core/src/test/org/apache/solr/request/TestWriterPerf.java
@@ -179,8 +179,7 @@ public class TestWriterPerf extends SolrTestCaseJ4 {
     System.gc();
     RTimer timer = new RTimer();
     for (int i = 0; i < encIter; i++) {
-      if (w instanceof BinaryQueryResponseWriter) {
-        BinaryQueryResponseWriter binWriter = (BinaryQueryResponseWriter) w;
+      if (w instanceof BinaryQueryResponseWriter binWriter) {
         out = new ByteArrayOutputStream();
         binWriter.write(out, req, rsp);
         out.close();

--- a/solr/core/src/test/org/apache/solr/schema/SchemaVersionSpecificBehaviorTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/SchemaVersionSpecificBehaviorTest.java
@@ -50,8 +50,7 @@ public class SchemaVersionSpecificBehaviorTest extends SolrTestCaseJ4 {
               field.omitTermFreqAndPositions());
 
           // 1.4: autoGeneratePhraseQueries default changed to false
-          if (field.getType() instanceof TextField) {
-            TextField ft = (TextField) field.getType();
+          if (field.getType() instanceof TextField ft) {
             assertEquals(
                 f + " field's autoPhrase is wrong for ver=" + ver,
                 (v < 1.4F),

--- a/solr/core/src/test/org/apache/solr/search/RankQueryTestPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/RankQueryTestPlugin.java
@@ -105,8 +105,7 @@ public class RankQueryTestPlugin extends QParserPlugin {
 
     @Override
     public boolean equals(Object o) {
-      if (o instanceof TestRankQuery) {
-        TestRankQuery trq = (TestRankQuery) o;
+      if (o instanceof TestRankQuery trq) {
 
         return (trq.q.equals(q) && trq.collector == collector);
       }

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -3124,8 +3124,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
       Query query, String field, String value, int boost, boolean fuzzy) {
 
     float queryBoost = 1f;
-    if (query instanceof BoostQuery) {
-      BoostQuery bq = (BoostQuery) query;
+    if (query instanceof BoostQuery bq) {
       query = bq.getQuery();
       queryBoost = bq.getBoost();
     }

--- a/solr/core/src/test/org/apache/solr/search/mlt/CloudMLTQContentParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/mlt/CloudMLTQContentParserTest.java
@@ -177,8 +177,7 @@ public class CloudMLTQContentParserTest extends SolrCloudTestCase {
         new String[] {"lowerfilt_u:bmw lowerfilt_u:usa", "lowerfilt_u:usa lowerfilt_u:bmw"};
 
     String[] actualParsedQueries;
-    if (queryResponse.getDebugMap().get("parsedquery") instanceof String) {
-      String parsedQueryString = (String) queryResponse.getDebugMap().get("parsedquery");
+    if (queryResponse.getDebugMap().get("parsedquery") instanceof String parsedQueryString) {
       assertTrue(
           parsedQueryString.equals(expectedQueryStrings[0])
               || parsedQueryString.equals(expectedQueryStrings[1]));

--- a/solr/core/src/test/org/apache/solr/search/mlt/CloudMLTQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/mlt/CloudMLTQParserTest.java
@@ -239,8 +239,7 @@ public class CloudMLTQParserTest extends SolrCloudTestCase {
         };
 
     String[] actualParsedQueries;
-    if (queryResponse.getDebugMap().get("parsedquery") instanceof String) {
-      String parsedQueryString = (String) queryResponse.getDebugMap().get("parsedquery");
+    if (queryResponse.getDebugMap().get("parsedquery") instanceof String parsedQueryString) {
       assertTrue(
           parsedQueryString.equals(expectedQueryStrings[0])
               || parsedQueryString.equals(expectedQueryStrings[1]));

--- a/solr/core/src/test/org/apache/solr/security/PrincipalWithUserRoles.java
+++ b/solr/core/src/test/org/apache/solr/security/PrincipalWithUserRoles.java
@@ -65,9 +65,8 @@ public class PrincipalWithUserRoles implements Principal, VerifiedUserRoles {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PrincipalWithUserRoles)) return false;
+    if (!(o instanceof PrincipalWithUserRoles that)) return false;
 
-    PrincipalWithUserRoles that = (PrincipalWithUserRoles) o;
     if (!username.equals(that.username)) return false;
     return roles.equals(that.roles);
   }

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesStandalone.java
@@ -1256,10 +1256,9 @@ public class TestInPlaceUpdatesStandalone extends SolrTestCaseJ4 {
         final long version = addAndGetVersion(sdoc, null);
 
         final Object val = sdoc.getFieldValue(valField);
-        if (val instanceof Map) {
+        if (val instanceof Map<?, ?> atomicUpdate) {
           // atomic update of the field we're modeling
 
-          Map<String, ?> atomicUpdate = (Map) val;
           assertEquals(sdoc.toString(), 1, atomicUpdate.size());
           if (atomicUpdate.containsKey("inc")) {
             // Solr treats inc on a non-existing doc (or doc w/o existing value) as if existing

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
@@ -254,9 +254,8 @@ public class SolrMessageProcessor extends MessageProcessor
    * @param request The SolrRequest to be cleaned up for submitting locally.
    */
   private void prepareIfUpdateRequest(SolrRequest<?> request) {
-    if (request instanceof UpdateRequest) {
+    if (request instanceof UpdateRequest updateRequest) {
       // Remove versions from add requests
-      UpdateRequest updateRequest = (UpdateRequest) request;
 
       List<SolrInputDocument> documents = updateRequest.getDocuments();
       if (log.isTraceEnabled()) {
@@ -318,8 +317,7 @@ public class SolrMessageProcessor extends MessageProcessor
    * @param mirroredSolrRequest MirroredSolrRequest object that is being processed.
    */
   void preventCircularMirroring(MirroredSolrRequest<?> mirroredSolrRequest) {
-    if (mirroredSolrRequest.getSolrRequest() instanceof UpdateRequest) {
-      UpdateRequest updateRequest = (UpdateRequest) mirroredSolrRequest.getSolrRequest();
+    if (mirroredSolrRequest.getSolrRequest() instanceof UpdateRequest updateRequest) {
       ModifiableSolrParams params = updateRequest.getParams();
       String shouldMirror = (params == null ? null : params.get(CrossDcConstants.SHOULD_MIRROR));
       if (shouldMirror == null) {

--- a/solr/modules/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
+++ b/solr/modules/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
@@ -394,11 +394,10 @@ public class OpenNLPExtractNamedEntitiesUpdateProcessorFactory extends UpdateReq
             throw new SolrException(
                 SERVER_ERROR, "Init param '" + SOURCE_PARAM + "' child 'exclude' can not be null");
           }
-          if (!(excObj instanceof NamedList)) {
+          if (!(excObj instanceof NamedList<?> exc)) {
             throw new SolrException(
                 SERVER_ERROR, "Init param '" + SOURCE_PARAM + "' child 'exclude' must be <lst/>");
           }
-          NamedList<?> exc = (NamedList<?>) excObj;
           srcExclusions.add(parseSelectorParams(exc));
           if (0 < exc.size()) {
             throw new SolrException(
@@ -445,8 +444,7 @@ public class OpenNLPExtractNamedEntitiesUpdateProcessorFactory extends UpdateReq
               + "for OpenNLPExtractNamedEntitiesUpdateProcessor for further details.");
     }
 
-    if (d instanceof NamedList) {
-      NamedList<?> destList = (NamedList<?>) d;
+    if (d instanceof NamedList<?> destList) {
 
       Object patt = destList.remove(PATTERN_PARAM);
       Object replacement = destList.remove(REPLACEMENT_PARAM);

--- a/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/common/MirroredSolrRequest.java
+++ b/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/common/MirroredSolrRequest.java
@@ -267,8 +267,7 @@ public class MirroredSolrRequest<T extends SolrResponse> {
     sb.append(type.toString());
     sb.append(", method=" + solrRequest.getMethod());
     sb.append(", params=" + solrRequest.getParams());
-    if (solrRequest instanceof UpdateRequest) {
-      UpdateRequest req = (UpdateRequest) solrRequest;
+    if (solrRequest instanceof UpdateRequest req) {
       sb.append(", add=" + (req.getDocuments() != null ? req.getDocuments().size() : "0"));
       sb.append(", del=" + (req.getDeleteByIdMap() != null ? req.getDeleteByIdMap().size() : "0"));
       sb.append(", dbq=" + (req.getDeleteQuery() != null ? req.getDeleteQuery().size() : "0"));

--- a/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/common/MirroredSolrRequestSerializer.java
+++ b/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/common/MirroredSolrRequestSerializer.java
@@ -184,14 +184,11 @@ public class MirroredSolrRequestSerializer
       map.put("submitTimeNanos", request.getSubmitTimeNanos());
       map.put("params", solrRequest.getParams());
       map.put("type", request.getType().toString());
-      if (solrRequest instanceof UpdateRequest) {
-        UpdateRequest update = (UpdateRequest) solrRequest;
+      if (solrRequest instanceof UpdateRequest update) {
         map.put("docs", update.getDocuments());
         map.put("deletes", update.getDeleteById());
         map.put("deleteQuery", update.getDeleteQuery());
-      } else if (solrRequest instanceof MirroredSolrRequest.MirroredConfigSetRequest) {
-        MirroredSolrRequest.MirroredConfigSetRequest config =
-            (MirroredSolrRequest.MirroredConfigSetRequest) solrRequest;
+      } else if (solrRequest instanceof MirroredSolrRequest.MirroredConfigSetRequest config) {
         map.put("method", config.getMethod().toString());
         if (config.getContentStreams() != null) {
           List<Map<String, Object>> streamsList = new ArrayList<>();

--- a/solr/modules/extraction/src/java/org/apache/solr/handler/extraction/XLSXResponseWriter.java
+++ b/solr/modules/extraction/src/java/org/apache/solr/handler/extraction/XLSXResponseWriter.java
@@ -264,8 +264,7 @@ class XLSXWriter extends TabularResponseWriter {
 
       } else {
         // normalize to first value
-        if (val instanceof Collection) {
-          Collection<?> values = (Collection<?>) val;
+        if (val instanceof Collection<?> values) {
           val = values.iterator().next();
         }
         writeVal(xlField.name, val);
@@ -285,8 +284,7 @@ class XLSXWriter extends TabularResponseWriter {
     StringBuilder output = new StringBuilder();
     while (val.hasNext()) {
       Object v = val.next();
-      if (v instanceof IndexableField) {
-        IndexableField f = (IndexableField) v;
+      if (v instanceof IndexableField f) {
         if (v instanceof Date) {
           output.append(((Date) val).toInstant().toString()).append("; ");
         } else {

--- a/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/KerberosFilter.java
+++ b/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/KerberosFilter.java
@@ -83,8 +83,7 @@ public class KerberosFilter extends AuthenticationFilter {
   private HttpServletRequest substituteOriginalUserRequest(HttpServletRequest request) {
     final HttpServletRequest originalRequest = request;
     AuthorizationPlugin authzPlugin = coreContainer.getAuthorizationPlugin();
-    if (authzPlugin instanceof RuleBasedAuthorizationPlugin) {
-      RuleBasedAuthorizationPlugin ruleBased = (RuleBasedAuthorizationPlugin) authzPlugin;
+    if (authzPlugin instanceof RuleBasedAuthorizationPlugin ruleBased) {
       if (request.getHeader(KerberosPlugin.ORIGINAL_USER_PRINCIPAL_HEADER) != null
           && ruleBased.doesUserHavePermission(
               request.getUserPrincipal(), PermissionNameProvider.Name.ALL)) {

--- a/solr/modules/hdfs/src/java/org/apache/solr/hdfs/store/HdfsLockFactory.java
+++ b/solr/modules/hdfs/src/java/org/apache/solr/hdfs/store/HdfsLockFactory.java
@@ -42,11 +42,10 @@ public class HdfsLockFactory extends LockFactory {
 
   @Override
   public Lock obtainLock(Directory dir, String lockName) throws IOException {
-    if (!(dir instanceof HdfsDirectory)) {
+    if (!(dir instanceof HdfsDirectory hdfsDir)) {
       throw new UnsupportedOperationException(
           "HdfsLockFactory can only be used with HdfsDirectory subclasses, got: " + dir);
     }
-    final HdfsDirectory hdfsDir = (HdfsDirectory) dir;
     final Configuration conf = hdfsDir.getConfiguration();
     final Path lockPath = hdfsDir.getHdfsDirPath();
     final Path lockFile = new Path(lockPath, lockName);

--- a/solr/modules/hdfs/src/java/org/apache/solr/hdfs/store/blockcache/BlockCacheKey.java
+++ b/solr/modules/hdfs/src/java/org/apache/solr/hdfs/store/blockcache/BlockCacheKey.java
@@ -64,8 +64,7 @@ public class BlockCacheKey implements Cloneable {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (!(obj instanceof BlockCacheKey)) return false;
-    BlockCacheKey other = (BlockCacheKey) obj;
+    if (!(obj instanceof BlockCacheKey other)) return false;
     return block == other.block && file == other.file && Objects.equals(path, other.path);
   }
 

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
@@ -956,10 +956,8 @@ public class JWTAuthPlugin extends AuthenticationPlugin
 
   @Override
   protected boolean interceptInternodeRequest(HttpRequest httpRequest, HttpContext httpContext) {
-    if (httpContext instanceof HttpClientContext) {
-      HttpClientContext httpClientContext = (HttpClientContext) httpContext;
-      if (httpClientContext.getUserToken() instanceof JWTPrincipal) {
-        JWTPrincipal jwtPrincipal = (JWTPrincipal) httpClientContext.getUserToken();
+    if (httpContext instanceof HttpClientContext httpClientContext) {
+      if (httpClientContext.getUserToken() instanceof JWTPrincipal jwtPrincipal) {
         httpRequest.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtPrincipal.getToken());
         return true;
       }
@@ -970,8 +968,7 @@ public class JWTAuthPlugin extends AuthenticationPlugin
   @Override
   protected boolean interceptInternodeRequest(Request request) {
     Object userToken = request.getAttributes().get(Http2SolrClient.REQ_PRINCIPAL_KEY);
-    if (userToken instanceof JWTPrincipal) {
-      JWTPrincipal jwtPrincipal = (JWTPrincipal) userToken;
+    if (userToken instanceof JWTPrincipal jwtPrincipal) {
       request.headers(h -> h.put(HttpHeaders.AUTHORIZATION, "Bearer " + jwtPrincipal.getToken()));
       return true;
     }

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTPrincipal.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTPrincipal.java
@@ -62,8 +62,7 @@ public class JWTPrincipal implements Principal {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof JWTPrincipal)) return false;
-    JWTPrincipal that = (JWTPrincipal) o;
+    if (!(o instanceof JWTPrincipal that)) return false;
     return Objects.equals(username, that.username)
         && Objects.equals(token, that.token)
         && Objects.equals(claims, that.claims);

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTPrincipalWithUserRoles.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTPrincipalWithUserRoles.java
@@ -48,8 +48,7 @@ public class JWTPrincipalWithUserRoles extends JWTPrincipal implements VerifiedU
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof JWTPrincipalWithUserRoles)) return false;
-    JWTPrincipalWithUserRoles that = (JWTPrincipalWithUserRoles) o;
+    if (!(o instanceof JWTPrincipalWithUserRoles that)) return false;
     return super.equals(o) && roles.equals(that.roles);
   }
 

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/LTRScoringModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/LTRScoringModel.java
@@ -215,8 +215,7 @@ public abstract class LTRScoringModel implements Accountable {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (!(obj instanceof LTRScoringModel)) return false;
-    final LTRScoringModel other = (LTRScoringModel) obj;
+    if (!(obj instanceof LTRScoringModel other)) return false;
     return Objects.equals(features, other.features)
         && Objects.equals(norms, other.norms)
         && Objects.equals(name, other.name)

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/WrapperModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/WrapperModel.java
@@ -69,8 +69,7 @@ public abstract class WrapperModel extends AdapterModel {
   public boolean equals(Object obj) {
     if (this == obj) return true;
     if (!super.equals(obj)) return false;
-    if (!(obj instanceof WrapperModel)) return false;
-    WrapperModel other = (WrapperModel) obj;
+    if (!(obj instanceof WrapperModel other)) return false;
     return Objects.equals(model, other.model)
         && Objects.equals(solrResourceLoader, other.solrResourceLoader);
   }

--- a/solr/modules/s3-repository/src/java/org/apache/solr/s3/S3StorageClient.java
+++ b/solr/modules/s3-repository/src/java/org/apache/solr/s3/S3StorageClient.java
@@ -582,8 +582,7 @@ public class S3StorageClient {
    */
   static S3Exception handleAmazonException(SdkException sdke) {
 
-    if (sdke instanceof AwsServiceException) {
-      AwsServiceException ase = (AwsServiceException) sdke;
+    if (sdke instanceof AwsServiceException ase) {
       String errMessage =
           String.format(
               Locale.ROOT,

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/CalciteJDBCStream.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/CalciteJDBCStream.java
@@ -62,8 +62,7 @@ public class CalciteJDBCStream extends JDBCStream {
                 if (resultSet.wasNull()) {
                   return null;
                 }
-                if (o instanceof Array) {
-                  Array array = (Array) o;
+                if (o instanceof Array array) {
                   return array.getArray();
                 } else {
                   return o;

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -263,10 +263,9 @@ class SolrFilter extends Filter implements SolrRel {
     }
 
     protected String translateIsNullOrIsNotNull(RexNode node) {
-      if (!(node instanceof RexCall)) {
+      if (!(node instanceof RexCall call)) {
         throw new AssertionError("expected RexCall for predicate but found: " + node);
       }
-      RexCall call = (RexCall) node;
       List<RexNode> operands = call.getOperands();
       if (operands.size() != 1) {
         throw new AssertionError("expected 1 operand for " + node);
@@ -531,10 +530,9 @@ class SolrFilter extends Filter implements SolrRel {
 
     protected Pair<Pair<String, RexLiteral>, Character> getFieldValuePairWithEscapeCharacter(
         RexNode node) {
-      if (!(node instanceof RexCall)) {
+      if (!(node instanceof RexCall call)) {
         throw new AssertionError("expected RexCall for predicate but found: " + node);
       }
-      RexCall call = (RexCall) node;
       if (call.getOperands().size() == 3) {
         RexNode escapeNode = call.getOperands().get(2);
         Character escapeChar = null;
@@ -552,11 +550,10 @@ class SolrFilter extends Filter implements SolrRel {
     }
 
     protected Pair<String, RexLiteral> getFieldValuePair(RexNode node) {
-      if (!(node instanceof RexCall)) {
+      if (!(node instanceof RexCall call)) {
         throw new AssertionError("expected RexCall for predicate but found: " + node);
       }
 
-      RexCall call = (RexCall) node;
       Pair<String, RexLiteral> binaryTranslated =
           call.getOperands().size() == 2 ? translateBinary(call) : null;
       if (binaryTranslated == null) {
@@ -654,15 +651,13 @@ class SolrFilter extends Filter implements SolrRel {
           !expanded.getOperands().isEmpty() ? expanded.getOperands().get(0) : null;
       if (expanded.op.kind == SqlKind.AND) {
         // See if NOT IN was translated into a big AND not
-        if (peekAt0 instanceof RexCall) {
-          RexCall op0 = (RexCall) peekAt0;
+        if (peekAt0 instanceof RexCall op0) {
           if (op0.op.kind == SqlKind.NOT_EQUALS) {
             return "*:* -" + fieldName + ":" + toOrSetOnSameField(fieldName, expanded);
           }
         }
       } else if (expanded.op.kind == SqlKind.OR) {
-        if (peekAt0 instanceof RexCall) {
-          RexCall op0 = (RexCall) peekAt0;
+        if (peekAt0 instanceof RexCall op0) {
           if (op0.op.kind == SqlKind.EQUALS) {
             return fieldName + ":" + toOrSetOnSameField(fieldName, expanded);
           }

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/MetricsQueryTemplate.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/MetricsQueryTemplate.java
@@ -116,8 +116,7 @@ public class MetricsQueryTemplate {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof MetricsQueryTemplate)) return false;
-    MetricsQueryTemplate that = (MetricsQueryTemplate) o;
+    if (!(o instanceof MetricsQueryTemplate that)) return false;
     return name.equals(that.name)
         && Objects.equals(defaultType, that.defaultType)
         && template.equals(that.template);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/FieldComparator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/FieldComparator.java
@@ -162,14 +162,12 @@ public class FieldComparator implements StreamComparator {
     if (null == base) {
       return false;
     }
-    if (base instanceof FieldComparator) {
-      FieldComparator baseComp = (FieldComparator) base;
+    if (base instanceof FieldComparator baseComp) {
       return (leftFieldName.equals(baseComp.leftFieldName)
               || rightFieldName.equals(baseComp.rightFieldName))
           && order == baseComp.order;
-    } else if (base instanceof MultipleFieldComparator) {
+    } else if (base instanceof MultipleFieldComparator baseComps) {
       // must equal the first one
-      MultipleFieldComparator baseComps = (MultipleFieldComparator) base;
       if (baseComps.getComps().length > 0) {
         return isDerivedFrom(baseComps.getComps()[0]);
       }
@@ -194,8 +192,7 @@ public class FieldComparator implements StreamComparator {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof FieldComparator)) return false;
-    FieldComparator that = (FieldComparator) o;
+    if (!(o instanceof FieldComparator that)) return false;
     // comparator is based on the other fields so is not needed in this compare
     return leftFieldName.equals(that.leftFieldName)
         && rightFieldName.equals(that.rightFieldName)

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/HashKey.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/HashKey.java
@@ -48,8 +48,7 @@ public class HashKey implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof HashKey)) return false;
-    HashKey h = (HashKey) o;
+    if (!(o instanceof HashKey h)) return false;
     for (int i = 0; i < parts.length; i++) {
       if (!parts[i].equals(h.parts[i])) {
         return false;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/MultipleFieldComparator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/comp/MultipleFieldComparator.java
@@ -60,8 +60,7 @@ public class MultipleFieldComparator implements StreamComparator {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof MultipleFieldComparator)) return false;
-    MultipleFieldComparator that = (MultipleFieldComparator) o;
+    if (!(o instanceof MultipleFieldComparator that)) return false;
     return Arrays.equals(comps, that.comps);
   }
 
@@ -93,8 +92,7 @@ public class MultipleFieldComparator implements StreamComparator {
     if (null == base) {
       return false;
     }
-    if (base instanceof MultipleFieldComparator) {
-      MultipleFieldComparator baseComp = (MultipleFieldComparator) base;
+    if (base instanceof MultipleFieldComparator baseComp) {
 
       if (baseComp.comps.length >= comps.length) {
         for (int idx = 0; idx < comps.length; ++idx) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eq/FieldEqualitor.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eq/FieldEqualitor.java
@@ -107,13 +107,11 @@ public class FieldEqualitor implements StreamEqualitor {
     if (null == base) {
       return false;
     }
-    if (base instanceof FieldEqualitor) {
-      FieldEqualitor baseEq = (FieldEqualitor) base;
+    if (base instanceof FieldEqualitor baseEq) {
       return leftFieldName.equals(baseEq.leftFieldName)
           && rightFieldName.equals(baseEq.rightFieldName);
-    } else if (base instanceof MultipleFieldEqualitor) {
+    } else if (base instanceof MultipleFieldEqualitor baseEqs) {
       // must equal the first one
-      MultipleFieldEqualitor baseEqs = (MultipleFieldEqualitor) base;
       if (baseEqs.getEqs().length > 0) {
         return isDerivedFrom(baseEqs.getEqs()[0]);
       }
@@ -127,13 +125,11 @@ public class FieldEqualitor implements StreamEqualitor {
     if (null == base) {
       return false;
     }
-    if (base instanceof FieldComparator) {
-      FieldComparator baseComp = (FieldComparator) base;
+    if (base instanceof FieldComparator baseComp) {
       return leftFieldName.equals(baseComp.getLeftFieldName())
           || rightFieldName.equals(baseComp.getRightFieldName());
-    } else if (base instanceof MultipleFieldComparator) {
+    } else if (base instanceof MultipleFieldComparator baseComps) {
       // must equal the first one
-      MultipleFieldComparator baseComps = (MultipleFieldComparator) base;
       if (baseComps.getComps().length > 0) {
         return isDerivedFrom(baseComps.getComps()[0]);
       }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eq/MultipleFieldEqualitor.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eq/MultipleFieldEqualitor.java
@@ -75,8 +75,7 @@ public class MultipleFieldEqualitor implements StreamEqualitor {
     if (null == base) {
       return false;
     }
-    if (base instanceof MultipleFieldEqualitor) {
-      MultipleFieldEqualitor baseEq = (MultipleFieldEqualitor) base;
+    if (base instanceof MultipleFieldEqualitor baseEq) {
 
       if (baseEq.eqs.length >= eqs.length) {
         for (int idx = 0; idx < eqs.length; ++idx) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/BicubicSplineEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/BicubicSplineEvaluator.java
@@ -47,7 +47,7 @@ public class BicubicSplineEvaluator extends RecursiveObjectEvaluator implements 
     double[] y = null;
     double[][] grid = null;
 
-    if (first instanceof List && second instanceof List && third instanceof Matrix) {
+    if (first instanceof List && second instanceof List && third instanceof Matrix matrix) {
       @SuppressWarnings({"unchecked"})
       List<Number> xlist = (List<Number>) first;
       x = new double[xlist.size()];
@@ -64,7 +64,6 @@ public class BicubicSplineEvaluator extends RecursiveObjectEvaluator implements 
         y[i] = ylist.get(i).doubleValue();
       }
 
-      Matrix matrix = (Matrix) third;
       grid = matrix.getData();
 
       PiecewiseBicubicSplineInterpolator interpolator = new PiecewiseBicubicSplineInterpolator();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ColumnAtEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ColumnAtEvaluator.java
@@ -42,8 +42,7 @@ public class ColumnAtEvaluator extends RecursiveObjectEvaluator implements TwoVa
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
 
-    if (value1 instanceof Matrix) {
-      Matrix matrix = (Matrix) value1;
+    if (value1 instanceof Matrix matrix) {
       Number index = (Number) value2;
       double[][] data = matrix.getData();
       List<Number> list = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ColumnCountEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ColumnCountEvaluator.java
@@ -32,7 +32,7 @@ public class ColumnCountEvaluator extends RecursiveObjectEvaluator implements On
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof Matrix)) {
+    if (!(value instanceof Matrix matrix)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class ColumnCountEvaluator extends RecursiveObjectEvaluator implements On
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      Matrix matrix = (Matrix) value;
       return matrix.getColumnCount();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/CorrelationEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/CorrelationEvaluator.java
@@ -127,8 +127,7 @@ public class CorrelationEvaluator extends RecursiveObjectEvaluator implements Ma
         return null;
       }
     } else if (values.length == 1) {
-      if (values[0] instanceof Matrix) {
-        Matrix matrix = (Matrix) values[0];
+      if (values[0] instanceof Matrix matrix) {
         double[][] data = matrix.getData();
         if (type.equals(CorrelationType.pearsons)) {
           PearsonsCorrelation pearsonsCorrelation = new PearsonsCorrelation(data);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/CorrelationSignificanceEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/CorrelationSignificanceEvaluator.java
@@ -45,11 +45,9 @@ public class CorrelationSignificanceEvaluator extends RecursiveObjectEvaluator
   public Object doWork(Object value) throws IOException {
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
-      Matrix matrix = (Matrix) value;
+    } else if (value instanceof Matrix matrix) {
       Object corr = matrix.getAttribute("corr");
-      if (corr instanceof PearsonsCorrelation) {
-        PearsonsCorrelation pcorr = (PearsonsCorrelation) corr;
+      if (corr instanceof PearsonsCorrelation pcorr) {
         RealMatrix realMatrix = pcorr.getCorrelationPValues();
         return new Matrix(realMatrix.getData());
       } else {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/CumulativeProbabilityEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/CumulativeProbabilityEvaluator.java
@@ -65,8 +65,7 @@ public class CumulativeProbabilityEvaluator extends RecursiveObjectEvaluator
               first.getClass().getSimpleName()));
     }
 
-    if (first instanceof RealDistribution) {
-      RealDistribution rd = (RealDistribution) first;
+    if (first instanceof RealDistribution rd) {
       Number predictOver = (Number) second;
       return rd.cumulativeProbability(predictOver.doubleValue());
     } else {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/DensityEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/DensityEvaluator.java
@@ -33,7 +33,7 @@ public class DensityEvaluator extends RecursiveObjectEvaluator implements TwoVal
   @Override
   public Object doWork(Object first, Object second) throws IOException {
 
-    if (!(first instanceof MultivariateRealDistribution)) {
+    if (!(first instanceof MultivariateRealDistribution multivariateRealDistribution)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -50,8 +50,6 @@ public class DensityEvaluator extends RecursiveObjectEvaluator implements TwoVal
               first.getClass().getSimpleName()));
     }
 
-    MultivariateRealDistribution multivariateRealDistribution =
-        (MultivariateRealDistribution) first;
     @SuppressWarnings({"unchecked"})
     List<Number> nums = (List<Number>) second;
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/DerivativeEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/DerivativeEvaluator.java
@@ -42,7 +42,7 @@ public class DerivativeEvaluator extends RecursiveObjectEvaluator implements One
               toExpression(constructingFactory)));
     }
 
-    if (!(value instanceof VectorFunction)) {
+    if (!(value instanceof VectorFunction vectorFunction)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -50,8 +50,6 @@ public class DerivativeEvaluator extends RecursiveObjectEvaluator implements One
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     }
-
-    VectorFunction vectorFunction = (VectorFunction) value;
 
     DifferentiableUnivariateFunction func = null;
     double[] x = (double[]) vectorFunction.getFromContext("x");

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/DistanceEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/DistanceEvaluator.java
@@ -46,8 +46,7 @@ public class DistanceEvaluator extends RecursiveObjectEvaluator implements ManyV
   public Object doWork(Object... values) throws IOException {
 
     if (values.length == 1) {
-      if (values[0] instanceof Matrix) {
-        Matrix matrix = (Matrix) values[0];
+      if (values[0] instanceof Matrix matrix) {
         EuclideanDistance euclideanDistance = new EuclideanDistance();
         return distance(euclideanDistance, matrix);
       } else {
@@ -74,8 +73,7 @@ public class DistanceEvaluator extends RecursiveObjectEvaluator implements ManyV
                 toExpression(constructingFactory)));
       }
 
-      if (first instanceof Matrix) {
-        Matrix matrix = (Matrix) first;
+      if (first instanceof Matrix matrix) {
         DistanceMeasure distanceMeasure = (DistanceMeasure) second;
         return distance(distanceMeasure, matrix);
       } else {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/FeatureSelectEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/FeatureSelectEvaluator.java
@@ -45,8 +45,7 @@ public class FeatureSelectEvaluator extends RecursiveObjectEvaluator implements 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
 
-    if (value1 instanceof Matrix) {
-      Matrix matrix = (Matrix) value1;
+    if (value1 instanceof Matrix matrix) {
       double[][] data = matrix.getData();
 
       List<String> labels = matrix.getColumnLabels();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/FieldValueEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/FieldValueEvaluator.java
@@ -63,8 +63,7 @@ public class FieldValueEvaluator extends SourceEvaluator {
     // if we have an iterable that is not a list then convert to ArrayList
     // lists are good to go
     if (null != value) {
-      if (value instanceof Object[]) {
-        Object[] array = (Object[]) value;
+      if (value instanceof Object[] array) {
         List<Object> list = new ArrayList<>(array.length);
         for (Object obj : array) {
           list.add(obj);
@@ -74,8 +73,7 @@ public class FieldValueEvaluator extends SourceEvaluator {
         return value;
       } else if (value instanceof VectorFunction) {
         return value;
-      } else if (value instanceof Iterable && !(value instanceof List<?>)) {
-        Iterable<?> iter = (Iterable<?>) value;
+      } else if (value instanceof Iterable<?> iter && !(value instanceof List<?>)) {
         List<Object> list = new ArrayList<>();
         for (Object obj : iter) {
           list.add(obj);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAmplitudeEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAmplitudeEvaluator.java
@@ -32,7 +32,7 @@ public class GetAmplitudeEvaluator extends RecursiveObjectEvaluator implements O
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof VectorFunction)) {
+    if (!(value instanceof VectorFunction vectorFunction)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetAmplitudeEvaluator extends RecursiveObjectEvaluator implements O
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      VectorFunction vectorFunction = (VectorFunction) value;
       return vectorFunction.getFromContext("amplitude");
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAngularFrequencyEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAngularFrequencyEvaluator.java
@@ -33,7 +33,7 @@ public class GetAngularFrequencyEvaluator extends RecursiveObjectEvaluator
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof VectorFunction)) {
+    if (!(value instanceof VectorFunction vectorFunction)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -41,7 +41,6 @@ public class GetAngularFrequencyEvaluator extends RecursiveObjectEvaluator
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      VectorFunction vectorFunction = (VectorFunction) value;
       return vectorFunction.getFromContext("angularFrequency");
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAreaEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAreaEvaluator.java
@@ -32,7 +32,7 @@ public class GetAreaEvaluator extends RecursiveObjectEvaluator implements OneVal
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof ConvexHull2D)) {
+    if (!(value instanceof ConvexHull2D convexHull2D)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetAreaEvaluator extends RecursiveObjectEvaluator implements OneVal
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      ConvexHull2D convexHull2D = (ConvexHull2D) value;
       return convexHull2D.createRegion().getSize();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAttributeEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAttributeEvaluator.java
@@ -32,7 +32,7 @@ public class GetAttributeEvaluator extends RecursiveObjectEvaluator implements T
 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
-    if (!(value1 instanceof Attributes)) {
+    if (!(value1 instanceof Attributes attributes)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetAttributeEvaluator extends RecursiveObjectEvaluator implements T
               toExpression(constructingFactory),
               value1.getClass().getSimpleName()));
     } else {
-      Attributes attributes = (Attributes) value1;
       String key = (String) value2;
       return attributes.getAttribute(key.replace("\"", ""));
     }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAttributesEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetAttributesEvaluator.java
@@ -32,7 +32,7 @@ public class GetAttributesEvaluator extends RecursiveObjectEvaluator implements 
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof Attributes)) {
+    if (!(value instanceof Attributes attributes)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetAttributesEvaluator extends RecursiveObjectEvaluator implements 
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      Attributes attributes = (Attributes) value;
       return attributes.getAttributes();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetBaryCenterEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetBaryCenterEvaluator.java
@@ -36,7 +36,7 @@ public class GetBaryCenterEvaluator extends RecursiveObjectEvaluator implements 
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof ConvexHull2D)) {
+    if (!(value instanceof ConvexHull2D convexHull2D)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -44,7 +44,6 @@ public class GetBaryCenterEvaluator extends RecursiveObjectEvaluator implements 
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      ConvexHull2D convexHull2D = (ConvexHull2D) value;
       Vector2D vector2D = (Vector2D) convexHull2D.createRegion().getBarycenter();
       List<Number> vec = new ArrayList<>();
       vec.add(vector2D.getX());

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetBoundarySizeEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetBoundarySizeEvaluator.java
@@ -33,7 +33,7 @@ public class GetBoundarySizeEvaluator extends RecursiveObjectEvaluator implement
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof ConvexHull2D)) {
+    if (!(value instanceof ConvexHull2D convexHull2D)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -41,7 +41,6 @@ public class GetBoundarySizeEvaluator extends RecursiveObjectEvaluator implement
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      ConvexHull2D convexHull2D = (ConvexHull2D) value;
       return convexHull2D.createRegion().getBoundarySize();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetCenterEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetCenterEvaluator.java
@@ -35,7 +35,7 @@ public class GetCenterEvaluator extends RecursiveObjectEvaluator implements OneV
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof EnclosingBall)) {
+    if (!(value instanceof EnclosingBall<?, ?> enclosingBall)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -43,7 +43,6 @@ public class GetCenterEvaluator extends RecursiveObjectEvaluator implements OneV
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      EnclosingBall<?, ?> enclosingBall = (EnclosingBall<?, ?>) value;
       Vector2D vec = (Vector2D) enclosingBall.getCenter();
       List<Number> center = new ArrayList<>();
       center.add(vec.getX());

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetCentroidsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetCentroidsEvaluator.java
@@ -35,7 +35,7 @@ public class GetCentroidsEvaluator extends RecursiveObjectEvaluator implements O
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof KmeansEvaluator.ClusterTuple)) {
+    if (!(value instanceof KmeansEvaluator.ClusterTuple clusterTuple)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -43,7 +43,6 @@ public class GetCentroidsEvaluator extends RecursiveObjectEvaluator implements O
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      KmeansEvaluator.ClusterTuple clusterTuple = (KmeansEvaluator.ClusterTuple) value;
       List<CentroidCluster<KmeansEvaluator.ClusterPoint>> clusters = clusterTuple.getClusters();
       double[][] data = new double[clusters.size()][];
       for (int i = 0; i < clusters.size(); i++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetClusterEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetClusterEvaluator.java
@@ -35,7 +35,7 @@ public class GetClusterEvaluator extends RecursiveObjectEvaluator implements Two
 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
-    if (!(value1 instanceof KmeansEvaluator.ClusterTuple)) {
+    if (!(value1 instanceof KmeansEvaluator.ClusterTuple clusterTuple)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -44,7 +44,6 @@ public class GetClusterEvaluator extends RecursiveObjectEvaluator implements Two
               value1.getClass().getSimpleName()));
     } else {
 
-      KmeansEvaluator.ClusterTuple clusterTuple = (KmeansEvaluator.ClusterTuple) value1;
       List<CentroidCluster<KmeansEvaluator.ClusterPoint>> clusters = clusterTuple.getClusters();
 
       Number index = (Number) value2;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetColumnLabelsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetColumnLabelsEvaluator.java
@@ -32,7 +32,7 @@ public class GetColumnLabelsEvaluator extends RecursiveObjectEvaluator implement
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof Matrix)) {
+    if (!(value instanceof Matrix matrix)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetColumnLabelsEvaluator extends RecursiveObjectEvaluator implement
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      Matrix matrix = (Matrix) value;
       return matrix.getColumnLabels();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetMembershipMatrixEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetMembershipMatrixEvaluator.java
@@ -33,7 +33,7 @@ public class GetMembershipMatrixEvaluator extends RecursiveObjectEvaluator
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof KmeansEvaluator.ClusterTuple)) {
+    if (!(value instanceof KmeansEvaluator.ClusterTuple clusterTuple)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -41,7 +41,6 @@ public class GetMembershipMatrixEvaluator extends RecursiveObjectEvaluator
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      KmeansEvaluator.ClusterTuple clusterTuple = (KmeansEvaluator.ClusterTuple) value;
       return clusterTuple.getMembershipMatrix();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetPhaseEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetPhaseEvaluator.java
@@ -31,7 +31,7 @@ public class GetPhaseEvaluator extends RecursiveObjectEvaluator implements OneVa
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof VectorFunction)) {
+    if (!(value instanceof VectorFunction vectorFunction)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -39,7 +39,6 @@ public class GetPhaseEvaluator extends RecursiveObjectEvaluator implements OneVa
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      VectorFunction vectorFunction = (VectorFunction) value;
       return vectorFunction.getFromContext("phase");
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetRadiusEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetRadiusEvaluator.java
@@ -32,7 +32,7 @@ public class GetRadiusEvaluator extends RecursiveObjectEvaluator implements OneV
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof EnclosingBall)) {
+    if (!(value instanceof EnclosingBall<?, ?> enclosingBall)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetRadiusEvaluator extends RecursiveObjectEvaluator implements OneV
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      EnclosingBall<?, ?> enclosingBall = (EnclosingBall<?, ?>) value;
       return enclosingBall.getRadius();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetRowLabelsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetRowLabelsEvaluator.java
@@ -32,7 +32,7 @@ public class GetRowLabelsEvaluator extends RecursiveObjectEvaluator implements O
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof Matrix)) {
+    if (!(value instanceof Matrix matrix)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class GetRowLabelsEvaluator extends RecursiveObjectEvaluator implements O
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      Matrix matrix = (Matrix) value;
       return matrix.getRowLabels();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetSupportPointsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetSupportPointsEvaluator.java
@@ -35,7 +35,7 @@ public class GetSupportPointsEvaluator extends RecursiveObjectEvaluator implemen
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof EnclosingBall)) {
+    if (!(value instanceof EnclosingBall<?, ?> enclosingBall)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -43,7 +43,6 @@ public class GetSupportPointsEvaluator extends RecursiveObjectEvaluator implemen
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      EnclosingBall<?, ?> enclosingBall = (EnclosingBall<?, ?>) value;
       Point<?>[] points = enclosingBall.getSupport();
       double[][] data = new double[points.length][2];
       int i = 0;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetValueEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetValueEvaluator.java
@@ -41,8 +41,7 @@ public class GetValueEvaluator extends RecursiveObjectEvaluator implements TwoVa
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
 
-    if (value1 instanceof Tuple) {
-      Tuple tuple = (Tuple) value1;
+    if (value1 instanceof Tuple tuple) {
       String key = (String) value2;
       key = key.replace("\"", "");
       return tuple.get(key);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetVerticesEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GetVerticesEvaluator.java
@@ -34,7 +34,7 @@ public class GetVerticesEvaluator extends RecursiveObjectEvaluator implements On
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof ConvexHull2D)) {
+    if (!(value instanceof ConvexHull2D convexHull2D)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -42,7 +42,6 @@ public class GetVerticesEvaluator extends RecursiveObjectEvaluator implements On
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      ConvexHull2D convexHull2D = (ConvexHull2D) value;
       Vector2D[] vectors = convexHull2D.getVertices();
       double[][] data = new double[vectors.length][2];
       for (int i = 0; i < vectors.length; i++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GrandSumEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/GrandSumEvaluator.java
@@ -41,8 +41,7 @@ public class GrandSumEvaluator extends RecursiveObjectEvaluator implements OneVa
   public Object doWork(Object value) throws IOException {
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
-      Matrix matrix = (Matrix) value;
+    } else if (value instanceof Matrix matrix) {
       double[][] data = matrix.getData();
       double grandSum = 0;
       for (double[] row : data) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/IFFTEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/IFFTEvaluator.java
@@ -46,9 +46,8 @@ public class IFFTEvaluator extends RecursiveObjectEvaluator implements OneValueW
   @Override
   public Object doWork(Object v) throws IOException {
 
-    if (v instanceof Matrix) {
+    if (v instanceof Matrix matrix) {
 
-      Matrix matrix = (Matrix) v;
       double[][] data = matrix.getData();
       double[] real = data[0];
       double[] imaginary = data[1];

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/IndexOfEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/IndexOfEvaluator.java
@@ -32,7 +32,7 @@ public class IndexOfEvaluator extends RecursiveObjectEvaluator implements TwoVal
 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
-    if (!(value1 instanceof List)) {
+    if (!(value1 instanceof List<?> list)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -40,7 +40,6 @@ public class IndexOfEvaluator extends RecursiveObjectEvaluator implements TwoVal
               toExpression(constructingFactory),
               value1.getClass().getSimpleName()));
     } else {
-      List<?> list = (List<?>) value1;
       String find = value2.toString().replace("\"", "");
       for (int i = 0; i < list.size(); i++) {
         Object o = list.get(i);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/IntegrateEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/IntegrateEvaluator.java
@@ -38,7 +38,7 @@ public class IntegrateEvaluator extends RecursiveObjectEvaluator implements Many
       throw new IOException("The integrate function requires at most 3 parameters");
     }
 
-    if (!(values[0] instanceof VectorFunction)) {
+    if (!(values[0] instanceof VectorFunction vectorFunction)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -47,12 +47,9 @@ public class IntegrateEvaluator extends RecursiveObjectEvaluator implements Many
               values[0].getClass().getSimpleName()));
     }
 
-    VectorFunction vectorFunction = (VectorFunction) values[0];
-    if (!(vectorFunction.getFunction() instanceof UnivariateFunction)) {
+    if (!(vectorFunction.getFunction() instanceof UnivariateFunction func)) {
       throw new IOException("Cannot evaluate integral from parameter.");
     }
-
-    UnivariateFunction func = (UnivariateFunction) vectorFunction.getFunction();
 
     if (values.length == 3) {
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/KolmogorovSmirnovEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/KolmogorovSmirnovEvaluator.java
@@ -69,8 +69,7 @@ public class KolmogorovSmirnovEvaluator extends RecursiveObjectEvaluator impleme
     double[] data =
         ((List<?>) second).stream().mapToDouble(item -> ((Number) item).doubleValue()).toArray();
 
-    if (first instanceof RealDistribution) {
-      RealDistribution realDistribution = (RealDistribution) first;
+    if (first instanceof RealDistribution realDistribution) {
 
       Tuple tuple = new Tuple();
       tuple.put(StreamParams.P_VALUE, ks.kolmogorovSmirnovTest(realDistribution, data));

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/LatLonVectorsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/LatLonVectorsEvaluator.java
@@ -64,11 +64,10 @@ public class LatLonVectorsEvaluator extends RecursiveObjectEvaluator implements 
 
     if (objects.length == 1) {
       // Just docs
-      if (!(objects[0] instanceof List)) {
+      if (!(objects[0] instanceof List<?> list)) {
         throw new IOException(
             "The latlonVectors function expects a list of Tuples as a parameter.");
       } else {
-        List<?> list = (List<?>) objects[0];
         if (list.size() > 0) {
           Object o = list.get(0);
           if (!(o instanceof Tuple)) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/LeftShiftEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/LeftShiftEvaluator.java
@@ -41,8 +41,7 @@ public class LeftShiftEvaluator extends RecursiveObjectEvaluator implements TwoV
 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
-    if (value1 instanceof List && value2 instanceof Number) {
-      List<?> actual = (List<?>) value1;
+    if (value1 instanceof List<?> actual && value2 instanceof Number) {
       int val = ((Number) value2).intValue();
 
       List<Object> shifted = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MarkovChainEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MarkovChainEvaluator.java
@@ -50,8 +50,7 @@ public class MarkovChainEvaluator extends RecursiveObjectEvaluator implements Ma
       state = ((Number) values[1]).intValue();
     }
 
-    if (values[0] instanceof Matrix) {
-      Matrix matrix = (Matrix) values[0];
+    if (values[0] instanceof Matrix matrix) {
       return new MarkovChain(matrix, state);
     } else {
       throw new IOException("matrix parameter expected for markovChain function");

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MatrixMultiplyEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MatrixMultiplyEvaluator.java
@@ -55,8 +55,7 @@ public class MatrixMultiplyEvaluator extends RecursiveObjectEvaluator implements
   }
 
   private Array2DRowRealMatrix getMatrix(Object o) throws IOException {
-    if (o instanceof Matrix) {
-      Matrix matrix = (Matrix) o;
+    if (o instanceof Matrix matrix) {
       return new Array2DRowRealMatrix(matrix.getData(), false);
     } else if (o instanceof List) {
       @SuppressWarnings({"unchecked"})

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MemsetEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MemsetEvaluator.java
@@ -70,7 +70,7 @@ public class MemsetEvaluator extends RecursiveEvaluator {
     }
 
     if (null == colsExpression
-        || !(colsExpression.getParameter() instanceof StreamExpressionValue)) {
+        || !(colsExpression.getParameter() instanceof StreamExpressionValue colsExpressionValue)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -79,7 +79,7 @@ public class MemsetEvaluator extends RecursiveEvaluator {
     }
 
     if (null == varsExpression
-        || !(varsExpression.getParameter() instanceof StreamExpressionValue)) {
+        || !(varsExpression.getParameter() instanceof StreamExpressionValue varsExpressionValue)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -96,10 +96,6 @@ public class MemsetEvaluator extends RecursiveEvaluator {
 
     in = factory.constructStream(streamExpressions.get(0));
 
-    StreamExpressionValue colsExpressionValue =
-        (StreamExpressionValue) colsExpression.getParameter();
-    StreamExpressionValue varsExpressionValue =
-        (StreamExpressionValue) varsExpression.getParameter();
     String colsString = colsExpressionValue.getValue();
     String varsString = varsExpressionValue.getValue();
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MinMaxScaleEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MinMaxScaleEvaluator.java
@@ -45,8 +45,7 @@ public class MinMaxScaleEvaluator extends RecursiveObjectEvaluator implements Ma
       max = ((Number) values[2]).doubleValue();
     }
 
-    if (values[0] instanceof Matrix) {
-      Matrix matrix = (Matrix) values[0];
+    if (values[0] instanceof Matrix matrix) {
       double[][] data = matrix.getData();
       double[][] scaled = new double[data.length][];
       for (int i = 0; i < scaled.length; i++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MonteCarloEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MonteCarloEvaluator.java
@@ -113,9 +113,8 @@ public class MonteCarloEvaluator extends RecursiveEvaluator {
     for (Map.Entry<String, Object> entry : entries) {
       String name = entry.getKey();
       Object o = entry.getValue();
-      if (o instanceof TupleStream) {
+      if (o instanceof TupleStream tStream) {
         List<Tuple> tuples = new ArrayList<>();
-        TupleStream tStream = (TupleStream) o;
         tStream.setStreamContext(streamContext);
         try {
           tStream.open();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MovingAverageEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MovingAverageEvaluator.java
@@ -48,7 +48,7 @@ public class MovingAverageEvaluator extends RecursiveNumericEvaluator implements
               "Invalid expression %s - null found for the second value",
               toExpression(constructingFactory)));
     }
-    if (!(first instanceof List<?>)) {
+    if (!(first instanceof List<?> values)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -65,7 +65,6 @@ public class MovingAverageEvaluator extends RecursiveNumericEvaluator implements
               first.getClass().getSimpleName()));
     }
 
-    List<?> values = (List<?>) first;
     int window = ((Number) second).intValue();
 
     List<Number> moving = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MovingMADEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MovingMADEvaluator.java
@@ -47,7 +47,7 @@ public class MovingMADEvaluator extends RecursiveNumericEvaluator implements Two
               "Invalid expression %s - null found for the second value",
               toExpression(constructingFactory)));
     }
-    if (!(first instanceof List<?>)) {
+    if (!(first instanceof List<?> values)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -64,7 +64,6 @@ public class MovingMADEvaluator extends RecursiveNumericEvaluator implements Two
               first.getClass().getSimpleName()));
     }
 
-    List<?> values = (List<?>) first;
     int window = ((Number) second).intValue();
 
     List<Number> moving = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MovingMedianEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/MovingMedianEvaluator.java
@@ -49,7 +49,7 @@ public class MovingMedianEvaluator extends RecursiveNumericEvaluator implements 
               "Invalid expression %s - null found for the second value",
               toExpression(constructingFactory)));
     }
-    if (!(first instanceof List<?>)) {
+    if (!(first instanceof List<?> values)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -66,7 +66,6 @@ public class MovingMedianEvaluator extends RecursiveNumericEvaluator implements 
               first.getClass().getSimpleName()));
     }
 
-    List<?> values = (List<?>) first;
     int window = ((Number) second).intValue();
 
     List<Number> moving = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/NormalizeEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/NormalizeEvaluator.java
@@ -55,8 +55,7 @@ public class NormalizeEvaluator extends RecursiveObjectEvaluator implements OneV
                           .toArray()))
           .boxed()
           .collect(Collectors.toList());
-    } else if (value instanceof Matrix) {
-      Matrix matrix = (Matrix) value;
+    } else if (value instanceof Matrix matrix) {
       double[][] data = matrix.getData();
       double[][] standardized = new double[data.length][];
       for (int i = 0; i < data.length; i++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/NormalizeSumEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/NormalizeSumEvaluator.java
@@ -55,8 +55,7 @@ public class NormalizeSumEvaluator extends RecursiveObjectEvaluator implements M
 
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
-      Matrix matrix = (Matrix) value;
+    } else if (value instanceof Matrix matrix) {
 
       double[][] data = matrix.getData();
       double[][] unitData = new double[data.length][];

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/OutliersEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/OutliersEvaluator.java
@@ -85,9 +85,7 @@ public class OutliersEvaluator extends RecursiveObjectEvaluator implements ManyV
 
     List<Tuple> outliers = new ArrayList<>();
 
-    if (dist instanceof IntegerDistribution) {
-
-      IntegerDistribution d = (IntegerDistribution) dist;
+    if (dist instanceof IntegerDistribution d) {
 
       for (int i = 0; i < vec.size(); i++) {
 
@@ -110,9 +108,8 @@ public class OutliersEvaluator extends RecursiveObjectEvaluator implements ManyV
 
       return outliers;
 
-    } else if (dist instanceof AbstractRealDistribution) {
+    } else if (dist instanceof AbstractRealDistribution d) {
 
-      AbstractRealDistribution d = (AbstractRealDistribution) dist;
       for (int i = 0; i < vec.size(); i++) {
 
         Number n = vec.get(i);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/PowerEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/PowerEvaluator.java
@@ -47,10 +47,8 @@ public class PowerEvaluator extends RecursiveNumericEvaluator implements TwoValu
       return null;
     }
 
-    if (first instanceof Number) {
-      Number value = (Number) first;
-      if (second instanceof Number) {
-        Number exponent = (Number) second;
+    if (first instanceof Number value) {
+      if (second instanceof Number exponent) {
         return Math.pow(value.doubleValue(), exponent.doubleValue());
       } else if (second instanceof List) {
         @SuppressWarnings({"unchecked"})
@@ -67,8 +65,7 @@ public class PowerEvaluator extends RecursiveNumericEvaluator implements TwoValu
     } else if (first instanceof List) {
       @SuppressWarnings({"unchecked"})
       List<Number> values = (List<Number>) first;
-      if (second instanceof Number) {
-        Number exponent = (Number) second;
+      if (second instanceof Number exponent) {
 
         List<Number> out = new ArrayList<>(values.size());
         for (Number value : values) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/PrecisionEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/PrecisionEvaluator.java
@@ -49,9 +49,8 @@ public class PrecisionEvaluator extends RecursiveObjectEvaluator implements TwoV
           .stream()
               .map(innerValue -> doWork(innerValue, ((Number) value2).intValue()))
               .collect(Collectors.toList());
-    } else if (value instanceof Matrix) {
+    } else if (value instanceof Matrix matrix) {
       int p = ((Number) value2).intValue();
-      Matrix matrix = (Matrix) value;
       double[][] data = matrix.getData();
       for (int i = 0; i < data.length; ++i) {
         for (int j = 0; j < data[i].length; j++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/PredictEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/PredictEvaluator.java
@@ -66,10 +66,8 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
               first.getClass().getSimpleName()));
     }
 
-    if (first instanceof RegressionEvaluator.RegressionTuple) {
+    if (first instanceof RegressionEvaluator.RegressionTuple regressedTuple) {
 
-      RegressionEvaluator.RegressionTuple regressedTuple =
-          (RegressionEvaluator.RegressionTuple) first;
       if (second instanceof Number) {
         return regressedTuple.predict(((Number) second).doubleValue());
       } else {
@@ -79,10 +77,8 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
                 .collect(Collectors.toList());
       }
 
-    } else if (first instanceof OLSRegressionEvaluator.MultipleRegressionTuple) {
+    } else if (first instanceof OLSRegressionEvaluator.MultipleRegressionTuple regressedTuple) {
 
-      OLSRegressionEvaluator.MultipleRegressionTuple regressedTuple =
-          (OLSRegressionEvaluator.MultipleRegressionTuple) first;
       if (second instanceof List) {
         @SuppressWarnings({"unchecked"})
         List<Number> list = (List<Number>) second;
@@ -93,9 +89,8 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
         }
 
         return regressedTuple.predict(predictors);
-      } else if (second instanceof Matrix) {
+      } else if (second instanceof Matrix m) {
 
-        Matrix m = (Matrix) second;
         double[][] data = m.getData();
         List<Number> predictions = new ArrayList<>();
         for (double[] predictors : data) {
@@ -104,9 +99,7 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
         return predictions;
       }
 
-    } else if (first instanceof KnnRegressionEvaluator.KnnRegressionTuple) {
-      KnnRegressionEvaluator.KnnRegressionTuple regressedTuple =
-          (KnnRegressionEvaluator.KnnRegressionTuple) first;
+    } else if (first instanceof KnnRegressionEvaluator.KnnRegressionTuple regressedTuple) {
 
       if (regressedTuple.getBivariate()) {
         // Handle bi-variate regression
@@ -141,9 +134,8 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
           }
 
           return regressedTuple.predict(predictors);
-        } else if (second instanceof Matrix) {
+        } else if (second instanceof Matrix m) {
 
-          Matrix m = (Matrix) second;
           if (regressedTuple.getScale()) {
             m = regressedTuple.scale(m);
           }
@@ -155,8 +147,7 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
           return predictions;
         }
       }
-    } else if (first instanceof VectorFunction) {
-      VectorFunction vectorFunction = (VectorFunction) first;
+    } else if (first instanceof VectorFunction vectorFunction) {
       UnivariateFunction univariateFunction = (UnivariateFunction) vectorFunction.getFunction();
       if (second instanceof Number) {
         double x = ((Number) second).doubleValue();
@@ -167,8 +158,7 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
                 .map(value -> univariateFunction.value(((Number) value).doubleValue()))
                 .collect(Collectors.toList());
       }
-    } else if (first instanceof BivariateFunction) {
-      BivariateFunction bivariateFunction = (BivariateFunction) first;
+    } else if (first instanceof BivariateFunction bivariateFunction) {
       if (objects.length == 3) {
         Object third = objects[2];
         double x = 0.0;
@@ -181,8 +171,7 @@ public class PredictEvaluator extends RecursiveObjectEvaluator implements ManyVa
           throw new IOException("BivariateFunction requires two numeric parameters.");
         }
       } else if (objects.length == 2) {
-        if (second instanceof Matrix) {
-          Matrix m = (Matrix) second;
+        if (second instanceof Matrix m) {
           double[][] data = m.getData();
           if (data[0].length == 2) {
             List<Number> out = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ProbabilityEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ProbabilityEvaluator.java
@@ -56,7 +56,7 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
                 "Invalid expression %s - null found for the second value",
                 toExpression(constructingFactory)));
       }
-      if (!(first instanceof IntegerDistribution)) {
+      if (!(first instanceof IntegerDistribution d)) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -64,7 +64,7 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
                 toExpression(constructingFactory),
                 first.getClass().getSimpleName()));
       }
-      if (!(second instanceof Number)) {
+      if (!(second instanceof Number predictOver)) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -73,8 +73,6 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
                 first.getClass().getSimpleName()));
       }
 
-      IntegerDistribution d = (IntegerDistribution) first;
-      Number predictOver = (Number) second;
       return d.probability(predictOver.intValue());
 
     } else if (values.length == 3) {
@@ -82,7 +80,7 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
       second = values[1];
       third = values[2];
 
-      if (!(first instanceof AbstractRealDistribution)) {
+      if (!(first instanceof AbstractRealDistribution realDistribution)) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -90,7 +88,7 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
                 toExpression(constructingFactory),
                 first.getClass().getSimpleName()));
       }
-      if (!(second instanceof Number)) {
+      if (!(second instanceof Number start)) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -99,7 +97,7 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
                 first.getClass().getSimpleName()));
       }
 
-      if (!(third instanceof Number)) {
+      if (!(third instanceof Number end)) {
         throw new IOException(
             String.format(
                 Locale.ROOT,
@@ -108,9 +106,6 @@ public class ProbabilityEvaluator extends RecursiveObjectEvaluator implements Ma
                 first.getClass().getSimpleName()));
       }
 
-      AbstractRealDistribution realDistribution = (AbstractRealDistribution) first;
-      Number start = (Number) second;
-      Number end = (Number) third;
       return realDistribution.probability(start.doubleValue(), end.doubleValue());
     } else {
       throw new IOException("The probability function expects 2 or 3 parameters");

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ProjectToBorderEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ProjectToBorderEvaluator.java
@@ -37,7 +37,7 @@ public class ProjectToBorderEvaluator extends RecursiveObjectEvaluator implement
 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
-    if (!(value1 instanceof ConvexHull2D)) {
+    if (!(value1 instanceof ConvexHull2D convexHull2D)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -46,7 +46,7 @@ public class ProjectToBorderEvaluator extends RecursiveObjectEvaluator implement
               value1.getClass().getSimpleName()));
     }
 
-    if (!(value2 instanceof Matrix)) {
+    if (!(value2 instanceof Matrix matrix)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -55,8 +55,6 @@ public class ProjectToBorderEvaluator extends RecursiveObjectEvaluator implement
               value2.getClass().getSimpleName()));
     }
 
-    ConvexHull2D convexHull2D = (ConvexHull2D) value1;
-    Matrix matrix = (Matrix) value2;
     double[][] data = matrix.getData();
     Region<Euclidean2D> region = convexHull2D.createRegion();
     double[][] borderPoints = new double[data.length][2];

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RecursiveEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RecursiveEvaluator.java
@@ -112,8 +112,7 @@ public abstract class RecursiveEvaluator implements StreamEvaluator, ValueWorker
       return null;
     } else if (value instanceof VectorFunction) {
       return value;
-    } else if (value instanceof BigDecimal) {
-      BigDecimal bd = (BigDecimal) value;
+    } else if (value instanceof BigDecimal bd) {
       return bd.doubleValue();
     } else if (value instanceof Long || value instanceof Integer) {
       return ((Number) value).longValue();
@@ -125,11 +124,10 @@ public abstract class RecursiveEvaluator implements StreamEvaluator, ValueWorker
       // normalize each value in the list
       return ((List<?>) value)
           .stream().map(innerValue -> normalizeOutputType(innerValue)).collect(Collectors.toList());
-    } else if (value instanceof Tuple && value.getClass().getEnclosingClass() == null) {
+    } else if (value instanceof Tuple tuple && value.getClass().getEnclosingClass() == null) {
       // If it's a tuple and not an inner class that has extended tuple, which occurs in a number of
       // cases so that mathematical models can be contained within a tuple.
 
-      Tuple tuple = (Tuple) value;
       Tuple newTuple = new Tuple();
       for (String s : tuple.getFields().keySet()) {
         Object v = tuple.get(s);
@@ -152,9 +150,8 @@ public abstract class RecursiveEvaluator implements StreamEvaluator, ValueWorker
         factory.getOperandsOfType(expression, StreamExpressionParameter.class);
 
     for (StreamExpressionParameter parameter : parameters) {
-      if (parameter instanceof StreamExpression) {
+      if (parameter instanceof StreamExpression streamExpression) {
         // possible evaluator
-        StreamExpression streamExpression = (StreamExpression) parameter;
         if (factory.doesRepresentTypes(streamExpression, RecursiveEvaluator.class)) {
           containedEvaluators.add(factory.constructEvaluator(streamExpression));
         } else if (factory.doesRepresentTypes(streamExpression, SourceEvaluator.class)) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RecursiveTemporalEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RecursiveTemporalEvaluator.java
@@ -79,8 +79,7 @@ public abstract class RecursiveTemporalEvaluator extends RecursiveEvaluator
     } else if (value instanceof Date) {
       // Convert to Instant and recurse in
       return normalizeInputType(((Date) value).toInstant());
-    } else if (value instanceof String) {
-      String valueStr = (String) value;
+    } else if (value instanceof String valueStr) {
       if (!valueStr.isEmpty()) {
         try {
           // Convert to Instant and recurse in

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ReverseEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ReverseEvaluator.java
@@ -43,8 +43,7 @@ public class ReverseEvaluator extends RecursiveObjectEvaluator implements OneVal
   public Object doWork(Object value) {
     if (null == value) {
       return null;
-    } else if (value instanceof List) {
-      List<?> actual = (List<?>) value;
+    } else if (value instanceof List<?> actual) {
 
       List<Object> reversed = new ArrayList<>();
       for (int idx = actual.size() - 1; idx >= 0; --idx) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RightShiftEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RightShiftEvaluator.java
@@ -42,8 +42,7 @@ public class RightShiftEvaluator extends RecursiveObjectEvaluator implements Two
 
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
-    if (value1 instanceof List && value2 instanceof Number) {
-      List<?> actual = (List<?>) value1;
+    if (value1 instanceof List<?> actual && value2 instanceof Number) {
       int val = ((Number) value2).intValue();
 
       List<Object> shifted = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RowAtEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RowAtEvaluator.java
@@ -42,8 +42,7 @@ public class RowAtEvaluator extends RecursiveObjectEvaluator implements TwoValue
   @Override
   public Object doWork(Object value1, Object value2) throws IOException {
 
-    if (value1 instanceof Matrix) {
-      Matrix matrix = (Matrix) value1;
+    if (value1 instanceof Matrix matrix) {
       Number index = (Number) value2;
       double[] row = matrix.getData()[index.intValue()];
       List<Number> list = new ArrayList<>();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RowCountEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/RowCountEvaluator.java
@@ -31,7 +31,7 @@ public class RowCountEvaluator extends RecursiveObjectEvaluator implements OneVa
 
   @Override
   public Object doWork(Object value) throws IOException {
-    if (!(value instanceof Matrix)) {
+    if (!(value instanceof Matrix matrix)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -39,7 +39,6 @@ public class RowCountEvaluator extends RecursiveObjectEvaluator implements OneVa
               toExpression(constructingFactory),
               value.getClass().getSimpleName()));
     } else {
-      Matrix matrix = (Matrix) value;
       return matrix.getRowCount();
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SampleEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SampleEvaluator.java
@@ -67,8 +67,7 @@ public class SampleEvaluator extends RecursiveObjectEvaluator implements ManyVal
       second = objects[1];
     }
 
-    if (first instanceof MarkovChainEvaluator.MarkovChain) {
-      MarkovChainEvaluator.MarkovChain markovChain = (MarkovChainEvaluator.MarkovChain) first;
+    if (first instanceof MarkovChainEvaluator.MarkovChain markovChain) {
       if (second != null) {
         return Arrays.stream(markovChain.sample(((Number) second).intValue()))
             .mapToObj(item -> item)
@@ -76,8 +75,7 @@ public class SampleEvaluator extends RecursiveObjectEvaluator implements ManyVal
       } else {
         return markovChain.sample();
       }
-    } else if (first instanceof RealDistribution) {
-      RealDistribution realDistribution = (RealDistribution) first;
+    } else if (first instanceof RealDistribution realDistribution) {
       if (second != null) {
         return Arrays.stream(realDistribution.sample(((Number) second).intValue()))
             .mapToObj(item -> item)

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ScalarAddEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ScalarAddEvaluator.java
@@ -53,8 +53,7 @@ public class ScalarAddEvaluator extends RecursiveObjectEvaluator implements TwoV
 
       return out;
 
-    } else if (value2 instanceof Matrix) {
-      Matrix matrix = (Matrix) value2;
+    } else if (value2 instanceof Matrix matrix) {
       double[][] data = matrix.getData();
       double[][] newData = new double[data.length][];
       for (int i = 0; i < data.length; i++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SetColumnLabelsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SetColumnLabelsEvaluator.java
@@ -41,7 +41,7 @@ public class SetColumnLabelsEvaluator extends RecursiveObjectEvaluator implement
               "Invalid expression %s - found type %s for value, expecting a Matrix",
               toExpression(constructingFactory),
               value1.getClass().getSimpleName()));
-    } else if (!(value2 instanceof List)) {
+    } else if (!(value2 instanceof List<?> colLabels)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -51,7 +51,6 @@ public class SetColumnLabelsEvaluator extends RecursiveObjectEvaluator implement
     } else {
       Matrix matrix = (Matrix) value1;
 
-      List<?> colLabels = (List<?>) value2;
       // Convert numeric labels to strings.
       List<String> strLabels = new ArrayList<>(colLabels.size());
       for (Object o : colLabels) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SetRowLabelsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SetRowLabelsEvaluator.java
@@ -41,7 +41,7 @@ public class SetRowLabelsEvaluator extends RecursiveObjectEvaluator implements T
               "Invalid expression %s - found type %s for value, expecting a Matrix",
               toExpression(constructingFactory),
               value1.getClass().getSimpleName()));
-    } else if (!(value2 instanceof List)) {
+    } else if (!(value2 instanceof List<?> rowlabels)) {
       throw new IOException(
           String.format(
               Locale.ROOT,
@@ -50,7 +50,6 @@ public class SetRowLabelsEvaluator extends RecursiveObjectEvaluator implements T
               value2.getClass().getSimpleName()));
     } else {
       Matrix matrix = (Matrix) value1;
-      List<?> rowlabels = (List<?>) value2;
 
       // Convert numeric labels to strings.
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SetValueEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SetValueEvaluator.java
@@ -40,8 +40,7 @@ public class SetValueEvaluator extends RecursiveObjectEvaluator implements ManyV
 
   @Override
   public Object doWork(Object... values) throws IOException {
-    if (values[0] instanceof Tuple) {
-      Tuple tuple = (Tuple) values[0];
+    if (values[0] instanceof Tuple tuple) {
       String key = (String) values[1];
       Object value = values[2];
       if (value instanceof String) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SumColumnsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SumColumnsEvaluator.java
@@ -46,10 +46,9 @@ public class SumColumnsEvaluator extends RecursiveObjectEvaluator implements One
   public Object doWork(Object value) throws IOException {
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
+    } else if (value instanceof Matrix matrix) {
 
       // First transpose the matrix
-      Matrix matrix = (Matrix) value;
       double[][] data = matrix.getData();
       RealMatrix realMatrix = new Array2DRowRealMatrix(data, false);
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SumRowsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/SumRowsEvaluator.java
@@ -43,9 +43,8 @@ public class SumRowsEvaluator extends RecursiveObjectEvaluator implements OneVal
   public Object doWork(Object value) throws IOException {
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
+    } else if (value instanceof Matrix matrix) {
 
-      Matrix matrix = (Matrix) value;
       double[][] data = matrix.getData();
       List<Number> sums = new ArrayList<>(data.length);
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TermVectorsEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TermVectorsEvaluator.java
@@ -71,10 +71,9 @@ public class TermVectorsEvaluator extends RecursiveObjectEvaluator implements Ma
 
     if (objects.length == 1) {
       // Just docs
-      if (!(objects[0] instanceof List)) {
+      if (!(objects[0] instanceof List<?> list)) {
         throw new IOException("The termVectors function expects a list of Tuples as a parameter.");
       } else {
-        List<?> list = (List<?>) objects[0];
         if (list.size() > 0) {
           Object o = list.get(0);
           if (!(o instanceof Tuple)) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TimeDifferencingEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TimeDifferencingEvaluator.java
@@ -95,11 +95,10 @@ public class TimeDifferencingEvaluator extends RecursiveObjectEvaluator implemen
                   (timeseriesValues.get(n).doubleValue()
                       - timeseriesValues.get(n - lag).doubleValue()))
           .collect(Collectors.toList());
-    } else if (values[0] instanceof Matrix) {
+    } else if (values[0] instanceof Matrix matrix) {
 
       // Diff each row of the matrix
 
-      Matrix matrix = (Matrix) values[0];
       double[][] data = matrix.getData();
       double[][] diffedData = new double[data.length][];
       Number lagValue = 1;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TopFeaturesEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TopFeaturesEvaluator.java
@@ -46,9 +46,8 @@ public class TopFeaturesEvaluator extends RecursiveObjectEvaluator implements Tw
 
     int k = ((Number) value2).intValue();
 
-    if (value1 instanceof Matrix) {
+    if (value1 instanceof Matrix matrix) {
 
-      Matrix matrix = (Matrix) value1;
       List<String> features = matrix.getColumnLabels();
 
       if (features == null) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TransposeEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/TransposeEvaluator.java
@@ -42,8 +42,7 @@ public class TransposeEvaluator extends RecursiveObjectEvaluator implements OneV
   public Object doWork(Object value) throws IOException {
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
-      Matrix matrix = (Matrix) value;
+    } else if (value instanceof Matrix matrix) {
       double[][] data = matrix.getData();
       Array2DRowRealMatrix amatrix = new Array2DRowRealMatrix(data, false);
       Array2DRowRealMatrix tmatrix = (Array2DRowRealMatrix) amatrix.transpose();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/UnitEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/UnitEvaluator.java
@@ -45,8 +45,7 @@ public class UnitEvaluator extends RecursiveObjectEvaluator implements OneValueW
   public Object doWork(Object value) throws IOException {
     if (null == value) {
       return null;
-    } else if (value instanceof Matrix) {
-      Matrix matrix = (Matrix) value;
+    } else if (value instanceof Matrix matrix) {
       double[][] data = matrix.getData();
       double[][] unitData = new double[data.length][];
       for (int i = 0; i < data.length; i++) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ValueAtEvaluator.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/eval/ValueAtEvaluator.java
@@ -47,9 +47,8 @@ public class ValueAtEvaluator extends RecursiveObjectEvaluator implements ManyVa
       }
       return c.get(index);
 
-    } else if (values[0] instanceof Matrix) {
+    } else if (values[0] instanceof Matrix c) {
 
-      Matrix c = (Matrix) values[0];
       double[][] data = c.getData();
       int row = -1;
       int col = -1;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/graph/GatherNodesStream.java
@@ -411,8 +411,7 @@ public class GatherNodesStream extends TupleStream implements Expressible {
       expression.addParameter(
           new StreamExpressionNamedParameter("maxDocFreq", Integer.toString(maxDocFreq)));
     }
-    if (tupleStream instanceof NodeStream) {
-      NodeStream nodeStream = (NodeStream) tupleStream;
+    if (tupleStream instanceof NodeStream nodeStream) {
       expression.addParameter(
           new StreamExpressionNamedParameter("walk", nodeStream.toString() + "->" + traverseTo));
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/BiJoinStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/BiJoinStream.java
@@ -91,10 +91,8 @@ public abstract class BiJoinStream extends JoinStream implements Expressible {
         StreamEqualitor sourceEqualitor = ((MultipleFieldEqualitor) eq).getEqs()[idx];
         StreamComparator sourceComparator = ((MultipleFieldComparator) comp).getComps()[idx];
 
-        if (sourceEqualitor instanceof FieldEqualitor
-            && sourceComparator instanceof FieldComparator) {
-          FieldEqualitor fieldEqualitor = (FieldEqualitor) sourceEqualitor;
-          FieldComparator fieldComparator = (FieldComparator) sourceComparator;
+        if (sourceEqualitor instanceof FieldEqualitor fieldEqualitor
+            && sourceComparator instanceof FieldComparator fieldComparator) {
           compoundComps[idx] =
               new FieldComparator(
                   fieldEqualitor.getLeftFieldName(),
@@ -109,10 +107,8 @@ public abstract class BiJoinStream extends JoinStream implements Expressible {
       StreamEqualitor sourceEqualitor = eq;
       StreamComparator sourceComparator = ((MultipleFieldComparator) comp).getComps()[0];
 
-      if (sourceEqualitor instanceof FieldEqualitor
-          && sourceComparator instanceof FieldComparator) {
-        FieldEqualitor fieldEqualitor = (FieldEqualitor) sourceEqualitor;
-        FieldComparator fieldComparator = (FieldComparator) sourceComparator;
+      if (sourceEqualitor instanceof FieldEqualitor fieldEqualitor
+          && sourceComparator instanceof FieldComparator fieldComparator) {
         return new FieldComparator(
             fieldEqualitor.getLeftFieldName(),
             fieldEqualitor.getRightFieldName(),
@@ -124,10 +120,8 @@ public abstract class BiJoinStream extends JoinStream implements Expressible {
       StreamEqualitor sourceEqualitor = eq;
       StreamComparator sourceComparator = comp;
 
-      if (sourceEqualitor instanceof FieldEqualitor
-          && sourceComparator instanceof FieldComparator) {
-        FieldEqualitor fieldEqualitor = (FieldEqualitor) sourceEqualitor;
-        FieldComparator fieldComparator = (FieldComparator) sourceComparator;
+      if (sourceEqualitor instanceof FieldEqualitor fieldEqualitor
+          && sourceComparator instanceof FieldComparator fieldComparator) {
         return new FieldComparator(
             fieldEqualitor.getLeftFieldName(),
             fieldEqualitor.getRightFieldName(),
@@ -148,8 +142,7 @@ public abstract class BiJoinStream extends JoinStream implements Expressible {
       for (int idx = 0; idx < compoundComps.length; ++idx) {
         StreamComparator sourceComparator = ((MultipleFieldComparator) comp).getComps()[idx];
 
-        if (sourceComparator instanceof FieldComparator) {
-          FieldComparator fieldComparator = (FieldComparator) sourceComparator;
+        if (sourceComparator instanceof FieldComparator fieldComparator) {
           compoundComps[idx] =
               new FieldComparator(
                   fieldComparator.getLeftFieldName(),
@@ -163,8 +156,7 @@ public abstract class BiJoinStream extends JoinStream implements Expressible {
     } else if (comp instanceof MultipleFieldComparator) {
       StreamComparator sourceComparator = ((MultipleFieldComparator) comp).getComps()[0];
 
-      if (sourceComparator instanceof FieldComparator) {
-        FieldComparator fieldComparator = (FieldComparator) sourceComparator;
+      if (sourceComparator instanceof FieldComparator fieldComparator) {
         return new FieldComparator(
             fieldComparator.getLeftFieldName(),
             fieldComparator.getRightFieldName(),
@@ -175,8 +167,7 @@ public abstract class BiJoinStream extends JoinStream implements Expressible {
     } else {
       StreamComparator sourceComparator = comp;
 
-      if (sourceComparator instanceof FieldComparator) {
-        FieldComparator fieldComparator = (FieldComparator) sourceComparator;
+      if (sourceComparator instanceof FieldComparator fieldComparator) {
         return new FieldComparator(
             fieldComparator.getLeftFieldName(),
             fieldComparator.getRightFieldName(),

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/HashRollupStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/HashRollupStream.java
@@ -117,8 +117,7 @@ public class HashRollupStream extends TupleStream implements Expressible {
 
     if (equalitor instanceof FieldEqualitor) {
       flattenedList.add((FieldEqualitor) equalitor);
-    } else if (equalitor instanceof MultipleFieldEqualitor) {
-      MultipleFieldEqualitor mEqualitor = (MultipleFieldEqualitor) equalitor;
+    } else if (equalitor instanceof MultipleFieldEqualitor mEqualitor) {
       for (StreamEqualitor subEqualitor : mEqualitor.getEqs()) {
         flattenedList.addAll(flattenEqualitor(subEqualitor));
       }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
@@ -406,8 +406,7 @@ public class JDBCStream extends TupleStream implements Expressible {
               if (resultSet.wasNull()) {
                 return null;
               }
-              if (obj instanceof String) {
-                String s = (String) obj;
+              if (obj instanceof String s) {
                 if (s.contains(sep)) {
                   s = s.substring(1);
                   return s.split(sep);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/LetStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/LetStream.java
@@ -173,9 +173,8 @@ public class LetStream extends TupleStream implements Expressible {
     for (Map.Entry<String, Object> entry : entries) {
       String name = entry.getKey();
       Object o = entry.getValue();
-      if (o instanceof TupleStream) {
+      if (o instanceof TupleStream tStream) {
         List<Tuple> tuples = new ArrayList<>();
-        TupleStream tStream = (TupleStream) o;
         tStream.setStreamContext(streamContext);
         try {
           tStream.open();
@@ -192,12 +191,11 @@ public class LetStream extends TupleStream implements Expressible {
         } finally {
           tStream.close();
         }
-      } else if (o instanceof StreamEvaluator) {
+      } else if (o instanceof StreamEvaluator evaluator) {
         // Add the data from the StreamContext to a tuple.
         // Let the evaluator works from this tuple.
         // This will allow columns to be created from tuples already in the StreamContext.
         Tuple eTuple = new Tuple(lets);
-        StreamEvaluator evaluator = (StreamEvaluator) o;
         evaluator.setStreamContext(streamContext);
         Object eo = evaluator.evaluate(eTuple);
         if (evaluator instanceof MemsetEvaluator) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ReducerStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ReducerStream.java
@@ -75,8 +75,7 @@ public class ReducerStream extends TupleStream implements Expressible {
   }
 
   private StreamEqualitor convertToEqualitor(StreamComparator comp) {
-    if (comp instanceof MultipleFieldComparator) {
-      MultipleFieldComparator mComp = (MultipleFieldComparator) comp;
+    if (comp instanceof MultipleFieldComparator mComp) {
       StreamEqualitor[] eqs = new StreamEqualitor[mComp.getComps().length];
       for (int idx = 0; idx < mComp.getComps().length; ++idx) {
         eqs[idx] = convertToEqualitor(mComp.getComps()[idx]);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/RollupStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/RollupStream.java
@@ -119,8 +119,7 @@ public class RollupStream extends TupleStream implements Expressible {
 
     if (equalitor instanceof FieldEqualitor) {
       flattenedList.add((FieldEqualitor) equalitor);
-    } else if (equalitor instanceof MultipleFieldEqualitor) {
-      MultipleFieldEqualitor mEqualitor = (MultipleFieldEqualitor) equalitor;
+    } else if (equalitor instanceof MultipleFieldEqualitor mEqualitor) {
       for (StreamEqualitor subEqualitor : mEqualitor.getEqs()) {
         flattenedList.addAll(flattenEqualitor(subEqualitor));
       }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ScoreNodesStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ScoreNodesStream.java
@@ -109,8 +109,7 @@ public class ScoreNodesStream extends TupleStream implements Expressible {
   private void init(TupleStream tupleStream, String termFreq) throws IOException {
     this.stream = tupleStream;
     this.termFreq = termFreq;
-    if (stream instanceof FacetStream) {
-      FacetStream facetStream = (FacetStream) stream;
+    if (stream instanceof FacetStream facetStream) {
 
       if (facetStream.getBuckets().length != 1) {
         throw new IOException(

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/TupStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/TupStream.java
@@ -229,8 +229,7 @@ public class TupStream extends TupleStream implements Expressible {
       for (Object o : values.values()) {
         if (o instanceof Tuple) {
           unnestedTuple = (Tuple) o;
-        } else if (o instanceof List) {
-          List<?> l = (List<?>) o;
+        } else if (o instanceof List<?> l) {
           if (l.size() > 0 && l.get(0) instanceof Tuple) {
             @SuppressWarnings({"unchecked"})
             List<Tuple> tl = (List<Tuple>) l;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ZplotStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ZplotStream.java
@@ -152,13 +152,11 @@ public class ZplotStream extends TupleStream implements Expressible {
       }
 
       Object o = entry.getValue();
-      if (o instanceof StreamEvaluator) {
+      if (o instanceof StreamEvaluator evaluator) {
         Tuple eTuple = new Tuple(lets);
-        StreamEvaluator evaluator = (StreamEvaluator) o;
         evaluator.setStreamContext(streamContext);
         Object eo = evaluator.evaluate(eTuple);
-        if (eo instanceof List) {
-          List<?> l = (List<?>) eo;
+        if (eo instanceof List<?> l) {
           if (numTuples == -1) {
             numTuples = l.size();
           } else {
@@ -175,8 +173,7 @@ public class ZplotStream extends TupleStream implements Expressible {
         }
       } else {
         Object eval = lets.get(o);
-        if (eval instanceof List) {
-          List<?> l = (List<?>) eval;
+        if (eval instanceof List<?> l) {
           if (numTuples == -1) {
             numTuples = l.size();
           } else {
@@ -223,8 +220,7 @@ public class ZplotStream extends TupleStream implements Expressible {
       }
     } else if (clusters) {
       Object o = evaluated.get("clusters");
-      if (o instanceof KmeansEvaluator.ClusterTuple) {
-        KmeansEvaluator.ClusterTuple ct = (KmeansEvaluator.ClusterTuple) o;
+      if (o instanceof KmeansEvaluator.ClusterTuple ct) {
         List<CentroidCluster<KmeansEvaluator.ClusterPoint>> cs = ct.getClusters();
         int clusterNum = 0;
         for (CentroidCluster<KmeansEvaluator.ClusterPoint> c : cs) {
@@ -238,8 +234,7 @@ public class ZplotStream extends TupleStream implements Expressible {
             outTuples.add(tuple);
           }
         }
-      } else if (o instanceof DbscanEvaluator.ClusterTuple) {
-        DbscanEvaluator.ClusterTuple ct = (DbscanEvaluator.ClusterTuple) o;
+      } else if (o instanceof DbscanEvaluator.ClusterTuple ct) {
         List<Cluster<DbscanEvaluator.ClusterPoint>> cs = ct.getClusters();
         int clusterNum = 0;
         for (Cluster<DbscanEvaluator.ClusterPoint> c : cs) {
@@ -256,11 +251,9 @@ public class ZplotStream extends TupleStream implements Expressible {
       }
     } else if (distribution) {
       Object o = evaluated.get("dist");
-      if (o instanceof RealDistribution) {
-        RealDistribution realDistribution = (RealDistribution) o;
+      if (o instanceof RealDistribution realDistribution) {
         List<SummaryStatistics> binStats = null;
-        if (realDistribution instanceof EmpiricalDistribution) {
-          EmpiricalDistribution empiricalDistribution = (EmpiricalDistribution) realDistribution;
+        if (realDistribution instanceof EmpiricalDistribution empiricalDistribution) {
           binStats = empiricalDistribution.getBinStats();
         } else {
           double[] samples = realDistribution.sample(500000);
@@ -288,8 +281,7 @@ public class ZplotStream extends TupleStream implements Expressible {
             outTuples.add(tuple);
           }
         }
-      } else if (o instanceof IntegerDistribution) {
-        IntegerDistribution integerDistribution = (IntegerDistribution) o;
+      } else if (o instanceof IntegerDistribution integerDistribution) {
         int[] samples = integerDistribution.sample(50000);
         Frequency frequency = new Frequency();
         for (int i : samples) {
@@ -314,8 +306,7 @@ public class ZplotStream extends TupleStream implements Expressible {
           tuple.put("y", y[i]);
           outTuples.add(tuple);
         }
-      } else if (o instanceof List) {
-        List<?> list = (List<?>) o;
+      } else if (o instanceof List<?> list) {
         if (list.get(0) instanceof Tuple) {
           @SuppressWarnings({"unchecked"})
           List<Tuple> tlist = (List<Tuple>) o;
@@ -340,8 +331,7 @@ public class ZplotStream extends TupleStream implements Expressible {
     } else if (table) {
       // Handle the Tuple and List of Tuples
       Object o = evaluated.get("table");
-      if (o instanceof Matrix) {
-        Matrix m = (Matrix) o;
+      if (o instanceof Matrix m) {
         List<String> rowLabels = m.getRowLabels();
         List<String> colLabels = m.getColumnLabels();
         double[][] data = m.getData();
@@ -371,8 +361,7 @@ public class ZplotStream extends TupleStream implements Expressible {
     } else if (heat) {
       // Handle the Tuple and List of Tuples
       Object o = evaluated.get("heat");
-      if (o instanceof Matrix) {
-        Matrix m = (Matrix) o;
+      if (o instanceof Matrix m) {
         List<String> rowLabels = m.getRowLabels();
         List<String> colLabels = m.getColumnLabels();
         double[][] data = m.getData();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpression.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpression.java
@@ -99,11 +99,9 @@ public class StreamExpression implements StreamExpressionParameter {
 
   @Override
   public boolean equals(Object other) {
-    if (!(other instanceof StreamExpression)) {
+    if (!(other instanceof StreamExpression check)) {
       return false;
     }
-
-    StreamExpression check = (StreamExpression) other;
 
     if (null == this.functionName && null != check.functionName) {
       return false;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
@@ -96,11 +96,9 @@ public class StreamExpressionNamedParameter implements StreamExpressionParameter
 
   @Override
   public boolean equals(Object other) {
-    if (!(other instanceof StreamExpressionNamedParameter)) {
+    if (!(other instanceof StreamExpressionNamedParameter check)) {
       return false;
     }
-
-    StreamExpressionNamedParameter check = (StreamExpressionNamedParameter) other;
 
     if (null == this.name && null != check.name) {
       return false;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionValue.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionValue.java
@@ -47,11 +47,9 @@ public class StreamExpressionValue implements StreamExpressionParameter {
 
   @Override
   public boolean equals(Object other) {
-    if (!(other instanceof StreamExpressionValue)) {
+    if (!(other instanceof StreamExpressionValue check)) {
       return false;
     }
-
-    StreamExpressionValue check = (StreamExpressionValue) other;
 
     if (null == this.value && null == check.value) {
       return true;
@@ -60,7 +58,7 @@ public class StreamExpressionValue implements StreamExpressionParameter {
       return false;
     }
 
-    return this.value.equals(((StreamExpressionValue) other).value);
+    return this.value.equals(check.value);
   }
 
   @Override

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/MaxMetric.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/MaxMetric.java
@@ -82,14 +82,12 @@ public class MaxMetric extends Metric {
       if (d > doubleMax) {
         doubleMax = d;
       }
-    } else if (o instanceof Float) {
-      Float f = (Float) o;
+    } else if (o instanceof Float f) {
       double d = f.doubleValue();
       if (d > doubleMax) {
         doubleMax = d;
       }
-    } else if (o instanceof Integer) {
-      Integer i = (Integer) o;
+    } else if (o instanceof Integer i) {
       long l = i.longValue();
       if (l > longMax) {
         longMax = l;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/MeanMetric.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/MeanMetric.java
@@ -78,17 +78,13 @@ public class MeanMetric extends Metric {
   public void update(Tuple tuple) {
     ++count;
     Object o = tuple.get(columnName);
-    if (o instanceof Double) {
-      Double d = (Double) o;
+    if (o instanceof Double d) {
       doubleSum += d;
-    } else if (o instanceof Float) {
-      Float f = (Float) o;
+    } else if (o instanceof Float f) {
       doubleSum += f.doubleValue();
-    } else if (o instanceof Integer) {
-      Integer i = (Integer) o;
+    } else if (o instanceof Integer i) {
       longSum += i.longValue();
-    } else if (o instanceof Long) {
-      Long l = (Long) o;
+    } else if (o instanceof Long l) {
       longSum += l;
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/MinMetric.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/MinMetric.java
@@ -83,14 +83,12 @@ public class MinMetric extends Metric {
       if (d < doubleMin) {
         doubleMin = d;
       }
-    } else if (o instanceof Float) {
-      Float f = (Float) o;
+    } else if (o instanceof Float f) {
       double d = f.doubleValue();
       if (d < doubleMin) {
         doubleMin = d;
       }
-    } else if (o instanceof Integer) {
-      Integer i = (Integer) o;
+    } else if (o instanceof Integer i) {
       long l = i.longValue();
       if (l < longMin) {
         longMin = l;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/SumMetric.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/SumMetric.java
@@ -68,17 +68,13 @@ public class SumMetric extends Metric {
   @Override
   public void update(Tuple tuple) {
     Object o = tuple.get(columnName);
-    if (o instanceof Double) {
-      Double d = (Double) o;
+    if (o instanceof Double d) {
       doubleSum += d;
-    } else if (o instanceof Float) {
-      Float f = (Float) o;
+    } else if (o instanceof Float f) {
       doubleSum += f.doubleValue();
-    } else if (o instanceof Integer) {
-      Integer i = (Integer) o;
+    } else if (o instanceof Integer i) {
       longSum += i.longValue();
-    } else if (o instanceof Long) {
-      Long l = (Long) o;
+    } else if (o instanceof Long l) {
       longSum += l;
     }
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/WeightedSumMetric.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/metrics/WeightedSumMetric.java
@@ -80,12 +80,10 @@ public class WeightedSumMetric extends Metric {
   public void update(Tuple tuple) {
     Object c = tuple.get(countCol);
     Object o = tuple.get(valueCol);
-    if (c instanceof Number && o instanceof Number) {
+    if (c instanceof Number count && o instanceof Number value) {
       if (parts == null) {
         parts = new ArrayList<>();
       }
-      Number count = (Number) c;
-      Number value = (Number) o;
       parts.add(new Part(count.longValue(), value.doubleValue()));
     }
   }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/VersionedData.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/VersionedData.java
@@ -82,8 +82,7 @@ public class VersionedData implements MapWriter {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof VersionedData)) return false;
-    VersionedData that = (VersionedData) o;
+    if (!(o instanceof VersionedData that)) return false;
     return version == that.version
         && Arrays.equals(data, that.data)
         && Objects.equals(owner, that.owner)

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/NodeValueFetcher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/NodeValueFetcher.java
@@ -93,8 +93,7 @@ public class NodeValueFetcher {
     public Object convertVal(Object val) {
       if (val instanceof String) {
         return Double.valueOf((String) val);
-      } else if (val instanceof Number) {
-        Number num = (Number) val;
+      } else if (val instanceof Number num) {
         return num.doubleValue();
 
       } else {

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -2118,9 +2118,7 @@ public class ZkStateReader implements SolrCloseable {
 
     @Override
     public boolean equals(Object other) {
-      if (other instanceof DocCollectionAndLiveNodesWatcherWrapper) {
-        DocCollectionAndLiveNodesWatcherWrapper that =
-            (DocCollectionAndLiveNodesWatcherWrapper) other;
+      if (other instanceof DocCollectionAndLiveNodesWatcherWrapper that) {
         return this.collectionName.equals(that.collectionName)
             && this.delegate.equals(that.delegate);
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrQuery.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrQuery.java
@@ -1362,8 +1362,7 @@ public class SolrQuery extends ModifiableSolrParams {
     @Override
     public boolean equals(Object other) {
       if (this == other) return true;
-      if (!(other instanceof SortClause)) return false;
-      final SortClause that = (SortClause) other;
+      if (!(other instanceof SortClause that)) return false;
       return this.getItem().equals(that.getItem()) && this.getOrder().equals(that.getOrder());
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/beans/DocumentObjectBinder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/beans/DocumentObjectBinder.java
@@ -112,8 +112,7 @@ public class DocumentObjectBinder {
   private void addChild(Object obj, DocField field, SolrInputDocument doc) {
     Object val = field.get(obj);
     if (val == null) return;
-    if (val instanceof Collection) {
-      Collection<?> collection = (Collection<?>) val;
+    if (val instanceof Collection<?> collection) {
       for (Object o : collection) {
         SolrInputDocument child = toSolrInputDocument(o);
         doc.addChildDocument(child);
@@ -285,9 +284,8 @@ public class DocumentObjectBinder {
         // assigned a default type
         type = Object.class;
         if (field != null) {
-          if (field.getGenericType() instanceof ParameterizedType) {
+          if (field.getGenericType() instanceof ParameterizedType parameterizedType) {
             // check what are the generic values
-            ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
             Type[] types = parameterizedType.getActualTypeArguments();
             if (types != null && types.length == 2 && types[0] == String.class) {
               // the key should always be String

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BinaryRequestWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BinaryRequestWriter.java
@@ -37,8 +37,7 @@ public class BinaryRequestWriter extends RequestWriter {
 
   @Override
   public ContentWriter getContentWriter(SolrRequest<?> req) {
-    if (req instanceof UpdateRequest) {
-      UpdateRequest updateRequest = (UpdateRequest) req;
+    if (req instanceof UpdateRequest updateRequest) {
       if (isEmpty(updateRequest)) return null;
       return new ContentWriter() {
         @Override
@@ -58,8 +57,7 @@ public class BinaryRequestWriter extends RequestWriter {
 
   @Override
   public Collection<ContentStream> getContentStreams(SolrRequest<?> req) throws IOException {
-    if (req instanceof UpdateRequest) {
-      UpdateRequest updateRequest = (UpdateRequest) req;
+    if (req instanceof UpdateRequest updateRequest) {
       if (isEmpty(updateRequest)) return null;
       throw new RuntimeException("This Should not happen");
     } else {
@@ -74,8 +72,7 @@ public class BinaryRequestWriter extends RequestWriter {
 
   @Override
   public void write(SolrRequest<?> request, OutputStream os) throws IOException {
-    if (request instanceof UpdateRequest) {
-      UpdateRequest updateRequest = (UpdateRequest) request;
+    if (request instanceof UpdateRequest updateRequest) {
       new JavaBinUpdateRequestCodec().marshal(updateRequest, os);
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -101,8 +101,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
       ClusterStateProvider stateProvider =
           ClusterStateProvider.newZkClusterStateProvider(
               builder.zkHosts, builder.zkChroot, builder.canUseZkACLs);
-      if (stateProvider instanceof SolrZkClientTimeoutAware) {
-        var timeoutAware = (SolrZkClientTimeoutAware) stateProvider;
+      if (stateProvider instanceof SolrZkClientTimeoutAware timeoutAware) {
         timeoutAware.setZkClientTimeout(builder.zkClientTimeout);
         timeoutAware.setZkConnectTimeout(builder.zkConnectTimeout);
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudLegacySolrClient.java
@@ -380,8 +380,7 @@ public class CloudLegacySolrClient extends CloudSolrClient {
         } else if (!zkHosts.isEmpty()) {
           this.stateProvider =
               ClusterStateProvider.newZkClusterStateProvider(zkHosts, zkChroot, canUseZkACLs);
-          if (stateProvider instanceof SolrZkClientTimeoutAware) {
-            var timeoutAware = (SolrZkClientTimeoutAware) stateProvider;
+          if (stateProvider instanceof SolrZkClientTimeoutAware timeoutAware) {
             timeoutAware.setZkClientTimeout(zkClientTimeout);
             timeoutAware.setZkConnectTimeout(zkConnectTimeout);
           }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -453,8 +453,7 @@ public abstract class CloudSolrClient extends SolrClient {
 
       if (exceptions.size() > 0) {
         Throwable firstException = exceptions.getVal(0);
-        if (firstException instanceof SolrException) {
-          SolrException e = (SolrException) firstException;
+        if (firstException instanceof SolrException e) {
           throw getRouteException(
               SolrException.ErrorCode.getErrorCode(e.code()), exceptions, routes);
         } else {
@@ -611,8 +610,7 @@ public abstract class CloudSolrClient extends SolrClient {
         status = s;
       }
       Object rfObj = header.get(UpdateRequest.REPFACT);
-      if (rfObj != null && rfObj instanceof Integer) {
-        Integer routeRf = (Integer) rfObj;
+      if (rfObj != null && rfObj instanceof Integer routeRf) {
         if (rf == null || routeRf < rf) rf = routeRf;
       }
 
@@ -639,10 +637,9 @@ public abstract class CloudSolrClient extends SolrClient {
       }
       for (String updateType : Arrays.asList("adds", "deletes", "deleteByQuery")) {
         Object obj = shardResponse.get(updateType);
-        if (obj instanceof NamedList) {
+        if (obj instanceof NamedList<?> nl) {
           NamedList<Object> versionsList =
               versions.containsKey(updateType) ? versions.get(updateType) : new NamedList<>();
-          NamedList<?> nl = (NamedList<?>) obj;
           versionsList.addAll(nl);
           versions.put(updateType, versionsList);
         }
@@ -732,8 +729,7 @@ public abstract class CloudSolrClient extends SolrClient {
       NamedList<String> metadata = new NamedList<String>();
       for (int i = 0; i < throwables.size(); i++) {
         Throwable t = throwables.getVal(i);
-        if (t instanceof SolrException) {
-          SolrException e = (SolrException) t;
+        if (t instanceof SolrException e) {
           NamedList<String> eMeta = e.getMetadata();
           if (null != eMeta) {
             metadata.addAll(eMeta);
@@ -825,8 +821,7 @@ public abstract class CloudSolrClient extends SolrClient {
       }
     }
 
-    if (request.getParams() instanceof ModifiableSolrParams) {
-      ModifiableSolrParams params = (ModifiableSolrParams) request.getParams();
+    if (request.getParams() instanceof ModifiableSolrParams params) {
       if (stateVerParam != null) {
         params.set(STATE_VERSION, stateVerParam);
       } else {
@@ -840,11 +835,10 @@ public abstract class CloudSolrClient extends SolrClient {
       // to avoid an O(n) operation we always add STATE_VERSION to the last and try to read it from
       // there
       Object o = resp == null || resp.size() == 0 ? null : resp.get(STATE_VERSION, resp.size() - 1);
-      if (o != null && o instanceof Map) {
+      if (o != null && o instanceof Map<?, ?> invalidStates) {
         // remove this because no one else needs this and tests would fail if they are comparing
         // responses
         resp.remove(resp.size() - 1);
-        Map<?, ?> invalidStates = (Map<?, ?>) o;
         for (Map.Entry<?, ?> e : invalidStates.entrySet()) {
           getDocCollection((String) e.getKey(), (Integer) e.getValue());
         }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateHttp2SolrClient.java
@@ -362,10 +362,9 @@ public class ConcurrentUpdateHttp2SolrClient extends SolrClient {
         ClientUtils.shouldApplyDefaultCollection(collection, request)
             ? defaultCollection
             : collection;
-    if (!(request instanceof UpdateRequest)) {
+    if (!(request instanceof UpdateRequest req)) {
       return client.requestWithBaseUrl(basePath, (c) -> c.request(request, effectiveCollection));
     }
-    UpdateRequest req = (UpdateRequest) request;
     // this happens for commit...
     if (streamDeletes) {
       if ((req.getDocuments() == null || req.getDocuments().isEmpty())

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrClient.java
@@ -488,10 +488,9 @@ public class ConcurrentUpdateSolrClient extends SolrClient {
       throws SolrServerException, IOException {
     if (ClientUtils.shouldApplyDefaultCollection(collection, request))
       collection = defaultCollection;
-    if (!(request instanceof UpdateRequest)) {
+    if (!(request instanceof UpdateRequest req)) {
       return client.request(request, collection);
     }
-    UpdateRequest req = (UpdateRequest) request;
 
     // this happens for commit...
     if (streamDeletes) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
@@ -217,8 +217,7 @@ public class Krb5HttpClientBuilder implements HttpClientBuilderFactory {
   // Set a buffered entity based request interceptor
   private HttpRequestInterceptor bufferedEntityInterceptor =
       (request, context) -> {
-        if (request instanceof HttpEntityEnclosingRequest) {
-          HttpEntityEnclosingRequest enclosingRequest = ((HttpEntityEnclosingRequest) request);
+        if (request instanceof HttpEntityEnclosingRequest enclosingRequest) {
           HttpEntity requestEntity = enclosingRequest.getEntity();
           enclosingRequest.setEntity(new BufferedHttpEntity(requestEntity));
         }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -173,8 +173,7 @@ public abstract class LBSolrClient extends SolrClient {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof Endpoint)) return false;
-      final Endpoint rhs = (Endpoint) obj;
+      if (!(obj instanceof Endpoint rhs)) return false;
 
       return Objects.equals(baseUrl, rhs.baseUrl) && Objects.equals(core, rhs.core);
     }
@@ -497,8 +496,7 @@ public abstract class LBSolrClient extends SolrClient {
     // Some implementations of LBSolrClient.getClient(...) return a Http2SolrClient that may not be
     // pointed at the desired URL (or any URL for that matter).  We special case that here to ensure
     // the appropriate URL is provided.
-    if (solrClient instanceof Http2SolrClient) {
-      final var httpSolrClient = (Http2SolrClient) solrClient;
+    if (solrClient instanceof Http2SolrClient httpSolrClient) {
       return httpSolrClient.requestWithBaseUrl(baseUrl, (c) -> c.request(solrRequest, collection));
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
@@ -352,8 +352,7 @@ public class JavaBinUpdateRequestCodec {
       m.forEach(
           (k, v) -> {
             if (CHILDDOC.equals(k.toString())) {
-              if (v instanceof List) {
-                List<?> list = (List<?>) v;
+              if (v instanceof List<?> list) {
                 for (Object o : list) {
                   if (o instanceof Map) {
                     result.addChildDocument(convertMapToSolrInputDoc((Map<?, ?>) o));

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/RequestWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/RequestWriter.java
@@ -51,8 +51,7 @@ public class RequestWriter {
    * to do a pull write.
    */
   public ContentWriter getContentWriter(SolrRequest<?> req) {
-    if (req instanceof UpdateRequest) {
-      UpdateRequest updateRequest = (UpdateRequest) req;
+    if (req instanceof UpdateRequest updateRequest) {
       if (isEmpty(updateRequest)) return null;
       return new ContentWriter() {
         @Override
@@ -90,8 +89,7 @@ public class RequestWriter {
   }
 
   public void write(SolrRequest<?> request, OutputStream os) throws IOException {
-    if (request instanceof UpdateRequest) {
-      UpdateRequest updateRequest = (UpdateRequest) request;
+    if (request instanceof UpdateRequest updateRequest) {
       BufferedWriter writer =
           new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
       updateRequest.writeXML(writer);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/V2Request.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/V2Request.java
@@ -78,8 +78,7 @@ public class V2Request extends SolrRequest<V2Response> implements MapWriter {
     return new RequestWriter.ContentWriter() {
       @Override
       public void write(OutputStream os) throws IOException {
-        if (payload instanceof ByteBuffer) {
-          ByteBuffer b = (ByteBuffer) payload;
+        if (payload instanceof ByteBuffer b) {
           os.write(b.array(), b.arrayOffset(), b.limit());
           return;
         }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/PluginMeta.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/PluginMeta.java
@@ -60,8 +60,7 @@ public class PluginMeta implements ReflectMapWriter {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof PluginMeta) {
-      PluginMeta that = (PluginMeta) obj;
+    if (obj instanceof PluginMeta that) {
       return Objects.equals(this.name, that.name)
           && Objects.equals(this.klass, that.klass)
           && Objects.equals(this.version, that.version)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
@@ -47,8 +47,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof RateLimiterPayload) {
-      RateLimiterPayload that = (RateLimiterPayload) obj;
+    if (obj instanceof RateLimiterPayload that) {
       return Objects.equals(this.enabled, that.enabled)
           && Objects.equals(this.guaranteedSlots, that.guaranteedSlots)
           && Objects.equals(this.allowedRequests, that.allowedRequests)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
@@ -382,8 +382,7 @@ public class QueryResponse extends SolrResponseBase {
       Object rawGap = values.get("gap");
 
       RangeFacet rangeFacet;
-      if (rawGap instanceof Number) {
-        Number gap = (Number) rawGap;
+      if (rawGap instanceof Number gap) {
         Number start = (Number) values.get("start");
         Number end = (Number) values.get("end");
 
@@ -393,9 +392,7 @@ public class QueryResponse extends SolrResponseBase {
 
         rangeFacet =
             new RangeFacet.Numeric(facet.getKey(), start, end, gap, before, after, between);
-      } else if (rawGap instanceof String && values.get("start") instanceof Date) {
-        String gap = (String) rawGap;
-        Date start = (Date) values.get("start");
+      } else if (rawGap instanceof String gap && values.get("start") instanceof Date start) {
         Date end = (Date) values.get("end");
 
         Number before = (Number) values.get("before");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/Suggestion.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/Suggestion.java
@@ -34,9 +34,7 @@ public class Suggestion {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof Suggestion)) return false;
-
-    Suggestion that = (Suggestion) o;
+    if (!(o instanceof Suggestion that)) return false;
 
     return payload.equals(that.payload) && term.equals(that.term);
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/json/NestableJsonFacet.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/json/NestableJsonFacet.java
@@ -56,8 +56,8 @@ public class NestableJsonFacet {
           || entry.getValue() instanceof Date) {
         // Stat/agg facet value
         statsByName.put(key, entry.getValue());
-      } else if (entry.getValue() instanceof NamedList) { // Either heatmap/query/range/terms facet
-        final NamedList<?> facet = (NamedList<?>) entry.getValue();
+      } else if (entry.getValue()
+          instanceof NamedList<?> facet) { // Either heatmap/query/range/terms facet
         final boolean isBucketBased = facet.get("buckets") != null;
         final boolean isHeatmap = HeatmapJsonFacet.isHeatmapFacet(facet);
         if (isBucketBased) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
@@ -122,8 +122,7 @@ public class ClientUtils {
           for (Entry<Object, Object> entry : ((Map<Object, Object>) v).entrySet()) {
             update = entry.getKey().toString();
             v = entry.getValue();
-            if (v instanceof Collection) {
-              Collection<?> values = (Collection<?>) v;
+            if (v instanceof Collection<?> values) {
               for (Object value : values) {
                 writeVal(writer, name, value, update);
               }
@@ -150,11 +149,9 @@ public class ClientUtils {
       throws IOException {
     if (v instanceof Date) {
       v = ((Date) v).toInstant().toString();
-    } else if (v instanceof byte[]) {
-      byte[] bytes = (byte[]) v;
+    } else if (v instanceof byte[] bytes) {
       v = Base64.getEncoder().encodeToString(bytes);
-    } else if (v instanceof ByteBuffer) {
-      ByteBuffer bytes = (ByteBuffer) v;
+    } else if (v instanceof ByteBuffer bytes) {
       v =
           new String(
               Base64.getEncoder()
@@ -168,8 +165,7 @@ public class ClientUtils {
     }
 
     XML.Writable valWriter = null;
-    if (v instanceof SolrInputDocument) {
-      final SolrInputDocument solrDoc = (SolrInputDocument) v;
+    if (v instanceof SolrInputDocument solrDoc) {
       valWriter = (writer1) -> writeXML(solrDoc, writer1);
     } else if (v != null) {
       final Object val = v;

--- a/solr/solrj/src/java/org/apache/solr/common/EnumFieldValue.java
+++ b/solr/solrj/src/java/org/apache/solr/common/EnumFieldValue.java
@@ -42,9 +42,8 @@ public final class EnumFieldValue implements Serializable, Comparable<EnumFieldV
   @Override
   public boolean equals(Object obj) {
     if (obj == null) return false;
-    if (!(obj instanceof EnumFieldValue)) return false;
+    if (!(obj instanceof EnumFieldValue otherEnumFieldValue)) return false;
 
-    EnumFieldValue otherEnumFieldValue = (EnumFieldValue) obj;
     return equalsIntegers(intValue, otherEnumFieldValue.intValue)
         && equalStrings(stringValue, otherEnumFieldValue.stringValue);
   }

--- a/solr/solrj/src/java/org/apache/solr/common/SolrDocument.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrDocument.java
@@ -166,8 +166,7 @@ public class SolrDocument extends SolrDocumentBase<Object, SolrDocument>
   /** returns the first value for a field */
   public Object getFirstValue(String name) {
     Object v = _fields.get(name);
-    if (v == null || !(v instanceof Collection)) return v;
-    Collection<?> c = (Collection<?>) v;
+    if (v == null || !(v instanceof Collection<?> c)) return v;
     if (c.size() > 0) {
       return c.iterator().next();
     }
@@ -215,8 +214,7 @@ public class SolrDocument extends SolrDocumentBase<Object, SolrDocument>
       final Object value = keyVal.getValue();
       if (value instanceof SolrDocument) {
         consumer.accept(keyVal.getKey(), (SolrDocument) value);
-      } else if (value instanceof Collection) {
-        Collection<?> cVal = (Collection<?>) value;
+      } else if (value instanceof Collection<?> cVal) {
         for (Object v : cVal) {
           if (v instanceof SolrDocument) {
             consumer.accept(keyVal.getKey(), (SolrDocument) v);

--- a/solr/solrj/src/java/org/apache/solr/common/SolrException.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrException.java
@@ -157,8 +157,7 @@ public class SolrException extends RuntimeException {
    *     no-op.
    */
   public static SolrException wrapLuceneTragicExceptionIfNecessary(Exception e) {
-    if (e instanceof SolrException) {
-      final SolrException solrException = (SolrException) e;
+    if (e instanceof SolrException solrException) {
       assert solrException.code() >= 500 && solrException.code() < 600;
       return solrException;
     }

--- a/solr/solrj/src/java/org/apache/solr/common/SolrInputDocument.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrInputDocument.java
@@ -288,8 +288,7 @@ public class SolrInputDocument extends SolrDocumentBase<SolrInputField, SolrInpu
       final Object value = field.getValue();
       if (value instanceof SolrInputDocument) {
         consumer.accept(field.name, (SolrInputDocument) value);
-      } else if (value instanceof Collection) {
-        Collection<?> cVal = (Collection<?>) value;
+      } else if (value instanceof Collection<?> cVal) {
         for (Object v : cVal) {
           if (v instanceof SolrInputDocument) {
             consumer.accept(field.name, (SolrInputDocument) v);

--- a/solr/solrj/src/java/org/apache/solr/common/SolrInputField.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrInputField.java
@@ -41,8 +41,7 @@ public class SolrInputField implements Iterable<Object>, Serializable {
    * then that collection will be used as the backing collection for the values.
    */
   public void setValue(Object v) {
-    if (v instanceof Object[]) {
-      Object[] arr = (Object[]) v;
+    if (v instanceof Object[] arr) {
       Collection<Object> c = new ArrayList<>(arr.length);
       for (Object o : arr) {
         c.add(o);
@@ -100,8 +99,7 @@ public class SolrInputField implements Iterable<Object>, Serializable {
   // ---------------------------------------------------------------
 
   public Object getFirstValue() {
-    if (value instanceof Collection) {
-      Collection<?> c = (Collection<?>) value;
+    if (value instanceof Collection<?> c) {
       if (c.size() > 0) {
         return c.iterator().next();
       }

--- a/solr/solrj/src/java/org/apache/solr/common/ToleratedUpdateError.java
+++ b/solr/solrj/src/java/org/apache/solr/common/ToleratedUpdateError.java
@@ -193,8 +193,7 @@ public final class ToleratedUpdateError {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof ToleratedUpdateError) {
-      ToleratedUpdateError that = (ToleratedUpdateError) o;
+    if (o instanceof ToleratedUpdateError that) {
       return that.type.equals(this.type)
           && that.id.equals(this.id)
           && that.message.equals(this.message);

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -379,8 +379,7 @@ public class ClusterState implements MapWriter {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (!(obj instanceof ClusterState)) return false;
-    ClusterState other = (ClusterState) obj;
+    if (!(obj instanceof ClusterState other)) return false;
     if (liveNodes == null) {
       return other.liveNodes == null;
     } else return liveNodes.equals(other.liveNodes);

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
@@ -514,8 +514,7 @@ public class DocCollection extends ZkNodeProps implements Iterable<Slice> {
 
   @Override
   public boolean equals(Object that) {
-    if (!(that instanceof DocCollection)) return false;
-    DocCollection other = (DocCollection) that;
+    if (!(that instanceof DocCollection other)) return false;
     return super.equals(that)
         && Objects.equals(this.name, other.name)
         && this.znodeVersion == other.znodeVersion

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DocRouter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DocRouter.java
@@ -136,8 +136,7 @@ public abstract class DocRouter {
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof Range)) return false;
-      Range other = (Range) obj;
+      if (!(obj instanceof Range other)) return false;
       return this.min == other.min && this.max == other.max;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/PerReplicaStates.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/PerReplicaStates.java
@@ -291,8 +291,7 @@ public class PerReplicaStates implements ReflectMapWriter {
 
     @Override
     public boolean equals(Object o) {
-      if (o instanceof State) {
-        State that = (State) o;
+      if (o instanceof State that) {
         return Objects.equals(this.asString, that.asString);
       }
       return false;

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
@@ -282,10 +282,8 @@ public class Replica extends ZkNodeProps implements MapWriter {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof Replica)) return false;
+    if (!(o instanceof Replica other)) return false;
     if (!super.equals(o)) return false;
-
-    Replica other = (Replica) o;
 
     return name.equals(other.name);
   }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Slice.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Slice.java
@@ -206,8 +206,7 @@ public class Slice extends ZkNodeProps implements Iterable<Replica> {
       this.routingRules = new HashMap<>();
       for (Map.Entry<String, Object> entry : rules.entrySet()) {
         Object o = entry.getValue();
-        if (o instanceof Map) {
-          Map map = (Map) o;
+        if (o instanceof Map map) {
           RoutingRule rule = new RoutingRule(entry.getKey(), map);
           routingRules.put(entry.getKey(), rule);
         } else {

--- a/solr/solrj/src/java/org/apache/solr/common/util/ByteArrayUtf8CharSequence.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ByteArrayUtf8CharSequence.java
@@ -124,9 +124,8 @@ public class ByteArrayUtf8CharSequence implements Utf8CharSequence {
   public boolean equals(Object other) {
     if (other instanceof Utf8CharSequence) {
       if (size() != ((Utf8CharSequence) other).size()) return false;
-      if (other instanceof ByteArrayUtf8CharSequence) {
-        if (this.length != ((ByteArrayUtf8CharSequence) other).length) return false;
-        ByteArrayUtf8CharSequence that = (ByteArrayUtf8CharSequence) other;
+      if (other instanceof ByteArrayUtf8CharSequence that) {
+        if (this.length != that.length) return false;
         return _equals(
             this.buf,
             this.offset,

--- a/solr/solrj/src/java/org/apache/solr/common/util/CommandOperation.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/CommandOperation.java
@@ -101,8 +101,7 @@ public class CommandOperation {
       }
       return commandData;
     }
-    if (commandData instanceof Map) {
-      Map<?, ?> metaData = (Map<?, ?>) commandData;
+    if (commandData instanceof Map<?, ?> metaData) {
       return metaData.get(key);
     } else {
       String msg = " value has to be an object for operation :" + name;
@@ -284,8 +283,7 @@ public class CommandOperation {
       Object key = ob.getKey();
       ev = parser.nextEvent();
       Object val = ob.getVal();
-      if (val instanceof List && !singletonCommands.contains(key)) {
-        List<?> list = (List<?>) val;
+      if (val instanceof List<?> list && !singletonCommands.contains(key)) {
         for (Object o : list) {
           if (!(o instanceof Map)) {
             operations.add(new CommandOperation(String.valueOf(key), list));
@@ -371,8 +369,7 @@ public class CommandOperation {
   public Integer getInt(String name, Integer def) {
     Object o = getVal(name);
     if (o == null) return def;
-    if (o instanceof Number) {
-      Number number = (Number) o;
+    if (o instanceof Number number) {
       return number.intValue();
     } else {
       try {

--- a/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
@@ -887,8 +887,7 @@ public class JavaBinCodec implements PushWriter {
         if (this == obj) {
           return true;
         }
-        if (obj instanceof Map.Entry<?, ?>) {
-          Entry<?, ?> entry = (Entry<?, ?>) obj;
+        if (obj instanceof Map.Entry<?, ?> entry) {
           return (this.getKey().equals(entry.getKey()) && this.getValue().equals(entry.getValue()));
         }
         return false;
@@ -1096,8 +1095,7 @@ public class JavaBinCodec implements PushWriter {
     } else if (val instanceof byte[]) {
       writeByteArray((byte[]) val, 0, ((byte[]) val).length);
       return true;
-    } else if (val instanceof ByteBuffer) {
-      ByteBuffer buf = (ByteBuffer) val;
+    } else if (val instanceof ByteBuffer buf) {
       writeByteArray(buf.array(), buf.arrayOffset() + buf.position(), buf.limit() - buf.position());
       return true;
     } else if (val == END_OBJ) {

--- a/solr/solrj/src/java/org/apache/solr/common/util/JsonSchemaValidator.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JsonSchemaValidator.java
@@ -339,8 +339,7 @@ class OneOfValidator extends Validator<List<String>> {
 
   @Override
   boolean validate(Object o, List<String> errs) {
-    if (o instanceof Map) {
-      Map<?, ?> map = (Map<?, ?>) o;
+    if (o instanceof Map<?, ?> map) {
       for (Object key : map.keySet()) {
         if (oneOfProps.contains(key.toString())) return true;
       }

--- a/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
@@ -502,8 +502,7 @@ public class NamedList<T>
       }
       Object old = result.put(getName(i), val);
       if (old != null) {
-        if (old instanceof List) {
-          List list = (List) old;
+        if (old instanceof List list) {
           list.add(val);
           result.put(getName(i), old);
         } else {
@@ -529,8 +528,7 @@ public class NamedList<T>
       Object val = this.getVal(i);
       if (val instanceof String[]) {
         MultiMapSolrParams.addParam(name, (String[]) val, map);
-      } else if (val instanceof List) {
-        List l = (List) val;
+      } else if (val instanceof List l) {
         String[] s = new String[l.size()];
         for (int j = 0; j < l.size(); j++) {
           s[j] = l.get(j) == null ? null : l.get(j).toString();
@@ -813,8 +811,7 @@ public class NamedList<T>
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof NamedList)) return false;
-    NamedList<?> nl = (NamedList<?>) obj;
+    if (!(obj instanceof NamedList<?> nl)) return false;
     return this.nvPairs.equals(nl.nvPairs);
   }
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/TextWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/TextWriter.java
@@ -99,8 +99,7 @@ public interface TextWriter extends PushWriter {
       writeArray(name, ((Iterable) val).iterator(), raw);
     } else if (val instanceof Object[]) {
       writeArray(name, (Object[]) val, raw);
-    } else if (val instanceof byte[]) {
-      byte[] arr = (byte[]) val;
+    } else if (val instanceof byte[] arr) {
       writeByteArr(name, arr, 0, arr.length);
     } else if (val instanceof EnumFieldValue) {
       if (raw) {

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -165,8 +165,7 @@ public class Utils {
 
   @SuppressWarnings({"unchecked"})
   public static void forEachMapEntry(Object o, @SuppressWarnings({"rawtypes"}) BiConsumer fun) {
-    if (o instanceof MapWriter) {
-      MapWriter m = (MapWriter) o;
+    if (o instanceof MapWriter m) {
       try {
         m.writeMap(
             new MapWriter.EntryWriter() {
@@ -530,8 +529,7 @@ public class Utils {
         Object o = getVal(obj, s, -1);
         if (o == null) return null;
         if (idx > -1) {
-          if (o instanceof List) {
-            List<?> l = (List<?>) o;
+          if (o instanceof List<?> l) {
             o = idx < l.size() ? l.get(idx) : null;
           } else if (o instanceof IteratorWriter) {
             o = getValueAt((IteratorWriter) o, idx);

--- a/solr/solrj/src/java/org/apache/solr/common/util/ValidatingJsonMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ValidatingJsonMap.java
@@ -53,8 +53,7 @@ public class ValidatingJsonMap implements Map<String, Object>, NavigableObject {
   @SuppressWarnings({"rawtypes"})
   public static final PredicateWithErrMsg<Pair> ENUM_OF =
       pair -> {
-        if (pair.second() instanceof Set) {
-          Set<?> set = (Set<?>) pair.second();
+        if (pair.second() instanceof Set<?> set) {
           if (pair.first() instanceof Collection) {
             for (Object o : (Collection<?>) pair.first()) {
               if (!set.contains(o)) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleCborTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleCborTest.java
@@ -245,8 +245,7 @@ public class SolrExampleCborTest extends SolrExampleTests {
 
       @Override
       public ContentWriter getContentWriter(SolrRequest<?> request) {
-        if (request instanceof UpdateRequest) {
-          UpdateRequest updateRequest = (UpdateRequest) request;
+        if (request instanceof UpdateRequest updateRequest) {
           List<SolrInputDocument> docs = updateRequest.getDocuments();
           if (docs == null || docs.isEmpty()) return super.getContentWriter(request);
           return new ContentWriter() {
@@ -298,8 +297,7 @@ public class SolrExampleCborTest extends SolrExampleTests {
           NamedList nl = new NamedList();
           m.forEach(
               (k, v) -> {
-                if (v instanceof Map) {
-                  Map map = (Map) v;
+                if (v instanceof Map map) {
                   if ("response".equals(k)) {
                     v = convertResponse((Map) v);
                   } else {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
@@ -740,10 +740,8 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
       ex = expectThrows(SolrException.class, () -> client.add(doc));
       assertEquals(400, ex.code());
       assertTrue(ex.getMessage().indexOf("contains multiple values for uniqueKey") > 0);
-    } else if (client instanceof ErrorTrackingConcurrentUpdateSolrClient) {
+    } else if (client instanceof ErrorTrackingConcurrentUpdateSolrClient concurrentClient) {
       // XXX concurrentupdatesolrserver reports errors differently
-      ErrorTrackingConcurrentUpdateSolrClient concurrentClient =
-          (ErrorTrackingConcurrentUpdateSolrClient) client;
       concurrentClient.lastError = null;
       concurrentClient.add(doc);
       concurrentClient.blockUntilFinished();
@@ -2425,20 +2423,18 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
       if (client instanceof HttpSolrClient) {
         // XXX concurrent client reports exceptions differently
         fail("Operation should throw an exception!");
-      } else if (client instanceof ErrorTrackingConcurrentUpdateSolrClient) {
+      } else if (client instanceof ErrorTrackingConcurrentUpdateSolrClient concurrentClient) {
         client.commit(); // just to be sure the client has sent the doc
-        ErrorTrackingConcurrentUpdateSolrClient concurrentClient =
-            (ErrorTrackingConcurrentUpdateSolrClient) client;
         assertNotNull(
             "ConcurrentUpdateSolrClient did not report an error", concurrentClient.lastError);
         assertTrue(
             "ConcurrentUpdateSolrClient did not report an error",
             concurrentClient.lastError.getMessage().contains("Conflict"));
       } else if (client
-          instanceof SolrExampleStreamingHttp2Test.ErrorTrackingConcurrentUpdateSolrClient) {
+          instanceof
+          SolrExampleStreamingHttp2Test.ErrorTrackingConcurrentUpdateSolrClient
+          concurrentClient) {
         client.commit(); // just to be sure the client has sent the doc
-        SolrExampleStreamingHttp2Test.ErrorTrackingConcurrentUpdateSolrClient concurrentClient =
-            (SolrExampleStreamingHttp2Test.ErrorTrackingConcurrentUpdateSolrClient) client;
         assertNotNull(
             "ConcurrentUpdateSolrClient did not report an error", concurrentClient.lastError);
         assertTrue(

--- a/solr/solrj/src/test/org/apache/solr/common/util/TestJavaBinCodec.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/TestJavaBinCodec.java
@@ -209,9 +209,7 @@ public class TestJavaBinCodec extends SolrTestCaseJ4 {
     assertEquals(unmarshalledObj.size(), matchObj.size());
     for (int i = 0; i < unmarshalledObj.size(); i++) {
 
-      if (unmarshalledObj.get(i) instanceof byte[] && matchObj.get(i) instanceof byte[]) {
-        byte[] b1 = (byte[]) unmarshalledObj.get(i);
-        byte[] b2 = (byte[]) matchObj.get(i);
+      if (unmarshalledObj.get(i) instanceof byte[] b1 && matchObj.get(i) instanceof byte[] b2) {
         assertArrayEquals(b1, b2);
       } else if (unmarshalledObj.get(i) instanceof SolrDocument
           && matchObj.get(i) instanceof SolrDocument) {

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -938,10 +938,11 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     }
 
     if ((flags & FUZZY) != 0) {
-      if ((a instanceof Double && b instanceof Double)) {
-        double aaa = (Double) a;
-        double bbb = (Double) b;
-        if (aaa == bbb || (((Double) a).isNaN() && ((Double) b).isNaN())) {
+
+      if ((a instanceof Double aa && b instanceof Double bb)) {
+        double aaa = aa;
+        double bbb = bb;
+        if (aaa == bbb || (aa.isNaN() && bb.isNaN())) {
           return null;
         }
         if ((aaa == 0.0) || (bbb == 0.0)) {

--- a/solr/test-framework/src/java/org/apache/solr/JSONTestUtil.java
+++ b/solr/test-framework/src/java/org/apache/solr/JSONTestUtil.java
@@ -233,8 +233,7 @@ class CollectionTester {
     // generic fallback
     if (!expected.equals(val)) {
 
-      if (expected instanceof String) {
-        String str = (String) expected;
+      if (expected instanceof String str) {
         if (str.length() > 6 && str.startsWith("///") && str.endsWith("///")) {
           return handleSpecialString(str);
         }

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -1765,16 +1765,14 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof Doc)) return false;
-      Doc other = (Doc) o;
+      if (!(o instanceof Doc other)) return false;
       return this == other || Objects.equals(id, other.id);
     }
 
     @Override
     @SuppressWarnings({"unchecked"})
     public int compareTo(Object o) {
-      if (!(o instanceof Doc)) return this.getClass().hashCode() - o.getClass().hashCode();
-      Doc other = (Doc) o;
+      if (!(o instanceof Doc other)) return this.getClass().hashCode() - o.getClass().hashCode();
       return this.id.compareTo(other.id);
     }
 
@@ -2350,16 +2348,14 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   public boolean compareSolrDocument(Object expected, Object actual) {
 
-    if (!(expected instanceof SolrDocument) || !(actual instanceof SolrDocument)) {
+    if (!(expected instanceof SolrDocument solrDocument1)
+        || !(actual instanceof SolrDocument solrDocument2)) {
       return false;
     }
 
     if (expected == actual) {
       return true;
     }
-
-    SolrDocument solrDocument1 = (SolrDocument) expected;
-    SolrDocument solrDocument2 = (SolrDocument) actual;
 
     if (solrDocument1.getFieldNames().size() != solrDocument2.getFieldNames().size()) {
       return false;
@@ -2401,16 +2397,14 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
 
   public boolean compareSolrDocumentList(Object expected, Object actual) {
-    if (!(expected instanceof SolrDocumentList) || !(actual instanceof SolrDocumentList)) {
+    if (!(expected instanceof SolrDocumentList list1)
+        || !(actual instanceof SolrDocumentList list2)) {
       return false;
     }
 
     if (expected == actual) {
       return true;
     }
-
-    SolrDocumentList list1 = (SolrDocumentList) expected;
-    SolrDocumentList list2 = (SolrDocumentList) actual;
 
     if (list1.getMaxScore() == null) {
       if (list2.getMaxScore() != null) {
@@ -2435,16 +2429,14 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   public boolean compareSolrInputDocument(Object expected, Object actual) {
 
-    if (!(expected instanceof SolrInputDocument) || !(actual instanceof SolrInputDocument)) {
+    if (!(expected instanceof SolrInputDocument sdoc1)
+        || !(actual instanceof SolrInputDocument sdoc2)) {
       return false;
     }
 
     if (expected == actual) {
       return true;
     }
-
-    SolrInputDocument sdoc1 = (SolrInputDocument) expected;
-    SolrInputDocument sdoc2 = (SolrInputDocument) actual;
 
     if (sdoc1.getFieldNames().size() != sdoc2.getFieldNames().size()) {
       return false;
@@ -2510,16 +2502,13 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
 
   public boolean assertSolrInputFieldEquals(Object expected, Object actual) {
-    if (!(expected instanceof SolrInputField) || !(actual instanceof SolrInputField)) {
+    if (!(expected instanceof SolrInputField sif1) || !(actual instanceof SolrInputField sif2)) {
       return false;
     }
 
     if (expected == actual) {
       return true;
     }
-
-    SolrInputField sif1 = (SolrInputField) expected;
-    SolrInputField sif2 = (SolrInputField) actual;
 
     if (!sif1.getName().equals(sif2.getName())) {
       return false;
@@ -2944,8 +2933,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
 
   private static boolean isChildDoc(Object o) {
-    if (o instanceof Collection) {
-      Collection<?> col = (Collection<?>) o;
+    if (o instanceof Collection<?> col) {
       if (col.size() == 0) {
         return false;
       }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -177,8 +177,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof CloudJettyRunner)) return false;
-      CloudJettyRunner other = (CloudJettyRunner) obj;
+      if (!(obj instanceof CloudJettyRunner other)) return false;
       return Objects.equals(url, other.url);
     }
 
@@ -215,8 +214,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (!(obj instanceof CloudSolrServerClient)) return false;
-      CloudSolrServerClient other = (CloudSolrServerClient) obj;
+      if (!(obj instanceof CloudSolrServerClient other)) return false;
       return Objects.equals(solrClient, other.solrClient);
     }
   }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
@@ -285,7 +285,7 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
     verifySecurityStatus(cl, url, objPath, expected, count, makeBasicAuthHeader(user, pwd));
   }
 
-  @SuppressWarnings({"unchecked"})
+  @SuppressWarnings({"unchecked", "rawtypes"})
   protected static void verifySecurityStatus(
       HttpClient cl, String url, String objPath, Object expected, int count, String authHeader)
       throws IOException, InterruptedException {
@@ -297,7 +297,6 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
       if (authHeader != null) setAuthorizationHeader(get, authHeader);
       HttpResponse rsp = cl.execute(get);
       s = EntityUtils.toString(rsp.getEntity());
-      @SuppressWarnings({"rawtypes"})
       Map m = null;
       try {
         m = (Map) Utils.fromJSONString(s);
@@ -306,9 +305,7 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
       }
       Utils.consumeFully(rsp.getEntity());
       Object actual = Utils.getObjectByPath(m, true, hierarchy);
-      if (expected instanceof Predicate) {
-        @SuppressWarnings({"rawtypes"})
-        Predicate predicate = (Predicate) expected;
+      if (expected instanceof Predicate predicate) {
         if (predicate.test(actual)) {
           success = true;
           break;

--- a/solr/test-framework/src/java/org/apache/solr/cluster/placement/ClusterAbstractionsForTest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cluster/placement/ClusterAbstractionsForTest.java
@@ -96,8 +96,7 @@ class ClusterAbstractionsForTest {
     @Override
     public boolean equals(Object obj) {
       if (obj == this) return true;
-      if (!(obj instanceof NodeImpl)) return false;
-      NodeImpl other = (NodeImpl) obj;
+      if (!(obj instanceof NodeImpl other)) return false;
       return Objects.equals(this.nodeName, other.nodeName);
     }
 
@@ -219,8 +218,7 @@ class ClusterAbstractionsForTest {
     @Override
     public boolean equals(Object obj) {
       if (obj == this) return true;
-      if (!(obj instanceof ShardImpl)) return false;
-      ShardImpl other = (ShardImpl) obj;
+      if (!(obj instanceof ShardImpl other)) return false;
       return Objects.equals(this.shardName, other.shardName)
           && Objects.equals(this.collection, other.collection)
           && Objects.equals(this.shardState, other.shardState)
@@ -295,8 +293,7 @@ class ClusterAbstractionsForTest {
     @Override
     public boolean equals(Object obj) {
       if (obj == this) return true;
-      if (!(obj instanceof ReplicaImpl)) return false;
-      ReplicaImpl other = (ReplicaImpl) obj;
+      if (!(obj instanceof ReplicaImpl other)) return false;
       return Objects.equals(this.replicaName, other.replicaName)
           && Objects.equals(this.coreName, other.coreName)
           && Objects.equals(this.shard, other.shard)

--- a/solr/test-framework/src/java/org/apache/solr/core/MockDirectoryFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/core/MockDirectoryFactory.java
@@ -54,8 +54,7 @@ public class MockDirectoryFactory extends EphemeralDirectoryFactory {
     cdir = reduce(cdir);
     cdir = reduce(cdir);
 
-    if (cdir instanceof MockDirectoryWrapper) {
-      MockDirectoryWrapper mockDirWrapper = (MockDirectoryWrapper) cdir;
+    if (cdir instanceof MockDirectoryWrapper mockDirWrapper) {
 
       // we can't currently do this check because of how
       // Solr has to reboot a new Directory sometimes when replicating

--- a/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
@@ -355,9 +355,8 @@ public class TestHarness extends BaseTestHarness {
         throw rsp.getException();
       }
       QueryResponseWriter responseWriter = core.getQueryResponseWriter(req);
-      if (responseWriter instanceof BinaryQueryResponseWriter) {
+      if (responseWriter instanceof BinaryQueryResponseWriter writer) {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(32000);
-        BinaryQueryResponseWriter writer = (BinaryQueryResponseWriter) responseWriter;
         writer.write(byteArrayOutputStream, req, rsp);
         return new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
       } else {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16427

# Description

With the new errorprone rules and starting from 16+ we can use pattern-matching for `instanceof`.

# Solution

This PR enables `PatternMatchingInstanceof` and applies auto-refactoring from IntelliJ for pattern-matching cases.

Note that **these changes are not backwards compatible** (branch_9x) as the refactored code makes use of a JDK 16 feature.

# Tests

No tests were added or removed. Tests with pattern-matching improvements were refactored accordingly.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
