### PR TITLE
SOLR-16390: fix flaky test ClusterPropsAPITest.testClusterPropertyOpsAllGood

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/admin/api/ClusterPropsAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/ClusterPropsAPITest.java
@@ -18,6 +18,8 @@
 package org.apache.solr.handler.admin.api;
 
 import static org.apache.solr.common.util.Utils.getObjectByPath;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 import java.net.URL;
 import java.util.List;
@@ -86,17 +88,14 @@ public class ClusterPropsAPITest extends SolrCloudTestCase {
   @Test
   public void testClusterPropertyOpsAllGood() throws Exception {
     try (HttpSolrClient client = new HttpSolrClient.Builder(baseUrl.toString()).build()) {
-      // List Properties, confirm there aren't any
+      // List Properties, confirm the test property does not exist
+      // This ignores eventually existing other properties
       Object o =
           Utils.executeGET(client.getHttpClient(), baseUrlV2ClusterProps, Utils.JSONCONSUMER);
       assertNotNull(o);
-
-      // When running in SSL mode, urlScheme property is auto-added by test framework in
-      // MiniSolrCloudCluster
-      // Make sure we always ignore this one when counting properties
-      int initCount = isSSLMode() ? 1 : 0;
-
-      assertEquals(initCount, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
+      @SuppressWarnings("unchecked")
+      List<String> initProperties = (List<String>) getObjectByPath(o, true, "clusterProperties");
+      assertThat(initProperties, not(hasItem(testClusterProperty)));
 
       // Create a single cluster property
       String path = baseUrlV2ClusterProps + "/" + testClusterProperty;
@@ -106,12 +105,12 @@ public class ClusterPropsAPITest extends SolrCloudTestCase {
       o = Utils.executeHttpMethod(client.getHttpClient(), path, Utils.JSONCONSUMER, httpPut);
       assertNotNull(o);
 
-      // List Properties, this time there should be 1
+      // List Properties, this time there should be the just added property
       o = Utils.executeGET(client.getHttpClient(), baseUrlV2ClusterProps, Utils.JSONCONSUMER);
       assertNotNull(o);
-      assertEquals(initCount + 1, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
-      assertTrue(
-          ((List<?>) getObjectByPath(o, true, "clusterProperties")).contains(testClusterProperty));
+      @SuppressWarnings("unchecked")
+      List<String> updatedProperties = (List<String>) getObjectByPath(o, true, "clusterProperties");
+      assertThat(updatedProperties, hasItem(testClusterProperty));
 
       // Fetch Cluster Property
       // Same path as used in the Create step above
@@ -127,10 +126,12 @@ public class ClusterPropsAPITest extends SolrCloudTestCase {
       o = Utils.executeHttpMethod(client.getHttpClient(), path, Utils.JSONCONSUMER, httpDelete);
       assertNotNull(o);
 
-      // List Properties, should be back to 0
+      // List Properties, the test property should be gone
       o = Utils.executeGET(client.getHttpClient(), baseUrlV2ClusterProps, Utils.JSONCONSUMER);
       assertNotNull(o);
-      assertEquals(initCount, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
+      @SuppressWarnings("unchecked")
+      List<String> clearedProperties = (List<String>) getObjectByPath(o, true, "clusterProperties");
+      assertThat(clearedProperties, not(hasItem(testClusterProperty)));
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/ClusterPropsAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/ClusterPropsAPITest.java
@@ -90,7 +90,13 @@ public class ClusterPropsAPITest extends SolrCloudTestCase {
       Object o =
           Utils.executeGET(client.getHttpClient(), baseUrlV2ClusterProps, Utils.JSONCONSUMER);
       assertNotNull(o);
-      assertEquals(0, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
+
+      // When running in SSL mode, urlScheme property is auto-added by test framework in
+      // MiniSolrCloudCluster
+      // Make sure we always ignore this one when counting properties
+      int initCount = isSSLMode() ? 1 : 0;
+
+      assertEquals(initCount, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
 
       // Create a single cluster property
       String path = baseUrlV2ClusterProps + "/" + testClusterProperty;
@@ -103,10 +109,9 @@ public class ClusterPropsAPITest extends SolrCloudTestCase {
       // List Properties, this time there should be 1
       o = Utils.executeGET(client.getHttpClient(), baseUrlV2ClusterProps, Utils.JSONCONSUMER);
       assertNotNull(o);
-      assertEquals(1, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
-      assertEquals(
-          testClusterProperty,
-          (String) ((List<?>) getObjectByPath(o, true, "clusterProperties")).get(0));
+      assertEquals(initCount + 1, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
+      assertTrue(
+          ((List<?>) getObjectByPath(o, true, "clusterProperties")).contains(testClusterProperty));
 
       // Fetch Cluster Property
       // Same path as used in the Create step above
@@ -125,7 +130,7 @@ public class ClusterPropsAPITest extends SolrCloudTestCase {
       // List Properties, should be back to 0
       o = Utils.executeGET(client.getHttpClient(), baseUrlV2ClusterProps, Utils.JSONCONSUMER);
       assertNotNull(o);
-      assertEquals(0, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
+      assertEquals(initCount, ((List<?>) getObjectByPath(o, true, "clusterProperties")).size());
     }
   }
 


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-16390
(linking to the Jira that introduced the test)


<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

The test fails when SSL is enabled, because of testing framework that set 'urlScheme' cluster property.

I was looking at the failure in another PR, and it seems this test fails quite often since #2788. I don't think it is tracked somewhere else.

# Solution

 This change updates the test to ignore existing cluster properties.

# Tests

n/a

