### PR TITLE
Move DOMUtil ConfigNode methods to ConfigNode, with some name changes.

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -228,7 +228,7 @@ public class SolrConfig implements MapSerializable {
       getRequestParams();
       initLibs(loader);
       String val =
-          root.child(
+          root.childRequired(
                   IndexSchema.LUCENE_MATCH_VERSION_PARAM,
                   () -> new RuntimeException("Missing: " + IndexSchema.LUCENE_MATCH_VERSION_PARAM))
               .txt();
@@ -517,7 +517,7 @@ public class SolrConfig implements MapSerializable {
     final Function<SolrConfig, List<ConfigNode>> configReader;
 
     private SolrPluginInfo(Class<?> clz, String tag, PluginOpts... opts) {
-      this(solrConfig -> solrConfig.root.getAll(null, tag), clz, tag, opts);
+      this(solrConfig -> solrConfig.root.getAll(tag), clz, tag, opts);
     }
 
     private SolrPluginInfo(

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -289,7 +289,7 @@ public class SolrXmlConfig {
   }
 
   private static NamedList<Object> readNodeListAsNamedList(ConfigNode cfg, String section) {
-    NamedList<Object> nl = DOMUtil.readNamedListChildren(cfg);
+    NamedList<Object> nl = cfg.childNodesToNamedList();
     Set<String> keys = new HashSet<>();
     for (Map.Entry<String, Object> entry : nl) {
       if (!keys.add(entry.getKey()))
@@ -724,7 +724,7 @@ public class SolrXmlConfig {
     builder.setHistogramSupplier(getPluginInfo(metrics.get("suppliers").get("histogram")));
 
     if (metrics.get("missingValues").exists()) {
-      NamedList<Object> missingValues = DOMUtil.childNodesToNamedList(metrics.get("missingValues"));
+      NamedList<Object> missingValues = metrics.get("missingValues").childNodesToNamedList();
       builder.setNullNumber(decodeNullValue(missingValues.get("nullNumber")));
       builder.setNotANumber(decodeNullValue(missingValues.get("notANumber")));
       builder.setNullString(decodeNullValue(missingValues.get("nullString")));
@@ -734,7 +734,7 @@ public class SolrXmlConfig {
     ConfigNode caching = metrics.get("solr/metrics/caching");
     if (caching != null) {
       Object threadsCachingIntervalSeconds =
-          DOMUtil.childNodesToNamedList(caching).get("threadsIntervalSeconds");
+          caching.childNodesToNamedList().get("threadsIntervalSeconds");
       builder.setCacheConfig(
           new MetricsConfig.CacheConfig(
               threadsCachingIntervalSeconds == null

--- a/solr/core/src/java/org/apache/solr/schema/FieldTypePluginLoader.java
+++ b/solr/core/src/java/org/apache/solr/schema/FieldTypePluginLoader.java
@@ -21,6 +21,7 @@ import static org.apache.solr.common.params.CommonParams.NAME;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,7 +35,6 @@ import org.apache.solr.analysis.TokenizerChain;
 import org.apache.solr.common.ConfigNode;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.SolrClassLoader;
-import org.apache.solr.common.util.DOMUtil;
 import org.apache.solr.core.SolrConfig;
 import org.apache.solr.util.plugin.AbstractPluginLoader;
 import org.slf4j.Logger;
@@ -74,19 +74,19 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
     FieldType ft = loader.newInstance(className, FieldType.class);
     ft.setTypeName(name);
 
-    ConfigNode anode = node.child(it -> "query".equals(it.attributes().get("type")), "analyzer");
+    ConfigNode anode = node.child("analyzer", it -> "query".equals(it.attributes().get("type")));
     Analyzer queryAnalyzer = readAnalyzer(anode);
 
-    anode = node.child(it -> "multiterm".equals(it.attributes().get("type")), "analyzer");
+    anode = node.child("analyzer", it -> "multiterm".equals(it.attributes().get("type")));
     Analyzer multiAnalyzer = readAnalyzer(anode);
 
     // An analyzer without a type specified, or with type="index"
     anode =
         node.child(
+            "analyzer",
             it ->
                 (it.attributes().get("type") == null
-                    || "index".equals(it.attributes().get("type"))),
-            "analyzer");
+                    || "index".equals(it.attributes().get("type"))));
     Analyzer analyzer = readAnalyzer(anode);
 
     // a custom similarity[Factory]
@@ -144,9 +144,7 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
 
   @Override
   protected void init(FieldType plugin, ConfigNode node) throws Exception {
-
-    Map<String, String> params = DOMUtil.toMapExcept(node, NAME);
-    plugin.setArgs(schema, params);
+    plugin.setArgs(schema, node.attributesExcept(NAME));
   }
 
   @Override
@@ -185,7 +183,7 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
     // parent node used to be passed in as "fieldtype"
 
     if (node == null) return null;
-    String analyzerName = DOMUtil.getAttr(node, "class", null);
+    String analyzerName = node.attr("class");
 
     // check for all of these up front, so we can error if used in
     // conjunction with an explicit analyzer class.
@@ -213,7 +211,7 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
         final Class<? extends Analyzer> clazz = loader.findClass(analyzerName, Analyzer.class);
         Analyzer analyzer = clazz.getConstructor().newInstance();
 
-        final String matchVersionStr = DOMUtil.getAttr(node, LUCENE_MATCH_VERSION_PARAM, null);
+        final String matchVersionStr = node.attr(LUCENE_MATCH_VERSION_PARAM);
         final Version luceneMatchVersion =
             (matchVersionStr == null)
                 ? schema.getDefaultLuceneMatchVersion()
@@ -246,7 +244,7 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
           protected CharFilterFactory create(
               SolrClassLoader loader, String name, String className, ConfigNode node)
               throws Exception {
-            final Map<String, String> params = DOMUtil.toMapExcept(node);
+            final Map<String, String> params = new HashMap<>(node.attributes());
             String configuredVersion = params.remove(LUCENE_MATCH_VERSION_PARAM);
             params.put(
                 LUCENE_MATCH_VERSION_PARAM,
@@ -310,7 +308,7 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
           protected TokenizerFactory create(
               SolrClassLoader loader, String name, String className, ConfigNode node)
               throws Exception {
-            final Map<String, String> params = DOMUtil.toMap(node);
+            final Map<String, String> params = new HashMap<>(node.attributes());
             String configuredVersion = params.remove(LUCENE_MATCH_VERSION_PARAM);
             params.put(
                 LUCENE_MATCH_VERSION_PARAM,
@@ -381,7 +379,7 @@ public final class FieldTypePluginLoader extends AbstractPluginLoader<FieldType>
           protected TokenFilterFactory create(
               SolrClassLoader loader, String name, String className, ConfigNode node)
               throws Exception {
-            final Map<String, String> params = DOMUtil.toMap(node);
+            final Map<String, String> params = new HashMap<>(node.attributes());
             String configuredVersion = params.remove(LUCENE_MATCH_VERSION_PARAM);
             params.put(
                 LUCENE_MATCH_VERSION_PARAM,

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
@@ -68,7 +68,6 @@ import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.Cache;
-import org.apache.solr.common.util.DOMUtil;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.Pair;
 import org.apache.solr.common.util.SimpleOrderedMap;
@@ -532,9 +531,9 @@ public class IndexSchema {
       final FieldTypePluginLoader typeLoader =
           new FieldTypePluginLoader(this, fieldTypes, schemaAware);
 
-      List<ConfigNode> fTypes = rootNode.getAll(null, FIELDTYPE_KEYS);
+      List<ConfigNode> fTypes = rootNode.getAll(FIELDTYPE_KEYS, null);
       ConfigNode types = rootNode.child(TYPES);
-      if (types != null) fTypes.addAll(types.getAll(null, FIELDTYPE_KEYS));
+      if (types != null) fTypes.addAll(types.getAll(FIELDTYPE_KEYS, null));
       typeLoader.load(solrClassLoader, fTypes);
 
       // load the fields
@@ -574,7 +573,7 @@ public class IndexSchema {
       }
 
       node =
-          rootNode.child(it -> it.attributes().get("defaultOperator") != null, "solrQueryParser");
+          rootNode.child("solrQueryParser", it -> it.attributes().get("defaultOperator") != null);
       if (node != null) {
         throw new SolrException(
             ErrorCode.SERVER_ERROR,
@@ -697,17 +696,17 @@ public class IndexSchema {
 
     ArrayList<DynamicField> dFields = new ArrayList<>();
 
-    List<ConfigNode> nodes = n.getAll(null, FIELD_KEYS);
+    List<ConfigNode> nodes = n.getAll(FIELD_KEYS, null);
     ConfigNode child = n.child(FIELDS);
     if (child != null) {
       nodes = new ArrayList<>(nodes);
-      nodes.addAll(child.getAll(null, FIELD_KEYS));
+      nodes.addAll(child.getAll(FIELD_KEYS, null));
     }
 
     for (ConfigNode node : nodes) {
-      String name = DOMUtil.getAttr(node, NAME, "field definition");
+      String name = node.attrRequired(NAME, "field definition");
       log.trace("reading field def {}", name);
-      String type = DOMUtil.getAttr(node, TYPE, "field " + name);
+      String type = node.attrRequired(TYPE, "field " + name);
 
       FieldType ft = fieldTypes.get(type);
       if (ft == null) {
@@ -716,7 +715,7 @@ public class IndexSchema {
             "Unknown " + FIELD_TYPE + " '" + type + "' specified on field " + name);
       }
 
-      Map<String, String> args = DOMUtil.toMapExcept(node, NAME, TYPE);
+      Map<String, String> args = node.attributesExcept(NAME, TYPE);
       if (null != args.get(REQUIRED)) {
         explicitRequiredProp.put(name, Boolean.valueOf(args.get(REQUIRED)));
       }
@@ -793,9 +792,9 @@ public class IndexSchema {
     }
     for (ConfigNode node : nodes) {
 
-      String source = DOMUtil.getAttr(node, SOURCE, COPY_FIELD + " definition");
-      String dest = DOMUtil.getAttr(node, DESTINATION, COPY_FIELD + " definition");
-      String maxChars = DOMUtil.getAttr(node, MAX_CHARS, null);
+      String source = node.attrRequired(SOURCE, COPY_FIELD + " definition");
+      String dest = node.attrRequired(DESTINATION, COPY_FIELD + " definition");
+      String maxChars = node.attr(MAX_CHARS);
 
       int maxCharsInt = CopyField.UNLIMITED;
       if (maxChars != null) {
@@ -1089,7 +1088,7 @@ public class IndexSchema {
       final Object obj = loader.newInstance(classArg, Object.class, "search.similarities.");
       if (obj instanceof SimilarityFactory) {
         // configure a factory, get a similarity back
-        final NamedList<Object> namedList = DOMUtil.childNodesToNamedList(node);
+        final NamedList<Object> namedList = node.childNodesToNamedList();
         namedList.add(SimilarityFactory.CLASS_NAME, classArg);
         SolrParams params = namedList.toSolrParams();
         similarityFactory = (SimilarityFactory) obj;

--- a/solr/core/src/java/org/apache/solr/util/DOMConfigNode.java
+++ b/solr/core/src/java/org/apache/solr/util/DOMConfigNode.java
@@ -30,7 +30,11 @@ import org.w3c.dom.NodeList;
 public class DOMConfigNode implements ConfigNode {
 
   private final Node node;
-  Map<String, String> attrs;
+  private Map<String, String> attrs; // lazy populated
+
+  public DOMConfigNode(Node node) {
+    this.node = node;
+  }
 
   @Override
   public String name() {
@@ -40,10 +44,6 @@ public class DOMConfigNode implements ConfigNode {
   @Override
   public String txt() {
     return DOMUtil.getText(node);
-  }
-
-  public DOMConfigNode(Node node) {
-    this.node = node;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/util/DataConfigNode.java
+++ b/solr/core/src/java/org/apache/solr/util/DataConfigNode.java
@@ -94,9 +94,13 @@ public class DataConfigNode implements ConfigNode {
   }
 
   @Override
-  public List<ConfigNode> getAll(Predicate<ConfigNode> test, Set<String> matchNames) {
+  public List<ConfigNode> getAll(Set<String> names, Predicate<ConfigNode> test) {
+    if (names == null) {
+      return ConfigNode.super.getAll(names, test);
+    }
+    // fast implementation based on our index on named children:
     List<ConfigNode> result = new ArrayList<>();
-    for (String s : matchNames) {
+    for (String s : names) {
       List<ConfigNode> vals = kids.get(s);
       if (vals != null) {
         vals.forEach(

--- a/solr/core/src/java/org/apache/solr/util/plugin/AbstractPluginLoader.java
+++ b/solr/core/src/java/org/apache/solr/util/plugin/AbstractPluginLoader.java
@@ -26,7 +26,6 @@ import org.apache.solr.common.ConfigNode;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.cloud.SolrClassLoader;
-import org.apache.solr.common.util.DOMUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,9 +132,9 @@ public abstract class AbstractPluginLoader<T> {
       for (ConfigNode node : nodes) {
         String name = null;
         try {
-          name = DOMUtil.getAttr(node, NAME, requireName ? type : null);
-          String className = DOMUtil.getAttr(node, "class", null);
-          String defaultStr = DOMUtil.getAttr(node, "default", null);
+          name = requireName ? node.attrRequired(NAME, type) : node.attr(NAME);
+          String className = node.attr("class");
+          String defaultStr = node.attr("default");
 
           if (Objects.isNull(className) && Objects.isNull(name)) {
             throw new RuntimeException(type + ": missing mandatory attribute 'class' or 'name'");
@@ -219,8 +218,8 @@ public abstract class AbstractPluginLoader<T> {
     T plugin = null;
 
     try {
-      String name = DOMUtil.getAttr(node, NAME, requireName ? type : null);
-      String className = DOMUtil.getAttr(node, "class", type);
+      String name = requireName ? node.attrRequired(NAME, type) : node.attr(NAME);
+      String className = node.attrRequired("class", type);
       plugin = create(loader, name, className, node);
       if (log.isDebugEnabled()) {
         log.debug("created {}: {}", name, plugin.getClass().getName());

--- a/solr/core/src/java/org/apache/solr/util/plugin/MapPluginLoader.java
+++ b/solr/core/src/java/org/apache/solr/util/plugin/MapPluginLoader.java
@@ -20,7 +20,6 @@ import static org.apache.solr.common.params.CommonParams.NAME;
 
 import java.util.Map;
 import org.apache.solr.common.ConfigNode;
-import org.apache.solr.common.util.DOMUtil;
 
 /**
  * @since solr 1.3
@@ -35,7 +34,7 @@ public class MapPluginLoader<T extends MapInitializedPlugin> extends AbstractPlu
 
   @Override
   protected void init(T plugin, ConfigNode node) throws Exception {
-    Map<String, String> params = DOMUtil.toMapExcept(node, NAME, "class");
+    Map<String, String> params = node.attributesExcept(NAME, "class");
     plugin.init(params);
   }
 

--- a/solr/core/src/java/org/apache/solr/util/plugin/NamedListPluginLoader.java
+++ b/solr/core/src/java/org/apache/solr/util/plugin/NamedListPluginLoader.java
@@ -18,7 +18,6 @@ package org.apache.solr.util.plugin;
 
 import java.util.Map;
 import org.apache.solr.common.ConfigNode;
-import org.apache.solr.common.util.DOMUtil;
 
 /**
  * @since solr 1.3
@@ -34,7 +33,7 @@ public class NamedListPluginLoader<T extends NamedListInitializedPlugin>
 
   @Override
   protected void init(T plugin, ConfigNode node) throws Exception {
-    plugin.init(DOMUtil.childNodesToNamedList(node));
+    plugin.init(node.childNodesToNamedList());
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/core/TestCodecSupport.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCodecSupport.java
@@ -20,7 +20,6 @@ import static org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat.MODE_
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.lucene912.Lucene912Codec.Mode;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
@@ -239,7 +238,7 @@ public class TestCodecSupport extends SolrTestCaseJ4 {
         config.get("codecFactory").attr("class"));
     assertTrue(
         "Unexpected configuration of codec factory for this test. Expecting empty element",
-        config.get("codecFactory").getAll(null, Set.of()).isEmpty());
+        config.get("codecFactory").getAll(null, null).isEmpty());
     IndexSchema schema = IndexSchemaFactory.buildIndexSchema("schema_codec.xml", config);
 
     CoreContainer coreContainer = h.getCoreContainer();

--- a/solr/solrj/src/java/org/apache/solr/common/ConfigNode.java
+++ b/solr/solrj/src/java/org/apache/solr/common/ConfigNode.java
@@ -22,15 +22,15 @@ import static org.apache.solr.common.ConfigNode.Helpers._int;
 import static org.apache.solr.common.ConfigNode.Helpers._txt;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import org.apache.solr.common.util.CollectionUtil;
+import org.apache.solr.common.util.DOMUtil;
+import org.apache.solr.common.util.NamedList;
 
 /**
  * A generic interface that represents a config file, mostly XML Please note that this is an
@@ -39,15 +39,28 @@ import java.util.function.Supplier;
 public interface ConfigNode {
   ThreadLocal<Function<String, String>> SUBSTITUTES = new ThreadLocal<>();
 
-  /** Name of the tag */
+  /** Name of the tag/element. */
   String name();
 
-  /** Attributes */
+  /** Attributes of this node. Immutable shared instance. Not null. */
   Map<String, String> attributes();
+
+  /** Mutable copy of {@link #attributes()}, excluding {@code exclusions} keys. */
+  default Map<String, String> attributesExcept(String... exclusions) {
+    assert exclusions.length < 5 : "non-performant exclusion list";
+    final var attributes = attributes();
+    Map<String, String> args = CollectionUtil.newHashMap(attributes.size());
+    attributes.forEach(
+        (k, v) -> {
+          for (String ex : exclusions) if (ex.equals(k)) return;
+          args.put(k, v);
+        });
+    return args;
+  }
 
   /** Child by name */
   default ConfigNode child(String name) {
-    return child(null, name);
+    return child(name, null);
   }
 
   /**
@@ -55,23 +68,24 @@ public interface ConfigNode {
    * first element. This never returns a null.
    */
   default ConfigNode get(String name) {
-    ConfigNode child = child(null, name);
+    ConfigNode child = child(name, null);
     return child == null ? EMPTY : child;
   }
 
   default ConfigNode get(String name, Predicate<ConfigNode> test) {
-    List<ConfigNode> children = getAll(test, name);
+    List<ConfigNode> children = getAll(Set.of(name), test);
     if (children.isEmpty()) return EMPTY;
     return children.get(0);
   }
 
+  // @VisibleForTesting  Helps writing tests
   default ConfigNode get(String name, int idx) {
-    List<ConfigNode> children = getAll(null, name);
+    List<ConfigNode> children = getAll(name);
     if (idx < children.size()) return children.get(idx);
     return EMPTY;
   }
 
-  default ConfigNode child(String name, Supplier<RuntimeException> err) {
+  default ConfigNode childRequired(String name, Supplier<RuntimeException> err) {
     ConfigNode n = child(name);
     if (n == null) throw err.get();
     return n;
@@ -93,9 +107,16 @@ public interface ConfigNode {
     return attributes().get(name);
   }
 
-  default String requiredStrAttr(String name, Supplier<RuntimeException> err) {
+  /**
+   * Like {@link #attr(String)} but throws an error (incorporating {@code missing_err}) if not
+   * found.
+   */
+  default String attrRequired(String name, String missing_err) {
+    assert missing_err != null;
     String attr = attr(name);
-    if (attr == null && err != null) throw err.get();
+    if (attr == null) {
+      throw new RuntimeException(missing_err + ": missing mandatory attribute '" + name + "'");
+    }
     return attr;
   }
 
@@ -117,8 +138,8 @@ public interface ConfigNode {
     return _double(txt(), def);
   }
 
-  /** Iterate through child nodes with the name and return the first child that matches */
-  default ConfigNode child(Predicate<ConfigNode> test, String name) {
+  /** Iterate through child nodes with the tag/element name and return the first matching */
+  default ConfigNode child(String name, Predicate<ConfigNode> test) {
     ConfigNode[] result = new ConfigNode[1];
     forEachChild(
         it -> {
@@ -135,34 +156,24 @@ public interface ConfigNode {
   /**
    * Iterate through child nodes with the names and return all the matching children
    *
-   * @param nodeNames names of tags to be returned
-   * @param test check for the nodes to be returned
+   * @param names names of tags/elements to be returned. Null means all nodes.
+   * @param test check for the nodes to be returned. Null means all nodes.
    */
-  default List<ConfigNode> getAll(Predicate<ConfigNode> test, String... nodeNames) {
-    return getAll(
-        test, nodeNames == null ? Collections.emptySet() : new HashSet<>(Arrays.asList(nodeNames)));
-  }
-
-  /**
-   * Iterate through child nodes with the names and return all the matching children
-   *
-   * @param matchNames names of tags to be returned
-   * @param test check for the nodes to be returned
-   */
-  default List<ConfigNode> getAll(Predicate<ConfigNode> test, Set<String> matchNames) {
+  default List<ConfigNode> getAll(Set<String> names, Predicate<ConfigNode> test) {
+    assert names == null || !names.isEmpty() : "Intended to pass null?";
     List<ConfigNode> result = new ArrayList<>();
     forEachChild(
         it -> {
-          if (matchNames != null && !matchNames.isEmpty() && !matchNames.contains(it.name()))
-            return Boolean.TRUE;
-          if (test == null || test.test(it)) result.add(it);
+          if ((names == null || names.contains(it.name())) && (test == null || test.test(it)))
+            result.add(it);
           return Boolean.TRUE;
         });
     return result;
   }
 
+  /** A list of all child nodes with the tag/element name. */
   default List<ConfigNode> getAll(String name) {
-    return getAll(null, Collections.singleton(name));
+    return getAll(Set.of(name), null);
   }
 
   default boolean exists() {
@@ -179,6 +190,35 @@ public interface ConfigNode {
    * @param fun consume the node and return true to continue or false to abort
    */
   void forEachChild(Function<ConfigNode, Boolean> fun);
+
+  default NamedList<Object> childNodesToNamedList() {
+    NamedList<Object> result = new NamedList<>();
+    forEachChild(
+        it -> {
+          String tag = it.name();
+          String varName = it.attributes().get("name");
+          if (DOMUtil.NL_TAGS.contains(tag)) {
+            result.add(varName, DOMUtil.parseVal(tag, varName, it.txt()));
+          }
+          if ("lst".equals(tag)) {
+            result.add(varName, it.childNodesToNamedList());
+          } else if ("arr".equals(tag)) {
+            List<Object> l = new ArrayList<>();
+            result.add(varName, l);
+            it.forEachChild(
+                n -> {
+                  if (DOMUtil.NL_TAGS.contains(n.name())) {
+                    l.add(DOMUtil.parseVal(n.name(), null, n.txt()));
+                  } else if ("lst".equals(n.name())) {
+                    l.add(n.childNodesToNamedList());
+                  }
+                  return Boolean.TRUE;
+                });
+          }
+          return Boolean.TRUE;
+        });
+    return result;
+  }
 
   /** An empty node object. usually returned when the node is absent */
   ConfigNode EMPTY =

--- a/solr/solrj/src/java/org/apache/solr/common/ConfigNode.java
+++ b/solr/solrj/src/java/org/apache/solr/common/ConfigNode.java
@@ -108,14 +108,13 @@ public interface ConfigNode {
   }
 
   /**
-   * Like {@link #attr(String)} but throws an error (incorporating {@code missing_err}) if not
-   * found.
+   * Like {@link #attr(String)} but throws an error (incorporating {@code missingErr}) if not found.
    */
-  default String attrRequired(String name, String missing_err) {
-    assert missing_err != null;
+  default String attrRequired(String name, String missingErr) {
+    assert missingErr != null;
     String attr = attr(name);
     if (attr == null) {
-      throw new RuntimeException(missing_err + ": missing mandatory attribute '" + name + "'");
+      throw new RuntimeException(missingErr + ": missing mandatory attribute '" + name + "'");
     }
     return attr;
   }


### PR DESCRIPTION
ConfigNode.requiredStrAttr -> attrRequired
ConfigNode.child (ex) -> childRequired
ConfigNode.getAll move name to first param; don't use empty set

PluginInfo: don't need the XML Node constructor anymore

A Solr 10-only change