### PR TITLE
SOLR-17405: allow a single thread to reestablish ZK session

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -19,7 +19,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* SOLR-17405: Fix race condition where Zookeeper session could be re-established by multiple threads concurrently in
+ case of frequent session expirations. (Pierre Salagnac)
 
 Dependency Upgrades
 ---------------------

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ConnectionManager.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ConnectionManager.java
@@ -179,7 +179,7 @@ public class ConnectionManager implements Watcher {
           connectionStrategy.reconnect(
               zkServerAddress,
               client.getZkClientTimeout(),
-              this,
+              client.wrapWatcher(this),
               new ZkClientConnectionStrategy.ZkUpdate() {
                 @Override
                 public void update(ZooKeeper keeper) {

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/SolrZkClient.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/SolrZkClient.java
@@ -218,6 +218,7 @@ public class SolrZkClient implements Closeable {
       } catch (InterruptedException e1) {
         Thread.currentThread().interrupt();
       }
+      zkCallbackExecutor.shutdown();
       zkConnManagerCallbackExecutor.shutdown();
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
     }
@@ -1077,7 +1078,19 @@ public class SolrZkClient implements Closeable {
     public void process(final WatchedEvent event) {
       log.debug("Submitting job to respond to event {}", event);
       try {
-        if (watcher instanceof ConnectionManager) {
+        // We want all the code that re-creates the Zookeeper session and then invoke
+        // ZkController.onReconnect() to never be executed by two threads concurrently.
+        // Pool 'zkConnManagerCallbackExecutor' is single threaded. We make sure such events
+        // are processed only by this pool. Consequently, in case of a session expiration, we
+        // don't try to re-create a new session until the previous call to onReconnect()
+        // returned.
+        //
+        // All other events goes to pool 'zkCallbackExecutor', which is unbounded and may
+        // spawn as many threads as there are events to process.
+        // This includes event on ConnectionManager others than session expiration. Consequently,
+        // there is no deadlock when the thread currently reestablishing the session waits for
+        // the 'SyncConnected' event.
+        if (watcher instanceof ConnectionManager && event.getState() == Event.KeeperState.Expired) {
           zkConnManagerCallbackExecutor.execute(() -> watcher.process(event));
         } else {
           zkCallbackExecutor.execute(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17405

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

`OnReconnect` can be invoked by several threads concurrently (see Jira for the explanation).

Same change as #2644, but against `9x` branch. This bug does not exist anymore in `main` since the move to Curator.

# Solution

Always add the wrapper on the watch that handle the session expiration events. This makes sure the session is re-established in a dedicated thread, and this thread exists only once per server.

# Tests

No new tests added. Unfortunately, this is super tricky to reproduce.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
