### PR TITLE
SOLR-17406: Update labeler.yml to correctly set dependency label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,8 @@
 dependencies:
   - changed-files:
       - any-glob-to-any-file:
-        - versions.props
+        - gradle/libs.versions.toml # Solr 10+
+        - versions.props # Solr < v10
         - versions.lock
         - solr/licenses/**
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17406

# Description

With the updates from https://github.com/apache/solr/pull/2706 the GitHub action does not take the new `gradle/libs.version.toml` into account when setting the `dependencies` label.

# Solution

Add `gradle/libs.versions.toml` to the watched file list of the dependencies label.

Note that we still want to keep `versions.props` in the list to also label 9X PRs that make changes in the versions.props file.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- ~I have added tests for my changes.~
- ~I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)~
