### PR TITLE
IOUtils: add back closeQuietly(Closeable)

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/util/IOUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/IOUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.common.util;
 
+import java.io.Closeable;
 import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,5 +32,9 @@ public class IOUtils {
     } catch (Exception e) {
       log.error("Error while closing", e);
     }
+  }
+
+  public static void closeQuietly(Closeable closeable) {
+    closeQuietly((AutoCloseable) closeable);
   }
 }


### PR DESCRIPTION
To retain compatibility within 9x.

Not bringing this to main/10x.
This issue was introduced by [SOLR-17593: New home for default http2 client apache/solr#2689](https://github.com/apache/solr/pull/2689) and was seen to be a compatibility issue in the DIH for one: https://github.com/SearchScale/dataimporthandler/issues/91