### PR TITLE
[FIX] -- Correct typo in CoreAdmin create api documentation.

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/coreadmin-api.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/coreadmin-api.adoc
@@ -120,7 +120,7 @@ V1 API::
 Assuming you are using an existing configSet to create your new core:
 [source,bash]
 ----
-http://localhost:8983/solr/admin/cores?action=CREATE&&name=techproducts_v2&configSet=sample_techproducts_configs
+http://localhost:8983/solr/admin/cores?action=CREATE&name=techproducts_v2&configSet=sample_techproducts_configs
 
 ----
 


### PR DESCRIPTION
- Remove extra '&' character in the URL query parameter example in the CoreAdmin API documentation to ensure accuracy.
- The typo was located in `solr/solr-ref-guide/modules/configuration-guide/pages/coreadmin-api.adoc` at line 123.
- This improves clarity and prevents confusion for users following the documentation.

# Issue
The typo issue can be seen in the Solr documentation at: [Documentation Link](https://solr.apache.org/guide/solr/latest/configuration-guide/coreadmin-api.html#coreadmin-create)

![Solr_Core_Typo](https://github.com/user-attachments/assets/297e2569-14d2-4658-8f30-9781961a5242)

# Description

This pull request fixes a typo in the CoreAdmin API documentation by removing an extra `&` character in a URL query parameter example. The change ensures the documentation accurately reflects the correct syntax for creating a Solr core, improving clarity for users.

# Solution

The solution involves a simple edit to remove the erroneous `&&` and replace it with a single `&` in the URL example provided in the `coreadmin-api.adoc` file. No additional code changes, tests, or complex modifications are required, as this is a documentation-only fix.

# Tests

No new tests are required for this change, as it is a minor documentation typo fix that does not affect Solr’s functionality or behavior.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`. (not applicable for documentation-only changes)
- [ ] I have added tests for my changes. (not applicable for documentation-only changes)
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide) (already addressed by this fix)