### PR TITLE
SOLR-17654: DistribFileStore._getRealPath() has issues on Windows

### DIFF
--- a/solr/core/src/java/org/apache/solr/filestore/DistribFileStore.java
+++ b/solr/core/src/java/org/apache/solr/filestore/DistribFileStore.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -88,13 +89,13 @@ public class DistribFileStore implements FileStore {
     return _getRealPath(path, solrHome);
   }
 
-  private static Path _getRealPath(String dir, Path solrHome) {
-    Path path = Path.of(dir);
-    SolrPaths.assertNotUnc(path);
-
-    if (path.isAbsolute()) {
-      // Strip the path of from being absolute to become relative to resolve with SolrHome
-      path = path.subpath(0, path.getNameCount());
+  private static Path _getRealPath(String path, Path solrHome) {
+    if (FileSystems.getDefault().getSeparator().equals("\\")) {
+      path = path.replace("/", FileSystems.getDefault().getSeparator());
+    }
+    SolrPaths.assertNotUnc(Path.of(path));
+    while (path.startsWith(FileSystems.getDefault().getSeparator())) { // Trim all leading slashes
+      path = path.substring(1);
     }
 
     var finalPath = getFileStoreDirPath(solrHome).resolve(path);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17654

# Description

Number of tests failing on windows due to beginning slash in a path not being stripped to become relative.

# Solution

Revert to old logic but use more modern `FileSystems.getDefault().getSeparator()` instead.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
