### PR TITLE
Remove broken and unused ZkStateReader.getReplicaProps()

### DIFF
--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1002,30 +1002,12 @@ public class ZkStateReader implements SolrCloseable {
 
   public List<ZkCoreNodeProps> getReplicaProps(
       String collection, String shardId, String thisCoreNodeName) {
-    return getReplicaProps(collection, shardId, thisCoreNodeName, null);
-  }
-
-  public List<ZkCoreNodeProps> getReplicaProps(
-      String collection,
-      String shardId,
-      String thisCoreNodeName,
-      Replica.State mustMatchStateFilter) {
-    return getReplicaProps(collection, shardId, thisCoreNodeName, mustMatchStateFilter, null);
-  }
-
-  public List<ZkCoreNodeProps> getReplicaProps(
-      String collection,
-      String shardId,
-      String thisCoreNodeName,
-      Replica.State mustMatchStateFilter,
-      Replica.State mustNotMatchStateFilter) {
-    // TODO: We don't need all these getReplicaProps method overloading. Also, it's odd that the
-    // default is to return replicas of type TLOG and NRT only
+    // TODO: It's odd that the default is to return replicas of type TLOG and NRT only
     return getReplicaProps(
         collection,
         shardId,
         thisCoreNodeName,
-        mustMatchStateFilter,
+        null,
         null,
         EnumSet.of(Replica.Type.TLOG, Replica.Type.NRT));
   }


### PR DESCRIPTION
Remove broken and unused implementation of `getReplicaProps()` which is error prone.