### PR TITLE
in tests replace deprecated IndexSearcher.doc() calls

### DIFF
--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -763,7 +763,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
     core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
 
     DocList dl = ((ResultContext) rsp.getResponse()).getDocList();
-    Document d = req.getSearcher().storedFields().document(dl.iterator().nextDoc());
+    Document d = req.getSearcher().getDocFetcher().doc(dl.iterator().nextDoc());
     // ensure field in fl is not lazy
     assertNotEquals("LazyField", ((Field) d.getField("test_hlt")).getClass().getSimpleName());
     assertNotEquals("LazyField", ((Field) d.getField("title")).getClass().getSimpleName());
@@ -791,7 +791,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
     DocList dl = ((ResultContext) rsp.getResponse()).getDocList();
     DocIterator di = dl.iterator();
-    Document d1 = req.getSearcher().storedFields().document(di.nextDoc());
+    Document d1 = req.getSearcher().getDocFetcher().doc(di.nextDoc());
     IndexableField[] values1 = null;
 
     // ensure fl field is non lazy, and non-fl field is lazy
@@ -813,7 +813,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
     dl = ((ResultContext) rsp.getResponse()).getDocList();
     di = dl.iterator();
-    Document d2 = req.getSearcher().storedFields().document(di.nextDoc());
+    Document d2 = req.getSearcher().getDocFetcher().doc(di.nextDoc());
     // ensure same doc, same lazy field now
     assertSame("Doc was not cached", d1, d2);
     IndexableField[] values2 = d2.getFields("test_hlt");

--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -763,7 +763,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
     core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
 
     DocList dl = ((ResultContext) rsp.getResponse()).getDocList();
-    Document d = req.getSearcher().doc(dl.iterator().nextDoc());
+    Document d = req.getSearcher().storedFields().document(dl.iterator().nextDoc());
     // ensure field in fl is not lazy
     assertNotEquals("LazyField", ((Field) d.getField("test_hlt")).getClass().getSimpleName());
     assertNotEquals("LazyField", ((Field) d.getField("title")).getClass().getSimpleName());
@@ -791,7 +791,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
     DocList dl = ((ResultContext) rsp.getResponse()).getDocList();
     DocIterator di = dl.iterator();
-    Document d1 = req.getSearcher().doc(di.nextDoc());
+    Document d1 = req.getSearcher().storedFields().document(di.nextDoc());
     IndexableField[] values1 = null;
 
     // ensure fl field is non lazy, and non-fl field is lazy
@@ -813,7 +813,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
     dl = ((ResultContext) rsp.getResponse()).getDocList();
     di = dl.iterator();
-    Document d2 = req.getSearcher().doc(di.nextDoc());
+    Document d2 = req.getSearcher().storedFields().document(di.nextDoc());
     // ensure same doc, same lazy field now
     assertSame("Doc was not cached", d1, d2);
     IndexableField[] values2 = d2.getFields("test_hlt");

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
@@ -45,7 +45,6 @@ import org.apache.solr.request.SolrQueryRequestBase;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.DocIterator;
 import org.apache.solr.search.DocList;
-import org.apache.solr.search.SolrDocumentFetcher;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
@@ -140,12 +139,11 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
     NamedList<?> rspValues = rsp.getValues();
     Map<String, String> matchingNames = new HashMap<>();
     SolrIndexSearcher searcher = req.getSearcher();
