### PR TITLE
SOLR-17671 Replication and Backup use an unwrapped Directory.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -224,6 +224,9 @@ Other Changes
 * SOLR-17648: multiThreaded=true: changed queue implementation from unlimited to 1000 max, after
   which the caller thread will execute.  (David Smiley)
 
+* SOLR-17671: Replication and backup have their DirectoryFactory.DirContext so the directory they use is unwrapped
+  when copying files. (Bruno Roustant, David Smiley)
+
 ==================  9.8.0 ==================
 New Features
 ---------------------

--- a/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
@@ -428,7 +428,7 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
 
   /**
    * Potentially filters or unwraps the cached {@link Directory} depending on the intended use
-   * defined by the {@link DirContext}.
+   * defined by the {@link org.apache.solr.core.DirectoryFactory.DirContext}.
    */
   protected Directory filterDirectory(Directory dir, DirContext dirContext) {
     // If the DirContext is REPLICATE or BACKUP, then unwrap the Directory to allow the caller to

--- a/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.solr.common.SolrException;
@@ -392,13 +391,13 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
   public final Directory get(String path, DirContext dirContext, String rawLockType)
       throws IOException {
     String fullPath = normalize(path);
-    Directory directory = null;
     synchronized (this) {
       if (closed) {
         throw new AlreadyClosedException("Already closed");
       }
 
       final CacheValue cacheValue = byPathCache.get(fullPath);
+      Directory directory = null;
       if (cacheValue != null) {
         directory = cacheValue.directory;
       }
@@ -422,21 +421,9 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
         cacheValue.refCnt++;
         log.debug("Reusing cached directory: {}", cacheValue);
       }
-    }
-    return filterDirectory(directory, dirContext);
-  }
 
-  /**
-   * Potentially filters or unwraps the cached {@link Directory} depending on the intended use
-   * defined by the {@link org.apache.solr.core.DirectoryFactory.DirContext}.
-   */
-  protected Directory filterDirectory(Directory dir, DirContext dirContext) {
-    // If the DirContext is REPLICATE or BACKUP, then unwrap the Directory to allow the caller to
-    // copy raw bytes, skipping any additional logic that would be added by a FilterDirectory on
-    // top of the raw Directory.
-    return dirContext == DirContext.REPLICATE || dirContext == DirContext.BACKUP
-        ? FilterDirectory.unwrap(dir)
-        : dir;
+      return directory;
+    }
   }
 
   /*

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -102,6 +102,8 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
    *
    * @throws IOException If there is a low-level I/O error.
    */
+  // TODO: remove the DirContext param from this method and have the DirectoryFactory implementation
+  // extend the new CachingDirectoryFactory.filterDirectory if needed.
   protected abstract Directory create(String path, LockFactory lockFactory, DirContext dirContext)
       throws IOException;
 

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -55,10 +55,16 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
   // Absolute.
   protected Path dataHomePath;
 
-  // hint about what the directory contains - default is index directory
+  /** Hint about what the directory contains or what the directory will be used for. */
   public enum DirContext {
+    /** Default is index directory. */
     DEFAULT,
-    META_DATA
+    /** Directory containing metadata. */
+    META_DATA,
+    /** Directory used to copy raw files during replication. */
+    REPLICATE,
+    /** Directory used to copy raw files during backup. */
+    BACKUP,
   }
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -55,11 +55,11 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
   // Absolute.
   protected Path dataHomePath;
 
