### PR TITLE
SOLR-17583: Bring back documentation for Adding Custom Expressions

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/streaming-expressions.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/streaming-expressions.adoc
@@ -100,6 +100,15 @@ In your JSON client you'll need to iterate each doc (tuple) and check for the EO
 
 Timeouts for Streaming Expressions can be configured with the `socketTimeout` and `connTimeout` startup parameters.
 
+=== Adding Custom Expressions
+
+Creating your own custom expressions can be easily done by implementing the {solr-javadocs}/solrj-streaming/org/apache/solr/client/solrj/io/stream/expr/Expressible.html[Expressible] interface.   To add a custom expression to the
+list of known mappings for the `/stream` and `/graph` handlers, you just need to declare it as a plugin in `solrconfig.xml` via:
+
+[source,xml]
+<expressible name="custom" class="org.example.CustomStreamingExpression"/>
+
+
 == Elements of the Language
 
 === Stream Sources


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17583

# Description

The section for adding Custom Expressions was removed in Solr 8.8. This change brings it back.

# Solution

This change was cherry-picked from the same change on the main branch.

# Tests

I ran ```./gradlew tidy updateLicenses check -x test``` and then opened my local copy of the Reference Guide. I verified that I see the new text and that the link to the Expressible javadoc is working.

# Checklist

Please review the following and check all that apply:

- [ x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ x] I have created a Jira issue and added the issue ID to my pull request title.
- [ x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