-    SolrDocumentFetcher docFetcher = searcher.getDocFetcher();
     DocList docList = (DocList) rspValues.get("response");
     DocIterator iter = docList.iterator();
     while (iter.hasNext()) {
       int docId = iter.next();
-      Document doc = docFetcher.doc(docId);
+      Document doc = searcher.storedFields().document(docId);
       String id = doc.getField("id").stringValue();
       String name = lookupByName(doc.get("name"));
       assertEquals("looking for " + name, NAMES.indexOf(name) + "", id);

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
@@ -143,7 +143,7 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
     DocIterator iter = docList.iterator();
     while (iter.hasNext()) {
       int docId = iter.next();
-      Document doc = searcher.storedFields().document(docId);
+      Document doc = searcher.getDocFetcher().doc(docId);
       String id = doc.getField("id").stringValue();
       String name = lookupByName(doc.get("name"));
       assertEquals("looking for " + name, NAMES.indexOf(name) + "", id);

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
@@ -45,6 +45,7 @@ import org.apache.solr.request.SolrQueryRequestBase;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.DocIterator;
 import org.apache.solr.search.DocList;
+import org.apache.solr.search.SolrDocumentFetcher;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
@@ -139,11 +140,12 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
     NamedList<?> rspValues = rsp.getValues();
     Map<String, String> matchingNames = new HashMap<>();
     SolrIndexSearcher searcher = req.getSearcher();
+    SolrDocumentFetcher docFetcher = searcher.getDocFetcher();
     DocList docList = (DocList) rspValues.get("response");
     DocIterator iter = docList.iterator();
     while (iter.hasNext()) {
       int docId = iter.next();
-      Document doc = searcher.storedFields().document(docId);
+      Document doc = docFetcher.doc(docId);
       String id = doc.getField("id").stringValue();
       String name = lookupByName(doc.get("name"));
       assertEquals("looking for " + name, NAMES.indexOf(name) + "", id);

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
@@ -143,7 +143,7 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
     DocIterator iter = docList.iterator();
     while (iter.hasNext()) {
       int docId = iter.next();
-      Document doc = searcher.doc(docId);
+      Document doc = searcher.storedFields().document(docId);
       String id = doc.getField("id").stringValue();
       String name = lookupByName(doc.get("name"));
       assertEquals("looking for " + name, NAMES.indexOf(name) + "", id);

--- a/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery32.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery32.java
@@ -183,12 +183,12 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
       assertEquals("Score doc count" + type, count, sd.length);
-      Document doc = searcher.doc(sd[0].doc);
+      Document doc = searcher.storedFields().document(sd[0].doc);
       assertEquals(
           "First doc" + type,
           2 * distance + startOffset,
           doc.getField(field).numericValue().intValue());
-      doc = searcher.doc(sd[sd.length - 1].doc);
+      doc = searcher.storedFields().document(sd[sd.length - 1].doc);
       assertEquals(
           "Last doc" + type,
           (1 + count) * distance + startOffset,
@@ -231,9 +231,9 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     ScoreDoc[] sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", count, sd.length);
-    Document doc = searcher.doc(sd[0].doc);
+    Document doc = searcher.storedFields().document(sd[0].doc);
     assertEquals("First doc", startOffset, doc.getField(field).numericValue().intValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (count - 1) * distance + startOffset,
@@ -244,9 +244,9 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", count, sd.length);
-    doc = searcher.doc(sd[0].doc);
+    doc = searcher.storedFields().document(sd[0].doc);
     assertEquals("First doc", startOffset, doc.getField(field).numericValue().intValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (count - 1) * distance + startOffset,
@@ -281,10 +281,10 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     ScoreDoc[] sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", noDocs - count, sd.length);
-    Document doc = searcher.doc(sd[0].doc);
+    Document doc = searcher.storedFields().document(sd[0].doc);
     assertEquals(
         "First doc", count * distance + startOffset, doc.getField(field).numericValue().intValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (noDocs - 1) * distance + startOffset,
@@ -297,10 +297,10 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", noDocs - count, sd.length);
-    doc = searcher.doc(sd[0].doc);
+    doc = searcher.storedFields().document(sd[0].doc);
     assertEquals(
         "First doc", count * distance + startOffset, doc.getField(field).numericValue().intValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (noDocs - 1) * distance + startOffset,

--- a/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery64.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery64.java
@@ -195,12 +195,12 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
       assertEquals("Score doc count" + type, count, sd.length);
-      Document doc = searcher.doc(sd[0].doc);
+      Document doc = searcher.storedFields().document(sd[0].doc);
       assertEquals(
           "First doc" + type,
           2 * distance + startOffset,
           doc.getField(field).numericValue().longValue());
-      doc = searcher.doc(sd[sd.length - 1].doc);
+      doc = searcher.storedFields().document(sd[sd.length - 1].doc);
       assertEquals(
           "Last doc" + type,
           (1 + count) * distance + startOffset,
@@ -249,9 +249,9 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
     ScoreDoc[] sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", count, sd.length);
-    Document doc = searcher.doc(sd[0].doc);
+    Document doc = searcher.storedFields().document(sd[0].doc);
     assertEquals("First doc", startOffset, doc.getField(field).numericValue().longValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (count - 1) * distance + startOffset,
@@ -262,9 +262,9 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
     sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", count, sd.length);
-    doc = searcher.doc(sd[0].doc);
+    doc = searcher.storedFields().document(sd[0].doc);
     assertEquals("First doc", startOffset, doc.getField(field).numericValue().longValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (count - 1) * distance + startOffset,
@@ -301,12 +301,12 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
     ScoreDoc[] sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", noDocs - count, sd.length);
-    Document doc = searcher.doc(sd[0].doc);
+    Document doc = searcher.storedFields().document(sd[0].doc);
     assertEquals(
         "First doc",
         count * distance + startOffset,
         doc.getField(field).numericValue().longValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (noDocs - 1) * distance + startOffset,
@@ -317,12 +317,12 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
     sd = topDocs.scoreDocs;
     assertNotNull(sd);
     assertEquals("Score doc count", noDocs - count, sd.length);
-    doc = searcher.doc(sd[0].doc);
+    doc = searcher.storedFields().document(sd[0].doc);
     assertEquals(
         "First doc",
         count * distance + startOffset,
         doc.getField(field).numericValue().longValue());
-    doc = searcher.doc(sd[sd.length - 1].doc);
+    doc = searcher.storedFields().document(sd[sd.length - 1].doc);
     assertEquals(
         "Last doc",
         (noDocs - 1) * distance + startOffset,

--- a/solr/core/src/test/org/apache/solr/search/LargeFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/search/LargeFieldTest.java
@@ -96,7 +96,7 @@ public class LargeFieldTest extends SolrTestCaseJ4 {
     assertQ(req("q", "101", "df", ID_FLD, "fl", ID_FLD)); // eager load ID_FLD; rest are lazy
 
     // fetch the document; we know it will be from the documentCache, docId 0
-    final Document d = h.getCore().withSearcher(searcher -> searcher.storedFields().document(0));
+    final Document d = h.getCore().withSearcher(searcher -> searcher.getDocFetcher().doc(0));
 
     assertEager(d, ID_FLD);
     assertLazyNotLoaded(d, LAZY_FIELD);

--- a/solr/core/src/test/org/apache/solr/search/LargeFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/search/LargeFieldTest.java
@@ -96,7 +96,7 @@ public class LargeFieldTest extends SolrTestCaseJ4 {
     assertQ(req("q", "101", "df", ID_FLD, "fl", ID_FLD)); // eager load ID_FLD; rest are lazy
 
     // fetch the document; we know it will be from the documentCache, docId 0
-    final Document d = h.getCore().withSearcher(searcher -> searcher.doc(0));
+    final Document d = h.getCore().withSearcher(searcher -> searcher.storedFields().document(0));
 
     assertEager(d, ID_FLD);
     assertLazyNotLoaded(d, LAZY_FIELD);

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheSort.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheSort.java
@@ -88,7 +88,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", sortType));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // 'bar' comes before 'foo'
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -127,7 +127,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", sortType));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null comes first
     assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -164,7 +164,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", sortType, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // 'foo' comes after 'bar' in reverse order
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -203,7 +203,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null comes first
     assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -243,7 +243,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     // null comes last
@@ -284,7 +284,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     // null comes last
@@ -325,7 +325,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null comes first
     assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -352,7 +352,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(SortField.FIELD_DOC);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // docid 0, then docid 1
     assertEquals(0, td.scoreDocs[0].doc);
     assertEquals(1, td.scoreDocs[1].doc);
@@ -378,7 +378,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField(null, SortField.Type.DOC, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // docid 1, then docid 0
     assertEquals(1, td.scoreDocs[0].doc);
     assertEquals(0, td.scoreDocs[1].doc);
@@ -404,11 +404,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort();
 
     TopDocs actual = searcher.search(new TermQuery(new Term("value", "foo")), 10, sort);
-    assertEquals(2, actual.totalHits.value());
+    assertEquals(2, actual.totalHits.value);
 
     TopDocs expected = searcher.search(new TermQuery(new Term("value", "foo")), 10);
     // the two topdocs should be the same
-    assertEquals(expected.totalHits.value(), actual.totalHits.value());
+    assertEquals(expected.totalHits.value, actual.totalHits.value);
     for (int i = 0; i < actual.scoreDocs.length; i++) {
       assertEquals(actual.scoreDocs[i].doc, expected.scoreDocs[i].doc);
     }
@@ -436,11 +436,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField(null, SortField.Type.SCORE, true));
 
     TopDocs actual = searcher.search(new TermQuery(new Term("value", "foo")), 10, sort);
-    assertEquals(2, actual.totalHits.value());
+    assertEquals(2, actual.totalHits.value);
 
     TopDocs expected = searcher.search(new TermQuery(new Term("value", "foo")), 10);
     // the two topdocs should be the reverse of each other
-    assertEquals(expected.totalHits.value(), actual.totalHits.value());
+    assertEquals(expected.totalHits.value, actual.totalHits.value);
     assertEquals(actual.scoreDocs[0].doc, expected.scoreDocs[1].doc);
     assertEquals(actual.scoreDocs[1].doc, expected.scoreDocs[0].doc);
     TestUtil.checkReader(ir);
@@ -473,7 +473,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -506,7 +506,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as a 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -543,7 +543,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as an Integer.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -578,7 +578,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // reverse numeric order
     assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -610,7 +610,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -641,7 +641,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as a 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -677,7 +677,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as an Integer.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -709,7 +709,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // reverse numeric order
     assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -744,7 +744,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -777,7 +777,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -814,7 +814,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as Long.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -849,7 +849,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // reverse numeric order
     assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -881,7 +881,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -912,7 +912,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -948,7 +948,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as Long.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -980,7 +980,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // reverse numeric order
     assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1015,7 +1015,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1048,7 +1048,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1085,7 +1085,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as Float.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1120,7 +1120,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // reverse numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1152,7 +1152,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1183,7 +1183,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1219,7 +1219,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // null is treated as Float.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1251,7 +1251,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value());
+    assertEquals(3, td.totalHits.value);
     // reverse numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1290,11 +1290,13 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1323,10 +1325,22 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // numeric order
-    double v0 = searcher.storedFields().document(td.scoreDocs[0].doc).getField("value").numericValue().doubleValue();
-    double v1 = searcher.storedFields().document(td.scoreDocs[1].doc).getField("value").numericValue().doubleValue();
+    double v0 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[0].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
+    double v1 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[1].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
     assertEquals(0, v0, 0d);
     assertEquals(0, v1, 0d);
     // check sign bits
@@ -1364,12 +1378,14 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // null treated as a 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1407,11 +1423,13 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // null treated as Double.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1447,11 +1465,13 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1483,11 +1503,13 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1514,10 +1536,22 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // numeric order
-    double v0 = searcher.storedFields().document(td.scoreDocs[0].doc).getField("value").numericValue().doubleValue();
-    double v1 = searcher.storedFields().document(td.scoreDocs[1].doc).getField("value").numericValue().doubleValue();
+    double v0 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[0].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
+    double v1 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[1].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
     assertEquals(0, v0, 0d);
     assertEquals(0, v1, 0d);
     // check sign bits
@@ -1552,12 +1586,14 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // null treated as a 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1592,11 +1628,13 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // null treated as Double.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1628,11 +1666,13 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value());
+    assertEquals(4, td.totalHits.value);
     // numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1664,7 +1704,7 @@ public class TestFieldCacheSort extends SolrTestCase {
             new TermQuery(new Term("t", "1")),
             10,
             new Sort(new SortField("f", SortField.Type.STRING)));
-    assertEquals(2, hits.totalHits.value());
+    assertEquals(2, hits.totalHits.value);
     // null sorts first
     assertEquals(1, hits.scoreDocs[0].doc);
     assertEquals(0, hits.scoreDocs[1].doc);
@@ -1741,31 +1781,31 @@ public class TestFieldCacheSort extends SolrTestCase {
 
     Sort sort = new Sort();
     TopDocs td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value());
+    assertEquals(0, td.totalHits.value);
 
     sort = new Sort(SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value());
+    assertEquals(0, td.totalHits.value);
 
     sort = new Sort(new SortField("int", SortField.Type.INT), SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value());
+    assertEquals(0, td.totalHits.value);
 
     sort = new Sort(new SortField("string", SortField.Type.STRING, true), SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value());
+    assertEquals(0, td.totalHits.value);
 
     sort =
         new Sort(new SortField("string_val", SortField.Type.STRING_VAL, true), SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value());
+    assertEquals(0, td.totalHits.value);
 
     sort =
         new Sort(
             new SortField("float", SortField.Type.FLOAT),
             new SortField("string", SortField.Type.STRING));
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value());
+    assertEquals(0, td.totalHits.value);
   }
 
   /** Tests sorting a single document */
@@ -1783,7 +1823,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.STRING));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(1, td.totalHits.value());
+    assertEquals(1, td.totalHits.value);
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1805,10 +1845,10 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.STRING));
 
     TopDocs expected = searcher.search(new TermQuery(new Term("value", "foo")), 10);
-    assertEquals(1, expected.totalHits.value());
+    assertEquals(1, expected.totalHits.value);
     TopDocs actual = searcher.search(new TermQuery(new Term("value", "foo")), 10, sort, true);
 
-    assertEquals(expected.totalHits.value(), actual.totalHits.value());
+    assertEquals(expected.totalHits.value, actual.totalHits.value);
     assertEquals(expected.scoreDocs[0].score, actual.scoreDocs[0].score, 0F);
     TestUtil.checkReader(ir);
     ir.close();
@@ -1842,7 +1882,7 @@ public class TestFieldCacheSort extends SolrTestCase {
             new SortField("value", SortField.Type.STRING));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     // 'bar' comes before 'foo'
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1870,7 +1910,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     bq.add(new TermQuery(new Term("value", "foo")), Occur.SHOULD);
     bq.add(new MatchAllDocsQuery(), Occur.SHOULD);
     TopDocs td = searcher.search(bq.build(), 10, sort);
-    assertEquals(2, td.totalHits.value());
+    assertEquals(2, td.totalHits.value);
     if (Float.isNaN(td.scoreDocs[0].score) == false
         && Float.isNaN(td.scoreDocs[1].score) == false) {
       assertEquals(1, td.scoreDocs[0].doc);

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheSort.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheSort.java
@@ -90,8 +90,8 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(2, td.totalHits.value);
     // 'bar' comes before 'foo'
-    assertEquals("bar", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("foo", searcher.doc(td.scoreDocs[1].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
 
     TestUtil.checkReader(ir);
     ir.close();
@@ -129,9 +129,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null comes first
-    assertNull(searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("bar", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("foo", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -166,8 +166,8 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(2, td.totalHits.value);
     // 'foo' comes after 'bar' in reverse order
-    assertEquals("foo", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("bar", searcher.doc(td.scoreDocs[1].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -205,9 +205,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null comes first
-    assertNull(searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("bar", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("foo", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -244,10 +244,10 @@ public class TestFieldCacheSort extends SolrTestCase {
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
-    assertEquals("foo", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("bar", searcher.doc(td.scoreDocs[1].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     // null comes last
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -285,10 +285,10 @@ public class TestFieldCacheSort extends SolrTestCase {
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
-    assertEquals("bar", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("foo", searcher.doc(td.scoreDocs[1].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     // null comes last
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -327,9 +327,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null comes first
-    assertNull(searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("foo", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("bar", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -475,9 +475,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // numeric order
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("300000", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("300000", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -508,9 +508,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as a 0
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -545,9 +545,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as an Integer.MAX_VALUE
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -580,9 +580,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // reverse numeric order
-    assertEquals("300000", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("-1", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -612,9 +612,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // numeric order
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("300000", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("300000", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -643,9 +643,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as a 0
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -679,9 +679,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as an Integer.MAX_VALUE
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -711,9 +711,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // reverse numeric order
-    assertEquals("300000", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("-1", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -746,9 +746,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // numeric order
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("3000000000", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -779,9 +779,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as 0
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -816,9 +816,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as Long.MAX_VALUE
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -851,9 +851,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // reverse numeric order
-    assertEquals("3000000000", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("-1", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -883,9 +883,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // numeric order
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("3000000000", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -914,9 +914,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as 0
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -950,9 +950,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as Long.MAX_VALUE
-    assertEquals("-1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -982,9 +982,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // reverse numeric order
-    assertEquals("3000000000", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("-1", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1017,9 +1017,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // numeric order
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("30.1", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1050,9 +1050,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as 0
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1087,9 +1087,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as Float.MAX_VALUE
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1122,9 +1122,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // reverse numeric order
-    assertEquals("30.1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1154,9 +1154,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // numeric order
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("30.1", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1185,9 +1185,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as 0
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1221,9 +1221,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // null is treated as Float.MAX_VALUE
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1253,9 +1253,9 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(3, td.totalHits.value);
     // reverse numeric order
-    assertEquals("30.1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[2].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1292,10 +1292,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // numeric order
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertEquals("30.1", searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1325,8 +1327,20 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(2, td.totalHits.value);
     // numeric order
-    double v0 = searcher.doc(td.scoreDocs[0].doc).getField("value").numericValue().doubleValue();
-    double v1 = searcher.doc(td.scoreDocs[1].doc).getField("value").numericValue().doubleValue();
+    double v0 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[0].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
+    double v1 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[1].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
     assertEquals(0, v0, 0d);
     assertEquals(0, v1, 0d);
     // check sign bits
@@ -1366,10 +1380,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // null treated as a 0
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1409,10 +1425,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // null treated as Double.MAX_VALUE
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1449,10 +1467,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // numeric order
-    assertEquals("30.1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1485,10 +1505,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // numeric order
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertEquals("30.1", searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1516,8 +1538,20 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(2, td.totalHits.value);
     // numeric order
-    double v0 = searcher.doc(td.scoreDocs[0].doc).getField("value").numericValue().doubleValue();
-    double v1 = searcher.doc(td.scoreDocs[1].doc).getField("value").numericValue().doubleValue();
+    double v0 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[0].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
+    double v1 =
+        searcher
+            .storedFields()
+            .document(td.scoreDocs[1].doc)
+            .getField("value")
+            .numericValue()
+            .doubleValue();
     assertEquals(0, v0, 0d);
     assertEquals(0, v1, 0d);
     // check sign bits
@@ -1554,10 +1588,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // null treated as a 0
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1594,10 +1630,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // null treated as Double.MAX_VALUE
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertNull(searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1630,10 +1668,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(4, td.totalHits.value);
     // numeric order
-    assertEquals("30.1", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("4.2333333333333", searcher.doc(td.scoreDocs[1].doc).get("value"));
-    assertEquals("4.2333333333332", searcher.doc(td.scoreDocs[2].doc).get("value"));
-    assertEquals("-1.3", searcher.doc(td.scoreDocs[3].doc).get("value"));
+    assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals(
+        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals(
+        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1784,7 +1824,7 @@ public class TestFieldCacheSort extends SolrTestCase {
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(1, td.totalHits.value);
-    assertEquals("foo", searcher.doc(td.scoreDocs[0].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1844,8 +1884,8 @@ public class TestFieldCacheSort extends SolrTestCase {
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
     assertEquals(2, td.totalHits.value);
     // 'bar' comes before 'foo'
-    assertEquals("bar", searcher.doc(td.scoreDocs[0].doc).get("value"));
-    assertEquals("foo", searcher.doc(td.scoreDocs[1].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheSort.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheSort.java
@@ -88,7 +88,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", sortType));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // 'bar' comes before 'foo'
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -127,7 +127,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", sortType));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null comes first
     assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -164,7 +164,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", sortType, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // 'foo' comes after 'bar' in reverse order
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -203,7 +203,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null comes first
     assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -243,7 +243,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     // null comes last
@@ -284,7 +284,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     // null comes last
@@ -325,7 +325,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sf);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null comes first
     assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -352,7 +352,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(SortField.FIELD_DOC);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // docid 0, then docid 1
     assertEquals(0, td.scoreDocs[0].doc);
     assertEquals(1, td.scoreDocs[1].doc);
@@ -378,7 +378,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField(null, SortField.Type.DOC, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // docid 1, then docid 0
     assertEquals(1, td.scoreDocs[0].doc);
     assertEquals(0, td.scoreDocs[1].doc);
@@ -404,11 +404,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort();
 
     TopDocs actual = searcher.search(new TermQuery(new Term("value", "foo")), 10, sort);
-    assertEquals(2, actual.totalHits.value);
+    assertEquals(2, actual.totalHits.value());
 
     TopDocs expected = searcher.search(new TermQuery(new Term("value", "foo")), 10);
     // the two topdocs should be the same
-    assertEquals(expected.totalHits.value, actual.totalHits.value);
+    assertEquals(expected.totalHits.value(), actual.totalHits.value());
     for (int i = 0; i < actual.scoreDocs.length; i++) {
       assertEquals(actual.scoreDocs[i].doc, expected.scoreDocs[i].doc);
     }
@@ -436,11 +436,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField(null, SortField.Type.SCORE, true));
 
     TopDocs actual = searcher.search(new TermQuery(new Term("value", "foo")), 10, sort);
-    assertEquals(2, actual.totalHits.value);
+    assertEquals(2, actual.totalHits.value());
 
     TopDocs expected = searcher.search(new TermQuery(new Term("value", "foo")), 10);
     // the two topdocs should be the reverse of each other
-    assertEquals(expected.totalHits.value, actual.totalHits.value);
+    assertEquals(expected.totalHits.value(), actual.totalHits.value());
     assertEquals(actual.scoreDocs[0].doc, expected.scoreDocs[1].doc);
     assertEquals(actual.scoreDocs[1].doc, expected.scoreDocs[0].doc);
     TestUtil.checkReader(ir);
@@ -473,7 +473,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -506,7 +506,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as a 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -543,7 +543,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as an Integer.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -578,7 +578,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // reverse numeric order
     assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -610,7 +610,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -641,7 +641,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as a 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -677,7 +677,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as an Integer.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -709,7 +709,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.INT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // reverse numeric order
     assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -744,7 +744,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -777,7 +777,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -814,7 +814,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as Long.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -849,7 +849,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // reverse numeric order
     assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -881,7 +881,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // numeric order
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -912,7 +912,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as 0
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -948,7 +948,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as Long.MAX_VALUE
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -980,7 +980,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.LONG, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // reverse numeric order
     assertEquals("3000000000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1015,7 +1015,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1048,7 +1048,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1085,7 +1085,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as Float.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1120,7 +1120,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // reverse numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1152,7 +1152,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1183,7 +1183,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1219,7 +1219,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // null is treated as Float.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1251,7 +1251,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.FLOAT, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(3, td.totalHits.value);
+    assertEquals(3, td.totalHits.value());
     // reverse numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4.2", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1290,13 +1290,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1325,22 +1323,10 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // numeric order
-    double v0 =
-        searcher
-            .storedFields()
-            .document(td.scoreDocs[0].doc)
-            .getField("value")
-            .numericValue()
-            .doubleValue();
-    double v1 =
-        searcher
-            .storedFields()
-            .document(td.scoreDocs[1].doc)
-            .getField("value")
-            .numericValue()
-            .doubleValue();
+    double v0 = searcher.storedFields().document(td.scoreDocs[0].doc).getField("value").numericValue().doubleValue();
+    double v1 = searcher.storedFields().document(td.scoreDocs[1].doc).getField("value").numericValue().doubleValue();
     assertEquals(0, v0, 0d);
     assertEquals(0, v1, 0d);
     // check sign bits
@@ -1378,14 +1364,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // null treated as a 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1423,13 +1407,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // null treated as Double.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1465,13 +1447,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1503,13 +1483,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // numeric order
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1536,22 +1514,10 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // numeric order
-    double v0 =
-        searcher
-            .storedFields()
-            .document(td.scoreDocs[0].doc)
-            .getField("value")
-            .numericValue()
-            .doubleValue();
-    double v1 =
-        searcher
-            .storedFields()
-            .document(td.scoreDocs[1].doc)
-            .getField("value")
-            .numericValue()
-            .doubleValue();
+    double v0 = searcher.storedFields().document(td.scoreDocs[0].doc).getField("value").numericValue().doubleValue();
+    double v1 = searcher.storedFields().document(td.scoreDocs[1].doc).getField("value").numericValue().doubleValue();
     assertEquals(0, v0, 0d);
     assertEquals(0, v1, 0d);
     // check sign bits
@@ -1586,14 +1552,12 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // null treated as a 0
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
     dir.close();
@@ -1628,13 +1592,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(sortField);
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // null treated as Double.MAX_VALUE
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1666,13 +1628,11 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.DOUBLE, true));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(4, td.totalHits.value);
+    assertEquals(4, td.totalHits.value());
     // numeric order
     assertEquals("30.1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
-    assertEquals(
-        "4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
-    assertEquals(
-        "4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+    assertEquals("4.2333333333333", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("4.2333333333332", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
     assertEquals("-1.3", searcher.storedFields().document(td.scoreDocs[3].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1704,7 +1664,7 @@ public class TestFieldCacheSort extends SolrTestCase {
             new TermQuery(new Term("t", "1")),
             10,
             new Sort(new SortField("f", SortField.Type.STRING)));
-    assertEquals(2, hits.totalHits.value);
+    assertEquals(2, hits.totalHits.value());
     // null sorts first
     assertEquals(1, hits.scoreDocs[0].doc);
     assertEquals(0, hits.scoreDocs[1].doc);
@@ -1781,31 +1741,31 @@ public class TestFieldCacheSort extends SolrTestCase {
 
     Sort sort = new Sort();
     TopDocs td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value);
+    assertEquals(0, td.totalHits.value());
 
     sort = new Sort(SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value);
+    assertEquals(0, td.totalHits.value());
 
     sort = new Sort(new SortField("int", SortField.Type.INT), SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value);
+    assertEquals(0, td.totalHits.value());
 
     sort = new Sort(new SortField("string", SortField.Type.STRING, true), SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value);
+    assertEquals(0, td.totalHits.value());
 
     sort =
         new Sort(new SortField("string_val", SortField.Type.STRING_VAL, true), SortField.FIELD_DOC);
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value);
+    assertEquals(0, td.totalHits.value());
 
     sort =
         new Sort(
             new SortField("float", SortField.Type.FLOAT),
             new SortField("string", SortField.Type.STRING));
     td = empty.search(query, 10, sort, true);
-    assertEquals(0, td.totalHits.value);
+    assertEquals(0, td.totalHits.value());
   }
 
   /** Tests sorting a single document */
@@ -1823,7 +1783,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.STRING));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(1, td.totalHits.value);
+    assertEquals(1, td.totalHits.value());
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     TestUtil.checkReader(ir);
     ir.close();
@@ -1845,10 +1805,10 @@ public class TestFieldCacheSort extends SolrTestCase {
     Sort sort = new Sort(new SortField("value", SortField.Type.STRING));
 
     TopDocs expected = searcher.search(new TermQuery(new Term("value", "foo")), 10);
-    assertEquals(1, expected.totalHits.value);
+    assertEquals(1, expected.totalHits.value());
     TopDocs actual = searcher.search(new TermQuery(new Term("value", "foo")), 10, sort, true);
 
-    assertEquals(expected.totalHits.value, actual.totalHits.value);
+    assertEquals(expected.totalHits.value(), actual.totalHits.value());
     assertEquals(expected.scoreDocs[0].score, actual.scoreDocs[0].score, 0F);
     TestUtil.checkReader(ir);
     ir.close();
@@ -1882,7 +1842,7 @@ public class TestFieldCacheSort extends SolrTestCase {
             new SortField("value", SortField.Type.STRING));
 
     TopDocs td = searcher.search(new MatchAllDocsQuery(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     // 'bar' comes before 'foo'
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
@@ -1910,7 +1870,7 @@ public class TestFieldCacheSort extends SolrTestCase {
     bq.add(new TermQuery(new Term("value", "foo")), Occur.SHOULD);
     bq.add(new MatchAllDocsQuery(), Occur.SHOULD);
     TopDocs td = searcher.search(bq.build(), 10, sort);
-    assertEquals(2, td.totalHits.value);
+    assertEquals(2, td.totalHits.value());
     if (Float.isNaN(td.scoreDocs[0].score) == false
         && Float.isNaN(td.scoreDocs[1].score) == false) {
       assertEquals(1, td.scoreDocs[0].doc);

--- a/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms32.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms32.java
@@ -141,9 +141,11 @@ public class TestNumericTerms32 extends SolrTestCase {
       if (topDocs.totalHits.value == 0) continue;
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
-      int last = searcher.doc(sd[0].doc).getField(field).numericValue().intValue();
+      int last =
+          searcher.storedFields().document(sd[0].doc).getField(field).numericValue().intValue();
       for (int j = 1; j < sd.length; j++) {
-        int act = searcher.doc(sd[j].doc).getField(field).numericValue().intValue();
+        int act =
+            searcher.storedFields().document(sd[j].doc).getField(field).numericValue().intValue();
         assertTrue("Docs should be sorted backwards", last > act);
         last = act;
       }

--- a/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms32.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms32.java
@@ -20,7 +20,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -130,15 +135,17 @@ public class TestNumericTerms32 extends SolrTestCase {
         upper = a;
       }
       Query tq =
-          LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, true, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+          LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, true);
       TopDocs topDocs =
           searcher.search(tq, noDocs, new Sort(new SortField(field, SortField.Type.INT, true)));
-      if (topDocs.totalHits.value() == 0) continue;
+      if (topDocs.totalHits.value == 0) continue;
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
-      int last = searcher.storedFields().document(sd[0].doc).getField(field).numericValue().intValue();
+      int last =
+          searcher.storedFields().document(sd[0].doc).getField(field).numericValue().intValue();
       for (int j = 1; j < sd.length; j++) {
-        int act = searcher.storedFields().document(sd[j].doc).getField(field).numericValue().intValue();
+        int act =
+            searcher.storedFields().document(sd[j].doc).getField(field).numericValue().intValue();
         assertTrue("Docs should be sorted backwards", last > act);
         last = act;
       }

--- a/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms32.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms32.java
@@ -20,12 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.*;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -135,17 +130,15 @@ public class TestNumericTerms32 extends SolrTestCase {
         upper = a;
       }
       Query tq =
-          LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, true);
+          LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, true, MultiTermQuery.CONSTANT_SCORE_REWRITE);
       TopDocs topDocs =
           searcher.search(tq, noDocs, new Sort(new SortField(field, SortField.Type.INT, true)));
-      if (topDocs.totalHits.value == 0) continue;
+      if (topDocs.totalHits.value() == 0) continue;
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
-      int last =
-          searcher.storedFields().document(sd[0].doc).getField(field).numericValue().intValue();
+      int last = searcher.storedFields().document(sd[0].doc).getField(field).numericValue().intValue();
       for (int j = 1; j < sd.length; j++) {
-        int act =
-            searcher.storedFields().document(sd[j].doc).getField(field).numericValue().intValue();
+        int act = searcher.storedFields().document(sd[j].doc).getField(field).numericValue().intValue();
         assertTrue("Docs should be sorted backwards", last > act);
         last = act;
       }

--- a/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms64.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms64.java
@@ -20,12 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.*;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -141,17 +136,15 @@ public class TestNumericTerms64 extends SolrTestCase {
         upper = a;
       }
       Query tq =
-          LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, true);
+          LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, true, MultiTermQuery.CONSTANT_SCORE_REWRITE);
       TopDocs topDocs =
           searcher.search(tq, noDocs, new Sort(new SortField(field, SortField.Type.LONG, true)));
-      if (topDocs.totalHits.value == 0) continue;
+      if (topDocs.totalHits.value() == 0) continue;
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
-      long last =
-          searcher.storedFields().document(sd[0].doc).getField(field).numericValue().longValue();
+      long last = searcher.storedFields().document(sd[0].doc).getField(field).numericValue().longValue();
       for (int j = 1; j < sd.length; j++) {
-        long act =
-            searcher.storedFields().document(sd[j].doc).getField(field).numericValue().longValue();
+        long act = searcher.storedFields().document(sd[j].doc).getField(field).numericValue().longValue();
         assertTrue("Docs should be sorted backwards", last > act);
         last = act;
       }

--- a/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms64.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms64.java
@@ -20,7 +20,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -136,15 +141,17 @@ public class TestNumericTerms64 extends SolrTestCase {
         upper = a;
       }
       Query tq =
-          LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, true, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+          LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, true);
       TopDocs topDocs =
           searcher.search(tq, noDocs, new Sort(new SortField(field, SortField.Type.LONG, true)));
-      if (topDocs.totalHits.value() == 0) continue;
+      if (topDocs.totalHits.value == 0) continue;
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
-      long last = searcher.storedFields().document(sd[0].doc).getField(field).numericValue().longValue();
+      long last =
+          searcher.storedFields().document(sd[0].doc).getField(field).numericValue().longValue();
       for (int j = 1; j < sd.length; j++) {
-        long act = searcher.storedFields().document(sd[j].doc).getField(field).numericValue().longValue();
+        long act =
+            searcher.storedFields().document(sd[j].doc).getField(field).numericValue().longValue();
         assertTrue("Docs should be sorted backwards", last > act);
         last = act;
       }

--- a/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms64.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestNumericTerms64.java
@@ -147,9 +147,11 @@ public class TestNumericTerms64 extends SolrTestCase {
       if (topDocs.totalHits.value == 0) continue;
       ScoreDoc[] sd = topDocs.scoreDocs;
       assertNotNull(sd);
-      long last = searcher.doc(sd[0].doc).getField(field).numericValue().longValue();
+      long last =
+          searcher.storedFields().document(sd[0].doc).getField(field).numericValue().longValue();
       for (int j = 1; j < sd.length; j++) {
-        long act = searcher.doc(sd[j].doc).getField(field).numericValue().longValue();
+        long act =
+            searcher.storedFields().document(sd[j].doc).getField(field).numericValue().longValue();
         assertTrue("Docs should be sorted backwards", last > act);
         last = act;
       }

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -205,10 +205,10 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
     assertSingleParentOf(searcher, one("ab"), dubbed);
 
     final TopDocs docs = searcher.search(join(one("cd")), 10);
-    assertEquals(2, docs.totalHits.value);
+    assertEquals(2, docs.totalHits.value());
     final String pAct =
-        searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent)
-            + searcher.storedFields().document(docs.scoreDocs[1].doc).get(parent);
+        searcher.getDocFetcher().doc(docs.scoreDocs[0].doc).get(parent)
+            + searcher.getDocFetcher().doc(docs.scoreDocs[1].doc).get(parent);
     assertTrue(pAct.contains(dubbed) && pAct.contains(overwritten) && pAct.length() == 2);
 
     assertQ(req("id:66", "//*[@numFound='6']"));
@@ -1027,8 +1027,8 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
       final SolrIndexSearcher searcher, final String childTerm, String parentExp)
       throws IOException {
     final TopDocs docs = searcher.search(join(childTerm), 10);
-    assertEquals(1, docs.totalHits.value);
-    final String pAct = searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent);
+    assertEquals(1, docs.totalHits.value());
+    final String pAct = searcher.getDocFetcher().doc(docs.scoreDocs[0].doc).get(parent);
     assertEquals(parentExp, pAct);
   }
 

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -207,8 +207,8 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
     final TopDocs docs = searcher.search(join(one("cd")), 10);
     assertEquals(2, docs.totalHits.value);
     final String pAct =
-        searcher.doc(docs.scoreDocs[0].doc).get(parent)
-            + searcher.doc(docs.scoreDocs[1].doc).get(parent);
+        searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent)
+            + searcher.storedFields().document(docs.scoreDocs[1].doc).get(parent);
     assertTrue(pAct.contains(dubbed) && pAct.contains(overwritten) && pAct.length() == 2);
 
     assertQ(req("id:66", "//*[@numFound='6']"));
@@ -1028,7 +1028,7 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
       throws IOException {
     final TopDocs docs = searcher.search(join(childTerm), 10);
     assertEquals(1, docs.totalHits.value);
-    final String pAct = searcher.doc(docs.scoreDocs[0].doc).get(parent);
+    final String pAct = searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent);
     assertEquals(parentExp, pAct);
   }
 

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -207,8 +207,8 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
     final TopDocs docs = searcher.search(join(one("cd")), 10);
     assertEquals(2, docs.totalHits.value);
     final String pAct =
-        searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent)
-            + searcher.storedFields().document(docs.scoreDocs[1].doc).get(parent);
+        searcher.getDocFetcher().doc(docs.scoreDocs[0].doc).get(parent)
+            + searcher.getDocFetcher().doc(docs.scoreDocs[1].doc).get(parent);
     assertTrue(pAct.contains(dubbed) && pAct.contains(overwritten) && pAct.length() == 2);
 
     assertQ(req("id:66", "//*[@numFound='6']"));
@@ -1028,7 +1028,7 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
       throws IOException {
     final TopDocs docs = searcher.search(join(childTerm), 10);
     assertEquals(1, docs.totalHits.value);
-    final String pAct = searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent);
+    final String pAct = searcher.getDocFetcher().doc(docs.scoreDocs[0].doc).get(parent);
     assertEquals(parentExp, pAct);
   }
 

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -205,10 +205,10 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
     assertSingleParentOf(searcher, one("ab"), dubbed);
 
     final TopDocs docs = searcher.search(join(one("cd")), 10);
-    assertEquals(2, docs.totalHits.value());
+    assertEquals(2, docs.totalHits.value);
     final String pAct =
-        searcher.getDocFetcher().doc(docs.scoreDocs[0].doc).get(parent)
-            + searcher.getDocFetcher().doc(docs.scoreDocs[1].doc).get(parent);
+        searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent)
+            + searcher.storedFields().document(docs.scoreDocs[1].doc).get(parent);
     assertTrue(pAct.contains(dubbed) && pAct.contains(overwritten) && pAct.length() == 2);
 
     assertQ(req("id:66", "//*[@numFound='6']"));
@@ -1027,8 +1027,8 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
       final SolrIndexSearcher searcher, final String childTerm, String parentExp)
       throws IOException {
     final TopDocs docs = searcher.search(join(childTerm), 10);
-    assertEquals(1, docs.totalHits.value());
-    final String pAct = searcher.getDocFetcher().doc(docs.scoreDocs[0].doc).get(parent);
+    assertEquals(1, docs.totalHits.value);
+    final String pAct = searcher.storedFields().document(docs.scoreDocs[0].doc).get(parent);
     assertEquals(parentExp, pAct);
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/ClassificationUpdateProcessorIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/ClassificationUpdateProcessorIntegrationTest.java
@@ -283,7 +283,7 @@ public class ClassificationUpdateProcessorIntegrationTest extends SolrTestCaseJ4
       TermQuery query = new TermQuery(new Term(ID, id));
       TopDocs doc1 = searcher.search(query, 1);
       ScoreDoc scoreDoc = doc1.scoreDocs[0];
-      return searcher.storedFields().document(scoreDoc.doc);
+      return searcher.getDocFetcher().doc(scoreDoc.doc);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/ClassificationUpdateProcessorIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/ClassificationUpdateProcessorIntegrationTest.java
@@ -283,7 +283,7 @@ public class ClassificationUpdateProcessorIntegrationTest extends SolrTestCaseJ4
       TermQuery query = new TermQuery(new Term(ID, id));
       TopDocs doc1 = searcher.search(query, 1);
       ScoreDoc scoreDoc = doc1.scoreDocs[0];
-      return searcher.getDocFetcher().doc(scoreDoc.doc);
+      return searcher.storedFields().document(scoreDoc.doc);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/ClassificationUpdateProcessorIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/ClassificationUpdateProcessorIntegrationTest.java
@@ -283,7 +283,7 @@ public class ClassificationUpdateProcessorIntegrationTest extends SolrTestCaseJ4
       TermQuery query = new TermQuery(new Term(ID, id));
       TopDocs doc1 = searcher.search(query, 1);
       ScoreDoc scoreDoc = doc1.scoreDocs[0];
-      return searcher.doc(scoreDoc.doc);
+      return searcher.storedFields().document(scoreDoc.doc);
     }
   }
 

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -121,8 +121,8 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       // first run the standard query
       TopDocs hits = searcher.search(bqBuilder.build(), 10);
       assertEquals(2, hits.totalHits.value);
-      assertEquals("0", searcher.doc(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("1", searcher.doc(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
 
       final List<Feature> features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScore");
       final List<Normalizer> norms =
@@ -145,8 +145,8 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       hits = rescorer.rescore(searcher, hits, 2);
 
       // rerank using the field finalScore
-      assertEquals("1", searcher.doc(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("0", searcher.doc(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
     }
   }
 
@@ -173,11 +173,11 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       TopDocs hits = searcher.search(bqBuilder.build(), 10);
       assertEquals(5, hits.totalHits.value);
 
-      assertEquals("0", searcher.doc(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("1", searcher.doc(hits.scoreDocs[1].doc).get("id"));
-      assertEquals("2", searcher.doc(hits.scoreDocs[2].doc).get("id"));
-      assertEquals("3", searcher.doc(hits.scoreDocs[3].doc).get("id"));
-      assertEquals("4", searcher.doc(hits.scoreDocs[4].doc).get("id"));
+      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("2", searcher.storedFields().document(hits.scoreDocs[2].doc).get("id"));
+      assertEquals("3", searcher.storedFields().document(hits.scoreDocs[3].doc).get("id"));
+      assertEquals("4", searcher.storedFields().document(hits.scoreDocs[4].doc).get("id"));
 
       final List<Feature> features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScoreFloat");
       final List<Normalizer> norms =
@@ -201,11 +201,11 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       // rerank @ 0 should not change the order
       hits = rescorer.rescore(searcher, hits, 0);
-      assertEquals("0", searcher.doc(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("1", searcher.doc(hits.scoreDocs[1].doc).get("id"));
-      assertEquals("2", searcher.doc(hits.scoreDocs[2].doc).get("id"));
-      assertEquals("3", searcher.doc(hits.scoreDocs[3].doc).get("id"));
-      assertEquals("4", searcher.doc(hits.scoreDocs[4].doc).get("id"));
+      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("2", searcher.storedFields().document(hits.scoreDocs[2].doc).get("id"));
+      assertEquals("3", searcher.storedFields().document(hits.scoreDocs[3].doc).get("id"));
+      assertEquals("4", searcher.storedFields().document(hits.scoreDocs[4].doc).get("id"));
 
       // test rerank with different topN cuts
 
@@ -219,9 +219,14 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
         hits = rescorer.rescore(searcher, hits, topN);
         for (int i = topN - 1, j = 0; i >= 0; i--, j++) {
           if (log.isInfoEnabled()) {
-            log.info("doc {} in pos {}", searcher.doc(hits.scoreDocs[j].doc).get("id"), j);
+            log.info(
+                "doc {} in pos {}",
+                searcher.storedFields().document(hits.scoreDocs[j].doc).get("id"),
+                j);
           }
-          assertEquals(i, Integer.parseInt(searcher.doc(hits.scoreDocs[j].doc).get("id")));
+          assertEquals(
+              i,
+              Integer.parseInt(searcher.storedFields().document(hits.scoreDocs[j].doc).get("id")));
           assertEquals((i + 1) * features.size() * featureWeight, hits.scoreDocs[j].score, 0.00001);
         }
       }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -121,8 +121,8 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       // first run the standard query
       TopDocs hits = searcher.search(bqBuilder.build(), 10);
       assertEquals(2, hits.totalHits.value);
-      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("0", searcher.getDocFetcher().doc(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.getDocFetcher().doc(hits.scoreDocs[1].doc).get("id"));
 
       final List<Feature> features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScore");
       final List<Normalizer> norms =
@@ -145,8 +145,8 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       hits = rescorer.rescore(searcher, hits, 2);
 
       // rerank using the field finalScore
-      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("1", searcher.getDocFetcher().doc(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("0", searcher.getDocFetcher().doc(hits.scoreDocs[1].doc).get("id"));
     }
   }
 
@@ -173,11 +173,11 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       TopDocs hits = searcher.search(bqBuilder.build(), 10);
       assertEquals(5, hits.totalHits.value);
 
-      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
-      assertEquals("2", searcher.storedFields().document(hits.scoreDocs[2].doc).get("id"));
-      assertEquals("3", searcher.storedFields().document(hits.scoreDocs[3].doc).get("id"));
-      assertEquals("4", searcher.storedFields().document(hits.scoreDocs[4].doc).get("id"));
+      assertEquals("0", searcher.getDocFetcher().doc(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.getDocFetcher().doc(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("2", searcher.getDocFetcher().doc(hits.scoreDocs[2].doc).get("id"));
+      assertEquals("3", searcher.getDocFetcher().doc(hits.scoreDocs[3].doc).get("id"));
+      assertEquals("4", searcher.getDocFetcher().doc(hits.scoreDocs[4].doc).get("id"));
 
       final List<Feature> features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScoreFloat");
       final List<Normalizer> norms =
@@ -201,11 +201,11 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       // rerank @ 0 should not change the order
       hits = rescorer.rescore(searcher, hits, 0);
-      assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
-      assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
-      assertEquals("2", searcher.storedFields().document(hits.scoreDocs[2].doc).get("id"));
-      assertEquals("3", searcher.storedFields().document(hits.scoreDocs[3].doc).get("id"));
-      assertEquals("4", searcher.storedFields().document(hits.scoreDocs[4].doc).get("id"));
+      assertEquals("0", searcher.getDocFetcher().doc(hits.scoreDocs[0].doc).get("id"));
+      assertEquals("1", searcher.getDocFetcher().doc(hits.scoreDocs[1].doc).get("id"));
+      assertEquals("2", searcher.getDocFetcher().doc(hits.scoreDocs[2].doc).get("id"));
+      assertEquals("3", searcher.getDocFetcher().doc(hits.scoreDocs[3].doc).get("id"));
+      assertEquals("4", searcher.getDocFetcher().doc(hits.scoreDocs[4].doc).get("id"));
 
       // test rerank with different topN cuts
 
@@ -221,12 +221,11 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
           if (log.isInfoEnabled()) {
             log.info(
                 "doc {} in pos {}",
-                searcher.storedFields().document(hits.scoreDocs[j].doc).get("id"),
+                searcher.getDocFetcher().doc(hits.scoreDocs[j].doc).get("id"),
                 j);
           }
           assertEquals(
-              i,
-              Integer.parseInt(searcher.storedFields().document(hits.scoreDocs[j].doc).get("id")));
+              i, Integer.parseInt(searcher.getDocFetcher().doc(hits.scoreDocs[j].doc).get("id")));
           assertEquals((i + 1) * features.size() * featureWeight, hits.scoreDocs[j].score, 0.00001);
         }
       }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRScoringQuery.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRScoringQuery.java
@@ -193,8 +193,8 @@ public class TestLTRScoringQuery extends SolrTestCase {
     // first run the standard query
     final TopDocs hits = searcher.search(bqBuilder.build(), 10);
     assertEquals(2, hits.totalHits.value);
-    assertEquals("0", searcher.doc(hits.scoreDocs[0].doc).get("id"));
-    assertEquals("1", searcher.doc(hits.scoreDocs[1].doc).get("id"));
+    assertEquals("0", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
 
     List<Feature> features = makeFeatures(new int[] {0, 1, 2});
     final List<Feature> allFeatures = makeFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
@@ -138,8 +138,8 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
     // first run the standard query
     final TopDocs hits = searcher.search(bqBuilder.build(), 10);
     assertEquals(2, hits.totalHits.value);
-    assertEquals("10", searcher.doc(hits.scoreDocs[0].doc).get("id"));
-    assertEquals("11", searcher.doc(hits.scoreDocs[1].doc).get("id"));
+    assertEquals("10", searcher.storedFields().document(hits.scoreDocs[0].doc).get("id"));
+    assertEquals("11", searcher.storedFields().document(hits.scoreDocs[1].doc).get("id"));
 
     List<Feature> features = makeFeatures(new int[] {0, 1, 2});
     final List<Feature> allFeatures = makeFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});


### PR DESCRIPTION
The API is deprecated since Lucene 9.5 - https://github.com/apache/lucene/blob/releases/lucene/9.5.0/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java#L382-L391 -- and remove in Lucene 10.

So the replacement here can go to both `main` and `branch_9x` branches with no JIRA or solr/CHANGES.txt entry needed in my opinion.