### PR TITLE
SolrTestCaseJ4: don't reset HttpClient SSL stuff

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/SSLMigrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SSLMigrationTest.java
@@ -37,6 +37,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.embedded.JettyConfig;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.util.SSLTestConfig;
+import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -46,6 +47,11 @@ import org.junit.Test;
 @SuppressSSL
 @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-12028") // 17-Mar-2018
 public class SSLMigrationTest extends AbstractFullDistribZkTestBase {
+
+  @After
+  public void afterTest() {
+    HttpClientUtil.resetHttpClientBuilder(); // also resets SocketFactoryRegistryProvider
+  }
 
   @Test
   public void test() throws Exception {
@@ -64,7 +70,7 @@ public class SSLMigrationTest extends AbstractFullDistribZkTestBase {
     }
 
     HttpClientUtil.setSocketFactoryRegistryProvider(
-        sslConfig.buildClientSocketFactoryRegistryProvider());
+        sslConfig.buildClientSocketFactoryRegistryProvider()); // we reset in After
     for (int i = 0; i < this.jettys.size(); i++) {
       JettySolrRunner runner = jettys.get(i);
       JettyConfig config =

--- a/solr/core/src/test/org/apache/solr/cloud/TestMiniSolrCloudClusterSSL.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestMiniSolrCloudClusterSSL.java
@@ -104,8 +104,8 @@ public class TestMiniSolrCloudClusterSSL extends SolrTestCaseJ4 {
   public void testNoSsl() throws Exception {
     final SSLTestConfig sslConfig = new SSLTestConfig(false, false);
     HttpClientUtil.setSocketFactoryRegistryProvider(
-        sslConfig.buildClientSocketFactoryRegistryProvider());
-    Http2SolrClient.setDefaultSSLConfig(sslConfig.buildClientSSLConfig());
+        sslConfig.buildClientSocketFactoryRegistryProvider()); // must be reset
+    Http2SolrClient.setDefaultSSLConfig(sslConfig.buildClientSSLConfig()); // must be reset
     System.setProperty(ZkStateReader.URL_SCHEME, "http");
     checkClusterWithNodeReplacement(sslConfig);
   }

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -327,8 +327,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       System.clearProperty(URL_SCHEME);
       System.clearProperty("solr.cloud.wait-for-updates-with-stale-state-pause");
       System.clearProperty("solr.zkclienttmeout");
-      HttpClientUtil.resetHttpClientBuilder();
-      Http2SolrClient.resetSslContextFactory();
 
       clearNumericTypesProperties();
 


### PR DESCRIPTION
Only a test or two need to actually reset this.

AfterClass no longer calls:
* HttpClientUtil.resetHttpClientBuilder();
* Http2SolrClient.resetSslContextFactory();

----
The theme here is trimming away quirky one-off activities in STCJ4 AfterClass & BeforeClass

Planning to do main only.