### PR TITLE
SOLR-6122 POC new cancel handler for Collections api

### DIFF
--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelCollectionApiCallApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelCollectionApiCallApi.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.endpoint;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+
+/** V2 API definition for canceling CollectionApi Call. */
+@Path("/cluster/cancel/{requestid}")
+public interface CancelCollectionApiCallApi {
+  @PUT
+  @Operation(
+      summary = "Cancel collections api call",
+      tags = {"cluster-cancel"})
+  SolrJerseyResponse cancelCollectionApiCall(
+      @Parameter(description = "The name of the collection api to be canceled.", required = true)
+          @PathParam("requestid")
+          String requestId,
+      @Parameter(description = "An ID to track the request asynchronously") @QueryParam("async")
+          String asyncId)
+      throws Exception;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/model/CancelCollectionApiResponse.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/CancelCollectionApiResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CancelCollectionApiResponse extends SolrJerseyResponse {
+  @JsonProperty("msg")
+  public String msg;
+
+  @JsonProperty("asyncid")
+  public String asyncid;
+
+  @JsonProperty("status")
+  public String status;
+}

--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -1076,7 +1076,7 @@ public class Overseer implements SolrCloseable {
     return new ZkDistributedQueue(zkClient, "/overseer/queue-work", zkStats);
   }
 
-  /* Internal map for failed tasks, not to be used outside of the Overseer */
+  /* Internal map for running tasks, not to be used outside of the Overseer */
   static DistributedMap getRunningMap(final SolrZkClient zkClient) {
     return new DistributedMap(zkClient, "/overseer/collection-map-running");
   }

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerAsyncIdSerializer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerAsyncIdSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.cloud;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.util.Utils;
+
+public class OverseerAsyncIdSerializer {
+
+  /**
+   * This method serializes the content of an {@code OverseerSolrResponse}. Note that:
+   *
+   * <ul>
+   *   <li>The elapsed time is not serialized
+   *   <li>"Unknown" elements for the Javabin format will be serialized as Strings. See {@link
+   *       org.apache.solr.common.util.JavaBinCodec#writeVal}
+   * </ul>
+   */
+  public static byte[] serialize(String asyncId) throws IOException {
+    Objects.requireNonNull(asyncId);
+    try {
+      return Utils.toJavabin(asyncId).readAllBytes();
+    } catch (IOException | RuntimeException e) {
+      throw new SolrException(
+          ErrorCode.SERVER_ERROR, "Exception serializing asyncId to Javabin", e);
+    }
+  }
+
+  public static String deserialize(byte[] asyncIdBytes) throws IOException {
+    Objects.requireNonNull(asyncIdBytes);
+    try {
+      @SuppressWarnings("unchecked")
+      String asyncId = (String) Utils.fromJavabin(asyncIdBytes);
+      return asyncId;
+    } catch (IOException | RuntimeException e) {
+      throw new SolrException(
+          ErrorCode.SERVER_ERROR, "Exception deserializing response from Javabin", e);
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
@@ -16,11 +16,13 @@
  */
 package org.apache.solr.cloud;
 
+import static org.apache.solr.cloud.api.collections.OverseerCollectionMessageHandler.getCollectionAction;
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonParams.ID;
 
 import com.codahale.metrics.Timer;
 import java.io.Closeable;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,11 +41,13 @@ import org.apache.solr.cloud.OverseerTaskQueue.QueueEvent;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.Utils;
+import org.apache.solr.handler.admin.CollectionsHandler;
 import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.zookeeper.KeeperException;
@@ -339,7 +343,8 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
               workQueue.remove(head);
               continue;
             }
-            OverseerMessageHandler messageHandler = selector.selectOverseerMessageHandler(message);
+            OverseerMessageHandler messageHandler =
+                selector.selectOverseerMessageHandler(message, this);
             OverseerMessageHandler.Lock lock = messageHandler.lockTask(message, batchSessionId);
             if (lock == null) {
               if (log.isDebugEnabled()) {
@@ -519,11 +524,13 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
   }
 
   private void markTaskAsRunning(QueueEvent head, String asyncId)
-      throws KeeperException, InterruptedException {
+      throws KeeperException, InterruptedException, IOException {
     runningZKTasks.add(head.getId());
     runningTasks.add(head.getId());
 
-    if (asyncId != null) runningMap.put(asyncId, null);
+    if (asyncId != null) {
+      runningMap.put(asyncId, OverseerAsyncIdSerializer.serialize(head.getId()));
+    }
   }
 
   protected class Runner implements Runnable {
@@ -693,6 +700,54 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
     return myId;
   }
 
+  public boolean isAsyncTaskInProgress(String asyncId)
+      throws KeeperException, InterruptedException {
+    // Check if the task is currently running or still in the work queue
+    return runningMap.contains(asyncId);
+  }
+
+  public boolean isAsyncTaskInSubmitted(String asyncId)
+      throws KeeperException, InterruptedException {
+    return workQueue.containsTaskWithRequestId(ASYNC, asyncId);
+  }
+
+  public boolean removeSubmittedTask(String asyncId) throws KeeperException, InterruptedException {
+    // Remove the task from the work queue if it hasn't started yet
+    if (workQueue.containsTaskWithRequestId(ASYNC, asyncId)) {
+      workQueue.removeTaskWithRequestId(ASYNC, asyncId);
+
+      // we are going to need to change it
+      blockedTasks.clear();
+
+      return true;
+    }
+    return false;
+  }
+
+  public boolean cancelInProgressAsyncTask(String asyncId)
+      throws KeeperException, InterruptedException, IOException {
+    String workQueueZkId = OverseerAsyncIdSerializer.deserialize(runningMap.get(asyncId));
+    QueueEvent taskData = workQueue.get(workQueueZkId);
+    final ZkNodeProps message = ZkNodeProps.load(taskData.getBytes());
+
+    String operation = message.getStr(Overseer.QUEUE_OPERATION);
+    CollectionParams.CollectionAction action = getCollectionAction(operation);
+    CollectionsHandler.CollectionOperation collectionOperationToCancel =
+        CollectionsHandler.CollectionOperation.get(action);
+    boolean isInProgressCancelable = collectionOperationToCancel.isInProgressCancelable();
+
+    if (isInProgressCancelable) {
+      if (runningMap.contains(asyncId)) {
+        runningMap.remove(asyncId);
+        runningTasks.remove(workQueueZkId);
+        workQueue.removeTaskWithRequestId(ASYNC, asyncId);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /**
    * An interface to determine which {@link OverseerMessageHandler} handles a given message. This
    * could be a single OverseerMessageHandler for the case where a single type of message is handled
@@ -700,6 +755,7 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
    * contents of the message.
    */
   public interface OverseerMessageHandlerSelector extends Closeable {
-    OverseerMessageHandler selectOverseerMessageHandler(ZkNodeProps message);
+    OverseerMessageHandler selectOverseerMessageHandler(
+        ZkNodeProps message, OverseerTaskProcessor overseerTaskProcessor);
   }
 }

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
@@ -716,7 +716,7 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
     if (workQueue.containsTaskWithRequestId(ASYNC, asyncId)) {
       workQueue.removeTaskWithRequestId(ASYNC, asyncId);
 
-      // we are going to need to change it
+      // clear blockedTasks in case submitted task is in blocked tasks
       blockedTasks.clear();
 
       return true;

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
@@ -160,7 +160,7 @@ public class OverseerTaskQueue extends ZkDistributedQueue {
     }
   }
 
-  /** Return event based on ZK path within queue **/
+  /** Return event based on ZK path within queue * */
   public QueueEvent get(String path) throws KeeperException, InterruptedException {
     try {
       byte[] data = zookeeper.getData(path, null, null, true);

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
@@ -160,7 +160,7 @@ public class OverseerTaskQueue extends ZkDistributedQueue {
     }
   }
 
-  // TODO double check
+  /** Return event based on ZK path within queue **/
   public QueueEvent get(String path) throws KeeperException, InterruptedException {
     try {
       byte[] data = zookeeper.getData(path, null, null, true);

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
@@ -73,23 +73,33 @@ public class OverseerTaskQueue extends ZkDistributedQueue {
     }
   }
 
-  /** Returns true if the queue contains a task with the specified async id. */
-  public boolean containsTaskWithRequestId(String requestIdKey, String requestId)
+  /**
+   * Helper method to find the path of a first task with a specific request ID.
+   *
+   * @param requestIdKey The key of the request ID in the task message.
+   * @param requestId The request ID to look for.
+   * @return The path of the task if found, or null if not found.
+   */
+  private String findTaskWithRequestId(String requestIdKey, String requestId)
       throws KeeperException, InterruptedException {
 
     List<String> childNames = zookeeper.getChildren(dir, null, true);
     stats.setQueueLength(childNames.size());
     for (String childName : childNames) {
       if (childName != null && childName.startsWith(PREFIX)) {
+        String path = dir + "/" + childName;
         try {
-          byte[] data = zookeeper.getData(dir + "/" + childName, null, null, true);
+          byte[] data = zookeeper.getData(path, null, null, true);
           if (data != null) {
             ZkNodeProps message = ZkNodeProps.load(data);
             if (message.containsKey(requestIdKey)) {
               if (log.isDebugEnabled()) {
-                log.debug("Looking for {}, found {}", message.get(requestIdKey), requestId);
+                log.debug(
+                    "Looking for requestId '{}', found '{}'", requestId, message.get(requestIdKey));
               }
-              if (message.get(requestIdKey).equals(requestId)) return true;
+              if (message.get(requestIdKey).equals(requestId)) {
+                return path;
+              }
             }
           }
         } catch (KeeperException.NoNodeException e) {
@@ -97,8 +107,33 @@ public class OverseerTaskQueue extends ZkDistributedQueue {
         }
       }
     }
+    return null;
+  }
 
-    return false;
+  /** Returns true if the queue contains a task with the specified request ID. */
+  public boolean containsTaskWithRequestId(String requestIdKey, String requestId)
+      throws KeeperException, InterruptedException {
+
+    String path = findTaskWithRequestId(requestIdKey, requestId);
+    return path != null;
+  }
+
+  /** Removes the first task with the specified request ID from the queue. */
+  public void removeTaskWithRequestId(String requestIdKey, String requestId)
+      throws KeeperException, InterruptedException {
+
+    String path = findTaskWithRequestId(requestIdKey, requestId);
+    if (path != null) {
+      try {
+        zookeeper.delete(path, -1, true);
+        log.info("Removed task with requestId '{}' at path {}", requestId, path);
+      } catch (KeeperException.NoNodeException e) {
+        // Node might have been removed already
+        log.warn("Node at path {} does not exist. It might have been removed already.", path);
+      }
+    } else {
+      log.info("No task with requestId '{}' was found in the queue.", requestId);
+    }
   }
 
   /** Remove the event and save the response into the other path. */
@@ -123,6 +158,18 @@ public class OverseerTaskQueue extends ZkDistributedQueue {
     } finally {
       time.stop();
     }
+  }
+
+  // TODO double check
+  public QueueEvent get(String path) throws KeeperException, InterruptedException {
+    try {
+      byte[] data = zookeeper.getData(path, null, null, true);
+      return new QueueEvent(path, data, null);
+    } catch (KeeperException.NoNodeException ignored) {
+      // we must handle the race case where the node no longer exists
+      log.info("ZK path: {} doesn't exist. Requestor may have disconnected from ZooKeeper", path);
+    }
+    return null;
   }
 
   /** Watcher that blocks until a WatchedEvent occurs for a znode. */

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CollApiCmds.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CollApiCmds.java
@@ -113,7 +113,7 @@ public class CollApiCmds {
    * Interface implemented by all Collection API commands. Collection API commands are defined in
    * classes whose names ends in {@code Cmd}.
    */
-  protected interface CollectionApiCommand {
+  public interface CollectionApiCommand {
     void call(ClusterState state, ZkNodeProps message, NamedList<Object> results) throws Exception;
   }
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.cloud.api.collections;
+
+import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.REQUESTID;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import org.apache.solr.client.solrj.cloud.SolrCloudManager;
+import org.apache.solr.cloud.Overseer;
+import org.apache.solr.cloud.OverseerMessageHandler;
+import org.apache.solr.cloud.OverseerSolrResponse;
+import org.apache.solr.cloud.OverseerTaskProcessor;
+import org.apache.solr.cloud.Stats;
+import org.apache.solr.common.SolrCloseable;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.ZkNodeProps;
+import org.apache.solr.common.util.ExecutorUtil;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.SolrNamedThreadFactory;
+import org.apache.solr.handler.component.HttpShardHandlerFactory;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link OverseerMessageHandler} that handles cancelling API-related overseer messages. Works
+ * closely with {@link OverseerTaskProcessor}.
+ */
+public class OverseerCancelMessageHandler implements OverseerMessageHandler, SolrCloseable {
+
+  public static final String CANCEL_PREFIX = "cancel";
+
+  private final Set<String> onGoingCancelAsyncIds;
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final Overseer overseer;
+  private final HttpShardHandlerFactory shardHandlerFactory;
+  private final SolrCloudManager cloudManager;
+  private final Stats stats;
+  private OverseerTaskProcessor overseerTaskProcessor;
+  private final Set<String> cancelInProgressSet;
+
+  private final ExecutorService tpe =
+      new ExecutorUtil.MDCAwareThreadPoolExecutor(
+          5,
+          10,
+          0L,
+          TimeUnit.MILLISECONDS,
+          new SynchronousQueue<>(),
+          new SolrNamedThreadFactory("OverseerCancelMessageHandlerThreadFactory"));
+
+  private volatile boolean isClosed;
+
+  public OverseerCancelMessageHandler(
+      final HttpShardHandlerFactory shardHandlerFactory, Stats stats, Overseer overseer) {
+    this.shardHandlerFactory = shardHandlerFactory;
+    this.stats = stats;
+    this.overseer = overseer;
+    this.cloudManager = overseer.getSolrCloudManager();
+    this.isClosed = false;
+    this.onGoingCancelAsyncIds = new HashSet<>();
+    this.cancelInProgressSet = new HashSet<>();
+  }
+
+  @Override
+  public void close() throws IOException {
+    isClosed = true;
+    ExecutorUtil.shutdownAndAwaitTermination(tpe);
+  }
+
+  @Override
+  public OverseerSolrResponse processMessage(ZkNodeProps message, String operation) {
+
+    if (!operation.startsWith(CANCEL_PREFIX)) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST,
+          "Operation does not contain proper prefix: " + operation + " expected: " + CANCEL_PREFIX);
+    }
+
+    String targetAsyncId = message.getStr(REQUESTID);
+    if (targetAsyncId == null) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST,
+          "Cancel message must include 'REQUESTID' parameter.");
+    }
+
+    log.debug("OverseerCancelMessageHandler.processMessage : {} , {}", operation, targetAsyncId);
+
+    NamedList<Object> results = new SimpleOrderedMap<>();
+
+    try {
+      boolean isInProgress = overseerTaskProcessor.isAsyncTaskInProgress(targetAsyncId);
+      boolean isSubmitted = overseerTaskProcessor.isAsyncTaskInSubmitted(targetAsyncId);
+
+      if (!isSubmitted && !isInProgress) {
+        results =
+            buildResponse(
+                targetAsyncId, "not_found", "Task was not found or has already completed.");
+        return new OverseerSolrResponse(results);
+      }
+
+      if (!isInProgress) {
+        // Task is not in progress; attempt to remove from the queue
+        boolean removed = overseerTaskProcessor.removeSubmittedTask(targetAsyncId);
+        if (removed) {
+          results =
+              buildResponse(
+                  targetAsyncId,
+                  "removed",
+                  "Submitted Task was successfully removed from the queue.");
+        } else {
+          results =
+              buildResponse(
+                  targetAsyncId, "not_found", "Task was not found or has already completed.");
+        }
+        return new OverseerSolrResponse(results);
+      }
+
+      // Task is in progress
+      return handleTaskCancellation(targetAsyncId, results);
+
+    } catch (Exception e) {
+      log.error("Error cancelling task {}", targetAsyncId, e);
+      results.add(
+          "response",
+          buildResponse(
+              targetAsyncId,
+              "error",
+              "Exception occurred while cancelling task: " + e.getMessage()));
+      return new OverseerSolrResponse(results);
+    }
+  }
+
+  private OverseerSolrResponse handleTaskCancellation(
+      String targetAsyncId, NamedList<Object> results)
+      throws InterruptedException, KeeperException, IOException {
+    if (!true) {
+      results =
+          buildResponse(
+              targetAsyncId,
+              "not_cancelable",
+              "Operation does not support cancellation while in progress.");
+      return new OverseerSolrResponse(results);
+    }
+
+    // Attempt to cancel the in-progress task
+    boolean cancelled = overseerTaskProcessor.cancelInProgressAsyncTask(targetAsyncId);
+
+    if (cancelled) {
+      results = buildResponse(targetAsyncId, "cancelled", "Task was successfully cancelled.");
+    } else {
+      results =
+          buildResponse(
+              targetAsyncId, "failed", "Task could not be cancelled or has already completed.");
+    }
+
+    return new OverseerSolrResponse(results);
+  }
+
+  private NamedList<Object> buildResponse(String asyncId, String status, String message) {
+    NamedList<Object> response = new SimpleOrderedMap<>();
+    response.add("asyncId", asyncId);
+    response.add("status", status);
+    response.add("message", message);
+    return response;
+  }
+
+  @Override
+  public String getName() {
+    return "Overseer Cancel Message Handler";
+  }
+
+  @Override
+  public String getTimerName(String operation) {
+    return "OverseerCancelMessageHandlerTimer" + operation;
+  }
+
+  // TODO: find a better way to lock, currently lock based on asyncId being unique
+  public Lock lockTask(ZkNodeProps message, long ignored) {
+    String cancelTaskMsg = getTaskKey(message);
+    if (canExecute(cancelTaskMsg)) {
+      markExclusive(cancelTaskMsg);
+      return () -> unmarkExclusive(cancelTaskMsg);
+    }
+    return null;
+  }
+
+  private boolean canExecute(String cancelTaskMsg) {
+
+    synchronized (cancelInProgressSet) {
+      if (cancelInProgressSet.contains(cancelTaskMsg)) {
+        return false;
+      }
+      if (cancelTaskMsg != null && cancelInProgressSet.contains(cancelTaskMsg)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private void markExclusive(String cancelTaskMsg) {
+    synchronized (cancelInProgressSet) {
+      cancelInProgressSet.add(cancelTaskMsg);
+    }
+  }
+
+  private void unmarkExclusive(String cancelTaskMsg) {
+    synchronized (cancelInProgressSet) {
+      cancelInProgressSet.remove(cancelTaskMsg);
+    }
+  }
+
+  @Override
+  public String getTaskKey(ZkNodeProps message) {
+    // Return a constant key for all cancel operations
+    return message.getStr("operation") + ":" + message.getStr(REQUESTID);
+  }
+
+  public OverseerCancelMessageHandler withOverseerTaskProcessor(
+      OverseerTaskProcessor overseerTaskProcessor) {
+    this.overseerTaskProcessor = overseerTaskProcessor;
+    return this;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
@@ -51,7 +51,6 @@ public class OverseerCancelMessageHandler implements OverseerMessageHandler, Sol
 
   public static final String CANCEL_PREFIX = "cancel";
 
-
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final Overseer overseer;

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
@@ -51,7 +51,6 @@ public class OverseerCancelMessageHandler implements OverseerMessageHandler, Sol
 
   public static final String CANCEL_PREFIX = "cancel";
 
-  private final Set<String> onGoingCancelAsyncIds;
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -80,7 +79,6 @@ public class OverseerCancelMessageHandler implements OverseerMessageHandler, Sol
     this.overseer = overseer;
     this.cloudManager = overseer.getSolrCloudManager();
     this.isClosed = false;
-    this.onGoingCancelAsyncIds = new HashSet<>();
     this.cancelInProgressSet = new HashSet<>();
   }
 
@@ -156,14 +154,6 @@ public class OverseerCancelMessageHandler implements OverseerMessageHandler, Sol
   private OverseerSolrResponse handleTaskCancellation(
       String targetAsyncId, NamedList<Object> results)
       throws InterruptedException, KeeperException, IOException {
-    if (!true) {
-      results =
-          buildResponse(
-              targetAsyncId,
-              "not_cancelable",
-              "Operation does not support cancellation while in progress.");
-      return new OverseerSolrResponse(results);
-    }
 
     // Attempt to cancel the in-progress task
     boolean cancelled = overseerTaskProcessor.cancelInProgressAsyncTask(targetAsyncId);

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCancelMessageHandler.java
@@ -188,6 +188,7 @@ public class OverseerCancelMessageHandler implements OverseerMessageHandler, Sol
   }
 
   // TODO: find a better way to lock, currently lock based on asyncId being unique
+  @Override
   public Lock lockTask(ZkNodeProps message, long ignored) {
     String cancelTaskMsg = getTaskKey(message);
     if (canExecute(cancelTaskMsg)) {

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
@@ -141,7 +141,7 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
     return new OverseerSolrResponse(results);
   }
 
-  private CollectionAction getCollectionAction(String operation) {
+  public static CollectionAction getCollectionAction(String operation) {
     CollectionAction action = CollectionAction.get(operation);
     if (action == null) {
       throw new SolrException(ErrorCode.BAD_REQUEST, "Unknown operation:" + operation);
@@ -204,10 +204,5 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
         ExecutorUtil.shutdownAndAwaitTermination(tpe);
       }
     }
-  }
-
-  @Override
-  public boolean isClosed() {
-    return isClosed;
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -1075,8 +1075,6 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     CANCEL_OP(
         CANCEL,
         (req, rsp, h) -> {
-          log.info("WTF");
-
           final CancelCollectionsApiCall cancelCollectionsApiCall =
               new CancelCollectionsApiCall(h.coreContainer, req, rsp);
           req.getParams().required().check(REQUESTID);

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -47,6 +47,7 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.AD
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.ALIASPROP;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.BACKUP;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.BALANCESHARDUNIQUE;
+import static org.apache.solr.common.params.CollectionParams.CollectionAction.CANCEL;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.CLUSTERPROP;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.CLUSTERSTATUS;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.COLLECTIONPROP;
@@ -172,6 +173,7 @@ import org.apache.solr.handler.admin.api.AdminAPIBase;
 import org.apache.solr.handler.admin.api.AliasProperty;
 import org.apache.solr.handler.admin.api.BalanceReplicas;
 import org.apache.solr.handler.admin.api.BalanceShardUnique;
+import org.apache.solr.handler.admin.api.CancelCollectionsApiCall;
 import org.apache.solr.handler.admin.api.ClusterProperty;
 import org.apache.solr.handler.admin.api.CollectionProperty;
 import org.apache.solr.handler.admin.api.CollectionStatus;
@@ -1055,8 +1057,33 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         }),
     BACKUP_OP(
         BACKUP,
+        new CollectionOp() {
+          @Override
+          public Map<String, Object> execute(
+              SolrQueryRequest req, SolrQueryResponse rsp, CollectionsHandler h) throws Exception {
+            final var response =
+                CreateCollectionBackup.invokeFromV1Params(req, rsp, h.coreContainer);
+            V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
+            return null;
+          }
+
+          @Override
+          public boolean isInProgressCancelable() {
+            return true;
+          }
+        }),
+    CANCEL_OP(
+        CANCEL,
         (req, rsp, h) -> {
-          final var response = CreateCollectionBackup.invokeFromV1Params(req, rsp, h.coreContainer);
+          log.info("WTF");
+
+          final CancelCollectionsApiCall cancelCollectionsApiCall =
+              new CancelCollectionsApiCall(h.coreContainer, req, rsp);
+          req.getParams().required().check(REQUESTID);
+
+          final var response =
+              cancelCollectionsApiCall.cancelCollectionApiCall(
+                  req.getParams().get(REQUESTID), req.getParams().get(ASYNC));
           V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, response);
           return null;
         }),
@@ -1245,6 +1272,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     }
 
     public static CollectionOperation get(CollectionAction action) {
+      log.info("action:{}", action);
       for (CollectionOperation op : values()) {
         if (op.action == action) return op;
       }
@@ -1255,6 +1283,11 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
     public Map<String, Object> execute(
         SolrQueryRequest req, SolrQueryResponse rsp, CollectionsHandler h) throws Exception {
       return fun.execute(req, rsp, h);
+    }
+
+    @Override
+    public boolean isInProgressCancelable() {
+      return fun.isInProgressCancelable();
     }
   }
 
@@ -1344,6 +1377,11 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
   interface CollectionOp {
     Map<String, Object> execute(SolrQueryRequest req, SolrQueryResponse rsp, CollectionsHandler h)
         throws Exception;
+
+    // allowed to be in-progress canceled
+    default boolean isInProgressCancelable() {
+      return false;
+    }
   }
 
   @Override
@@ -1378,6 +1416,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         MigrateReplicas.class,
         BalanceReplicas.class,
         RestoreCollection.class,
+        CancelCollectionsApiCall.class,
         SyncShard.class,
         CollectionProperty.class,
         DeleteNode.class,

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CancelCollectionsApiCall.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CancelCollectionsApiCall.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.admin.api;
+
+import static org.apache.solr.cloud.Overseer.QUEUE_OPERATION;
+import static org.apache.solr.cloud.api.collections.CollectionHandlingUtils.REQUESTID;
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+import static org.apache.solr.handler.admin.CollectionsHandler.DEFAULT_COLLECTION_OP_TIMEOUT;
+import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
+
+import jakarta.inject.Inject;
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.solr.client.api.endpoint.CancelCollectionApiCallApi;
+import org.apache.solr.client.api.model.CancelCollectionApiResponse;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.solrj.SolrResponse;
+import org.apache.solr.common.cloud.ZkNodeProps;
+import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.handler.admin.CollectionsHandler;
+import org.apache.solr.jersey.PermissionName;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CancelCollectionsApiCall extends AdminAPIBase implements CancelCollectionApiCallApi {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Inject
+  public CancelCollectionsApiCall(
+      CoreContainer coreContainer,
+      SolrQueryRequest solrQueryRequest,
+      SolrQueryResponse solrQueryResponse) {
+    super(coreContainer, solrQueryRequest, solrQueryResponse);
+  }
+
+  @Override
+  @PermissionName(COLL_EDIT_PERM)
+  public SolrJerseyResponse cancelCollectionApiCall(String requestid, String asyncId)
+      throws Exception {
+
+    final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    final CoreContainer coreContainer = fetchAndValidateZooKeeperAwareCoreContainer();
+
+    final ZkNodeProps remoteMessage = createRemoteMessage(requestid, asyncId);
+    log.info("cancel: {}", remoteMessage);
+    final SolrResponse remoteResponse =
+        CollectionsHandler.submitCollectionApiCommand(
+            coreContainer,
+            coreContainer.getDistributedCollectionCommandRunner(),
+            remoteMessage,
+            CollectionParams.CollectionAction.CANCEL,
+            DEFAULT_COLLECTION_OP_TIMEOUT);
+
+    if (remoteResponse.getException() != null) {
+      throw remoteResponse.getException();
+    }
+    return populateResponse(remoteResponse);
+  }
+
+  public static ZkNodeProps createRemoteMessage(String requestid, String asyncId) {
+    final Map<String, Object> remoteMessage = new HashMap<>();
+    remoteMessage.put(QUEUE_OPERATION, CollectionParams.CollectionAction.CANCEL.toLower());
+    remoteMessage.put(REQUESTID, requestid);
+    insertIfNotNull(remoteMessage, ASYNC, asyncId);
+
+    return new ZkNodeProps(remoteMessage);
+  }
+
+  private CancelCollectionApiResponse populateResponse(SolrResponse remoteResponse) {
+    final CancelCollectionApiResponse response =
+        instantiateJerseyResponse(CancelCollectionApiResponse.class);
+
+    response.asyncid = (String) remoteResponse.getResponse().get("asyncId");
+    response.status = (String) remoteResponse.getResponse().get("status");
+    response.msg = (String) remoteResponse.getResponse().get("message");
+
+    return response;
+  }
+}

--- a/solr/solrj/src/java/org/apache/solr/common/params/CollectionParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CollectionParams.java
@@ -107,6 +107,7 @@ public interface CollectionParams {
     ADDREPLICA(true, LockLevel.SHARD),
     MOVEREPLICA(true, LockLevel.SHARD),
     OVERSEERSTATUS(false, LockLevel.NONE),
+    CANCEL(true, LockLevel.NONE),
     // For testing. Could eventually be exposed publicly if needed
     DISTRIBUTEDAPIPROCESSING(false, LockLevel.NONE),
     LIST(false, LockLevel.NONE),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-6122

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

This PR implemented a new overseer level message handler to cancel submitted & in-progress collections api calls.  As an example, this PR only opt-in backup collection api for in-progress cancel. 

in-progress collections api calls are not complete, as core level cancel is not implemented. Current implemention removes tracking of in-progress collections api from overseers, which can be useful in some situation like backup. 

# Solution
General flow: 
-> Client request cancle with async ID through 
```http://localhost:8983/solr/admin/collections?action=CANCEL&requestid=1```

-> Cancel message handled by `OverseerCancelMessageHandler` to determine if this asyncId exist and if it's currently in submitted or in-progress state :
  - if submitted: remove from `workQueue` and clear `blockedTasks` in case submitted task is in blocked tasks 
  - if in-progress: check if is `isInProgressCancelable` -> remove in-progress tasks from tracking queues in overseer `workQueue` & `runningMap` & `runningTasks` 
  

Api:
New V2 api interface for cancel handler 

Overseer: 
- stored asyncId on to ZK's running map to keep track of in-process async task easier 
- Adjust `OverseerTaskQueue` to handle remove / get item from queue given zk path

OverseerCancelMessageHandler:
- a new message handler specifically to handle cancel. Since cancel collections api involovs removing queue event from overseer's queue, added this part of logic as message handler instead of a new collection api


# Tests

Test locally through CURL, working on testing
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
