### PR TITLE
SOLR-17671 Add a hook in ReplicationHandler to allow extending CoreReplication.

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1611,7 +1611,8 @@ public class ReplicationHandler extends RequestHandlerBase
     return ReplicationHandlerConfig.class;
   }
 
-  protected CoreReplication createCoreReplication(SolrCore solrCore, SolrQueryRequest req, SolrQueryResponse rsp) {
+  protected CoreReplication createCoreReplication(
+      SolrCore solrCore, SolrQueryRequest req, SolrQueryResponse rsp) {
     return new CoreReplication(solrCore, req, rsp);
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -274,7 +274,7 @@ public class ReplicationHandler extends RequestHandlerBase
     } else if (command.equals(CMD_GET_FILE)) {
       getFileStream(solrParams, rsp, req);
     } else if (command.equals(CMD_GET_FILE_LIST)) {
-      final CoreReplication coreReplicationAPI = new CoreReplication(core, req, rsp);
+      final CoreReplication coreReplicationAPI = createCoreReplication(core, req, rsp);
       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
           rsp,
           coreReplicationAPI.fetchFileList(Long.parseLong(solrParams.required().get(GENERATION))));
@@ -319,7 +319,7 @@ public class ReplicationHandler extends RequestHandlerBase
    * @see IndexFetcher.DirectoryFileFetcher
    */
   private void getFileStream(SolrParams solrParams, SolrQueryResponse rsp, SolrQueryRequest req) {
-    final CoreReplication coreReplicationAPI = new CoreReplication(core, req, rsp);
+    final CoreReplication coreReplicationAPI = createCoreReplication(core, req, rsp);
     String fileName;
     String dirType;
 
@@ -1358,7 +1358,7 @@ public class ReplicationHandler extends RequestHandlerBase
 
   @Override
   public Collection<Class<? extends JerseyResource>> getJerseyResources() {
-    return List.of(CoreReplication.class, SnapshotBackupAPI.class);
+    return List.of(getCoreReplicationClass(), SnapshotBackupAPI.class);
   }
 
   @Override
@@ -1609,5 +1609,13 @@ public class ReplicationHandler extends RequestHandlerBase
   @Override
   public Class<ReplicationHandlerConfig> getConfigClass() {
     return ReplicationHandlerConfig.class;
+  }
+
+  protected CoreReplication createCoreReplication(SolrCore solrCore, SolrQueryRequest req, SolrQueryResponse rsp) {
+    return new CoreReplication(solrCore, req, rsp);
+  }
+
+  protected Class<? extends CoreReplication> getCoreReplicationClass() {
+    return CoreReplication.class;
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/ReplicationAPIBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/ReplicationAPIBase.java
@@ -193,7 +193,8 @@ public abstract class ReplicationAPIBase extends JerseyResource {
         fileMetaData.name = infos.getSegmentsFileName();
         fileMetaData.size = filteredDir.fileLength(infos.getSegmentsFileName());
         if (infos.getId() != null) {
-          try (final IndexInput in = filteredDir.openInput(infos.getSegmentsFileName(), IOContext.READONCE)) {
+          try (final IndexInput in =
+              filteredDir.openInput(infos.getSegmentsFileName(), IOContext.READONCE)) {
             try {
               fileMetaData.checksum = CodecUtil.retrieveChecksum(in);
             } catch (Exception e) {
@@ -246,9 +247,7 @@ public abstract class ReplicationAPIBase extends JerseyResource {
     return filesResponse;
   }
 
-  /**
-   * Potentially filters or unwraps the {@link Directory} to use to copy index files.
-   */
+  /** Potentially filters or unwraps the {@link Directory} to use to copy index files. */
   protected Directory filterDirectory(Directory directory) {
     return directory;
   }
@@ -384,7 +383,9 @@ public abstract class ReplicationAPIBase extends JerseyResource {
       try {
         initWrite();
 
-        Directory dir = filterDirectory(solrCore.withSearcher(searcher -> searcher.getIndexReader().directory()));
+        Directory dir =
+            filterDirectory(
+                solrCore.withSearcher(searcher -> searcher.getIndexReader().directory()));
         in = dir.openInput(fileName, IOContext.READONCE);
         // if offset is mentioned move the pointer to that point
         if (offset != -1) in.seek(offset);


### PR DESCRIPTION
While it is possible to define the replication handler class in solr.xml, it is not possible to extend CoreReplication logic to tune how index files are copied, or filter/unwrap the Directory used to open the files inputs.

The proposal is to add a hook method "createCoreReplication" in ReplicationHandler, and another "filterDirectory" in ReplicationAPIBase.

Example:
In the solr-sandbox encryption module, we would need a way to unwrap the Directory used to copy files during index fetching. Otherwise the files are decrypted by the EncryptionDirectory seamlessly during the files copy, ending up with follower replicas having cleartext index.