### PR TITLE
SOLR-17628: Add query quantiles metrics to prometheus endpoint

### DIFF
--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
@@ -119,7 +119,7 @@ public abstract class SolrPrometheusFormatter {
 
 
   /**
-   * Export {@link Timer} ands its mean rate to {@link
+   * Export {@link Timer} ands its quantile data to {@link
    * io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot}
    * and collect datapoint
    *
@@ -265,7 +265,7 @@ public abstract class SolrPrometheusFormatter {
   }
 
   /**
-   * Collects {@link io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot} and
+   * Collects {@link io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot} and
    * appends to existing metric or create new metric if name does not exist
    *
    * @param metricName Name of metric

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
@@ -29,13 +29,11 @@ import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.model.snapshots.Quantile;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.solr.util.stats.MetricUtils;
 
 /**
@@ -103,9 +101,9 @@ public abstract class SolrPrometheusFormatter {
   }
 
   /**
-   * Export {@link Timer} ands its quantile data to
-   * {@link io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot}
-   * and collect datapoint
+   * Export {@link Timer} ands its quantile data to {@link
+   * io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot} and collect
+   * datapoint
    *
    * @param metricName name of prometheus metric
    * @param dropwizardMetric the {@link Timer} to be exported
@@ -115,20 +113,22 @@ public abstract class SolrPrometheusFormatter {
     Snapshot snapshot = dropwizardMetric.getSnapshot();
 
     long count = snapshot.size();
-    double sum = Arrays.stream(snapshot.getValues())
-      .asDoubleStream()
-      .map(num -> MetricUtils.nsToMs(num))
-      .sum();
+    double sum =
+        Arrays.stream(snapshot.getValues())
+            .asDoubleStream()
+            .map(num -> MetricUtils.nsToMs(num))
+            .sum();
 
-    Quantiles quantiles = Quantiles.of(List.of(
-      new Quantile(0.50, MetricUtils.nsToMs(snapshot.getMedian())),
-      new Quantile(0.75, MetricUtils.nsToMs(snapshot.get75thPercentile())),
-      new Quantile(0.99, MetricUtils.nsToMs(snapshot.get99thPercentile())),
-      new Quantile(0.999, MetricUtils.nsToMs(snapshot.get999thPercentile()))
-    ));
+    Quantiles quantiles =
+        Quantiles.of(
+            List.of(
+                new Quantile(0.50, MetricUtils.nsToMs(snapshot.getMedian())),
+                new Quantile(0.75, MetricUtils.nsToMs(snapshot.get75thPercentile())),
+                new Quantile(0.99, MetricUtils.nsToMs(snapshot.get99thPercentile())),
+                new Quantile(0.999, MetricUtils.nsToMs(snapshot.get999thPercentile()))));
 
     SummarySnapshot.SummaryDataPointSnapshot summary =
-      createSummaryDataPointSnapshot(count, sum, quantiles, labels);
+        createSummaryDataPointSnapshot(count, sum, quantiles, labels);
 
     collectSummaryDatapoint(metricName, summary);
   }
@@ -212,13 +212,13 @@ public abstract class SolrPrometheusFormatter {
    * @param labels set of name/values labels
    */
   public SummarySnapshot.SummaryDataPointSnapshot createSummaryDataPointSnapshot(
-    long count, double sum, Quantiles quantiles, Labels labels) {
+      long count, double sum, Quantiles quantiles, Labels labels) {
     return SummarySnapshot.SummaryDataPointSnapshot.builder()
-      .count(count)
-      .sum(sum)
-      .labels(labels)
-      .quantiles(quantiles)
-      .build();
+        .count(count)
+        .sum(sum)
+        .labels(labels)
+        .quantiles(quantiles)
+        .build();
   }
 
   /**
@@ -252,14 +252,14 @@ public abstract class SolrPrometheusFormatter {
   }
 
   /**
-   * Collects {@link io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot} and
-   * appends to existing metric or create new metric if name does not exist
+   * Collects {@link io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot}
+   * and appends to existing metric or create new metric if name does not exist
    *
    * @param metricName Name of metric
    * @param dataPoint Gauge datapoint to be collected
    */
-  public void collectSummaryDatapoint(String metricName,
-    SummarySnapshot.SummaryDataPointSnapshot dataPoint) {
+  public void collectSummaryDatapoint(
+      String metricName, SummarySnapshot.SummaryDataPointSnapshot dataPoint) {
     if (!metricSummaries.containsKey(metricName)) {
       metricSummaries.put(metricName, new ArrayList<>());
     }
@@ -282,7 +282,8 @@ public abstract class SolrPrometheusFormatter {
           new GaugeSnapshot(new MetricMetadata(metricName), metricGauges.get(metricName)));
     }
     for (String metricName : metricSummaries.keySet()) {
-      snapshots.add(new SummarySnapshot(new MetricMetadata(metricName), metricSummaries.get(metricName)));
+      snapshots.add(
+          new SummarySnapshot(new MetricMetadata(metricName), metricSummaries.get(metricName)));
     }
 
     return new MetricSnapshots(snapshots);

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
@@ -115,7 +115,10 @@ public abstract class SolrPrometheusFormatter {
     Snapshot snapshot = dropwizardMetric.getSnapshot();
 
     long count = snapshot.size();
-    double sum = Arrays.stream(snapshot.getValues()).asDoubleStream().sum();
+    double sum = Arrays.stream(snapshot.getValues())
+      .asDoubleStream()
+      .map(num -> MetricUtils.nsToMs(num))
+      .sum();
 
     Quantiles quantiles = Quantiles.of(List.of(
       new Quantile(0.50, MetricUtils.nsToMs(snapshot.getMedian())),

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/SolrPrometheusFormatter.java
@@ -103,31 +103,15 @@ public abstract class SolrPrometheusFormatter {
   }
 
   /**
-   * Export {@link Timer} ands its mean rate to {@link
-   * io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot} and collect
-   * datapoint
-   *
-   * @param metricName name of prometheus metric
-   * @param dropwizardMetric the {@link Timer} to be exported
-   * @param labels label names and values to record
-   */
-  public void exportTimer(String metricName, Timer dropwizardMetric, Labels labels) {
-    GaugeSnapshot.GaugeDataPointSnapshot dataPoint =
-        createGaugeDatapoint(dropwizardMetric.getSnapshot().getMean(), labels);
-    collectGaugeDatapoint(metricName, dataPoint);
-  }
-
-
-  /**
-   * Export {@link Timer} ands its quantile data to {@link
-   * io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot}
+   * Export {@link Timer} ands its quantile data to
+   * {@link io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot}
    * and collect datapoint
    *
    * @param metricName name of prometheus metric
    * @param dropwizardMetric the {@link Timer} to be exported
    * @param labels label names and values to record
    */
-  public void exportTimerSummary(String metricName, Timer dropwizardMetric, Labels labels) {
+  public void exportTimer(String metricName, Timer dropwizardMetric, Labels labels) {
     Snapshot snapshot = dropwizardMetric.getSnapshot();
 
     long count = snapshot.size();

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHandlerMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHandlerMetric.java
@@ -28,8 +28,7 @@ public class SolrCoreHandlerMetric extends SolrCoreMetric {
   public static final String CORE_REQUESTS_TOTAL = "solr_metrics_core_requests";
   public static final String CORE_REQUESTS_UPDATE_HANDLER = "solr_metrics_core_update_handler";
   public static final String CORE_REQUESTS_TOTAL_TIME = "solr_metrics_core_requests_time";
-  public static final String CORE_REQUEST_TIMES = "solr_metrics_core_average_request_time";
-  public static final String CORE_REQUEST_TIME_SUMMARY = "solr_metrics_core_request_time";
+  public static final String CORE_REQUEST_TIMES = "solr_metrics_core_request_time";
 
   public SolrCoreHandlerMetric(Metric dropwizardMetric, String metricName) {
     super(dropwizardMetric, metricName);
@@ -73,7 +72,6 @@ public class SolrCoreHandlerMetric extends SolrCoreMetric {
       // Do not need type label for request times
       labels.remove("type");
       formatter.exportTimer(CORE_REQUEST_TIMES, (Timer) dropwizardMetric, getLabels());
-      formatter.exportTimerSummary(CORE_REQUEST_TIME_SUMMARY, (Timer) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHandlerMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreHandlerMetric.java
@@ -29,6 +29,7 @@ public class SolrCoreHandlerMetric extends SolrCoreMetric {
   public static final String CORE_REQUESTS_UPDATE_HANDLER = "solr_metrics_core_update_handler";
   public static final String CORE_REQUESTS_TOTAL_TIME = "solr_metrics_core_requests_time";
   public static final String CORE_REQUEST_TIMES = "solr_metrics_core_average_request_time";
+  public static final String CORE_REQUEST_TIME_SUMMARY = "solr_metrics_core_request_time";
 
   public SolrCoreHandlerMetric(Metric dropwizardMetric, String metricName) {
     super(dropwizardMetric, metricName);
@@ -72,6 +73,7 @@ public class SolrCoreHandlerMetric extends SolrCoreMetric {
       // Do not need type label for request times
       labels.remove("type");
       formatter.exportTimer(CORE_REQUEST_TIMES, (Timer) dropwizardMetric, getLabels());
+      formatter.exportTimerSummary(CORE_REQUEST_TIME_SUMMARY, (Timer) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreSearcherMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreSearcherMetric.java
@@ -27,8 +27,7 @@ import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 /** Dropwizard metrics of name SEARCHER.* */
 public class SolrCoreSearcherMetric extends SolrCoreMetric {
   public static final String CORE_SEARCHER_METRICS = "solr_metrics_core_searcher_documents";
-  public static final String CORE_SEARCHER_TIMES = "solr_metrics_core_average_searcher_warmup_time";
-  public static final String CORE_SEARCHER_TIME_SUMMARY = "solr_metrics_core_searcher_warmup_time";
+  public static final String CORE_SEARCHER_TIMES = "solr_metrics_core_searcher_warmup_time";
 
   public SolrCoreSearcherMetric(Metric dropwizardMetric, String metricName) {
     super(dropwizardMetric, metricName);
@@ -60,7 +59,6 @@ public class SolrCoreSearcherMetric extends SolrCoreMetric {
       }
     } else if (dropwizardMetric instanceof Timer) {
       formatter.exportTimer(CORE_SEARCHER_TIMES, (Timer) dropwizardMetric, getLabels());
-      formatter.exportTimerSummary(CORE_SEARCHER_TIME_SUMMARY, (Timer) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreSearcherMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/prometheus/core/SolrCoreSearcherMetric.java
@@ -28,6 +28,7 @@ import org.apache.solr.metrics.prometheus.SolrPrometheusFormatter;
 public class SolrCoreSearcherMetric extends SolrCoreMetric {
   public static final String CORE_SEARCHER_METRICS = "solr_metrics_core_searcher_documents";
   public static final String CORE_SEARCHER_TIMES = "solr_metrics_core_average_searcher_warmup_time";
+  public static final String CORE_SEARCHER_TIME_SUMMARY = "solr_metrics_core_searcher_warmup_time";
 
   public SolrCoreSearcherMetric(Metric dropwizardMetric, String metricName) {
     super(dropwizardMetric, metricName);
@@ -59,6 +60,7 @@ public class SolrCoreSearcherMetric extends SolrCoreMetric {
       }
     } else if (dropwizardMetric instanceof Timer) {
       formatter.exportTimer(CORE_SEARCHER_TIMES, (Timer) dropwizardMetric, getLabels());
+      formatter.exportTimerSummary(CORE_SEARCHER_TIME_SUMMARY, (Timer) dropwizardMetric, getLabels());
     }
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -26,7 +26,6 @@ import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -797,8 +796,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
                 "updateHandler"));
     assertEquals(0, actualGaugeDataPoint.getValue(), 0);
 
-    actualSnapshot =
-        getMetricSnapshot(actualSnapshots, "solr_metrics_core_searcher_warmup_time");
+    actualSnapshot = getMetricSnapshot(actualSnapshots, "solr_metrics_core_searcher_warmup_time");
     actualSummaryDataPoint =
         getSummaryDataPointSnapshot(
             actualSnapshot, Labels.of("core", "collection1", "type", "warmup"));

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -25,6 +25,8 @@ import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -731,12 +733,12 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertNotNull(actualSnapshots);
 
     MetricSnapshot actualSnapshot =
-        getMetricSnapshot(actualSnapshots, "solr_metrics_core_average_request_time");
-    GaugeSnapshot.GaugeDataPointSnapshot actualGaugeDataPoint =
-        getGaugeDatapointSnapshot(
+        getMetricSnapshot(actualSnapshots, "solr_metrics_core_request_time");
+    SummarySnapshot.SummaryDataPointSnapshot actualSummaryDataPoint =
+        getSummaryDataPointSnapshot(
             actualSnapshot,
             Labels.of("category", "QUERY", "core", "collection1", "handler", "/select[shard]"));
-    assertEquals(0, actualGaugeDataPoint.getValue(), 0);
+    assertEquals(0, actualSummaryDataPoint.getCount(), 0);
 
     actualSnapshot = getMetricSnapshot(actualSnapshots, "solr_metrics_core_requests");
     CounterSnapshot.CounterDataPointSnapshot actualCounterDataPoint =
@@ -754,7 +756,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertEquals(0, actualCounterDataPoint.getValue(), 0);
 
     actualSnapshot = getMetricSnapshot(actualSnapshots, "solr_metrics_core_cache");
-    actualGaugeDataPoint =
+    GaugeSnapshot.GaugeDataPointSnapshot actualGaugeDataPoint =
         getGaugeDatapointSnapshot(
             actualSnapshot,
             Labels.of("cacheType", "fieldValueCache", "core", "collection1", "item", "hits"));
@@ -796,11 +798,11 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertEquals(0, actualGaugeDataPoint.getValue(), 0);
 
     actualSnapshot =
-        getMetricSnapshot(actualSnapshots, "solr_metrics_core_average_searcher_warmup_time");
-    actualGaugeDataPoint =
-        getGaugeDatapointSnapshot(
+        getMetricSnapshot(actualSnapshots, "solr_metrics_core_searcher_warmup_time");
+    actualSummaryDataPoint =
+        getSummaryDataPointSnapshot(
             actualSnapshot, Labels.of("core", "collection1", "type", "warmup"));
-    assertEquals(0, actualGaugeDataPoint.getValue(), 0);
+    assertEquals(0, actualSummaryDataPoint.getCount(), 0);
 
     handler.close();
   }
@@ -1178,6 +1180,15 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
   private CounterSnapshot.CounterDataPointSnapshot getCounterDatapointSnapshot(
       MetricSnapshot snapshot, Labels labels) {
     return (CounterSnapshot.CounterDataPointSnapshot)
+        snapshot.getDataPoints().stream()
+            .filter(ss -> ss.getLabels().hasSameValues(labels))
+            .findAny()
+            .get();
+  }
+
+  private SummarySnapshot.SummaryDataPointSnapshot getSummaryDataPointSnapshot(
+      MetricSnapshot snapshot, Labels labels) {
+    return (SummarySnapshot.SummaryDataPointSnapshot)
         snapshot.getDataPoints().stream()
             .filter(ss -> ss.getLabels().hasSameValues(labels))
             .findAny()

--- a/solr/core/src/test/org/apache/solr/metrics/SolrPrometheusFormatterTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrPrometheusFormatterTest.java
@@ -29,7 +29,6 @@ import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/solr/core/src/test/org/apache/solr/metrics/SolrPrometheusFormatterTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrPrometheusFormatterTest.java
@@ -28,6 +28,8 @@ import com.codahale.metrics.Timer;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,11 +86,11 @@ public class SolrPrometheusFormatterTest extends SolrTestCaseJ4 {
 
     Labels expectedLabels = Labels.of("test", "test-value");
     testFormatter.exportTimer(expectedMetricName, metric, expectedLabels);
-    assertTrue(testFormatter.getMetricGauges().containsKey(expectedMetricName));
+    assertTrue(testFormatter.getMetricSummaries().containsKey(expectedMetricName));
 
-    GaugeSnapshot.GaugeDataPointSnapshot actual =
-        testFormatter.getMetricGauges().get("test_metric").get(0);
-    assertEquals(5000000000L, actual.getValue(), 500000000L);
+    SummarySnapshot.SummaryDataPointSnapshot actual =
+        testFormatter.getMetricSummaries().get("test_metric").get(0);
+    assertEquals(5000L, actual.getSum(), 500L);
     assertEquals(expectedLabels, actual.getLabels());
   }
 
@@ -198,6 +200,10 @@ public class SolrPrometheusFormatterTest extends SolrTestCaseJ4 {
 
     public Map<String, List<GaugeSnapshot.GaugeDataPointSnapshot>> getMetricGauges() {
       return metricGauges;
+    }
+
+    public Map<String, List<SummarySnapshot.SummaryDataPointSnapshot>> getMetricSummaries() {
+      return metricSummaries;
     }
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17628

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Modify the implementation of `SolrPrometheusFormatter.exportTimer` to export a Prometheus summary containing quantile information instead of a single Prometheus gauge. Rename the Timer-based metrics `solr_metrics_core_average_request_time` and `solr_metrics_core_average_searcher_warmup_time` to reflect this change.

# Solution

Prior to this change, Dropwizard Timer metrics (used for core request handlers and searchers) were exported in Prometheus format as single gauges representing the mean of all observations. This PR replaces the existing mean gauge metrics with a summary that includes quantile metrics, the count (number) of observations, and the sum of all observations.

## Sample old output:
```
# TYPE solr_metrics_core_average_request_time gauge
solr_metrics_core_average_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1"} 0.0
solr_metrics_core_average_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1"} 0.0
```

## Sample new output:
```
# TYPE solr_metrics_core_request_time summary
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1",quantile="0.5"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1",quantile="0.75"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1",quantile="0.99"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1",quantile="0.999"} 0.0
solr_metrics_core_request_time_count{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1"} 0
solr_metrics_core_request_time_sum{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/file",replica="replica_n1",shard="shard1"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1",quantile="0.5"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1",quantile="0.75"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1",quantile="0.99"} 0.0
solr_metrics_core_request_time{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1",quantile="0.999"} 0.0
solr_metrics_core_request_time_count{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1"} 0
solr_metrics_core_request_time_sum{category="ADMIN",collection="example-collection",core="core_example-collection_shard1_replica_n1",handler="/admin/luke",replica="replica_n1",shard="shard1"} 0.0
```

# Tests

I updated `MetricsHandlerTest` and `SolrPrometheusFormatterTest` to align with the changes to `exportTimer`. `./gradlew test` passes on my local machine.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
