### PR TITLE
@SOLR-17675 Remove DirContext param from DirectoryFactory create method.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -148,6 +148,8 @@ Other Changes
 
 * SOLR-17548: Switch all public Java APIs from File to Path. (Matthew Biscocho via Eric Pugh)
 
+* SOLR-17675: Remove DirContext param from DirectoryFactory.create method. (Bruno Roustant, David Smiley)
+
 ==================  9.9.0 ==================
 New Features
 ---------------------

--- a/solr/core/src/java/org/apache/solr/core/ByteBuffersDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/ByteBuffersDirectoryFactory.java
@@ -41,7 +41,7 @@ public class ByteBuffersDirectoryFactory extends EphemeralDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     return new ByteBuffersDirectory(lockFactory);
   }

--- a/solr/core/src/java/org/apache/solr/core/ByteBuffersDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/ByteBuffersDirectoryFactory.java
@@ -41,8 +41,7 @@ public class ByteBuffersDirectoryFactory extends EphemeralDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     return new ByteBuffersDirectory(lockFactory);
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A {@link DirectoryFactory} impl base class for caching Directory instances per path. Most
  * DirectoryFactory implementations will want to extend this class and simply implement {@link
- * DirectoryFactory#create(String, LockFactory, DirContext)}.
+ * DirectoryFactory#create(String, LockFactory)}.
  *
  * <p>This is an expert class and these API's are subject to change.
  */
@@ -402,7 +402,7 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
 
       cacheValue = byPathCache.get(fullPath);
       if (cacheValue == null) {
-        directory = create(fullPath, createLockFactory(rawLockType), dirContext);
+        directory = create(fullPath, createLockFactory(rawLockType));
         assert ObjectReleaseTracker.track(directory);
         boolean success = false;
         try {

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -102,8 +102,7 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
    *
    * @throws IOException If there is a low-level I/O error.
    */
-  protected abstract Directory create(String path, LockFactory lockFactory)
-      throws IOException;
+  protected abstract Directory create(String path, LockFactory lockFactory) throws IOException;
 
   /**
    * Creates a new LockFactory for a given path.

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -90,7 +90,7 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
   public abstract void addCloseListener(Directory dir, CloseListener closeListener);
 
   /**
-   * Close this factory and all of the Directories it contains.
+   * Close this factory and all the Directories it contains.
    *
    * @throws IOException If there is a low-level I/O error.
    */
@@ -102,9 +102,7 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
    *
    * @throws IOException If there is a low-level I/O error.
    */
-  // TODO: remove the DirContext param from this method and have the DirectoryFactory implementation
-  // extend the new CachingDirectoryFactory.filterDirectory if needed.
-  protected abstract Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected abstract Directory create(String path, LockFactory lockFactory)
       throws IOException;
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/MMapDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/MMapDirectoryFactory.java
@@ -63,8 +63,7 @@ public class MMapDirectoryFactory extends StandardDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     MMapDirectory mapDirectory = new MMapDirectory(Path.of(path), lockFactory, maxChunk);
     mapDirectory.setPreload(preload);
     return mapDirectory;

--- a/solr/core/src/java/org/apache/solr/core/MMapDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/MMapDirectoryFactory.java
@@ -63,7 +63,7 @@ public class MMapDirectoryFactory extends StandardDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     MMapDirectory mapDirectory = new MMapDirectory(Path.of(path), lockFactory, maxChunk);
     mapDirectory.setPreload(preload);

--- a/solr/core/src/java/org/apache/solr/core/NIOFSDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/NIOFSDirectoryFactory.java
@@ -26,7 +26,7 @@ import org.apache.lucene.store.NIOFSDirectory;
 public class NIOFSDirectoryFactory extends StandardDirectoryFactory {
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     return new NIOFSDirectory(Path.of(path), lockFactory);
   }

--- a/solr/core/src/java/org/apache/solr/core/NIOFSDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/NIOFSDirectoryFactory.java
@@ -26,8 +26,7 @@ import org.apache.lucene.store.NIOFSDirectory;
 public class NIOFSDirectoryFactory extends StandardDirectoryFactory {
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     return new NIOFSDirectory(Path.of(path), lockFactory);
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/NRTCachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/NRTCachingDirectoryFactory.java
@@ -47,7 +47,7 @@ public class NRTCachingDirectoryFactory extends StandardDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     return new NRTCachingDirectory(
         FSDirectory.open(Path.of(path), lockFactory), maxMergeSizeMB, maxCachedMB);

--- a/solr/core/src/java/org/apache/solr/core/NRTCachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/NRTCachingDirectoryFactory.java
@@ -47,8 +47,7 @@ public class NRTCachingDirectoryFactory extends StandardDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     return new NRTCachingDirectory(
         FSDirectory.open(Path.of(path), lockFactory), maxMergeSizeMB, maxCachedMB);
   }

--- a/solr/core/src/java/org/apache/solr/core/RAMDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/RAMDirectoryFactory.java
@@ -41,8 +41,7 @@ public class RAMDirectoryFactory extends EphemeralDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     return new ByteBuffersDirectory(lockFactory);
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/RAMDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/RAMDirectoryFactory.java
@@ -41,7 +41,7 @@ public class RAMDirectoryFactory extends EphemeralDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     return new ByteBuffersDirectory(lockFactory);
   }

--- a/solr/core/src/java/org/apache/solr/core/StandardDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/StandardDirectoryFactory.java
@@ -48,8 +48,7 @@ public class StandardDirectoryFactory extends CachingDirectoryFactory {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     return FSDirectory.open(Path.of(path), lockFactory);
   }
 

--- a/solr/core/src/java/org/apache/solr/core/StandardDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/StandardDirectoryFactory.java
@@ -48,7 +48,7 @@ public class StandardDirectoryFactory extends CachingDirectoryFactory {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     return FSDirectory.open(Path.of(path), lockFactory);
   }

--- a/solr/core/src/test/org/apache/solr/core/AlternateDirectoryTest.java
+++ b/solr/core/src/test/org/apache/solr/core/AlternateDirectoryTest.java
@@ -51,7 +51,7 @@ public class AlternateDirectoryTest extends SolrTestCaseJ4 {
     public static volatile boolean openCalled = false;
 
     @Override
-    public Directory create(String path, LockFactory lockFactory, DirContext dirContext) {
+    public Directory create(String path, LockFactory lockFactory) {
       openCalled = true;
 
       return newFSDirectory(Path.of(path), lockFactory);

--- a/solr/core/src/test/org/apache/solr/core/ByteBuffersDirectoryFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/core/ByteBuffersDirectoryFactoryTest.java
@@ -31,7 +31,7 @@ public class ByteBuffersDirectoryFactoryTest extends SolrTestCaseJ4 {
     ByteBuffersDirectoryFactory factory =
         new ByteBuffersDirectoryFactory() {
           @Override
-          protected Directory create(String path, LockFactory lockFactory, DirContext dirContext) {
+          protected Directory create(String path, LockFactory lockFactory) {
             return directory;
           }
         };

--- a/solr/core/src/test/org/apache/solr/core/RAMDirectoryFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/core/RAMDirectoryFactoryTest.java
@@ -36,7 +36,7 @@ public class RAMDirectoryFactoryTest extends SolrTestCase {
     RAMDirectoryFactory factory =
         new RAMDirectoryFactory() {
           @Override
-          protected Directory create(String path, LockFactory lockFactory, DirContext dirContext) {
+          protected Directory create(String path, LockFactory lockFactory) {
             return directory;
           }
         };

--- a/solr/core/src/test/org/apache/solr/handler/admin/CoreMergeIndexesAdminHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/CoreMergeIndexesAdminHandlerTest.java
@@ -52,12 +52,12 @@ public class CoreMergeIndexesAdminHandlerTest extends SolrTestCaseJ4 {
     public boolean fail = false;
 
     @Override
-    public Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+    public Directory create(String path, LockFactory lockFactory)
         throws IOException {
       if (fail) {
         throw new FailingDirectoryFactoryException();
       } else {
-        return super.create(path, lockFactory, dirContext);
+        return super.create(path, lockFactory);
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/admin/CoreMergeIndexesAdminHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/CoreMergeIndexesAdminHandlerTest.java
@@ -52,8 +52,7 @@ public class CoreMergeIndexesAdminHandlerTest extends SolrTestCaseJ4 {
     public boolean fail = false;
 
     @Override
-    public Directory create(String path, LockFactory lockFactory)
-        throws IOException {
+    public Directory create(String path, LockFactory lockFactory) throws IOException {
       if (fail) {
         throw new FailingDirectoryFactoryException();
       } else {

--- a/solr/test-framework/src/java/org/apache/solr/core/MockDirectoryFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/core/MockDirectoryFactory.java
@@ -44,7 +44,7 @@ public class MockDirectoryFactory extends EphemeralDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  protected Directory create(String path, LockFactory lockFactory)
       throws IOException {
     Directory dir;
     if (useMockDirectoryWrapper) dir = LuceneTestCase.newMockDirectory();

--- a/solr/test-framework/src/java/org/apache/solr/core/MockDirectoryFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/core/MockDirectoryFactory.java
@@ -44,8 +44,7 @@ public class MockDirectoryFactory extends EphemeralDirectoryFactory {
   }
 
   @Override
-  protected Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  protected Directory create(String path, LockFactory lockFactory) throws IOException {
     Directory dir;
     if (useMockDirectoryWrapper) dir = LuceneTestCase.newMockDirectory();
     else dir = LuceneTestCase.newDirectory(); // we ignore the given lock factory

--- a/solr/test-framework/src/java/org/apache/solr/core/MockFSDirectoryFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/core/MockFSDirectoryFactory.java
@@ -30,7 +30,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class MockFSDirectoryFactory extends StandardDirectoryFactory {
 
   @Override
-  public Directory create(String path, LockFactory lockFactory, DirContext dirContext)
+  public Directory create(String path, LockFactory lockFactory)
       throws IOException {
     Directory dir = LuceneTestCase.newFSDirectory(Path.of(path), lockFactory);
     // we can't currently do this check because of how

--- a/solr/test-framework/src/java/org/apache/solr/core/MockFSDirectoryFactory.java
+++ b/solr/test-framework/src/java/org/apache/solr/core/MockFSDirectoryFactory.java
@@ -30,8 +30,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class MockFSDirectoryFactory extends StandardDirectoryFactory {
 
   @Override
-  public Directory create(String path, LockFactory lockFactory)
-      throws IOException {
+  public Directory create(String path, LockFactory lockFactory) throws IOException {
     Directory dir = LuceneTestCase.newFSDirectory(Path.of(path), lockFactory);
     // we can't currently do this check because of how
     // Solr has to reboot a new Directory sometimes when replicating


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17675

In a previous [PR](https://github.com/apache/solr/pull/3185), we noted that the DirContext of the DirectoryFactory.create method should be removed. It was used only by the HdfsDirectoryFactory (now removed), and there was a bug in CachingDirectoryFactory which would create a Directory with this param, and cache it without this param in the cache key.

We already added a todo in DirectoryFactory, and the proposal is to apply this todo: remove the DirContext param from the DirectoryFactory.create method.