### PR TITLE
SOLR-17609:  mark deprecation of HDFS module in 9x and removal in 10

### DIFF
--- a/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
+++ b/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
@@ -79,6 +79,11 @@ import org.apache.solr.util.plugin.SolrCoreAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ *
+ * @deprecated The Solr HDFS Module will be removed in Solr 10 with no replacement.
+ */
+@Deprecated(forRemoval = true,since = "9.9")
 public class HdfsDirectoryFactory extends CachingDirectoryFactory
     implements SolrCoreAware, SolrMetricProducer {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
+++ b/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
@@ -80,7 +80,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
  * @deprecated The Solr HDFS Module will be removed in Solr 10 with no replacement.
  */
 @Deprecated(since = "9.9")

--- a/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
+++ b/solr/modules/hdfs/src/java/org/apache/solr/hdfs/HdfsDirectoryFactory.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
  *
  * @deprecated The Solr HDFS Module will be removed in Solr 10 with no replacement.
  */
-@Deprecated(forRemoval = true,since = "9.9")
+@Deprecated(since = "9.9")
 public class HdfsDirectoryFactory extends CachingDirectoryFactory
     implements SolrCoreAware, SolrMetricProducer {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
@@ -20,6 +20,8 @@
 The Solr HDFS Module has support for writing and reading Solr's index and transaction log files to the HDFS distributed filesystem.
 It does not use Hadoop MapReduce to process Solr data.
 
+IMPORTANT: The HDFS Module has been deprecated and will be retired in Solr 10.
+
 To use HDFS rather than a local filesystem, you must be using Hadoop 2.x and you will need to instruct Solr to use the `HdfsDirectoryFactory`.
 There are also several additional parameters to define.
 These can be set in one of three ways:

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-on-hdfs.adoc
@@ -20,7 +20,7 @@
 The Solr HDFS Module has support for writing and reading Solr's index and transaction log files to the HDFS distributed filesystem.
 It does not use Hadoop MapReduce to process Solr data.
 
-IMPORTANT: The HDFS Module has been deprecated and will be retired in Solr 10.
+IMPORTANT: The HDFS Module has been deprecated and will be removed in Solr 10.
 
 To use HDFS rather than a local filesystem, you must be using Hadoop 2.x and you will need to instruct Solr to use the `HdfsDirectoryFactory`.
 There are also several additional parameters to define.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17609



# Description

This PR updates `branch_9x` to flag that we are deprecating HDFS and removing it in Solr 10.

Pairs with https://github.com/apache/solr/pull/2923 that goes on `main`.

# Solution

Only apply to branch_9x.  We should try and get the current "latest" ref guide updated with this PR to give folks a chance to know in case 9.9 never happens.


# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.
