### PR TITLE
SOLR-17669: Reduce Memory Consumption by 80-90% when using Dynamic fields (DocumentObjectBinder)

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -165,6 +165,9 @@ Improvements
   other v2 APIs.  SolrJ now offers (experimental) SolrRequest implementations for all v2 configset APIs in
   `org.apache.solr.client.solrj.request.ConfigsetsApi`. (Jason Gerlowski)
 
+* SOLR-17669: Reduced memory usage in SolrJ getBeans() method when handling dynamic fields with wildcards. (Martin Anzinger)
+
+
 Optimizations
 ---------------------
 * SOLR-17578: Remove ZkController internal core supplier, for slightly faster reconnection after Zookeeper session loss. (Pierre Salagnac)

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -165,12 +165,11 @@ Improvements
   other v2 APIs.  SolrJ now offers (experimental) SolrRequest implementations for all v2 configset APIs in
   `org.apache.solr.client.solrj.request.ConfigsetsApi`. (Jason Gerlowski)
 
-* SOLR-17669: Reduced memory usage in SolrJ getBeans() method when handling dynamic fields with wildcards. (Martin Anzinger)
-
-
 Optimizations
 ---------------------
 * SOLR-17578: Remove ZkController internal core supplier, for slightly faster reconnection after Zookeeper session loss. (Pierre Salagnac)
