### PR TITLE
Allow lsof and sockstat to detect if solr started successfully

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1363,13 +1363,20 @@ function start_solr() {
     fi
 
     # no lsof on cygwin though
+    check_command=""
     if lsof -v 2>&1 | grep -q revision; then
+      check_command="lsof -t -PniTCP:$SOLR_PORT -sTCP:LISTEN"
+    elif which -s sockstat; then
+      check_command="sockstat -q46lp$SOLR_PORT"
+    fi
+
+    if [[ "${check_command}" != "" ]]; then
       echo -n "Waiting up to $SOLR_START_WAIT seconds to see Solr running on port $SOLR_PORT"
       # Launch in a subshell to show the spinner
       (loops=0
       while true
       do
-        running=$(lsof -t -PniTCP:$SOLR_PORT -sTCP:LISTEN || :)
+        running=$(${check_command} || :)
         if [ -z "${running:-}" ]; then
           slept=$((loops * 2))
           if [ $slept -lt $SOLR_START_WAIT ]; then
@@ -1388,7 +1395,7 @@ function start_solr() {
       done) &
       spinner $!
     else
-      echo -e "NOTE: Please install lsof as this script needs it to determine if Solr is listening on port $SOLR_PORT."
+      echo -e "NOTE: Please install lsof or sockstat as this script needs it to determine if Solr is listening on port $SOLR_PORT."
       sleep 10
       SOLR_PID=$(ps auxww | grep start\.jar | awk "/\-Djetty\.port=$SOLR_PORT/"' {print $2}' | sort -r)
       echo -e "\nStarted Solr server on port $SOLR_PORT (pid=$SOLR_PID). Happy searching!\n"


### PR DESCRIPTION
The tool lsof is not available on all systems, like FreeBSD.
Added the possibility to use sockstat to detect if solr started successfully.
The startup script is using the tool that is available.

https://issues.apache.org/jira/browse/SOLR-17594

* SOLR-17594: solr cannot detect start on FreeBSD as lsof does not exist

# Description

Allow the startup script to use lsof or sockstat to detect if solr was started successfully

# Solution

The script checks at first if lsof is available than if sockstat is available and than fallback to standard behaviour.

# Tests

I tested the patch on FreeBSD and will also commit the patch after the PR is created with a link to it.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
