### PR TITLE
SOLR-17663: Protect TimeOut from overflow.

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/TimeOut.java
+++ b/solr/core/src/java/org/apache/solr/util/TimeOut.java
@@ -24,9 +24,7 @@ import java.util.function.Supplier;
 import org.apache.solr.common.util.TimeSource;
 
 /**
- * Timeout tool to ease time unit conversion, to check time left or time elapsed, and to easily wait
- * on a {@link Supplier}. It is based on {@link TimeSource} to allow choosing the time source, and
- * to facilitate time control in tests.
+ * Timeout tool to ease checking time left, time elapsed, and waiting on a condition.
  */
 public class TimeOut {
 
@@ -35,18 +33,19 @@ public class TimeOut {
   private final TimeSource timeSource;
 
   /**
-   * Internally the timeout is stored in nanoseconds, so it cannot track more than {@link
-   * Long#MAX_VALUE} nanoseconds. Depending on the {@link TimeUnit} selected in this constructor,
-   * this means large {@code interval} can be truncated when converting to {@link Long#MAX_VALUE}
-   * nanoseconds.
+   * @param timeout after this maximum time, {@link #hasTimedOut()} will return true.
+   * @param unit the time unit of the timeout argument.
+   * @param timeSource the source of the time.
    */
-  public TimeOut(long interval, TimeUnit unit, TimeSource timeSource) {
+  public TimeOut(long timeout, TimeUnit unit, TimeSource timeSource) {
+    // Since timeout is stored in nanoseconds, it cannot track more than Long.MAX_VALUE nanoseconds.
+    // Depending on the time unit selected in this constructor, large timeout can be truncated when converting to Long.MAX_VALUE nanoseconds.
     this.timeSource = timeSource;
     startTime = timeSource.getTimeNs();
     // Consider negative interval as 0.
-    interval = Math.max(interval, 0L);
+    timeout = Math.max(timeout, 0L);
     // Detect long addition overflow.
-    long timeoutAt = startTime + NANOSECONDS.convert(interval, unit);
+    long timeoutAt = startTime + NANOSECONDS.convert(timeout, unit);
     this.timeoutAt = timeoutAt < startTime ? Long.MAX_VALUE : timeoutAt;
   }
 

--- a/solr/core/src/java/org/apache/solr/util/TimeOut.java
+++ b/solr/core/src/java/org/apache/solr/util/TimeOut.java
@@ -25,8 +25,8 @@ import org.apache.solr.common.util.TimeSource;
 
 /**
  * Timeout tool to ease time unit conversion, to check time left or time elapsed, and to easily wait
- * on a {@link Supplier<Boolean>}. It is based on {@link TimeSource} to allow choosing the time
- * source, and to facilitate time control in tests.
+ * on a {@link Supplier}. It is based on {@link TimeSource} to allow choosing the time source, and
+ * to facilitate time control in tests.
  */
 public class TimeOut {
 

--- a/solr/core/src/java/org/apache/solr/util/TimeOut.java
+++ b/solr/core/src/java/org/apache/solr/util/TimeOut.java
@@ -23,9 +23,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.solr.common.util.TimeSource;
 
-/**
- * Timeout tool to ease checking time left, time elapsed, and waiting on a condition.
- */
+/** Timeout tool to ease checking time left, time elapsed, and waiting on a condition. */
 public class TimeOut {
 
   // Internally, the time unit is nanosecond.
@@ -39,7 +37,8 @@ public class TimeOut {
    */
   public TimeOut(long timeout, TimeUnit unit, TimeSource timeSource) {
     // Since timeout is stored in nanoseconds, it cannot track more than Long.MAX_VALUE nanoseconds.
-    // Depending on the time unit selected in this constructor, large timeout can be truncated when converting to Long.MAX_VALUE nanoseconds.
+    // Depending on the time unit selected in this constructor, large timeout can be truncated when
+    // converting to Long.MAX_VALUE nanoseconds.
     this.timeSource = timeSource;
     startTime = timeSource.getTimeNs();
     // Consider negative interval as 0.

--- a/solr/core/src/test/org/apache/solr/util/TimeOutTest.java
+++ b/solr/core/src/test/org/apache/solr/util/TimeOutTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.util;
 
 import java.util.concurrent.TimeUnit;

--- a/solr/core/src/test/org/apache/solr/util/TimeOutTest.java
+++ b/solr/core/src/test/org/apache/solr/util/TimeOutTest.java
@@ -1,0 +1,61 @@
+package org.apache.solr.util;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.solr.SolrTestCase;
+import org.apache.solr.common.util.TimeSource;
+
+/** Tests {@link TimeOut}. */
+public class TimeOutTest extends SolrTestCase {
+
+  public void testConstructorOverflowProtection() {
+    TimeOut timeOut =
+        new TimeOut(Long.MAX_VALUE, TimeUnit.MILLISECONDS, new MockTimeSource(0L, 0L));
+    assertFalse(timeOut.hasTimedOut());
+    assertTrue(
+        timeOut.timeLeft(TimeUnit.MILLISECONDS) >= TimeUnit.NANOSECONDS.toMillis(Long.MAX_VALUE));
+    assertEquals(0L, timeOut.timeElapsed(TimeUnit.MILLISECONDS));
+
+    timeOut =
+        new TimeOut(Long.MAX_VALUE, TimeUnit.MILLISECONDS, new MockTimeSource(Long.MIN_VALUE, 0L));
+    assertFalse(timeOut.hasTimedOut());
+    assertTrue(
+        timeOut.timeLeft(TimeUnit.MILLISECONDS) >= TimeUnit.NANOSECONDS.toMillis(Long.MAX_VALUE));
+    assertEquals(0L, timeOut.timeElapsed(TimeUnit.MILLISECONDS));
+  }
+
+  private static class MockTimeSource extends TimeSource {
+
+    private final long timeNs;
+    private final long epochTimeNs;
+
+    MockTimeSource(long timeNs, long epochTimeNs) {
+      this.timeNs = timeNs;
+      this.epochTimeNs = epochTimeNs;
+    }
+
+    @Override
+    public long getTimeNs() {
+      return timeNs;
+    }
+
+    @Override
+    public long getEpochTimeNs() {
+      return epochTimeNs;
+    }
+
+    @Override
+    public long[] getTimeAndEpochNs() {
+      return new long[] {timeNs, epochTimeNs};
+    }
+
+    @Override
+    public void sleep(long ms) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long convertDelay(TimeUnit fromUnit, long value, TimeUnit toUnit) {
+      return fromUnit.convert(value, toUnit);
+    }
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17663

TimeOut constructor is passed a long interval parameter. If this long is large enough, the timeoutAt field overflows, making all the methods incorrect, including hasTimedOut() which returns true immediately.

TimeUnit.convert() deals with the same problem by checking the value to convert ahead of time and by setting fixed Long.MAX_VALUE to prevent overflow. We should do the same for timeoutAt in TimeOut constructor.