### PR TITLE
JavaBinUpdateRequestCodec: Dead code removal

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
@@ -25,6 +25,8 @@ import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -242,7 +244,7 @@ public class JavaBinUpdateRequestCodec {
         } else if (o instanceof Map<?, ?> m) { // doc.  To imitate JSON style.  SOLR-13731
           sdoc = convertMapToSolrInputDoc(m);
         } else {
-          throw new IllegalStateException("Unexpected data type: " + o.getClass());
+          throw new SolrException(ErrorCode.BAD_REQUEST, "Unexpected data type: " + o.getClass());
         }
 
         // peek at the next object to see if we're at the end

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
@@ -233,7 +233,6 @@ public class JavaBinUpdateRequestCodec {
               (Map.Entry<SolrInputDocument, Map<?, ?>>) o;
           sdoc = entry.getKey();
           Map<?, ?> p = entry.getValue();
-          assert p != null;
           if (p != null) {
             commitWithin = (Integer) p.get(UpdateRequest.COMMIT_WITHIN);
             overwrite = (Boolean) p.get(UpdateRequest.OVERWRITE);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
@@ -22,14 +22,9 @@ import static org.apache.solr.common.util.ByteArrayUtf8CharSequence.convertCharS
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -38,8 +33,6 @@ import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.DataInputInputStream;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides methods for marshalling an UpdateRequest to a NamedList which can be serialized in the
@@ -49,15 +42,6 @@ import org.slf4j.LoggerFactory;
  * @since solr 1.4
  */
 public class JavaBinUpdateRequestCodec {
-  private boolean readStringAsCharSeq = false;
-
-  public JavaBinUpdateRequestCodec setReadStringAsCharSeq(boolean flag) {
-    this.readStringAsCharSeq = flag;
-    return this;
-  }
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private static final AtomicBoolean WARNED_ABOUT_INDEX_TIME_BOOSTS = new AtomicBoolean();
 
   /**
    * Converts an UpdateRequest to a NamedList which can be serialized to the given OutputStream in
@@ -69,32 +53,32 @@ public class JavaBinUpdateRequestCodec {
    */
   public void marshal(UpdateRequest updateRequest, OutputStream os) throws IOException {
     NamedList<Object> nl = new NamedList<>();
+
     NamedList<Object> params = updateRequest.getParams().toNamedList();
     if (updateRequest.getCommitWithin() != -1) {
       params.add("commitWithin", updateRequest.getCommitWithin());
     }
-    Iterator<SolrInputDocument> docIter = null;
-
-    if (updateRequest.getDocIterator() != null) {
-      docIter = updateRequest.getDocIterator();
-    }
-
-    Map<SolrInputDocument, Map<String, Object>> docMap = updateRequest.getDocumentsMap();
-
     nl.add("params", params); // 0: params
+
     if (updateRequest.getDeleteByIdMap() != null) {
       nl.add("delByIdMap", updateRequest.getDeleteByIdMap());
     }
+
     nl.add("delByQ", updateRequest.getDeleteQuery());
 
+    Map<SolrInputDocument, Map<String, Object>> docMap = updateRequest.getDocumentsMap();
     if (docMap != null) {
-      nl.add("docsMap", docMap.entrySet().iterator());
+      nl.add("docsMap", docMap.entrySet().iterator()); // of Map.Entry
     } else {
+      Iterator<SolrInputDocument> docIter;
       if (updateRequest.getDocuments() != null) {
         docIter = updateRequest.getDocuments().iterator();
+      } else {
+        docIter = updateRequest.getDocIterator();
       }
       nl.add("docs", docIter);
     }
+
     try (JavaBinCodec codec = new JavaBinCodec()) {
       codec.marshal(nl, os);
     }
@@ -114,65 +98,48 @@ public class JavaBinUpdateRequestCodec {
   @SuppressWarnings({"unchecked"})
   public UpdateRequest unmarshal(InputStream is, final StreamingUpdateHandler handler)
       throws IOException {
+    final NamedList<Object> namedList;
+
+    // process documents:
+
+    // reads documents, sending to handler.  Other data is in NamedList
+    try (var codec = new StreamingCodec(handler)) {
+      namedList = codec.unmarshal(is);
+    }
+
+    // process deletes:
+
     final UpdateRequest updateRequest = new UpdateRequest();
-    List<List<NamedList<?>>> doclist;
-    List<Entry<SolrInputDocument, Map<Object, Object>>> docMap;
-    List<String> delById;
-    Map<String, Map<String, Object>> delByIdMap;
-    List<String> delByQ;
-    final NamedList<?>[] namedList = new NamedList<?>[1];
-    try (JavaBinCodec codec = new StreamingCodec(namedList, updateRequest, handler)) {
-      codec.unmarshal(is);
-    }
-
-    // NOTE: if the update request contains only delete commands the params
-    // must be loaded now
-    if (updateRequest.getParams().iterator().hasNext() == false) { // no params
-      NamedList<?> params = (NamedList<?>) namedList[0].get("params");
+    {
+      NamedList<?> params = (NamedList<?>) namedList.get("params");
       if (params != null) {
-        updateRequest.setParams(new ModifiableSolrParams(params.toSolrParams()));
+        updateRequest.setParams(ModifiableSolrParams.of(params.toSolrParams()));
       }
     }
-    delById = (List<String>) namedList[0].get("delById");
-    delByIdMap = (Map<String, Map<String, Object>>) namedList[0].get("delByIdMap");
-    delByQ = (List<String>) namedList[0].get("delByQ");
-    doclist = (List) namedList[0].get("docs");
-    Object docsMapObj = namedList[0].get("docsMap");
 
-    if (docsMapObj instanceof Map) { // SOLR-5762
-      docMap = new ArrayList<>(((Map) docsMapObj).entrySet());
-    } else {
-      docMap = (List<Entry<SolrInputDocument, Map<Object, Object>>>) docsMapObj;
+    for (String s : (List<String>) namedList.getOrDefault("delById", List.of())) {
+      updateRequest.deleteById(s);
     }
 
-    // we don't add any docs, because they were already processed
-    // deletes are handled later, and must be passed back on the UpdateRequest
-
-    if (delById != null) {
-      for (String s : delById) {
-        updateRequest.deleteById(s);
-      }
-    }
-    if (delByIdMap != null) {
-      for (Map.Entry<String, Map<String, Object>> entry : delByIdMap.entrySet()) {
-        Map<String, Object> params = entry.getValue();
-        if (params != null) {
-          Long version = (Long) params.get(UpdateRequest.VER);
-          if (params.containsKey(ShardParams._ROUTE_)) {
-            updateRequest.deleteById(
-                entry.getKey(), (String) params.get(ShardParams._ROUTE_), version);
-          } else {
-            updateRequest.deleteById(entry.getKey(), version);
-          }
+    for (var entry :
+        ((Map<String, Map<String, Object>>) namedList.getOrDefault("delByIdMap", Map.of()))
+            .entrySet()) {
+      Map<String, Object> params = entry.getValue();
+      if (params != null) {
+        Long version = (Long) params.get(UpdateRequest.VER);
+        if (params.containsKey(ShardParams._ROUTE_)) {
+          updateRequest.deleteById(
+              entry.getKey(), (String) params.get(ShardParams._ROUTE_), version);
         } else {
-          updateRequest.deleteById(entry.getKey());
+          updateRequest.deleteById(entry.getKey(), version);
         }
+      } else {
+        updateRequest.deleteById(entry.getKey());
       }
     }
-    if (delByQ != null) {
-      for (String s : delByQ) {
-        updateRequest.deleteByQuery(s);
-      }
+
+    for (String s : (List<String>) namedList.getOrDefault("delByQ", List.of())) {
+      updateRequest.deleteByQuery(s);
     }
 
     return updateRequest;
@@ -194,23 +161,23 @@ public class JavaBinUpdateRequestCodec {
     }
   }
 
-  class StreamingCodec extends JavaBinCodec {
+  static class StreamingCodec extends JavaBinCodec {
 
-    // TODO This could probably be an AtomicReference<NamedList<?>>
-    private final NamedList<?>[] namedList;
-    private final UpdateRequest updateRequest;
+    private NamedList<Object> resultNamedList;
     private final StreamingUpdateHandler handler;
     // NOTE: this only works because this is an anonymous inner class
     // which will only ever be used on a single stream -- if this class
     // is ever refactored, this will not work.
-    private boolean seenOuterMostDocIterator;
+    private boolean seenOuterMostDocIterator = false;
 
-    public StreamingCodec(
-        NamedList<?>[] namedList, UpdateRequest updateRequest, StreamingUpdateHandler handler) {
-      this.namedList = namedList;
-      this.updateRequest = updateRequest;
+    StreamingCodec(StreamingUpdateHandler handler) {
       this.handler = handler;
-      seenOuterMostDocIterator = false;
+    }
+
+    @Override
+    public NamedList<Object> unmarshal(InputStream is) throws IOException {
+      super.unmarshal(is);
+      return resultNamedList;
     }
 
     @Override
@@ -222,8 +189,8 @@ public class JavaBinUpdateRequestCodec {
     public NamedList<Object> readNamedList(DataInputInputStream dis) throws IOException {
       int sz = readSize(dis);
       NamedList<Object> nl = new NamedList<>();
-      if (namedList[0] == null) {
-        namedList[0] = nl;
+      if (this.resultNamedList == null) {
+        this.resultNamedList = nl;
       }
       for (int i = 0; i < sz; i++) {
         String name = (String) readVal(dis);
@@ -231,42 +198,6 @@ public class JavaBinUpdateRequestCodec {
         nl.add(name, val);
       }
       return nl;
-    }
-
-    private SolrInputDocument listToSolrInputDocument(List<NamedList<?>> namedList) {
-      SolrInputDocument doc = new SolrInputDocument();
-      for (int i = 0; i < namedList.size(); i++) {
-        NamedList<?> nl = namedList.get(i);
-        if (i == 0) {
-          Float boost = (Float) nl.getVal(0);
-          if (boost != null && boost.floatValue() != 1f) {
-            String message =
-                "Ignoring document boost: "
-                    + boost
-                    + " as index-time boosts are not supported anymore";
-            if (WARNED_ABOUT_INDEX_TIME_BOOSTS.compareAndSet(false, true)) {
-              log.warn(message);
-            } else {
-              log.debug(message);
-            }
-          }
-        } else {
-          Float boost = (Float) nl.getVal(2);
-          if (boost != null && boost.floatValue() != 1f) {
-            String message =
-                "Ignoring field boost: "
-                    + boost
-                    + " as index-time boosts are not supported anymore";
-            if (WARNED_ABOUT_INDEX_TIME_BOOSTS.compareAndSet(false, true)) {
-              log.warn(message);
-            } else {
-              log.debug(message);
-            }
-          }
-          doc.addField((String) nl.getVal(0), nl.getVal(1));
-        }
-      }
-      return doc;
     }
 
     @Override
@@ -277,72 +208,53 @@ public class JavaBinUpdateRequestCodec {
       // special treatment for first outermost Iterator
       // (the list of documents)
       seenOuterMostDocIterator = true;
-      return readOuterMostDocIterator(fis);
+      readDocs(fis);
+      return List.of(); // bogus; already processed
     }
 
-    private List<Object> readOuterMostDocIterator(DataInputInputStream fis) throws IOException {
-      if (namedList[0] == null) namedList[0] = new NamedList<>();
-      NamedList<?> params = (NamedList<?>) namedList[0].get("params");
-      if (params == null) params = new NamedList<>();
-      updateRequest.setParams(new ModifiableSolrParams(params.toSolrParams()));
-      if (handler == null) return super.readIterator(fis);
-      Integer commitWithin = null;
-      Boolean overwrite = null;
-      Object o = null;
-      super.readStringAsCharSeq = JavaBinUpdateRequestCodec.this.readStringAsCharSeq;
-      try {
-        while (true) {
-          if (o == null) {
-            o = readVal(fis);
-          }
+    private void readDocs(DataInputInputStream fis) throws IOException {
+      if (resultNamedList == null) resultNamedList = new NamedList<>();
 
-          if (o == END_OBJ) {
-            break;
-          }
+      UpdateRequest updateRequest = new UpdateRequest();
+      NamedList<?> params = (NamedList<?>) resultNamedList.get("params"); // always precedes docs
+      if (params != null) {
+        updateRequest.setParams(ModifiableSolrParams.of(params.toSolrParams()));
+      }
 
-          SolrInputDocument sdoc;
-          if (o instanceof List) { // never really happens?
-            assert false : o.toString();
-            @SuppressWarnings("unchecked")
-            List<NamedList<?>> list = (List<NamedList<?>>) o;
-            sdoc = listToSolrInputDocument(list);
-          } else if (o instanceof NamedList) { // never really happens? SOLR-2904
-            assert false : o.toString();
-            UpdateRequest req = new UpdateRequest();
-            req.setParams(new ModifiableSolrParams(((NamedList) o).toSolrParams()));
-            handler.update(null, req, null, null);
-            continue;
-          } else if (o instanceof Map.Entry) {
-            @SuppressWarnings("unchecked")
-            Map.Entry<SolrInputDocument, Map<?, ?>> entry =
-                (Map.Entry<SolrInputDocument, Map<?, ?>>) o;
-            sdoc = entry.getKey();
-            Map<?, ?> p = entry.getValue();
-            if (p != null) {
-              commitWithin = (Integer) p.get(UpdateRequest.COMMIT_WITHIN);
-              overwrite = (Boolean) p.get(UpdateRequest.OVERWRITE);
-            }
-          } else if (o instanceof SolrInputDocument) {
-            sdoc = (SolrInputDocument) o;
-          } else if (o instanceof Map) { // never really happens? SOLR-13731
-            sdoc = convertMapToSolrInputDoc((Map) o);
-          } else {
-            throw new IllegalStateException("Unexpected data type: " + o.getClass());
-          }
+      Object o = readVal(fis);
+      while (o != END_OBJ) {
+        Integer commitWithin = null;
+        Boolean overwrite = null;
 
-          // peek at the next object to see if we're at the end
-          o = readVal(fis);
-          if (o == END_OBJ) {
-            // indicate that we've hit the last doc in the batch, used to enable optimizations when
-            // doing replication
-            updateRequest.lastDocInBatch();
+        SolrInputDocument sdoc;
+        if (o instanceof Map.Entry) { // doc + options.  UpdateRequest "docsMap"
+          @SuppressWarnings("unchecked")
+          Map.Entry<SolrInputDocument, Map<?, ?>> entry =
+              (Map.Entry<SolrInputDocument, Map<?, ?>>) o;
+          sdoc = entry.getKey();
+          Map<?, ?> p = entry.getValue();
+          assert p != null;
+          if (p != null) {
+            commitWithin = (Integer) p.get(UpdateRequest.COMMIT_WITHIN);
+            overwrite = (Boolean) p.get(UpdateRequest.OVERWRITE);
           }
-
-          handler.update(sdoc, updateRequest, commitWithin, overwrite);
+        } else if (o instanceof SolrInputDocument d) { // doc.  UpdateRequest "docs""
+          sdoc = d;
+        } else if (o instanceof Map<?, ?> m) { // doc.  To imitate JSON style.  SOLR-13731
+          sdoc = convertMapToSolrInputDoc(m);
+        } else {
+          throw new IllegalStateException("Unexpected data type: " + o.getClass());
         }
-        return Collections.emptyList();
-      } finally {
-        super.readStringAsCharSeq = false;
+
+        // peek at the next object to see if we're at the end
+        o = readVal(fis);
+        if (o == END_OBJ) {
+          // indicate that we've hit the last doc in the batch, used to enable optimizations when
+          // doing replication
+          updateRequest.lastDocInBatch();
+        }
+
+        handler.update(sdoc, updateRequest, commitWithin, overwrite);
       }
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/JavaBinUpdateRequestCodec.java
@@ -300,15 +300,18 @@ public class JavaBinUpdateRequestCodec {
             break;
           }
 
-          SolrInputDocument sdoc = null;
-          if (o instanceof List) {
+          SolrInputDocument sdoc;
+          if (o instanceof List) { // never really happens?
+            assert false : o.toString();
             @SuppressWarnings("unchecked")
             List<NamedList<?>> list = (List<NamedList<?>>) o;
             sdoc = listToSolrInputDocument(list);
-          } else if (o instanceof NamedList) {
+          } else if (o instanceof NamedList) { // never really happens? SOLR-2904
+            assert false : o.toString();
             UpdateRequest req = new UpdateRequest();
             req.setParams(new ModifiableSolrParams(((NamedList) o).toSolrParams()));
             handler.update(null, req, null, null);
+            continue;
           } else if (o instanceof Map.Entry) {
             @SuppressWarnings("unchecked")
             Map.Entry<SolrInputDocument, Map<?, ?>> entry =
@@ -321,8 +324,10 @@ public class JavaBinUpdateRequestCodec {
             }
           } else if (o instanceof SolrInputDocument) {
             sdoc = (SolrInputDocument) o;
-          } else if (o instanceof Map) {
+          } else if (o instanceof Map) { // never really happens? SOLR-13731
             sdoc = convertMapToSolrInputDoc((Map) o);
+          } else {
+            throw new IllegalStateException("Unexpected data type: " + o.getClass());
           }
 
           // peek at the next object to see if we're at the end

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestUpdateRequestCodec.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestUpdateRequestCodec.java
@@ -247,13 +247,14 @@ public class TestUpdateRequestCodec extends SolrTestCase {
 
     InputStream is = getClass().getResourceAsStream("/solrj/updateReq_4_5.bin");
     assertNotNull("updateReq_4_5.bin was not found", is);
+    List<SolrInputDocument> unmarshalledDocs = new ArrayList<>();
     UpdateRequest updateUnmarshalled =
         new JavaBinUpdateRequestCodec()
             .unmarshal(
                 is,
                 (document, req, commitWithin, override) -> {
                   if (commitWithin == null) {
-                    req.add(document);
+                    unmarshalledDocs.add(document);
                   }
                   System.err.println(
                       "Doc"
@@ -263,6 +264,7 @@ public class TestUpdateRequestCodec extends SolrTestCase {
                           + " , override:"
                           + override);
                 });
+    updateUnmarshalled.add(unmarshalledDocs);
 
     System.err.println(updateUnmarshalled.getDocumentsMap());
     System.err.println(updateUnmarshalled.getDocuments());


### PR DESCRIPTION
This PR removes some dead code in JavaBinUpdateRequestCodec (no test exercises it), and simplifies related logic.  

*Disclaimer*  It's possible and maybe likely that an old SolrJ might have sent data encoded with these types.  It's also possible a user is using JavaBinCodec directly to do the same.  Henceforth, they will get an error.  As we have very little / inadequate backwards compatibility tests, I can't know for sure.  The disclaimer is so vague and frankly kind of expected for a major version (that this targets) that I'm not sure anything meaningful could be said in upgrade notes.

I plan to merge for 10.

Context:
----
While working on something nearby, I noticed that `JavaBinUpdateRequestCodec.readOuterMostDocIterator` (server side, processes an update request that's JavaBin formatted) reads the outer most object checking for a variety of possibilities.  I'm suspicious of them so added some asserts and found out when some were added.
https://issues.apache.org/jira/browse/SOLR-2904 weird
https://issues.apache.org/jira/browse/SOLR-13731 this one is actually tested but not realistically to how users use javabin.

Even if we just end up leaving some comments, it'd be helpful.