### PR TITLE
Coordinator: remove SolrQueryRequest.getCloudDescriptor

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/CoordinatorV2HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/api/CoordinatorV2HttpSolrCall.java
@@ -25,7 +25,6 @@ import org.apache.solr.servlet.CoordinatorHttpSolrCall;
 import org.apache.solr.servlet.SolrDispatchFilter;
 
 public class CoordinatorV2HttpSolrCall extends V2HttpCall {
-  private String collectionName;
   CoordinatorHttpSolrCall.Factory factory;
 
   public CoordinatorV2HttpSolrCall(
@@ -41,7 +40,6 @@ public class CoordinatorV2HttpSolrCall extends V2HttpCall {
 
   @Override
   protected SolrCore getCoreByCollection(String collectionName, boolean isPreferLeader) {
-    this.collectionName = collectionName;
     SolrCore core = super.getCoreByCollection(collectionName, isPreferLeader);
     if (core != null) return core;
     if (!path.endsWith("/select")) return null;
@@ -52,7 +50,7 @@ public class CoordinatorV2HttpSolrCall extends V2HttpCall {
   protected void init() throws Exception {
     super.init();
     if (action == SolrDispatchFilter.Action.PROCESS && core != null) {
-      solrReq = CoordinatorHttpSolrCall.wrappedReq(solrReq, collectionName, this);
+      solrReq = CoordinatorHttpSolrCall.wrappedReq(solrReq, this);
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -373,7 +373,7 @@ public class HttpShardHandler extends ShardHandler {
     final String shards = params.get(ShardParams.SHARDS);
 
     CoreDescriptor coreDescriptor = req.getCore().getCoreDescriptor();
-    CloudDescriptor cloudDescriptor = req.getCloudDescriptor();
+    CloudDescriptor cloudDescriptor = coreDescriptor.getCloudDescriptor();
     ZkController zkController = req.getCoreContainer().getZkController();
 
     final ReplicaListTransformer replicaListTransformer =

--- a/solr/core/src/java/org/apache/solr/request/DelegatingSolrQueryRequest.java
+++ b/solr/core/src/java/org/apache/solr/request/DelegatingSolrQueryRequest.java
@@ -20,7 +20,6 @@ import io.opentelemetry.api.trace.Span;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
-import org.apache.solr.cloud.CloudDescriptor;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.CommandOperation;
 import org.apache.solr.common.util.ContentStream;
@@ -157,10 +156,5 @@ public class DelegatingSolrQueryRequest implements SolrQueryRequest {
   @Override
   public CoreContainer getCoreContainer() {
     return delegate.getCoreContainer();
-  }
-
-  @Override
-  public CloudDescriptor getCloudDescriptor() {
-    return delegate.getCloudDescriptor();
   }
 }

--- a/solr/core/src/java/org/apache/solr/request/SolrQueryRequest.java
+++ b/solr/core/src/java/org/apache/solr/request/SolrQueryRequest.java
@@ -21,7 +21,6 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.apache.solr.cloud.CloudDescriptor;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.CommandOperation;
@@ -184,10 +183,6 @@ public interface SolrQueryRequest extends AutoCloseable {
   default CoreContainer getCoreContainer() {
     SolrCore core = getCore();
     return core == null ? null : core.getCoreContainer();
-  }
-
-  default CloudDescriptor getCloudDescriptor() {
-    return getCore().getCoreDescriptor().getCloudDescriptor();
   }
 
   /** The writer to use for this request, considering {@link CommonParams#WT}. Never null. */


### PR DESCRIPTION
I don't love seeing SolrQueryRequest.getCloudDescriptor -- we should be conservative of adding more methods to SolrQueryRequest.  It only has one caller.

Tests pass.  If it serves a purpose, removing it ought to demonstrate something's wrong.