### PR TITLE
SOLR-17674: Refresh bin/solr instructions to down play SolrCloud and introduce --user-managed example.

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -631,7 +631,7 @@ if [[ "$SCRIPT_CMD" == "auth" ]]; then
   exit $?
 fi
 
-# at this point all tools that have a custom run process, like "status" and "auth" have been run and exited.
+# At this point all tools that have a custom run process, like "status" and "auth" have been run and exited.
 # Unless a command is one of the ones in the if clause below, we will just run it with the default run_tool function and then exit.
 if [ "$SCRIPT_CMD" != "start" ] && [ "$SCRIPT_CMD" != "stop" ] && [ "$SCRIPT_CMD" != "restart" ]; then
   # hand off the command to the SolrCLI and let it handle the option parsing and validation

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -409,22 +409,28 @@ public class SolrCLI implements CLIO {
     print(
         "                                healthcheck, create, delete, auth, assert, config, export, api, package, post, stream,");
     print(
-        "                                zk ls, zk cp, zk rm , zk mv, zk mkroot, zk upconfig, zk downconfig,");
+        "                                zk ls, zk cp, zk rm , zk mvStandalone server example, zk mkroot, zk upconfig, zk downconfig,");
     print(
         "                                snapshot-create, snapshot-list, snapshot-delete, snapshot-export, snapshot-prepare-export");
     print("");
-    print("  Standalone server example (start Solr running in the background on port 8984):");
+    print("  Start Solr running in the background on port 8984:");
     print("");
     printGreen("    ./solr start -p 8984");
     print("");
     print(
-        "  SolrCloud example (start Solr running in SolrCloud mode using localhost:2181 to connect to Zookeeper, with 1g max heap size and remote Java debug options enabled):");
+        "  Start Solr connecting to external Zookeeper at localhost:2181, with 1g max heap size and remote Java debug options enabled):");
     print("");
     printGreen(
         "    ./solr start -m 1g -z localhost:2181 --jvm-opts \"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044\"");
     print("");
     print(
         "  Omit '-z localhost:2181' from the above command if you have defined ZK_HOST in solr.in.sh.");
+    print("");
+    print(
+            "  Start Solr in User Managed (aka standalone) mode:");
+    print("");
+    printGreen(
+            "    ./solr start --user-managed");
     print("");
     print("Global Options:");
     print("  -v,  --version           Print version information and quit");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17674


# Description

Update the examples for starting solr when bin/solr is run.

# Solution

Down play SolrCloud mode (it's the default anyway), and add a example of how to start up in User Managed aka Standalone mode.
