### PR TITLE
Fix TestReplicationHandler

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
+++ b/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -56,7 +57,8 @@ public final class ReplicationTestHelper {
   public static JettySolrRunner createAndStartJetty(SolrInstance instance) throws Exception {
     Files.copy(
         Path.of(SolrTestCaseJ4.TEST_HOME(), "solr.xml"),
-        Path.of(instance.getHomeDir(), "solr.xml"));
+        Path.of(instance.getHomeDir(), "solr.xml"),
+        StandardCopyOption.REPLACE_EXISTING);
     Properties nodeProperties = new Properties();
     nodeProperties.setProperty("solr.data.dir", instance.getDataDir());
     JettyConfig jettyConfig = JettyConfig.builder().setPort(0).build();

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -70,7 +70,6 @@ import org.apache.solr.core.CachingDirectoryFactory;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.StandardDirectoryFactory;
-import org.apache.solr.core.snapshots.SolrSnapshotMetaDataManager;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.handler.admin.api.ReplicationAPIBase;
 import org.apache.solr.security.AllowListUrlChecker;
@@ -1037,8 +1036,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
                   @Override
                   public boolean accept(File dir, String name) {
                     File f = new File(dir, name);
-                    return f.isDirectory()
-                        && !SolrSnapshotMetaDataManager.SNAPSHOT_METADATA_DIR.equals(name);
+                    return f.isDirectory() && !name.startsWith("snapshot");
                   }
                 });
     return list.length;


### PR DESCRIPTION
This actually stems from two commits on the same day, kind of eerie.

### [SOLR-17306](https://issues.apache.org/jira/browse/SOLR-17306)
This uncommented out:
```java
System.setProperty("solr.directoryFactory", "solr.StandardDirectoryFactory");
```
Apparently when using the StandardDirectoryFactory, we see core snapshot directories when we don't see them using the default DirectoryFactory. The code already accounted for snapshot metadata, but not snapshots themselves. I updated the check to ignore any snapshot directory when counting index directories. @dsmiley, you wrote the snapshot metadata filtering, so can you check this for me?

### [SOLR-17548](https://issues.apache.org/jira/browse/SOLR-17548)
In `ReplicationTestHelper`, this changed 
```java
FileUtils.copyFile(
        new File(SolrTestCaseJ4.TEST_HOME(), "solr.xml"),
        new File(instance.getHomeDir(), "solr.xml"));
```
to
```java
Files.copy(
        Path.of(SolrTestCaseJ4.TEST_HOME(), "solr.xml"),
        Path.of(instance.getHomeDir(), "solr.xml"));
```
However, this forgot to allow for overwrites, as was done in other cases in this PR. Probably because nightly tests are usually forgotten.