### PR TITLE
SOLR-17629: SQLHandler: remember to close if open fails

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -173,6 +173,9 @@ Bug Fixes
   doing distributed search (sharded collections). This could likely occur for fielded parameters such as
   f.CASE_SENSITIVE_FIELD.facet.limit=50. (Yue Yu, David Smiley)
 
+* SOLR-17629: If SQLHandler failed to open the underlying stream (e.g. Solr returns an error; could be user/syntax problem),
+  it needs to close the stream to cleanup resources but wasn't. (David Smiley)
+
 Dependency Upgrades
 ---------------------
 * SOLR-17471: Upgrade Lucene to 9.12.1. (Pierre Salagnac, Christine Poerschke)

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrEnumerator.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrEnumerator.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.stream.TupleStream;
+import org.apache.solr.common.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +43,11 @@ class SolrEnumerator implements Enumerator<Object> {
    * @param fields Fields to get from each Tuple
    */
   SolrEnumerator(TupleStream tupleStream, List<Map.Entry<String, Class<?>>> fields) {
-
     this.tupleStream = tupleStream;
     try {
       this.tupleStream.open();
     } catch (IOException e) {
+      IOUtils.closeQuietly(tupleStream);
       throw new RuntimeException(e);
     }
     this.fields = fields;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17629

This unblocks #2764 (more use of Http2SolrClient / Jetty HttpClient) which has greater use of ObjectReleaseTracker than Apache HttpClient, thus detecting problems formerly unseen.  