### PR TITLE
Update enabling-ssl.adoc - fix minor typo in example

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
@@ -236,7 +236,7 @@ The examples below use the `bin/solr` tool that comes with Solr to do this.
 ====
 [source,terminal]
 ----
-$ bin/solr cluster --property urlSchema --value https --zk-host server1:2181,server2:2181,server3:2181
+$ bin/solr cluster --property urlScheme --value https --zk-host server1:2181,server2:2181,server3:2181
 ----
 ====
 
@@ -245,7 +245,7 @@ Windows::
 ====
 [source,powershell]
 ----
-C:\> bin/solr.cmd --property urlSchema --value https --zk-host server1:2181,server2:2181,server3:2181
+C:\> bin/solr.cmd --property urlScheme --value https --zk-host server1:2181,server2:2181,server3:2181
 ----
 ====
 ======

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/enabling-ssl.adoc
@@ -245,7 +245,7 @@ Windows::
 ====
 [source,powershell]
 ----
-C:\> bin/solr.cmd --property urlScheme --value https --zk-host server1:2181,server2:2181,server3:2181
+C:\> bin/solr.cmd cluster --property urlScheme --value https --zk-host server1:2181,server2:2181,server3:2181
 ----
 ====
 ======


### PR DESCRIPTION


# Description

The example to update the Zookeeper properties has a typo as it uses urlSchema instead of urlScheme.

# Solution

Rename property in examples.

# Tests

None.

# Checklist

- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
