### PR TITLE
SOLR-17673: Add back in option to use max CPU threads for searching

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -148,6 +148,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   private static final boolean useExitableDirectoryReader =
       Boolean.getBoolean("solr.useExitableDirectoryReader");
 
+  public static final int EXECUTOR_MAX_CPU_THREADS = Runtime.getRuntime().availableProcessors();
+
   private final SolrCore core;
   private final IndexSchema schema;
   private final SolrDocumentFetcher docFetcher;
@@ -224,9 +226,13 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    * Shared across the whole node because it's a machine CPU resource.
    */
   public static ExecutorService initCollectorExecutor(NodeConfig cfg) {
-    final int indexSearcherExecutorThreads = cfg.getIndexSearcherExecutorThreads();
-    if (0 >= indexSearcherExecutorThreads) {
+    int indexSearcherExecutorThreads = cfg.getIndexSearcherExecutorThreads();
+    if (indexSearcherExecutorThreads == 0) {
       return null;
+    } else if (indexSearcherExecutorThreads < 0) {
+      // Treat a negative value as "unlimited" and set it to the value number of available CPU
+      // threads
+      indexSearcherExecutorThreads = EXECUTOR_MAX_CPU_THREADS;
     }
 
     // note that Lucene will catch a RejectedExecutionException to just run the task.

--- a/solr/server/solr/solr.xml
+++ b/solr/server/solr/solr.xml
@@ -34,6 +34,7 @@
   <str name="allowPaths">${solr.allowPaths:}</str>
   <str name="allowUrls">${solr.allowUrls:}</str>
   <str name="hideStackTrace">${solr.hideStackTrace:false}</str>
+  <int name="indexSearcherExecutorThreads">${solr.searchThreads:0}</int>
 
   <solrcloud>
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/configuring-solr-xml.adoc
@@ -183,10 +183,11 @@ The default value is equal to the number of processors.
 +
 [%autowidth,frame=none]
 |===
-|Optional |Default: number of available processors
+|Optional |Default: 0
 |===
 +
 Specifies the number of threads that will be assigned for search queries.
+A value of `-1` represents the total number of available processor threads available.
 
 `coreRootDirectory`::
 +

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc
@@ -72,6 +72,8 @@ Due to changes in Lucene 9, that isn't possible any more.
 In solrconfig.xml, the `indexSearcherExecutorThreads` now defaults to 0.
 Therefore, multi-threaded search execution is disabled at a node-level by default.
 It is currently recommended to only use an `indexSearcherExecutorThreads > 0` if all query requests sent to Solr opt-in to multiThreaded search.
+Additionally, `indexSearcherExecutorThreads = -1` can be given to use the number of available CPU threads available to Solr.
+This was the previous default.
 
 == Solr 9.8
 === Configuration


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17673

An addition to https://github.com/apache/solr/pull/3183
Spun off from @risdenk 's comment here : https://github.com/apache/solr/pull/3183#issuecomment-2659988149
