### PR TITLE
Make PGP signing the release announcement optional

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -116,10 +116,16 @@ templates:
 
     (( template=announce_solr_mail_body ))
     ----
-  announce_solr_sign_mail: |
+  announce_solr_announce_mail: |    
     The template below can be used to announce the Solr release to the
-    `announce@apache.org` mailing list. The mail *should be signed with PGP.*
-    and sent *from your `@apache.org` account*.
+    `announce@apache.org` mailing list. The email *must* be sent *from your `@apache.org` account*,
+    and it *can optionally* be signed with your PGP key. To sign the mail body, follow these steps:
+    
+    1. Copy the body of the announce email to clipboard
+    2. Run the command `gpg --output - --clearsign` in your terminal
+    3. Paste the body of the email into the terminal
+    4. Press `Ctrl-D` to end the input and obtain the signed text
+    5. Copy the signed text and paste it into the email client
 
     .Mail template
     ----
@@ -1588,7 +1594,7 @@ groups:
     For feature releases, your announcement should describe the main features included 
     in the release. *Send the announce as Plain-text email, not HTML.*
 
-    This step will generate email templates based on the news files you edited earler for the website.
+    This step will generate email templates based on the news files you edited earlier for the website.
     Do any last-minute necessary edits to the text as you copy it over to the email.
   todos:
   - !Todo
@@ -1597,29 +1603,13 @@ groups:
     description: |
       (( template=announce_solr_mail ))
   - !Todo
-    id: setup_pgp_mail
-    title: Setup your mail client for PGP
-    description: |
-      The announce mail to `announce@apache.org` should be cryptographically signed.
-      Make sure you have a PGP enabled email client with your apache key installed.
-      There are plugins for popular email programs, as well as browser plugins for webmail.
-      See links for help on how to setup your email client for PGP.
-
-      If you prefer to sign the announcements manually rather than using a plugin,
-      you can do so from the command line and then copy the output into your mail program.
-
-      gpg --output - --clearsign solr_announce.txt
-    links:
-    - https://www.openpgp.org/software/
-    - https://ssd.eff.org/en/module/how-use-pgp-mac-os-x
-    - https://ssd.eff.org/en/module/how-use-pgp-linux
-    - https://ssd.eff.org/en/module/how-use-pgp-windows
-    - https://www.openpgp.org/software/mailvelope/
-  - !Todo
     id: announce_solr_sig
     title: Announce the Solr release (announce@a.o)
     description: |
-      (( template=announce_solr_sign_mail ))
+      (( template=announce_solr_announce_mail ))
+    links:
+      - https://www.apache.org/legal/release-policy.html#release-announcements
+      - https://www.gnupg.org/gph/en/manual/x135.html
   - !Todo
     id: add_to_wikipedia
     title: Add the new version to Wikipedia

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -119,13 +119,8 @@ templates:
   announce_solr_announce_mail: |    
     The template below can be used to announce the Solr release to the
     `announce@apache.org` mailing list. The email *must* be sent *from your `@apache.org` account*,
-    and it *can optionally* be signed with your PGP key. To sign the mail body, follow these steps:
-    
-    1. Copy the body of the announce email to clipboard
-    2. Run the command `gpg --output - --clearsign` in your terminal
-    3. Paste the body of the email into the terminal
-    4. Press `Ctrl-D` to end the input and obtain the signed text
-    5. Copy the signed text and paste it into the email client
+    and it *can optionally* be signed with your PGP key, using the `--clearsign` option of 
+    gpg, as explained in https://www.gnupg.org/gph/en/manual/x135.html.
 
     .Mail template
     ----


### PR DESCRIPTION
As discussed in slack https://the-asf.slack.com/archives/CEKUCUNE9/p1738760259166169

I opted to keep the instructions in the wizard but clearly mark it as optional, skipping the S/MIME email client stuff and focusing only on gpg command line clearsign option.

Not ran the wizard after this change so may be formatting bugs...