### PR TITLE
Fix asciidoc errors and warnings

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/solr-plugins.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/solr-plugins.adoc
@@ -62,6 +62,7 @@ The next sections describe some installation options:
 | xref:package-manager.adoc[]: Package-based plugins.
 | xref:cluster-plugins.adoc[]: Cluster-level plugins.
 | xref:replica-placement-plugins.adoc[]: Plugins specifically for replica placement.
+|
 |===
 // end::plugin-sections[]
 ****

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cluster-node-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cluster-node-management.adoc
@@ -396,7 +396,7 @@ At this point, if you run a query on a node having e.g., `rack=rack1`, Solr will
 
 === List Cluster Properties
 
-[tabs#setobjproperty-request]
+[tabs#listclusterproperties-request]
 ======
 V1 API::
 +
@@ -440,7 +440,7 @@ curl -X GET http://localhost:8983/api/cluster/properties
 
 === Fetch Cluster Property
 
-[tabs#setobjproperty-request]
+[tabs#fetchclusterproperty-request]
 ======
 V1 API::
 +

--- a/solr/solr-ref-guide/modules/getting-started/pages/solr-admin-ui.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/solr-admin-ui.adoc
@@ -166,7 +166,8 @@ Here are sections throughout the Guide describing each screen of the Admin UI:
 | xref:query-guide:query-screen.adoc[]: Form-based query builder.
 | xref:query-guide:stream-screen.adoc[]: Submit streaming expressions and see results and parsing explanations.
 | xref:query-guide:sql-screen.adoc[]: SQL query runner with tabular results.
-| xref:query-guide:schema-browser-screen.adoc[]: Field-level schema details.
+| xref:indexing-guide:schema-browser-screen.adoc[]: Field-level schema details.
+|
 |===
 // end::ui-collection-tools[]
 ****

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/language-analysis.adoc
@@ -3270,7 +3270,7 @@ With class name (legacy)::
 
 *Example 2:*
 
-[tabs#lang-spanish]
+[tabs#lang-spanish-plural]
 ======
 With name::
 +

--- a/solr/solr-ref-guide/modules/query-guide/pages/query-syntax-and-parsers.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/query-syntax-and-parsers.adoc
@@ -66,7 +66,6 @@ If you have custom parsing needs, you may want to extend that class to create yo
 | xref:sql-query.adoc[]: SQL language support for Solr.
 | xref:query-screen.adoc[]: Form-based query builder.
 | xref:sql-screen.adoc[]: SQL query runner with tabular results.
-|
 |===
 // end::parser-sections[]
 ****

--- a/solr/solr-ref-guide/modules/query-guide/pages/text-to-vector.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/text-to-vector.adoc
@@ -129,7 +129,7 @@ Many are shared but for the full set of parameters of the model you are interest
 Apache Solr uses https://github.com/langchain4j/langchain4j[LangChain4j] to support text vectorisation.
 The models currently supported are:
 
-[tabs#supported-models]
+[tabs#supported-models-hugging-face]
 ======
 Hugging Face::
 +


### PR DESCRIPTION
# Description

The build outputs are reporting a few issues with tables cells that are not rendered and duplicate IDs.

# Solution

This PR fixes these issues by updating the duplicate IDs and adding additional cells so that the last row / cell is displayed again.

# Tests

Affected pages can be reviewed in current ref guide for the missing cells / page references.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
