### PR TITLE
LogListener: remove no-arg convenience methods

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
@@ -160,7 +160,6 @@ public final class LogListener implements Closeable, AutoCloseable {
   }
 
   // TODO: more factories for other levels?
-  // TODO: no-arg factory variants that use "" -- simpler syntax for ROOT logger?
 
   private static LogListener create(final Level level, final String logger) {
     final String name = createName(level);

--- a/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/LogListener.java
@@ -119,11 +119,6 @@ public final class LogListener implements Closeable, AutoCloseable {
         + ID_GEN.incrementAndGet();
   }
 
-  /** Listens for ERROR log messages at the ROOT logger */
-  public static LogListener error() {
-    return error("");
-  }
-
   /** Listens for ERROR log messages for the specified logger */
   public static LogListener error(final Class<?> logger) {
     return error(logger.getName());
@@ -132,11 +127,6 @@ public final class LogListener implements Closeable, AutoCloseable {
   /** Listens for ERROR log messages for the specified logger */
   public static LogListener error(final String logger) {
     return create(Level.ERROR, logger);
-  }
-
-  /** Listens for WARN log messages at the ROOT logger */
-  public static LogListener warn() {
-    return warn("");
   }
 
   /** Listens for WARN log messages for the specified logger */
@@ -149,11 +139,6 @@ public final class LogListener implements Closeable, AutoCloseable {
     return create(Level.WARN, logger);
   }
 
-  /** Listens for INFO log messages at the ROOT logger */
-  public static LogListener info() {
-    return info("");
-  }
-
   /** Listens for INFO log messages for the specified logger */
   public static LogListener info(final Class<?> logger) {
     return info(logger.getName());
@@ -162,11 +147,6 @@ public final class LogListener implements Closeable, AutoCloseable {
   /** Listens for INFO log messages for the specified logger */
   public static LogListener info(final String logger) {
     return create(Level.INFO, logger);
-  }
-
-  /** Listens for DEBUG log messages at the ROOT logger */
-  public static LogListener debug() {
-    return debug("");
   }
 
   /** Listens for DEBUG log messages for the specified logger */

--- a/solr/test-framework/src/test/org/apache/solr/util/TestErrorLogMuter.java
+++ b/solr/test-framework/src/test/org/apache/solr/util/TestErrorLogMuter.java
@@ -35,8 +35,8 @@ public class TestErrorLogMuter extends SolrTestCaseJ4 {
   @LogLevel("=WARN")
   public void testErrorMutingRegex() throws Exception {
 
-    try (LogListener rootWarnCheck = LogListener.warn();
-        LogListener rootErrorCheck = LogListener.error()) {
+    try (LogListener rootWarnCheck = LogListener.warn("");
+        LogListener rootErrorCheck = LogListener.error("")) {
 
       try (ErrorLogMuter x = ErrorLogMuter.regex("eRrOr\\s+Log")) {
         assertEquals(0, x.getCount());
@@ -68,8 +68,8 @@ public class TestErrorLogMuter extends SolrTestCaseJ4 {
   @LogLevel("=WARN")
   public void testMultipleMuters() throws Exception {
 
-    try (LogListener rootWarnCheck = LogListener.warn().substring("xxx");
-        LogListener rootErrorCheck = LogListener.error()) {
+    try (LogListener rootWarnCheck = LogListener.warn("").substring("xxx");
+        LogListener rootErrorCheck = LogListener.error("")) {
 
       // sanity check that muters "mute" in the order used...
       // (If this fails, then it means log4j has changed the precedence order it uses when addFilter
@@ -107,8 +107,8 @@ public class TestErrorLogMuter extends SolrTestCaseJ4 {
   public void testDeprecatedBaseClassMethods() throws Exception {
 
     // NOTE: using the same queue for both interceptors (mainly as proof that you can)
-    try (LogListener rootWarnCheck = LogListener.warn();
-        LogListener rootErrorCheck = LogListener.error().setQueue(rootWarnCheck.getQueue())) {
+    try (LogListener rootWarnCheck = LogListener.warn("");
+        LogListener rootErrorCheck = LogListener.error("").setQueue(rootWarnCheck.getQueue())) {
 
       log.error("this matches the default ignore_exception pattern");
       log.error("something matching foo that should make it"); // E1


### PR DESCRIPTION
These are hazardous/sloppy.  Tests should listen to a specific class/package.

Motivated by: https://issues.apache.org/jira/browse/SOLR-17667?focusedCommentId=17928175&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17928175