### PR TITLE
SOLR-17649: Fix Json faceting on  multivalue number types

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -187,7 +187,7 @@ Bug Fixes
 
 * SOLR-17652: Fix a bug that could cause long leader elections to leave PULL replicas in DOWN state forever. (hossman)
 
-* SOLR-17649: Fix a regression of faceting on multi-valued EnumFieldType, introduced by an earlier 9.x version. (Thomas Wöckinger, David Smiley, Houston Putman, Kevin Risden)
+* SOLR-17649: Fix a regression of faceting on multi-valued EnumFieldType, introduced by an earlier 9.x version. (Thomas Wöckinger, David Smiley)
 
 Dependency Upgrades
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -187,6 +187,8 @@ Bug Fixes
 
 * SOLR-17652: Fix a bug that could cause long leader elections to leave PULL replicas in DOWN state forever. (hossman)
 
+* SOLR-17649: Fix a regression of faceting on multi-valued EnumFieldType, introduced by an earlier 9.x version. (Thomas Wöckinger, David Smiley, Houston Putman, Kevin Risden)
+
 Dependency Upgrades
 ---------------------
 * SOLR-17471: Upgrade Lucene to 9.12.1. (Pierre Salagnac, Christine Poerschke)

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetField.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetField.java
@@ -152,11 +152,12 @@ public class FacetField extends FacetRequestSorted {
       }
     }
 
-    if (sf.hasDocValues() && sf.getType().isPointField()) {
+    // multi-valued after this point
+
+    if (sf.hasDocValues()
+        && (sf.getType().isPointField() || sf.getType().getNumberType() != null)) {
       return new FacetFieldProcessorByHashDV(fcontext, this, sf);
     }
-
-    // multi-valued after this point
 
     if (sf.hasDocValues() || method == FacetMethod.DV || !sf.isUninvertible()) {
       // single and multi-valued string docValues

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayDV.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayDV.java
@@ -38,7 +38,7 @@ import org.apache.solr.search.facet.SweepCountAware.SegCountGlobal;
 import org.apache.solr.search.facet.SweepCountAware.SegCountPerSeg;
 import org.apache.solr.uninverting.FieldCacheImpl;
 
-/** Grabs values from {@link DocValues}. */
+/** Grabs values from {@link SortedDocValues} or {@link SortedDocValues}. */
 class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
   static boolean unwrap_singleValued_multiDv = true; // only set to false for test coverage
 

--- a/solr/core/src/test-files/solr/collection1/conf/schema_latest.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema_latest.xml
@@ -729,6 +729,8 @@
   <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD"
              currencyConfig="currency.xml"/>
 
+  <fieldType name="severityType" class="solr.EnumFieldType" enumsConfig="enumsConfig.xml" enumName="severity"/>
+  <field name="severity_mv" type="severityType" indexed="true" stored="true" multiValued="true" docValues="true" />
 
   <!-- some examples for different languages (generally ordered by ISO code) -->
   <!-- REMOVED.  these reference things not in the test config, like lang/stopwords_en.txt -->

--- a/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
@@ -90,7 +90,8 @@ public class TestRawTransformer extends SolrCloudTestCase {
           "stopwords.txt",
           "synonyms.txt",
           "protwords.txt",
-          "currency.xml"
+          "currency.xml",
+          "enumsConfig.xml"
         }) {
       Files.copy(Path.of(src_dir, file), confDir.resolve(file));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17649

# Description

FacetFieldProcessorByArrayDV can not handle fields with DocValues of type DocValuesType.SORTED_NUMERIC.
If such a type is requested for faceting FacetFieldProcessorByHashDV must be used.

# Solution

Use the correct FacetFiledProcessor

# Tests

Create multi valued EnumFileds, which had DocValues enabled, to ensure the use of  DocValuesType.SORTED_NUMERIC, index a few multivalued docs and query the facets afterwards

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
