### PR TITLE
Prepare for having Renovate add separate PRs for branch_9x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Runs Renovate with solrbot for branch_9x, see dev-docs/dependency-upgrades.adoc for more",
+  "enabled": true,
+  "dependencyDashboard": false,
+  "enabledManagers": ["gradle", "github-actions"],
+  "includePaths": ["versions.*", "build.gradle", ".github/workflows/*"],
+  "postUpgradeTasks": {
+    "commands": ["./gradlew updateLicenses"],
+    "fileFilters": ["solr/licenses/*.sha1"],
+    "executionMode": "branch"
+  },
+  "packageRules": [
+    {
+      "description": "Fix for non-semantic versions for older artifacts",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "commons-collections:commons-collections",
+        "commons-io:commons-io",
+        "commons-lang:commons-lang"
+      ],
+      "versioning": "regex:^(?<major>\\d{1,4})\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "Group these calcite dependency upgrades together in same PR",
+      "matchPackagePrefixes": ["org.apache.calcite"],
+      "groupName": "org.apache.calcite"
+    },
+    {
+      "description": "Group these httpcomponents dependency upgrades together in same PR",
+      "matchPackagePrefixes": ["org.apache.httpcomponents"],
+      "groupName": "org.apache.httpcomponents"
+    },
+    {
+      "description": "Test-dependencies are checked less often than the shipped deps",
+      "matchDepTypes": ["test"],
+      "schedule": ["before 9am on the first day of the month"]
+    },
+    {
+      "description": "Noisy, frequently updated dependencies checked less often",
+      "matchPackagePrefixes": ["software.amazon.awssdk", "com.google.cloud"],
+      "schedule": ["before 9am on the first day of the month"]
+    },
+    {
+      "description": "Workaround for https://github.com/renovatebot/renovate/issues/19226",
+      "matchPackageNames": ["solr:modules", "HH:mm"],
+      "enabled": false
+    },
+    {
+      "description": "Lucene dependencies should be skipped",
+      "matchPackagePrefixes": ["org.apache.lucene"],
+      "enabled": false
+    },
+    {
+      "description": "Skip major jetty upgrades - must be done manually",
+      "matchPackagePrefixes": ["org.eclipse.jetty"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Changelog for commons-io",
+      "matchSourceUrls": [
+        "https://gitbox.apache.org/repos/asf?p=commons-io.git"
+      ],
+      "changelogUrl": "https://commons.apache.org/proper/commons-io/changes-report.html"
+    },
+    {
+      "description": "Changelog for zookeeper",
+      "matchSourceUrls": ["https://gitbox.apache.org/repos/asf/zookeeper.git"],
+      "changelogUrl": "https://zookeeper.apache.org/releases.html"
+    },
+    {
+      "description": "Changelog for commons-compress",
+      "matchSourceUrls": [
+        "https://gitbox.apache.org/repos/asf?p=commons-compress.git"
+      ],
+      "changelogUrl": "https://commons.apache.org/proper/commons-compress/changes-report.html"
+    },
+    {
+      "description": "Changelog for commons-configuration",
+      "matchSourceUrls": [
+        "https://gitbox.apache.org/repos/asf?p=commons-configuration.git"
+      ],
+      "changelogUrl": "https://commons.apache.org/proper/commons-configuration/changes-report.html"
+    }
+  ],
+  "schedule": ["* * * * *"],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 3,
+  "minimumReleaseAge": "5 days"
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,91 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Runs Renovate with solrbot for branch_9x, see dev-docs/dependency-upgrades.adoc for more",
-  "enabled": true,
-  "dependencyDashboard": false,
-  "enabledManagers": ["gradle", "github-actions"],
   "includePaths": ["versions.*", "build.gradle", ".github/workflows/*"],
   "postUpgradeTasks": {
     "commands": ["./gradlew updateLicenses"],
     "fileFilters": ["solr/licenses/*.sha1"],
     "executionMode": "branch"
   },
