### PR TITLE
SOLR-17569: fix flaky test TestLBHttpSolrClient (9.x) / LBHttp2SolrClientIntegrationTest (main)

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -71,6 +71,8 @@ public abstract class LBSolrClient extends SolrClient {
 
   protected static final String UPDATE_LIVE_SERVER_MESSAGE = "Updated alive server list";
 
+  private static final String UPDATE_LIVE_SERVER_LOG = UPDATE_LIVE_SERVER_MESSAGE + ": {}";
+
   // defaults
   protected static final Set<Integer> RETRY_CODES =
       new HashSet<>(Arrays.asList(404, 403, 503, 500));
@@ -420,7 +422,7 @@ public abstract class LBSolrClient extends SolrClient {
     synchronized (aliveServers) {
       aliveServerList = aliveServers.values().toArray(new EndpointWrapper[0]);
       if (log.isDebugEnabled()) {
-        log.debug(UPDATE_LIVE_SERVER_MESSAGE + ": {}", Arrays.toString(aliveServerList));
+        log.debug(UPDATE_LIVE_SERVER_LOG, Arrays.toString(aliveServerList));
       }
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -20,6 +20,7 @@ package org.apache.solr.client.solrj.impl;
 import static org.apache.solr.common.params.CommonParams.ADMIN_PATHS;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.lang.ref.WeakReference;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
@@ -60,9 +61,15 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.ObjectReleaseTracker;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.URLUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 public abstract class LBSolrClient extends SolrClient {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  protected static final String UPDATE_LIVE_SERVER_MESSAGE = "Updated alive server list";
 
   // defaults
   protected static final Set<Integer> RETRY_CODES =
@@ -412,6 +419,9 @@ public abstract class LBSolrClient extends SolrClient {
   protected void updateAliveList() {
     synchronized (aliveServers) {
       aliveServerList = aliveServers.values().toArray(new EndpointWrapper[0]);
+      if(log.isDebugEnabled()) {
+        log.debug(UPDATE_LIVE_SERVER_MESSAGE + ": {}", Arrays.toString(aliveServerList));
+      }
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBSolrClient.java
@@ -419,7 +419,7 @@ public abstract class LBSolrClient extends SolrClient {
   protected void updateAliveList() {
     synchronized (aliveServers) {
       aliveServerList = aliveServers.values().toArray(new EndpointWrapper[0]);
-      if(log.isDebugEnabled()) {
+      if (log.isDebugEnabled()) {
         log.debug(UPDATE_LIVE_SERVER_MESSAGE + ": {}", Arrays.toString(aliveServerList));
       }
     }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -37,12 +36,9 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SolrResponseBase;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.embedded.JettyConfig;
 import org.apache.solr.embedded.JettySolrRunner;
-import org.apache.solr.servlet.HttpSolrCall;
 import org.apache.solr.util.LogListener;
-import org.apache.solr.util.TimeOut;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -225,7 +221,7 @@ public class LBHttp2SolrClientIntegrationTest extends SolrTestCaseJ4 {
 
     try (LogListener logListener = LogListener.info().substring("distrib=false")) {
       solrInstance.startJetty();
-      while(true) {
+      while (true) {
         if (logListener.pollMessage() != null) {
           return;
         }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
@@ -215,7 +215,8 @@ public class LBHttp2SolrClientIntegrationTest extends SolrTestCaseJ4 {
   }
 
   private void startJettyAndWaitForAliveCheckQuery(SolrInstance solrInstance) throws Exception {
-    try (LogListener logListener = LogListener.debug().substring(LBSolrClient.UPDATE_LIVE_SERVER_MESSAGE)) {
+    try (LogListener logListener =
+        LogListener.debug().substring(LBSolrClient.UPDATE_LIVE_SERVER_MESSAGE)) {
       solrInstance.startJetty();
       if (logListener.pollMessage(10, TimeUnit.SECONDS) == null) {
         fail("The alive check query was not logged within 10 seconds.");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
@@ -215,7 +215,7 @@ public class LBHttp2SolrClientIntegrationTest extends SolrTestCaseJ4 {
   }
 
   private void startJettyAndWaitForAliveCheckQuery(SolrInstance solrInstance) throws Exception {
-    try (LogListener logListener = LogListener.info().substring("distrib=false")) {
+    try (LogListener logListener = LogListener.debug().substring(LBSolrClient.UPDATE_LIVE_SERVER_MESSAGE)) {
       solrInstance.startJetty();
       if (logListener.pollMessage(10, TimeUnit.SECONDS) == null) {
         fail("The alive check query was not logged within 10 seconds.");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttp2SolrClientIntegrationTest.java
@@ -215,26 +215,10 @@ public class LBHttp2SolrClientIntegrationTest extends SolrTestCaseJ4 {
   }
 
   private void startJettyAndWaitForAliveCheckQuery(SolrInstance solrInstance) throws Exception {
-    final int pollIntervalMs = 50;
-    final int timeoutMs = 10000;
-    int waitSoFarMs = 0;
-
     try (LogListener logListener = LogListener.info().substring("distrib=false")) {
       solrInstance.startJetty();
-      while (true) {
-        if (logListener.pollMessage() != null) {
-          return;
-        }
-        try {
-          Thread.sleep(pollIntervalMs);
-        } catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          fail("Our thread was interrupted while waiting for the alive check query");
-        }
-        waitSoFarMs += pollIntervalMs;
-        if (waitSoFarMs >= timeoutMs) {
-          fail("The alive check query was not logged within " + timeoutMs + "ms.");
-        }
+      if (logListener.pollMessage(10, TimeUnit.SECONDS) == null) {
+        fail("The alive check query was not logged within 10 seconds.");
       }
     }
   }

--- a/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
@@ -46,9 +46,9 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.solr.common.util.SuppressForbidden;
 
 /**
- * Helper code to listen for {@link LogEvent} messages (via a {@link BlockingQueue}) that you expect as a
- * result of the things you are testing, So you can make assertions about when a particular action
- * should/shouldn't cause Solr to produce a particular Log message
+ * Helper code to listen for {@link LogEvent} messages (via a {@link BlockingQueue}) that you expect
+ * as a result of the things you are testing, So you can make assertions about when a particular
+ * action should/shouldn't cause Solr to produce a particular Log message
  *
  * <p><code>
  * // simplest possible usage...
@@ -348,11 +348,12 @@ public final class LogListener implements Closeable, AutoCloseable {
   }
 
   /**
-   * Direct access to the Queue of Log events that have been recorded, for {@link BlockingQueue#poll}ing
-   * messages or any other inspection/manipulation.
+   * Direct access to the Queue of Log events that have been recorded, for {@link
+   * BlockingQueue#poll}ing messages or any other inspection/manipulation.
    *
    * <p>If a Log event is ever processed but can not be added to this queue (because {@link
-   * BlockingQueue#offer} returns false) then the {@link #close} method of this listener will fail the test.
+   * BlockingQueue#offer} returns false) then the {@link #close} method of this listener will fail
+   * the test.
    *
    * @see #setQueue
    * @see #pollMessage
@@ -381,7 +382,8 @@ public final class LogListener implements Closeable, AutoCloseable {
    *
    * @param timeout
    * @param unit
-   * @return the formatted message string of head of the queue, or null if the queue remained empty until the specified timeout.
+   * @return the formatted message string of head of the queue, or null if the queue remained empty
+   *     until the specified timeout.
    */
   public String pollMessage(long timeout, TimeUnit unit) {
     LogEvent event = null;

--- a/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
@@ -18,11 +18,13 @@
 package org.apache.solr.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.Closeable;
 import java.lang.invoke.MethodHandles;
-import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,7 +46,7 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.solr.common.util.SuppressForbidden;
 
 /**
- * Helper code to listen for {@link LogEvent} messages (via a {@link Queue}) that you expect as a
+ * Helper code to listen for {@link LogEvent} messages (via a {@link BlockingQueue}) that you expect as a
  * result of the things you are testing, So you can make assertions about when a particular action
  * should/shouldn't cause Solr to produce a particular Log message
  *
@@ -278,7 +280,7 @@ public final class LogListener implements Closeable, AutoCloseable {
    *
    * @see #getQueue
    */
-  public LogListener setQueue(Queue<LogEvent> queue) {
+  public LogListener setQueue(BlockingQueue<LogEvent> queue) {
     loggerAppender.setQueue(queue);
     return this;
   }
@@ -346,21 +348,21 @@ public final class LogListener implements Closeable, AutoCloseable {
   }
 
   /**
-   * Direct access to the Queue of Log events that have been recorded, for {@link Queue#poll}ing
+   * Direct access to the Queue of Log events that have been recorded, for {@link BlockingQueue#poll}ing
    * messages or any other inspection/manipulation.
    *
    * <p>If a Log event is ever processed but can not be added to this queue (because {@link
-   * Queue#offer} returns false) then the {@link #close} method of this listener will fail the test.
+   * BlockingQueue#offer} returns false) then the {@link #close} method of this listener will fail the test.
    *
    * @see #setQueue
    * @see #pollMessage
    */
-  public Queue<LogEvent> getQueue() {
+  public BlockingQueue<LogEvent> getQueue() {
     return loggerAppender.getQueue();
   }
 
   /**
-   * Convinience method for tests that want to assert things about the (formated) message string at
+   * Convenience method for tests that want to assert things about the (formated) message string at
    * the head of the queue, w/o needing to know/call methods on the underlying {@link LogEvent}
    * class.
    *
@@ -370,6 +372,25 @@ public final class LogListener implements Closeable, AutoCloseable {
    */
   public String pollMessage() {
     final LogEvent event = getQueue().poll();
+    return null == event ? null : event.getMessage().getFormattedMessage();
+  }
+
+  /**
+   * Convenience method for tests that want to assert things about the (formated) message string at
+   * the head of the queue, waiting up to the specified timeout for the message to arrive.
+   *
+   * @param timeout
+   * @param unit
+   * @return the formatted message string of head of the queue, or null if the queue remained empty until the specified timeout.
+   */
+  public String pollMessage(long timeout, TimeUnit unit) {
+    LogEvent event = null;
+    try {
+      event = getQueue().poll(timeout, unit);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      fail("Our thread was interrupted while polling the queue.");
+    }
     return null == event ? null : event.getMessage().getFormattedMessage();
   }
 
@@ -598,7 +619,7 @@ public final class LogListener implements Closeable, AutoCloseable {
   private static final class QueueAppender extends AbstractAppender {
 
     // may be mutated in main thread while background thread is actively logging
-    private final AtomicReference<Queue<LogEvent>> queue =
+    private final AtomicReference<BlockingQueue<LogEvent>> queue =
         new AtomicReference<>(new ArrayBlockingQueue<>(100));
     final AtomicInteger count = new AtomicInteger(0);
     final AtomicInteger capacityExceeded = new AtomicInteger(0);
@@ -611,7 +632,7 @@ public final class LogListener implements Closeable, AutoCloseable {
 
     @Override
     public void append(final LogEvent event) {
-      final Queue<LogEvent> q = queue.get(); // read from reference once
+      final BlockingQueue<LogEvent> q = queue.get(); // read from reference once
       final LogEvent memento =
           (event instanceof MutableLogEvent) ? ((MutableLogEvent) event).createMemento() : event;
       final int currentCount = count.incrementAndGet();
@@ -648,20 +669,20 @@ public final class LogListener implements Closeable, AutoCloseable {
      * Returns the number of times this appender was unable to queue a LogEvent due to exceeding
      * capacity
      *
-     * @see Queue#offer
+     * @see BlockingQueue#offer
      */
     public int getNumCapacityExceeded() {
       return capacityExceeded.get();
     }
 
     /** Changes the queue that will be used for any future events that are appended */
-    public void setQueue(final Queue<LogEvent> q) {
+    public void setQueue(final BlockingQueue<LogEvent> q) {
       assert null != q;
       this.queue.set(q);
     }
 
     /** Returns Raw access to the (current) queue */
-    public Queue<LogEvent> getQueue() {
+    public BlockingQueue<LogEvent> getQueue() {
       return queue.get();
     }
   }

--- a/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
@@ -380,8 +380,8 @@ public final class LogListener implements Closeable, AutoCloseable {
    * Convenience method for tests that want to assert things about the (formated) message string at
    * the head of the queue, waiting up to the specified timeout for the message to arrive.
    *
-   * @param timeout
-   * @param unit
+   * @param timeout the duation value
+   * @param unit the duration unit
    * @return the formatted message string of head of the queue, or null if the queue remained empty
    *     until the specified timeout.
    */


### PR DESCRIPTION
1. Remove "testReliability" because it had no asserts.

2. For "testTwoServers" and "testSimple", wait for the alive check query to be logged after restarting the node.  Previously a blind "Thread.sleep" was in use.