### PR TITLE
Fix renovate.json to work with version catalogs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
   "enabled": true,
   "dependencyDashboard": false,
   "enabledManagers": ["gradle", "github-actions"],
-  "includePaths": ["versions.*", "build.gradle", ".github/workflows/*"],
+  "includePaths": ["gradle/libs.versions.toml", "versions.*", "build.gradle", ".github/workflows/*"],
   "postUpgradeTasks": {
-    "commands": ["./gradlew updateLicenses"],
+    "commands": ["./gradlew writeLocks", "./gradlew updateLicenses"],
     "fileFilters": ["solr/licenses/*.sha1"],
     "executionMode": "branch"
   },


### PR DESCRIPTION
# Description

With the version catalogs the solrbot stopped working, and we considered switching to dependabot (see https://github.com/apache/solr/pull/2880). Since the switch to dependabot is not straight-forward and was proven difficult, we may update solrbot to work with version catalogs.

# Solution

This solution updates the renovate.json file, adds the version catalog file to the includePaths and executes the writeLocks task before updating licenses, as this step was also changed during the migration to version catalogs.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
