### PR TITLE
SOLR-17582: Stream CLUSTERSTATUS API for SolrJ version >= 9.9

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -353,7 +353,7 @@ public class StatusTool extends ToolBase {
     cloudStatus.put("liveNodes", String.valueOf(liveNodes.size()));
 
     // TODO get this as a metric from the metrics API instead, or something else.
-    var collections = (NamedList<Object>) json.findRecursive("cluster", "collections");
+    var collections = (Map<String, Object>) json.findRecursive("cluster", "collections");
     cloudStatus.put("collections", String.valueOf(collections.size()));
 
     return cloudStatus;

--- a/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
@@ -209,7 +209,7 @@ public class ClusterStatus {
       }
     }
 
-    if (solrVersion.greaterThanOrEqualTo(SolrVersion.valueOf("9.9.0"))) {
+    if (solrVersion == null || solrVersion.greaterThanOrEqualTo(SolrVersion.valueOf("9.9.0"))) {
       MapWriter collectionPropsWriter =
           ew -> {
             collectionStream.forEach(

--- a/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.solr.client.api.util.SolrVersion;
 import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.Aliases;
@@ -34,7 +35,6 @@ import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
@@ -101,7 +101,7 @@ public class ClusterStatus {
     collection = params.get(ZkStateReader.COLLECTION_PROP);
   }
 
-  public void getClusterStatus(NamedList<Object> results)
+  public void getClusterStatus(NamedList<Object> results, SolrVersion solrVersion)
       throws KeeperException, InterruptedException {
     NamedList<Object> clusterStatus = new SimpleOrderedMap<>();
 
@@ -127,7 +127,7 @@ public class ClusterStatus {
 
     if (withCollection) {
       assert liveNodes != null;
-      fetchClusterStatusForCollOrAlias(clusterStatus, liveNodes, aliases);
+      fetchClusterStatusForCollOrAlias(clusterStatus, liveNodes, aliases, solrVersion);
     }
 
     if (withAliases) {
@@ -158,7 +158,10 @@ public class ClusterStatus {
   }
 
   private void fetchClusterStatusForCollOrAlias(
-      NamedList<Object> clusterStatus, List<String> liveNodes, Aliases aliases) {
+      NamedList<Object> clusterStatus,
+      List<String> liveNodes,
+      Aliases aliases,
+      SolrVersion solrVersion) {
 
     // read aliases
     Map<String, List<String>> collectionVsAliases = new HashMap<>();
@@ -206,19 +209,7 @@ public class ClusterStatus {
       }
     }
 
-    // Because of back-compat for SolrJ, create the whole response into a NamedList
-    // Otherwise stream with MapWriter to save memory
-    if (CommonParams.JAVABIN.equals(solrParams.get(CommonParams.WT))) {
-      NamedList<Object> collectionProps = new SimpleOrderedMap<>();
-      collectionStream.forEach(
-          collectionState -> {
-            collectionProps.add(
-                collectionState.getName(),
-                buildResponseForCollection(
-                    collectionState, collectionVsAliases, routeKey, liveNodes, requestedShards));
-          });
-      clusterStatus.add("collections", collectionProps);
-    } else {
+    if (solrVersion.greaterThanOrEqualTo(SolrVersion.valueOf("9.9.0"))) {
       MapWriter collectionPropsWriter =
           ew -> {
             collectionStream.forEach(
@@ -234,6 +225,16 @@ public class ClusterStatus {
                 });
           };
       clusterStatus.add("collections", collectionPropsWriter);
+    } else {
+      NamedList<Object> collectionProps = new SimpleOrderedMap<>();
+      collectionStream.forEach(
+          collectionState -> {
+            collectionProps.add(
+                collectionState.getName(),
+                buildResponseForCollection(
+                    collectionState, collectionVsAliases, routeKey, liveNodes, requestedShards));
+          });
+      clusterStatus.add("collections", collectionProps);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -975,7 +975,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
         CLUSTERSTATUS,
         (req, rsp, h) -> {
           new ClusterStatus(h.coreContainer.getZkController().getZkStateReader(), req.getParams())
-              .getClusterStatus(rsp.getValues());
+              .getClusterStatus(rsp.getValues(), req.getHttpSolrCall().getUserAgentSolrVersion());
           return null;
         }),
     ADDREPLICAPROP_OP(

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestCollectionAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestCollectionAPI.java
@@ -131,10 +131,11 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
               .getResponse();
       NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertEquals(1, collections.size());
-      assertEquals("25", collections._getStr(List.of(COLLECTION_NAME, "replicationFactor"), null));
+      Map<?, ?> collectionProperties = (Map<?, ?>) collections.get(COLLECTION_NAME);
+      assertEquals("25", collectionProperties.get("replicationFactor"));
 
       params = new ModifiableSolrParams();
       params.set("action", CollectionParams.CollectionAction.MODIFYCOLLECTION.toString());
@@ -153,10 +154,11 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       System.out.println(rsp);
       cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      collections = (NamedList<?>) cluster.get("collections");
+      collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertEquals(1, collections.size());
-      assertNull(collections._getStr(List.of(COLLECTION_NAME, "replicationFactor"), null));
+      collectionProperties = (Map<?, ?>) collections.get(COLLECTION_NAME);
+      assertNull(collectionProperties.get("replicationFactor"));
 
       params = new ModifiableSolrParams();
       params.set("action", CollectionParams.CollectionAction.MODIFYCOLLECTION.toString());
@@ -255,7 +257,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<?> rsp = client.request(req);
       NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(
           "Testing to insure collections are returned", collections.get(COLLECTION_NAME1));
@@ -282,7 +284,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
     NamedList<Object> rsp = client.request(request);
     NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
     assertNotNull("Cluster state should not be null", cluster);
-    NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+    Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
     assertNotNull("Collections should not be null in cluster state", collections);
     assertEquals(1, collections.size());
     @SuppressWarnings({"unchecked"})
@@ -304,7 +306,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> rsp = client.request(request);
       NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(collections.get(COLLECTION_NAME));
       assertEquals(1, collections.size());
@@ -330,7 +332,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> rsp = request.process(client).getResponse();
       NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(collections.get(COLLECTION_NAME));
       assertEquals(1, collections.size());
@@ -465,7 +467,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> rsp = client.request(request);
       NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(collections.get(COLLECTION_NAME1));
       assertEquals(4, collections.size());
@@ -487,7 +489,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> rsp = client.request(request);
       NamedList<?> cluster = (NamedList<?>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<?> collections = (NamedList<?>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertEquals(1, collections.size());
       @SuppressWarnings({"unchecked"})
@@ -517,7 +519,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> rsp = client.request(request);
       NamedList<Object> cluster = (NamedList<Object>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      NamedList<Object> collections = (NamedList<Object>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertEquals(1, collections.size());
       Map<String, Object> collection = (Map<String, Object>) collections.get(cname);
@@ -533,7 +535,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
 
       rsp = client.request(request);
       cluster = (NamedList<Object>) rsp.get("cluster");
-      collections = (NamedList<Object>) cluster.get("collections");
+      collections = (Map<?, ?>) cluster.get("collections");
       collection = (Map<String, Object>) collections.get(cname);
       Integer newVersion = (Integer) collection.get("znodeVersion");
       assertNotNull(newVersion);
@@ -560,7 +562,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> cluster = (NamedList<Object>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
       @SuppressWarnings({"unchecked"})
-      NamedList<Object> collections = (NamedList<Object>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(collections.get(DEFAULT_COLLECTION));
       assertEquals(1, collections.size());
@@ -607,7 +609,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
           DEFAULT_COLLECTION + "," + COLLECTION_NAME,
           aliases.get("myalias"));
 
-      NamedList<Object> collections = (NamedList<Object>) cluster.get("collections");
+      Map<?, ?> collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(collections.get(DEFAULT_COLLECTION));
       Map<String, Object> collection = (Map<String, Object>) collections.get(DEFAULT_COLLECTION);
@@ -627,7 +629,7 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
 
       cluster = (NamedList<Object>) rsp.get("cluster");
       assertNotNull("Cluster state should not be null", cluster);
-      collections = (NamedList<Object>) cluster.get("collections");
+      collections = (Map<?, ?>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull(collections.get(DEFAULT_COLLECTION));
       assertNotNull(collections.get(COLLECTION_NAME));

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
@@ -29,7 +29,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -163,11 +162,8 @@ public abstract class BaseHttpClusterStateProvider implements ClusterStateProvid
 
     Map<String, DocCollection> collStateByName =
         CollectionUtil.newLinkedHashMap(collectionsMap.size());
-    for (Entry<String, Map<String, Object>> entry : collectionsMap.entrySet()) {
-      collStateByName.put(
-          entry.getKey(), getDocCollectionFromObjects(entry.getKey(), entry.getValue()));
-    }
-
+    collectionsMap.forEach(
+        (key, value) -> collStateByName.put(key, getDocCollectionFromObjects(key, value)));
     return new ClusterState(this.liveNodes, collStateByName);
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
@@ -46,7 +46,6 @@ import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.EnvUtils;
-import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.common.util.Utils;
@@ -160,11 +159,11 @@ public abstract class BaseHttpClusterStateProvider implements ClusterStateProvid
       liveNodesTimestamp = System.nanoTime();
     }
 
-    var collectionsNl = (NamedList<Map<String, Object>>) cluster.get("collections");
+    var collectionsMap = (Map<String, Map<String, Object>>) cluster.get("collections");
 
     Map<String, DocCollection> collStateByName =
-        CollectionUtil.newLinkedHashMap(collectionsNl.size());
-    for (Entry<String, Map<String, Object>> entry : collectionsNl) {
+        CollectionUtil.newLinkedHashMap(collectionsMap.size());
+    for (Entry<String, Map<String, Object>> entry : collectionsMap.entrySet()) {
       collStateByName.put(
           entry.getKey(), getDocCollectionFromObjects(entry.getKey(), entry.getValue()));
     }
@@ -205,7 +204,7 @@ public abstract class BaseHttpClusterStateProvider implements ClusterStateProvid
     SimpleOrderedMap<?> cluster =
         submitClusterStateRequest(client, collection, ClusterStateRequestType.FETCH_COLLECTION);
 
-    var collStateMap = (Map<String, Object>) cluster.findRecursive("collections", collection);
+    var collStateMap = (Map<String, Object>) cluster._get(List.of("collections", collection), null);
     if (collStateMap == null) {
       throw new NotACollectionException(); // probably an alias
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17582

# Description

Check for SolrJ version from a cluster status request user agent header to stream the response for any SolrJ clients >= 9.9 allowing for backwards compatibility.

# Solution

Removed old Javabin check that didn't allow streaming for SolrJ and use the requests Solr version as the check instead for >= 9.9 to either stream or collect whole response in a `SimpleOrderedMap`

# Tests

Created `testClusterStateProviderBackwardCompatability` to test backwards compatability

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
