### PR TITLE
Finally fix TestCoordinatorRole for good.

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/TestCoordinatorRole.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCoordinatorRole.java
@@ -361,11 +361,17 @@ public class TestCoordinatorRole extends SolrCloudTestCase {
         // TODO: could separate this out into a different test method, but this should suffice for
         // now
         pullJetty.start(true);
+        waitForState(
+            "Pull jetty replicas didn't become active in time",
+            COLL,
+            ((liveNodes, collectionState) ->
+                collectionState.getReplicas(pullJettyF.getNodeName()).stream()
+                    .allMatch(rep -> rep.getState() == Replica.State.ACTIVE)));
         AtomicBoolean done = new AtomicBoolean();
         long runMinutes = 1;
         long finishTimeMs =
             new Date().getTime() + TimeUnit.MILLISECONDS.convert(runMinutes, TimeUnit.MINUTES);
-        JettySolrRunner[] jettys = new JettySolrRunner[] {nrtJettyF, pullJettyF};
+        JettySolrRunner[] jettys = new JettySolrRunner[] {pullJettyF, nrtJettyF};
         Random threadRandom = new Random(r.nextInt());
         Future<Integer> f =
             executor.submit(
@@ -386,6 +392,12 @@ public class TestCoordinatorRole extends SolrCloudTestCase {
                       log.info("restarting {} ...", idx);
                       toManipulate.start(true);
                       log.info("restarted {}.", idx);
+                      waitForState(
+                          toManipulate.getNodeName() + " replicas didn't become active in time",
+                          COLL,
+                          ((liveNodes, collectionState) ->
+                              collectionState.getReplicas(toManipulate.getNodeName()).stream()
+                                  .allMatch(rep -> rep.getState() == Replica.State.ACTIVE)));
                     } catch (Exception e) {
                       throw new RuntimeException(e);
                     }


### PR DESCRIPTION
`TestCoordinatorRole.testNRTRestart()` has been flaky for a long time, and for various reasons. I believe this is the last one.

Basically in the last part, it's supposed to turn off the NRT replica and the PULL replica alternating, and keep trying requests that have `shards.preference=NRT`, until a PULL replica is forced to be used to serve the request.

The issue was that the pull node is started right before this. So if a very low (< 300 ms) random value is chosen for `serveTogetherTime`, then the Pull replica will fail to recover from the NRT replica leader. Pull replicas do not become active unless they recover on startup. So when the NRT replica is offline, requests will fail because there are no replicas serving the requested shard.

The `getHostCoreName` call can handle up to 500 ms of failures, so if `downTime` (another random int) is > 500, or a lower number, because it takes time to startup, then it will exceed the number of allowed errors.

The fix here is 2 parts:
- The only really necessary fix is waiting for the pull replica to come online before starting to take down other nodes
- In order to keep the spirit of the test, I reversed the ordering of the jettys that will be brought down, because otherwise the PULL replica is chosen immediately and we don't have to do any iterations of this loop. Because of this, we need to do the same replica-state-check at the end of the loop, to ensure the above failure scenario doesn't happen during our loop either.