### PR TITLE
Feature/update web dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -165,7 +165,7 @@ netty-tcnative = "2.0.66.Final"
 nimbusds-josejwt = "9.48"
 nodegradle-node = "7.0.1"
 # @keep Node JS version used in node.gradle (LTS)
-nodejs = "16.20.2"
+nodejs = "22.14.0"
 openapi = "7.6.0"
 openjdk-jmh = "1.37"
 opentelemetry = "1.46.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,11 +16,11 @@
 adobe-testing-s3mock = "2.17.0"
 amazon-awssdk = "2.26.19"
 # @keep Antora version used in ref-guide
-antora = "3.1.4"
-# @keep Most recent commit as of 2022-06-24, this repo does not have tags
-antora-default-ui = "51ad811622394027afb4e182c2fdabc235ae04dd"
+antora = "3.1.10"
+# @keep Most recent commit as of 2025-02-19, this repo does not have tags
+antora-default-ui = "687202ae5a50bdd3bd96e666ec1badb5ca3ff143"
 # @keep Antora Lunr extensions version used in ref-guide
-antora-lunr-extension = "1.0.0-alpha.8"
+antora-lunr-extension = "1.0.0-alpha.10"
 apache-calcite = "1.37.0"
 apache-calcite-avatica = "1.25.0"
 apache-commons-collections4 = "4.4"
@@ -112,7 +112,7 @@ google-protobuf = "3.25.3"
 gradle = "8.10"
 grpc = "1.65.1"
 # @keep Gulp version used in ref-guide
-gulp-cli = "2.3.0"
+gulp-cli = "3.0.0"
 hamcrest = "3.0"
 hk2 = "3.1.1"
 hsqldb = "2.7.4"

--- a/solr/ui/build.gradle.kts
+++ b/solr/ui/build.gradle.kts
@@ -17,6 +17,8 @@
 
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 repositories {
@@ -173,4 +175,9 @@ tasks.matching { task ->
     // Note that "gradlew check -x test --dry-run" does not correctly resolve this exclusion rule,
     // and you will see the test tasks being listed there as well, but they will be skipped as
     // expected
+}
+
+rootProject.plugins.withType(NodeJsRootPlugin::class.java) {
+    // Configure nodejs version to align with project's version
+    rootProject.the<NodeJsRootExtension>().version = libs.versions.nodejs.get()
 }


### PR DESCRIPTION
# Description

With NodeJS v16 reaching EOL in 2023, we should upgrade to the latest LTS.

# Solution

This PR updates the ref-guide dependencies (web), including NodeJS to v22 (latest LTS), as the current version (16) has reached EOL about two years ago.

The PR also aligns the UI module's node version with the one from the `libs.versions.toml`, so that we can maintain the same version across the project.

**Note that this upgrade requires GLIBC v2.28**, which is currently not present in our build servers and causes other tasks (like `:kotlinNpmInstall`) to fail as well.

# Tests

No tests have been added or removed._

GitHub workflows are likely not affected by version issues and may run successfully, but our jenkins jobs may (continue to) fail.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
