### PR TITLE
SOLR-17677: HashRangeQuery doesn't NEED SolrIndexSearcher

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/join/HashRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/join/HashRangeQuery.java
@@ -38,9 +38,14 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.util.Hash;
 import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SolrIndexSearcher;
-import org.apache.solr.search.SolrSearcherRequirer;
 
-public class HashRangeQuery extends Query implements SolrSearcherRequirer {
+/**
+ * Matches documents where the specified field hashes to a value within the given range. Can be used
+ * to create a filter that will only match documents falling within a certain shard's hash range.
+ *
+ * @see HashRangeQParser
+ */
+public class HashRangeQuery extends Query {
 
   protected final String field;
   protected final int lower;
@@ -89,6 +94,9 @@ public class HashRangeQuery extends Query implements SolrSearcherRequirer {
       private int[] getCache(LeafReaderContext context) throws IOException {
         IndexReader.CacheHelper cacheHelper = context.reader().getReaderCacheHelper();
         if (cacheHelper == null) {
+          return null;
+        }
+        if (!(searcher instanceof SolrIndexSearcher)) { // e.g. delete-by-query
           return null;
         }
         @SuppressWarnings("unchecked")

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudDeleteByQuery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudDeleteByQuery.java
@@ -270,8 +270,7 @@ public class TestCloudDeleteByQuery extends SolrCloudTestCase {
     final var unsupportedQueryExamples =
         new String[] {
           "{!join from=expected_shard_s to=expected_shard_s v=\"expected_shard_s:5\"}",
-          "{!graph from=expected_shard_s to=expected_shard_s v=\"expected_shard_s:5\"}",
-          "{!hash_range f=\"foo_i\" l=\"0\" u=\"12345\"}"
+          "{!graph from=expected_shard_s to=expected_shard_s v=\"expected_shard_s:5\"}"
         };
 
     update(params()).add(doc(f("id", UUID.randomUUID().toString()))).process(COLLECTION_CLIENT);

--- a/solr/core/src/test/org/apache/solr/search/SolrSearcherRequirementDetectorTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SolrSearcherRequirementDetectorTest.java
@@ -71,7 +71,7 @@ public class SolrSearcherRequirementDetectorTest extends SolrTestCase {
   }
 
   @Test
-  public void testDeteectsWhenQueriesDoRequireSolrSearcher_Nested() {
+  public void testDetectsWhenQueriesRequireSolrSearcher_Nested() {
     final var termQuery = new TermQuery(new Term("someField", "someFieldValue"));
     final var termQuery2 = new TermQuery(new Term("someField", "someOtherFieldValue"));
     final var joinQuery = new JoinQuery("fromField", "toField", "someCoreName", termQuery);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17677
