### PR TITLE
build: Fix Out of space in CodeCache error

### DIFF
--- a/gradle/template.gradle.properties
+++ b/gradle/template.gradle.properties
@@ -73,7 +73,7 @@ systemProp.file.encoding=UTF-8
 # Set up gradle JVM defaults.
 #
 # We also open up internal compiler modules for spotless/ google java format.
-org.gradle.jvmargs=-Xmx1g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \
+org.gradle.jvmargs=-Xmx1g -XX:ReservedCodeCacheSize=256m -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \
  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \


### PR DESCRIPTION
Fixing the same problem as https://github.com/apache/lucene/issues/14090

The full error is "VirtualMachineError: Out of space in CodeCache for adapters in gradle"

The fix is to increase the reservedCodeCacheSize from the default to 256m, which is what Lucene uses now.