+
+* SOLR-17669: Reduced memory usage in SolrJ getBeans() method when handling dynamic fields with wildcards. (Martin Anzinger)
 
 Bug Fixes
 ---------------------

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/beans/DocumentObjectBinder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/beans/DocumentObjectBinder.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
@@ -247,18 +248,10 @@ public class DocumentObjectBinder {
           String pattern = annotation.value().substring(0, annotation.value().length() - 1);
           dynamicFieldNamePatternMatcher = fieldName -> fieldName.startsWith(pattern);
         } else {
-          // fallback to old logic when * is in the middle of the Name.
-          // Should not happen, but was possible before that change
-          throw new IllegalArgumentException(
-              "Invalid dynamic field name: "
-                  + annotation.value()
-                  + ". The name should either start with a * or end with a *");
-
-          // Alternatively fallback to original logic?
-          // name = annotation.value().replaceFirst("\\*", "\\.*");
-          // Pattern compiledPattern = Pattern.compile("^" + name + "$");
-          // dynamicFieldNamePatternMatcher = fieldName ->
-          // compiledPattern.matcher(fieldName).find();
+          // handle when wildcard is in the middle
+          name = annotation.value().replaceFirst("\\*", "\\.*");
+          Pattern compiledPattern = Pattern.compile("^" + name + "$");
+          dynamicFieldNamePatternMatcher = fieldName -> compiledPattern.matcher(fieldName).find();
         }
       } else {
         name = annotation.value();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/beans/DocumentObjectBinder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/beans/DocumentObjectBinder.java
@@ -186,7 +186,7 @@ public class DocumentObjectBinder {
      * is set to <code>TRUE</code> as well as <code>isList</code> is set to <code>TRUE</code>
      */
     private boolean isContainedInMap;
-    private DynamicFieldNameMatcher dynamicFieldNamePatternMatcher;
+    private java.util.function.Predicate<String> dynamicFieldNamePatternMatcher;
 
     public DocField(AccessibleObject member) {
       if (member instanceof java.lang.reflect.Field) {
@@ -411,7 +411,7 @@ public class DocumentObjectBinder {
       }
 
       for (String field : solrDocument.getFieldNames()) {
-        if (dynamicFieldNamePatternMatcher.matches(field)) {
+        if (dynamicFieldNamePatternMatcher.test(field)) {
           Object val = solrDocument.getFieldValue(field);
           if (val == null) {
             continue;
@@ -522,8 +522,4 @@ public class DocumentObjectBinder {
   }
 
   public static final String DEFAULT = "#default";
-
-  private interface DynamicFieldNameMatcher {
-    boolean matches(String name);
-  }
 }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/beans/TestDocumentObjectBinder.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/beans/TestDocumentObjectBinder.java
@@ -98,6 +98,12 @@ public class TestDocumentObjectBinder extends SolrTestCase {
 
     List<String> supplierTwo = l.get(3).supplier.get("supplier_2");
     assertEquals("CCTV Store", supplierTwo.get(0));
+
+    String supplierMiddle = l.get(3).supplier_middle.get("supmiddle_mobile_middle");
+    assertEquals("Mobile Store in Middle", supplierMiddle);
+
+    String supplierBeginning = l.get(3).sup_beginning.get("mobile_supbeginning");
+    assertEquals("Mobile Store with Beginning Wildcard", supplierBeginning);
   }
 
   public void testChild() throws Exception {
@@ -182,6 +188,14 @@ public class TestDocumentObjectBinder extends SolrTestCase {
     @Field("sup_simple_*")
     Map<String, String> supplier_simple;
 
+
+    @Field("supmiddle_*_middle")
+    Map<String, String> supplier_middle;
+
+
+    @Field("*_supbeginning")
+    Map<String, String> sup_beginning;
+
     private String[] allSuppliers;
 
     @Field("supplier_*")
@@ -191,6 +205,24 @@ public class TestDocumentObjectBinder extends SolrTestCase {
 
     public String[] getAllSuppliers() {
       return this.allSuppliers;
+    }
+
+
+    public Map<String, String> getSupplier_middle() {
+      return supplier_middle;
+    }
+
+    public void setSupplier_middle(Map<String, String> supplier_middle) {
+      this.supplier_middle = supplier_middle;
+    }
+
+
+    public Map<String, String> getSup_beginning() {
+      return sup_beginning;
+    }
+
+    public void setSup_beginning(Map<String, String> sup_beginning) {
+      this.sup_beginning = sup_beginning;
     }
 
     @Field
@@ -275,6 +307,7 @@ public class TestDocumentObjectBinder extends SolrTestCase {
           + "<str name=\"manu\">Belkin</str><str name=\"name\">iPod &amp; iPod Mini USB 2.0 Cable</str>"
           + "<int name=\"popularity\">1</int><float name=\"price\">11.5</float><str name=\"sku\">IW-02</str>"
           + "<str name=\"supplier_1\">Mobile Store</str><str name=\"supplier_1\">iPod Store</str><str name=\"supplier_2\">CCTV Store</str>"
+          + "<str name=\"supmiddle_mobile_middle\">Mobile Store in Middle</str><str name=\"mobile_supbeginning\">Mobile Store with Beginning Wildcard</str>"
           + "<date name=\"timestamp\">2008-04-16T10:35:57.140Z</date><float name=\"weight\">2.0</float></doc></result>\n"
           + "</response>";
 }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/beans/TestDocumentObjectBinder.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/beans/TestDocumentObjectBinder.java
@@ -188,10 +188,8 @@ public class TestDocumentObjectBinder extends SolrTestCase {
     @Field("sup_simple_*")
     Map<String, String> supplier_simple;
 
-
     @Field("supmiddle_*_middle")
     Map<String, String> supplier_middle;
-
 
     @Field("*_supbeginning")
     Map<String, String> sup_beginning;
@@ -207,7 +205,6 @@ public class TestDocumentObjectBinder extends SolrTestCase {
       return this.allSuppliers;
     }
 
-
     public Map<String, String> getSupplier_middle() {
       return supplier_middle;
     }
@@ -215,7 +212,6 @@ public class TestDocumentObjectBinder extends SolrTestCase {
     public void setSupplier_middle(Map<String, String> supplier_middle) {
       this.supplier_middle = supplier_middle;
     }
-
 
     public Map<String, String> getSup_beginning() {
       return sup_beginning;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17669


# Description

Flame Graph in our Production System showed a siginificant high memory consumption of Pattern.matcher

# Solution

Wildcard can only be at beginning or end of Field Name, we replaced Pattern Regex with startsWith and endsWith

# Tests

No new tests needed, old tests are working fine with new code

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