-  "packageRules": [
-    {
-      "description": "Fix for non-semantic versions for older artifacts",
-      "matchDatasources": ["maven"],
-      "matchPackageNames": [
-        "commons-collections:commons-collections",
-        "commons-io:commons-io",
-        "commons-lang:commons-lang"
-      ],
-      "versioning": "regex:^(?<major>\\d{1,4})\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
-    },
-    {
-      "description": "Group these calcite dependency upgrades together in same PR",
-      "matchPackagePrefixes": ["org.apache.calcite"],
-      "groupName": "org.apache.calcite"
-    },
-    {
-      "description": "Group these httpcomponents dependency upgrades together in same PR",
-      "matchPackagePrefixes": ["org.apache.httpcomponents"],
-      "groupName": "org.apache.httpcomponents"
-    },
-    {
-      "description": "Test-dependencies are checked less often than the shipped deps",
-      "matchDepTypes": ["test"],
-      "schedule": ["before 9am on the first day of the month"]
-    },
-    {
-      "description": "Noisy, frequently updated dependencies checked less often",
-      "matchPackagePrefixes": ["software.amazon.awssdk", "com.google.cloud"],
-      "schedule": ["before 9am on the first day of the month"]
-    },
-    {
-      "description": "Workaround for https://github.com/renovatebot/renovate/issues/19226",
-      "matchPackageNames": ["solr:modules", "HH:mm"],
-      "enabled": false
-    },
-    {
-      "description": "Lucene dependencies should be skipped",
-      "matchPackagePrefixes": ["org.apache.lucene"],
-      "enabled": false
-    },
-    {
-      "description": "Skip major jetty upgrades - must be done manually",
-      "matchPackagePrefixes": ["org.eclipse.jetty"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
-      "description": "Changelog for commons-io",
-      "matchSourceUrls": [
-        "https://gitbox.apache.org/repos/asf?p=commons-io.git"
-      ],
-      "changelogUrl": "https://commons.apache.org/proper/commons-io/changes-report.html"
-    },
-    {
-      "description": "Changelog for zookeeper",
-      "matchSourceUrls": ["https://gitbox.apache.org/repos/asf/zookeeper.git"],
-      "changelogUrl": "https://zookeeper.apache.org/releases.html"
-    },
-    {
-      "description": "Changelog for commons-compress",
-      "matchSourceUrls": [
-        "https://gitbox.apache.org/repos/asf?p=commons-compress.git"
-      ],
-      "changelogUrl": "https://commons.apache.org/proper/commons-compress/changes-report.html"
-    },
-    {
-      "description": "Changelog for commons-configuration",
-      "matchSourceUrls": [
-        "https://gitbox.apache.org/repos/asf?p=commons-configuration.git"
-      ],
-      "changelogUrl": "https://commons.apache.org/proper/commons-configuration/changes-report.html"
-    }
-  ],
   "schedule": ["* * * * *"],
   "prConcurrentLimit": 3,
   "prHourlyLimit": 3,
-  "minimumReleaseAge": "5 days"
+  "branchPrefix": "renovate-9x/",
+  "commitMessageSuffix": " (branch_9x)",
+  "dryRun": "extract"
 }


### PR DESCRIPTION
Now that main branch uses gradle version catalogs (#2706), dependency upgrades cannot be easily back ported to branch_9x anymore, unless the version catalogs are back ported as well.

Also, many features are removed in main that still exist in branch_9x, so we will miss out on certain dep updates if we only rely on manual backports.

Therefore I propose, and will test with dryRun, that @solrbot files separate PRs for branch_9x, using the [baseBranches feature](https://docs.renovatebot.com/configuration-options/#basebranches). For that to work we define [`useBaseBranchConfig=merge`](https://docs.renovatebot.com/configuration-options/#usebasebranchconfig) so that we can use `renovate.json` on this branch as an overlay, specifying configs that differ from main and giving a PR title suffix etc. Steps:

* Place a `renovate.json` config in branch_9x, which targets old `versions.properties` and acts as overlay
* In [solrbot repo](https://github.com/solrbot/renovate-github-action/pull/2), configure `baseBranches` and `useBaseBranchConfig`
* Do a dry run and verify that it works

Once Solr 10 is released, we can redefine this to target latest `branch_9_x` which will have a long life in bugfix mode.