### PR TITLE
SOLR-17540: mark deprecation and removal of Hadoop Auth

### DIFF
--- a/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/HadoopAuthPlugin.java
+++ b/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/HadoopAuthPlugin.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  *
  * @deprecated The Hadoop Auth Plugin will be removed in Solr 10 with no replacement.
  */
-@Deprecated(forRemoval = true, since = "9.8")
+@Deprecated(since = "9.8")
 public class HadoopAuthPlugin extends AuthenticationPlugin {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/HadoopAuthPlugin.java
+++ b/solr/modules/hadoop-auth/src/java/org/apache/solr/security/hadoop/HadoopAuthPlugin.java
@@ -62,7 +62,10 @@ import org.slf4j.LoggerFactory;
  * communication. For this purpose {@linkplain ConfigurableInternodeAuthHadoopPlugin} should be
  * used. If this plugin is used in the SolrCloud mode, it will use PKI based authentication
  * mechanism for Solr internal communication.
+ *
+ * @deprecated The Hadoop Auth Plugin will be removed in Solr 10 with no replacement.
  */
+@Deprecated(forRemoval = true, since = "9.8")
 public class HadoopAuthPlugin extends AuthenticationPlugin {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/hadoop-authentication-plugin.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/hadoop-authentication-plugin.adoc
@@ -18,6 +18,8 @@
 
 The Hadoop authentication plugin enables Solr to use the https://hadoop.apache.org/docs/stable/hadoop-auth/index.html[Hadoop authentication library] for securing Solr nodes.
 
+IMPORTANT: The Hadoop authentication plugin has been deprecated and will be removed in Solr 10.
+
 This authentication plugin is a thin wrapper that delegates all functionality to the Hadoop authentication library.
 All configuration parameters for the library are passed through the plugin.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17540


# Description

Communicate to 9x users that Hadoop Auth is removed in 10 when it comes out.

# Solution

This goes with the already committed code in https://github.com/apache/solr/pull/2835 to `main` that removed Hadoop Auth.
