### PR TITLE
reusing empty NamedList rather than recreating a new empty NamedList …

### DIFF
--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -873,10 +873,10 @@ public class SimpleFacets {
    */
   public NamedList<Object> getFacetFieldCounts() throws IOException, SyntaxError {
 
-    NamedList<Object> res = new SimpleOrderedMap<>();
     String[] facetFs = global.getParams(FacetParams.FACET_FIELD);
+
     if (null == facetFs) {
-      return res;
+      return NamedList.emptyNamedList();
     }
 
     // Passing a negative number for FACET_THREADS implies an unlimited number of threads is
@@ -891,6 +891,7 @@ public class SimpleFacets {
       fdebugParent.putInfoItem("maxThreads", maxThreads);
     }
 
+    NamedList<Object> res;
     try {
       // Loop over fields; submit to executor, keeping the future
       for (String f : facetFs) {
@@ -932,6 +933,7 @@ public class SimpleFacets {
         futures.add(runnableFuture);
       } // facetFs loop
 
+      res = new SimpleOrderedMap<>();
       // Loop over futures to get the values. The order is the same as facetFs but shouldn't matter.
       for (Future<NamedList<?>> future : futures) {
         res.addAll(future.get());

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -871,12 +871,12 @@ public class SimpleFacets {
    * @see #getFieldMissingCount
    * @see #getFacetTermEnumCounts
    */
-  public NamedList<Object> getFacetFieldCounts() throws IOException, SyntaxError {
+  public SimpleOrderedMap<Object> getFacetFieldCounts() throws IOException, SyntaxError {
 
     String[] facetFs = global.getParams(FacetParams.FACET_FIELD);
 
     if (null == facetFs) {
-      return NamedList.emptyNamedList();
+      return  SimpleOrderedMap.emptySimpleOrderedMap();
     }
 
     // Passing a negative number for FACET_THREADS implies an unlimited number of threads is
@@ -891,7 +891,7 @@ public class SimpleFacets {
       fdebugParent.putInfoItem("maxThreads", maxThreads);
     }
 
-    NamedList<Object> res;
+    SimpleOrderedMap<Object> res;
     try {
       // Loop over fields; submit to executor, keeping the future
       for (String f : facetFs) {

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -876,7 +876,7 @@ public class SimpleFacets {
     String[] facetFs = global.getParams(FacetParams.FACET_FIELD);
 
     if (null == facetFs) {
-      return  SimpleOrderedMap.empty();
+      return  SimpleOrderedMap.of();
     }
 
     // Passing a negative number for FACET_THREADS implies an unlimited number of threads is

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -915,10 +915,8 @@ public class SimpleFacets {
                   result.add(key, getTermCounts(facetValue, parsed));
                 }
                 return result;
-              } catch (SolrException se) {
+              } catch (SolrException | ExitableDirectoryReader.ExitingReaderException se) {
                 throw se;
-              } catch (ExitableDirectoryReader.ExitingReaderException timeout) {
-                throw timeout;
               } catch (Exception e) {
                 throw new SolrException(
                     ErrorCode.SERVER_ERROR, "Exception during facet.field: " + facetValue, e);

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -876,7 +876,7 @@ public class SimpleFacets {
     String[] facetFs = global.getParams(FacetParams.FACET_FIELD);
 
     if (null == facetFs) {
-      return  SimpleOrderedMap.emptySimpleOrderedMap();
+      return  SimpleOrderedMap.empty();
     }
 
     // Passing a negative number for FACET_THREADS implies an unlimited number of threads is

--- a/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
@@ -63,7 +63,6 @@ import org.apache.solr.common.params.SolrParams;
 public class NamedList<T>
     implements Cloneable, Serializable, Iterable<Map.Entry<String, T>>, MapWriter, SimpleMap<T> {
 
-  private static final NamedList<Object> emptyNamedList = new NamedList(0);
   private static final long serialVersionUID = 1957981902839867821L;
   protected final List<Object> nvPairs;
 
@@ -861,9 +860,5 @@ public class NamedList<T>
   @Override
   public void forEachEntry(BiConsumer<String, ? super T> fun) {
     forEach(fun);
-  }
-
-  public static NamedList<Object> emptyNamedList() {
-    return emptyNamedList;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
@@ -63,6 +63,7 @@ import org.apache.solr.common.params.SolrParams;
 public class NamedList<T>
     implements Cloneable, Serializable, Iterable<Map.Entry<String, T>>, MapWriter, SimpleMap<T> {
 
+  private static final NamedList<Object> emptyNamedList = new NamedList(0);
   private static final long serialVersionUID = 1957981902839867821L;
   protected final List<Object> nvPairs;
 
@@ -860,5 +861,9 @@ public class NamedList<T>
   @Override
   public void forEachEntry(BiConsumer<String, ? super T> fun) {
     forEach(fun);
+  }
+
+  public static NamedList<Object> emptyNamedList() {
+    return emptyNamedList;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
@@ -72,39 +72,20 @@ public class SimpleOrderedMap<T> extends NamedList<T> {
 
   /**
    * Returns a shared, empty, and immutable instance of SimpleOrderedMap.
-   * @return empty SimpleOrderedMap (immutable) 
+   * @return Empty SimpleOrderedMap (immutable) 
    */
   public static SimpleOrderedMap<Object> of() {
     return EMPTY;
   }
 
   /**
-   * Returns an immutable instance of SimpleOrderedMap with a single element.
-   * @return List containing the elements
+   * Returns an immutable instance of SimpleOrderedMap with a single key-value pair.
+   * @return SimpleOrderedMap containing one key-value pair
    */
-  public static SimpleOrderedMap<Object> of(Object o1) {
-    return new SimpleOrderedMap<>(List.of(o1));
-  }
-  
-  /**
-   * Returns an immutable instance of SimpleOrderedMap with two elements.
-   * @return List containing the elements
-   */
-  public static SimpleOrderedMap<Object> of(Object o1, Object o2) {
-    return new SimpleOrderedMap<>(List.of(o1,o2));
-  }
-  
-  /**
-   * Returns an immutable instance of SimpleOrderedMap with an arbitrary number of elements. 
-   * @return List containing the elements
-   */
-  public static SimpleOrderedMap<Object> of(Object... elements) {
-	  return switch (elements.length) {
-		  case 0 -> of();
-		  case 1 -> of(elements[0]);
-		  case 2 -> of(elements[0], elements[1]);
-		  default -> new SimpleOrderedMap<>(List.of(elements));
-	  };
+
+  public static <T> SimpleOrderedMap<T> of(String name, T val)
+  {
+    return new SimpleOrderedMap<>(List.of(name, val));   
   }
   
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
@@ -17,6 +17,7 @@
 package org.apache.solr.common.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ import java.util.Map;
  */
 public class SimpleOrderedMap<T> extends NamedList<T> {
  
-  private static final SimpleOrderedMap<Object> emptySimpleOrderedMap = new SimpleOrderedMap<>(0);
+  private static final SimpleOrderedMap<Object> emptySimpleOrderedMap = new SimpleOrderedMap<>(Collections.emptyList());
   /** Creates an empty instance */
   public SimpleOrderedMap() {
     super();

--- a/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
@@ -74,7 +74,37 @@ public class SimpleOrderedMap<T> extends NamedList<T> {
    * Returns a shared, empty, and immutable instance of SimpleOrderedMap.
    * @return empty SimpleOrderedMap (immutable) 
    */
-  public static SimpleOrderedMap<Object> empty() {
+  public static SimpleOrderedMap<Object> of() {
     return EMPTY;
   }
+
+  /**
+   * Returns an immutable instance of SimpleOrderedMap with a single element.
+   * @return List containing the elements
+   */
+  public static SimpleOrderedMap<Object> of(Object o1) {
+    return new SimpleOrderedMap<>(List.of(o1));
+  }
+  
+  /**
+   * Returns an immutable instance of SimpleOrderedMap with two elements.
+   * @return List containing the elements
+   */
+  public static SimpleOrderedMap<Object> of(Object o1, Object o2) {
+    return new SimpleOrderedMap<>(List.of(o1,o2));
+  }
+  
+  /**
+   * Returns an immutable instance of SimpleOrderedMap with an arbitrary number of elements. 
+   * @return List containing the elements
+   */
+  public static SimpleOrderedMap<Object> of(Object... elements) {
+	  return switch (elements.length) {
+		  case 0 -> of();
+		  case 1 -> of(elements[0]);
+		  case 2 -> of(elements[0], elements[1]);
+		  default -> new SimpleOrderedMap<>(List.of(elements));
+	  };
+  }
+  
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
@@ -34,6 +34,8 @@ import java.util.Map;
  * serialized. It aims to minimize overhead and to be efficient at adding new elements.
  */
 public class SimpleOrderedMap<T> extends NamedList<T> {
+ 
+  private static final SimpleOrderedMap<Object> emptySimpleOrderedMap = new SimpleOrderedMap<>(0);
   /** Creates an empty instance */
   public SimpleOrderedMap() {
     super();
@@ -66,5 +68,9 @@ public class SimpleOrderedMap<T> extends NamedList<T> {
     ArrayList<Object> newList = new ArrayList<>(nvPairs.size());
     newList.addAll(nvPairs);
     return new SimpleOrderedMap<>(newList);
+  }
+  
+  public static SimpleOrderedMap<Object> emptySimpleOrderedMap() {
+    return emptySimpleOrderedMap;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
@@ -17,7 +17,6 @@
 package org.apache.solr.common.util;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +35,7 @@ import java.util.Map;
  */
 public class SimpleOrderedMap<T> extends NamedList<T> {
  
-  private static final SimpleOrderedMap<Object> emptySimpleOrderedMap = new SimpleOrderedMap<>(Collections.emptyList());
+  private static final SimpleOrderedMap<Object> EMPTY = new SimpleOrderedMap<>(List.of());
   /** Creates an empty instance */
   public SimpleOrderedMap() {
     super();
@@ -70,8 +69,12 @@ public class SimpleOrderedMap<T> extends NamedList<T> {
     newList.addAll(nvPairs);
     return new SimpleOrderedMap<>(newList);
   }
-  
-  public static SimpleOrderedMap<Object> emptySimpleOrderedMap() {
-    return emptySimpleOrderedMap;
+
+  /**
+   * Returns a shared, empty, and immutable instance of SimpleOrderedMap.
+   * @return empty SimpleOrderedMap (immutable) 
+   */
+  public static SimpleOrderedMap<Object> empty() {
+    return EMPTY;
   }
 }


### PR DESCRIPTION
For every call with face=true which is not providing any facet.fields, we do create an empty NamedList.
Having a single instance of an empty NamedList feels like the more efficient approach to me.