### PR TITLE
SOLR-17518: Remove deprecated XML methods from UpdateRequest

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -105,7 +105,9 @@ Deprecation Removals
 
 * SOLR-17540: Removed the Hadoop Auth module, and thus Kerberos authentication and other exotic options. (Eric Pugh)
 
-* SOLR-17609: Removd the HDFS module and therefore support for storing indexes in HDFS.  Existing "blockcache" code preserved by migrating it to core o.a.s.blackcache package.
+* SOLR-17609: Removed the HDFS module and therefore support for storing indexes in HDFS.  Existing "blockcache" code preserved by migrating it to core o.a.s.blackcache package.
+
+* SOLR-17518: Removed deprecated methods `getXml()` and `writeXml()` from `UpdateRequest`. (Pierre Salagnac)
 
 Dependency Upgrades
 ---------------------

--- a/solr/core/src/test/org/apache/solr/update/processor/TestPartialUpdateDeduplication.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TestPartialUpdateDeduplication.java
@@ -16,12 +16,8 @@
  */
 package org.apache.solr.update.processor;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.client.solrj.impl.XMLRequestWriter;
-import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,11 +37,9 @@ public class TestPartialUpdateDeduplication extends SolrTestCaseJ4 {
     doc.addField("id", "2a");
     Map<String, Object> map = Map.of("set", "Hello Dude man!");
     doc.addField("v_t", map);
-    UpdateRequest req = new UpdateRequest();
-    req.add(doc);
     boolean exception_ok = false;
     try {
-      addDoc(getXML(req), chain);
+      addDoc(adoc(doc), chain);
     } catch (Exception e) {
       exception_ok = true;
     }
@@ -59,18 +53,8 @@ public class TestPartialUpdateDeduplication extends SolrTestCaseJ4 {
     doc.addField("id", "2a");
     map = Map.of("set", "name changed");
     doc.addField("name", map);
-    req = new UpdateRequest();
-    req.add(doc);
-    addDoc(getXML(req), chain);
+    addDoc(adoc(doc), chain);
     addDoc(commit(), chain);
     SignatureUpdateProcessorFactoryTest.checkNumDocs(1);
-  }
-
-  public String getXML(UpdateRequest request) throws IOException {
-    StringWriter writer = new StringWriter();
-    XMLRequestWriter requestWriter = new XMLRequestWriter();
-    requestWriter.writeXML(request, writer);
-    writer.close();
-    return writer.toString();
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/processor/TestPartialUpdateDeduplication.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TestPartialUpdateDeduplication.java
@@ -16,8 +16,11 @@
  */
 package org.apache.solr.update.processor;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.impl.XMLRequestWriter;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.BeforeClass;
@@ -42,7 +45,7 @@ public class TestPartialUpdateDeduplication extends SolrTestCaseJ4 {
     req.add(doc);
     boolean exception_ok = false;
     try {
-      addDoc(req.getXML(), chain);
+      addDoc(getXML(req), chain);
     } catch (Exception e) {
       exception_ok = true;
     }
@@ -58,8 +61,16 @@ public class TestPartialUpdateDeduplication extends SolrTestCaseJ4 {
     doc.addField("name", map);
     req = new UpdateRequest();
     req.add(doc);
-    addDoc(req.getXML(), chain);
+    addDoc(getXML(req), chain);
     addDoc(commit(), chain);
     SignatureUpdateProcessorFactoryTest.checkNumDocs(1);
+  }
+
+  public String getXML(UpdateRequest request) throws IOException {
+    StringWriter writer = new StringWriter();
+    XMLRequestWriter requestWriter = new XMLRequestWriter();
+    requestWriter.writeXML(request, writer);
+    writer.close();
+    return writer.toString();
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
@@ -19,8 +19,6 @@ package org.apache.solr.client.solrj.request;
 import static org.apache.solr.common.params.ShardParams._ROUTE_;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -35,9 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.LBSolrClient;
-import org.apache.solr.client.solrj.impl.XMLRequestWriter;
 import org.apache.solr.client.solrj.response.UpdateResponse;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.DocRouter;
@@ -45,7 +41,6 @@ import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.UpdateParams;
 import org.apache.solr.common.util.CollectionUtil;
-import org.apache.solr.common.util.ContentStream;
 
 /**
  * @since solr 1.3
@@ -357,39 +352,6 @@ public class UpdateRequest extends AbstractUpdateRequest {
 
   public void setDeleteQuery(List<String> deleteQuery) {
     this.deleteQuery = deleteQuery;
-  }
-
-  /**
-   * @deprecated Method will be removed in Solr 10.0. Use {@link XMLRequestWriter} instead.
-   */
-  @Deprecated(since = "9.9")
-  @Override
-  public Collection<ContentStream> getContentStreams() throws IOException {
-    return ClientUtils.toContentStreams(getXML(), ClientUtils.TEXT_XML);
-  }
-
-  /**
-   * @deprecated Method will be removed in Solr 10.0. Use {@link XMLRequestWriter} instead.
-   */
-  @Deprecated(since = "9.9")
-  public String getXML() throws IOException {
-    StringWriter writer = new StringWriter();
-    writeXML(writer);
-    writer.flush();
-
-    // If action is COMMIT or OPTIMIZE, it is sent with params
-    String xml = writer.toString();
-    return (xml.length() > 0) ? xml : null;
-  }
-
-  /**
-   * @deprecated Method will be removed in Solr 10.0. Use {@link XMLRequestWriter} instead.
-   */
-  @Deprecated(since = "9.9")
-  public UpdateRequest writeXML(Writer writer) throws IOException {
-    XMLRequestWriter requestWriter = new XMLRequestWriter();
-    requestWriter.writeXML(this, writer);
-    return this;
   }
 
   public List<SolrInputDocument> getDocuments() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17518

This is a follow-up of #3200.
Deprecated methods are now removed in Solr 10.

