### PR TITLE
Address that the word solrcli doesnt find this main page in Ref Guide

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -16,14 +16,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-Solr includes a script known as "`bin/solr`" that allows you to perform many common operations on your Solr installation or cluster.
+The SolrCLI, available as the `bin/solr` script, is a versatile command-line tool that allows you to perform many common operations on your Solr installation or cluster.
 
 You can start and stop Solr, create and delete collections or cores, perform operations on ZooKeeper and check the status of Solr and configured shards.
 
 You can find the script in the `bin/` directory of your Solr installation.
-The `bin/solr` script makes Solr easier to work with by providing simple commands and options to quickly accomplish common goals.
+The SolrCLI makes Solr easier to work with by providing simple commands and options to quickly accomplish common goals.
 
-More examples of `bin/solr` in use are available throughout this Guide, but particularly in the sections xref:installing-solr.adoc#starting-solr[Starting Solr] and xref:getting-started:tutorial-solrcloud.adoc[].
+More examples of SolrCLI in use are available throughout this Guide, particularly in the sections xref:installing-solr.adoc#starting-solr[Starting Solr] and xref:getting-started:tutorial-solrcloud.adoc[].
 
 == Starting and Stopping
 


### PR DESCRIPTION


# Description

Use "SolrCLI" on the main page for the SolrCLI.

# Solution
this is a small fix, someday we need to rewrite/reorg the Solr Control Script page.    At least now the search bar finds "Solrcli"...