-  /** Hint about what the directory contains or what the directory will be used for. */
+  /** Hint about what the directory will be used for. */
   public enum DirContext {
-    /** Default is index directory. */
+    /** Directory used to read or write the index. */
     DEFAULT,
-    /** Directory containing metadata. */
+    /** Directory used to read or write metadata. */
     META_DATA,
     /** Directory used to copy raw files during replication. */
     REPLICATION,

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -55,19 +55,15 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
   // Absolute.
   protected Path dataHomePath;
 
-  /** Hint about what the directory contains. */
+  /** Hint about what the directory contains or what the directory will be used for. */
   public enum DirContext {
     /** Default is index directory. */
     DEFAULT,
     /** Directory containing metadata. */
     META_DATA,
-  }
-
-  /** Hint about what the directory will be used for. */
-  public enum DirUseContext {
-    /** Directory used to copy files during replication. */
+    /** Directory used to copy raw files during replication. */
     REPLICATION,
-    /** Directory used to copy files during backup. */
+    /** Directory used to copy raw files during backup. */
     BACKUP,
   }
 
@@ -463,18 +459,5 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
    */
   public UpdateLog newDefaultUpdateLog() {
     return new UpdateLog();
-  }
-
-  /**
-   * Unwraps the provided {@link Directory} depending on the intended use defined by the {@link
-   * org.apache.solr.core.DirectoryFactory.DirUseContext}.
-   */
-  @SuppressWarnings("unused")
-  public Directory unwrapFor(Directory dir, DirUseContext useContext) {
-    // By default, unwrap the Directory to allow the caller to copy raw bytes, skipping any
-    // additional logic that would be added by a FilterDirectory on top of the raw Directory.
-    // An extending DirectoryFactory can adapt how to unwrap depending on the intended use (e.g.
-    // encryption maybe does not unwrap for backup to compute checksum on cleartext).
-    return FilterDirectory.unwrap(dir);
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -55,15 +55,19 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
   // Absolute.
   protected Path dataHomePath;
 
-  /** Hint about what the directory contains or what the directory will be used for. */
+  /** Hint about what the directory contains. */
   public enum DirContext {
     /** Default is index directory. */
     DEFAULT,
     /** Directory containing metadata. */
     META_DATA,
-    /** Directory used to copy raw files during replication. */
-    REPLICATE,
-    /** Directory used to copy raw files during backup. */
+  }
+
+  /** Hint about what the directory will be used for. */
+  public enum DirUseContext {
+    /** Directory used to copy files during replication. */
+    REPLICATION,
+    /** Directory used to copy files during backup. */
     BACKUP,
   }
 
@@ -459,5 +463,18 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
    */
   public UpdateLog newDefaultUpdateLog() {
     return new UpdateLog();
+  }
+
+  /**
+   * Unwraps the provided {@link Directory} depending on the intended use defined by the {@link
+   * org.apache.solr.core.DirectoryFactory.DirUseContext}.
+   */
+  @SuppressWarnings("unused")
+  public Directory unwrapFor(Directory dir, DirUseContext useContext) {
+    // By default, unwrap the Directory to allow the caller to copy raw bytes, skipping any
+    // additional logic that would be added by a FilterDirectory on top of the raw Directory.
+    // An extending DirectoryFactory can adapt how to unwrap depending on the intended use (e.g.
+    // encryption maybe does not unwrap for backup to compute checksum on cleartext).
+    return FilterDirectory.unwrap(dir);
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
+++ b/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
@@ -150,7 +150,7 @@ public class IncrementalShardBackup {
             .getDirectoryFactory()
             .get(
                 solrCore.getIndexDir(),
-                DirectoryFactory.DirContext.DEFAULT,
+                DirectoryFactory.DirContext.BACKUP,
                 solrCore.getSolrConfig().indexConfig.lockType);
     try {
       BackupStats stats = incrementalCopy(files, dir);

--- a/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
+++ b/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
@@ -145,21 +145,22 @@ public class IncrementalShardBackup {
     details.startTime = Instant.now().toString();
 
     Collection<String> files = indexCommit.getFileNames();
+    DirectoryFactory directoryFactory = solrCore.getDirectoryFactory();
     Directory dir =
-        solrCore
-            .getDirectoryFactory()
-            .get(
-                solrCore.getIndexDir(),
-                DirectoryFactory.DirContext.BACKUP,
-                solrCore.getSolrConfig().indexConfig.lockType);
+        directoryFactory.get(
+            solrCore.getIndexDir(),
+            DirectoryFactory.DirContext.DEFAULT,
+            solrCore.getSolrConfig().indexConfig.lockType);
     try {
-      BackupStats stats = incrementalCopy(files, dir);
+      BackupStats stats =
+          incrementalCopy(
+              files, directoryFactory.unwrapFor(dir, DirectoryFactory.DirUseContext.BACKUP));
       details.indexFileCount = stats.fileCount;
       details.uploadedIndexFileCount = stats.uploadedFileCount;
       details.indexSizeMB = stats.getIndexSizeMB();
       details.uploadedIndexFileMB = stats.getTotalUploadedMB();
     } finally {
-      solrCore.getDirectoryFactory().release(dir);
+      directoryFactory.release(dir);
     }
 
     CloudDescriptor cd = solrCore.getCoreDescriptor().getCloudDescriptor();

--- a/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
+++ b/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
@@ -145,22 +145,21 @@ public class IncrementalShardBackup {
     details.startTime = Instant.now().toString();
 
     Collection<String> files = indexCommit.getFileNames();
-    DirectoryFactory directoryFactory = solrCore.getDirectoryFactory();
     Directory dir =
-        directoryFactory.get(
-            solrCore.getIndexDir(),
-            DirectoryFactory.DirContext.DEFAULT,
-            solrCore.getSolrConfig().indexConfig.lockType);
+        solrCore
+            .getDirectoryFactory()
+            .get(
+                solrCore.getIndexDir(),
+                DirectoryFactory.DirContext.BACKUP,
+                solrCore.getSolrConfig().indexConfig.lockType);
     try {
-      BackupStats stats =
-          incrementalCopy(
-              files, directoryFactory.unwrapFor(dir, DirectoryFactory.DirUseContext.BACKUP));
+      BackupStats stats = incrementalCopy(files, dir);
       details.indexFileCount = stats.fileCount;
       details.uploadedIndexFileCount = stats.uploadedFileCount;
       details.indexSizeMB = stats.getIndexSizeMB();
       details.uploadedIndexFileMB = stats.getTotalUploadedMB();
     } finally {
-      directoryFactory.release(dir);
+      solrCore.getDirectoryFactory().release(dir);
     }
 
     CloudDescriptor cd = solrCore.getCoreDescriptor().getCloudDescriptor();

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/ReplicationAPIBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/ReplicationAPIBase.java
@@ -160,13 +160,7 @@ public abstract class ReplicationAPIBase extends JerseyResource {
       List<FileMetaData> result = new ArrayList<>();
       Directory dir = null;
       try {
-        dir =
-            solrCore
-                .getDirectoryFactory()
-                .get(
-                    solrCore.getNewIndexDir(),
-                    DirectoryFactory.DirContext.DEFAULT,
-                    solrCore.getSolrConfig().indexConfig.lockType);
+        dir = getDirectory();
         SegmentInfos infos = SegmentInfos.readCommit(dir, commit.getSegmentsFileName());
         for (SegmentCommitInfo commitInfo : infos) {
           for (String file : commitInfo.files()) {
@@ -244,6 +238,15 @@ public abstract class ReplicationAPIBase extends JerseyResource {
       }
     }
     return filesResponse;
+  }
+
+  private Directory getDirectory() throws IOException {
+    return solrCore
+        .getDirectoryFactory()
+        .get(
+            solrCore.getNewIndexDir(),
+            DirectoryFactory.DirContext.REPLICATE,
+            solrCore.getSolrConfig().indexConfig.lockType);
   }
 
   /** This class is used to read and send files in the lucene index */
@@ -377,7 +380,7 @@ public abstract class ReplicationAPIBase extends JerseyResource {
       try {
         initWrite();
 
-        Directory dir = solrCore.withSearcher(searcher -> searcher.getIndexReader().directory());
+        Directory dir = getDirectory();
         in = dir.openInput(fileName, IOContext.READONCE);
         // if offset is mentioned move the pointer to that point
         if (offset != -1) in.seek(offset);


### PR DESCRIPTION
Currently Replication and Backup copy files using a Directory created with the configured DirectoryFactory. This Directory may be a FilterDirectory that adds additional logic (e.g. encryption) that should not run when copying files (e.g. do not decrypt).

The proposal is to add a new REPLICATE value in the DirectoryFactory.DirContext that would be used by replication, and a new BACKUP for backup to get the Directory to use. The DirectoryFactory would unwrap the Directory in this case.
One could expect that only one REPLICATE could be enough, but backup requires more inner checksum verifications that may need to differentiate the logic between the two (this is the case for encryption).

Example:
In the solr-sandbox encryption module, we would need a way to unwrap the Directory used to copy files during index fetching. Otherwise the files are decrypted by the EncryptionDirectory seamlessly during the files copy, ending up with follower replicas having cleartext index.