### PR TITLE
Fix flaky TestSchemaDesignerAPI

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/ZkContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/ZkContainer.java
@@ -246,7 +246,7 @@ public class ZkContainer {
           zkServer.stop();
         }
       } finally {
-        ExecutorUtil.shutdownAndAwaitTermination(coreZkRegister);
+        ExecutorUtil.shutdownNowAndAwaitTermination(coreZkRegister);
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerAPI.java
@@ -560,6 +560,8 @@ public class SchemaDesignerAPI implements SchemaDesignerConstants {
     } else {
       copyConfig(mutableId, configSet);
     }
+    settings.setDisabled(req.getParams().getBool(DISABLE_DESIGNER_PARAM, false));
+    settingsDAO.persistIfChanged(configSet, settings);
 
     boolean reloadCollections = req.getParams().getBool(RELOAD_COLLECTIONS_PARAM, false);
     if (reloadCollections) {
@@ -595,9 +597,6 @@ public class SchemaDesignerAPI implements SchemaDesignerConstants {
         log.warn("Failed to clean-up temp collection {} due to: {}", mutableId, excStr);
       }
     }
-
-    settings.setDisabled(req.getParams().getBool(DISABLE_DESIGNER_PARAM, false));
-    settingsDAO.persistIfChanged(configSet, settings);
 
     Map<String, Object> response = new HashMap<>();
     response.put(CONFIG_SET_PARAM, configSet);


### PR DESCRIPTION
This test currently flakes because the last command of `SchemaDesignerApi.publish()` is to persist a change to the overlay.json for the newly created collection.

In `TestSchemaDesignerAPI.testAddTechproductsProgressively()`, this is called near the end of the test. So quickly after it is called, the `@AfterClass` method deletes all of the collections.

However, persisting a change to the overlay.json will asynchronously kick-off a reload of the collection.

So there is a race condition here that if this reload starts before the collection deletion but doesn't finish before the deletion, then lots of errors will happen and ultimately the `StandardDirectoryFactory` will fail to delete directories, because they have already been deleted. And annoyingly `PathUtils.deleteDirectory()` cannot handle parallel deletes gracefully, it will throw `FileNotFoundException`s. So in this case, the CachingDirectoryFactory is not able to successfully close things, and we get an error that a `NRTCachingDirectory` is not closed when it should be.

So ultimately my answer to this is to:

- Move the new overlay.json to before the collection is created. In my mind, there is no reason to update the collection once its created, because we can just as easily create it with the settings we want.
- Change ZkContainer to interrupt the core registry thread pool, because there should be no reason to continue to register cores while the zkContainer is shutting down. The ConfigSet watching code is run via this executor, so stopping it in its tracks can only help us.