### PR TITLE
SOLR-17595: Fix Solr examples for Windows

### DIFF
--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -643,15 +643,36 @@ SHIFT
 goto parse_args
 
 :set_passthru
-set "PASSTHRU=%~1=%~2"
+set "PASSTHRU_KEY=%~1"
+set "PASSTHRU_VALUES="
+
+SHIFT
+:repeat_passthru
+set "arg=%~1"
+if "%arg%"=="" goto end_passthru
+set firstChar=%arg:~0,1%
+IF "%firstChar%"=="-" (
+  goto end_passthru
+)
+
+if defined PASSTHRU_VALUES (
+    set "PASSTHRU_VALUES=%PASSTHRU_VALUES%,%arg%"
+) else (
+    set "PASSTHRU_VALUES=%arg%"
+)
+SHIFT
+goto repeat_passthru
+
+:end_passthru
+set "PASSTHRU=%PASSTHRU_KEY%=%PASSTHRU_VALUES%"
+
 IF NOT "%SOLR_OPTS%"=="" (
   set "SOLR_OPTS=%SOLR_OPTS% %PASSTHRU%"
 ) ELSE (
   set "SOLR_OPTS=%PASSTHRU%"
 )
 set "PASS_TO_RUN_EXAMPLE=%PASSTHRU% !PASS_TO_RUN_EXAMPLE!"
-SHIFT
-SHIFT
+
 goto parse_args
 
 :set_noprompt


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17595

# Description

Since 9.7 the Solr examples (specifically the techproducts) are not working properly and throw an error on startup.

# Solution

This PR fixes these issues.

# Tests

Some changes are related to the Windows solr.cmd script for which we do not have any tests (see [SOLR-17508](https://issues.apache.org/jira/browse/SOLR-17508)), and the other changes simply remove unsupported glob patterns.

# Checklist

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
