### PR TITLE
Fix rarely flaky DeleteInactiveReplicaTest.

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/DeleteInactiveReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteInactiveReplicaTest.java
@@ -83,7 +83,7 @@ public class DeleteInactiveReplicaTest extends SolrCloudTestCase {
         "Expected replica " + replica.getName() + " on down node to be removed from cluster state",
         collectionName,
         (n, c) -> {
-          Replica r = c.getReplica(replica.getCoreName());
+          Replica r = c.getReplica(replica.getName());
           return r == null || r.getState() != Replica.State.ACTIVE;
         });
 
@@ -96,7 +96,7 @@ public class DeleteInactiveReplicaTest extends SolrCloudTestCase {
         "Expected deleted replica " + replica.getName() + " to be removed from cluster state",
         collectionName,
         (n, c) -> {
-          return c.getReplica(replica.getCoreName()) == null;
+          return c.getReplica(replica.getName()) == null;
         });
 
     cluster.startJettySolrRunner(jetty);


### PR DESCRIPTION

# Description

The test was retrieving a replica from cluster state using core name instead of correct replica name.
The test is rarely failing because of this, it may happen.

# Solution

Fix the test, just replace `getCoreName()` by `getName()`.
