### PR TITLE
SimpleOrderedMap MapWriter constructor

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -461,7 +461,7 @@ public class ReplicationHandler extends RequestHandlerBase
         if (currentIndexFetcher != null && currentIndexFetcher != pollingIndexFetcher) {
           currentIndexFetcher.destroy();
         }
-        currentIndexFetcher = new IndexFetcher(solrParams.toNamedList(), this, core);
+        currentIndexFetcher = new IndexFetcher(new SimpleOrderedMap<>(solrParams), this, core);
       } else {
         currentIndexFetcher = pollingIndexFetcher;
       }

--- a/solr/core/src/test/org/apache/solr/search/TestMinHashQParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMinHashQParser.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.request.SolrQueryRequest;
@@ -431,13 +432,12 @@ public class TestMinHashQParser extends SolrTestCaseJ4 {
 
   private SolrQueryRequest createRequest(String query) {
     SolrQueryRequest qr = req(query);
-    NamedList<Object> par = qr.getParams().toNamedList();
-    par.add("debug", "false");
-    par.add("rows", "30");
-    par.add("fl", "id,score");
+    ModifiableSolrParams par = ModifiableSolrParams.of(qr.getParams());
+    par.set("debug", "false");
+    par.set("rows", "30");
+    par.set("fl", "id,score");
     par.remove("qt");
-    SolrParams newp = par.toSolrParams();
-    qr.setParams(newp);
+    qr.setParams(par);
     return qr;
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/processor/RegexBoostProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/RegexBoostProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.solr.update.processor;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -32,7 +33,7 @@ import org.junit.Test;
 public class RegexBoostProcessorTest extends SolrTestCaseJ4 {
   private static RegexpBoostProcessor reProcessor;
   protected static SolrRequestParsers _parser;
-  protected static ModifiableSolrParams parameters;
+  protected static SimpleOrderedMap<String> config;
   private static RegexpBoostProcessorFactory factory;
   private SolrInputDocument document;
 
@@ -43,13 +44,13 @@ public class RegexBoostProcessorTest extends SolrTestCaseJ4 {
     SolrCore core = h.getCore();
     _parser = new SolrRequestParsers(null);
     SolrQueryResponse resp = null;
-    parameters = new ModifiableSolrParams();
-    parameters.set(RegexpBoostProcessor.BOOST_FILENAME_PARAM, "regex-boost-processor-test.txt");
-    parameters.set(RegexpBoostProcessor.INPUT_FIELD_PARAM, "url");
-    parameters.set(RegexpBoostProcessor.BOOST_FIELD_PARAM, "urlboost");
+    config = new SimpleOrderedMap<>();
+    config.add(RegexpBoostProcessor.BOOST_FILENAME_PARAM, "regex-boost-processor-test.txt");
+    config.add(RegexpBoostProcessor.INPUT_FIELD_PARAM, "url");
+    config.add(RegexpBoostProcessor.BOOST_FIELD_PARAM, "urlboost");
     SolrQueryRequest req = _parser.buildRequestFrom(core, new ModifiableSolrParams(), null);
     factory = new RegexpBoostProcessorFactory();
-    factory.init(parameters.toNamedList());
+    factory.init(config);
     reProcessor = (RegexpBoostProcessor) factory.getInstance(req, resp, null);
   }
 
@@ -58,7 +59,7 @@ public class RegexBoostProcessorTest extends SolrTestCaseJ4 {
     // null static members for gc
     reProcessor = null;
     _parser = null;
-    parameters = null;
+    config = null;
     factory = null;
   }
 

--- a/solr/modules/langid/src/test/org/apache/solr/update/processor/OpenNLPLangDetectUpdateProcessorFactoryTest.java
+++ b/solr/modules/langid/src/test/org/apache/solr/update/processor/OpenNLPLangDetectUpdateProcessorFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.solr.update.processor;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ public class OpenNLPLangDetectUpdateProcessorFactoryTest
     }
     SolrQueryRequest req = _parser.buildRequestFrom(h.getCore(), new ModifiableSolrParams(), null);
     OpenNLPLangDetectUpdateProcessorFactory factory = new OpenNLPLangDetectUpdateProcessorFactory();
-    factory.init(parameters.toNamedList());
+    factory.init(new SimpleOrderedMap<>(parameters));
     factory.inform(h.getCore());
     return (OpenNLPLangDetectUpdateProcessor) factory.getInstance(req, resp, null);
   }

--- a/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
@@ -76,6 +76,7 @@ public abstract class SolrParams
         assert value[0] != null;
         ew.put(entry.getKey(), value[0]);
       } else if (value.length > 1) {
+        // values shouldn't be null; not bothering to assert it
         ew.put(entry.getKey(), value);
       }
     }

--- a/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/SolrParams.java
@@ -69,18 +69,16 @@ public abstract class SolrParams
 
   @Override
   public void writeMap(EntryWriter ew) throws IOException {
-    // TODO don't call toNamedList; more efficiently implement here
-    // note: multiple values, if present, are a String[] under 1 key
-    toNamedList()
-        .forEach(
-            (k, v) -> {
-              if (v == null || "".equals(v)) return;
-              try {
-                ew.put(k, v);
-              } catch (IOException e) {
-                throw new RuntimeException("Error serializing", e);
-              }
-            });
+    for (Entry<String, String[]> entry : this) {
+      String[] value = entry.getValue();
+      // if only one value, don't wrap in an array
+      if (value.length == 1) {
+        assert value[0] != null;
+        ew.put(entry.getKey(), value[0]);
+      } else if (value.length > 1) {
+        ew.put(entry.getKey(), value);
+      }
+    }
   }
 
   /** Returns an Iterator of {@code Map.Entry} providing a multi-map view. Treat it as read-only. */
@@ -434,7 +432,10 @@ public abstract class SolrParams
   /**
    * Convert this to a NamedList of unique keys with either String or String[] values depending on
    * how many values there are for the parameter.
+   *
+   * @deprecated see {@link SimpleOrderedMap#SimpleOrderedMap(MapWriter)}
    */
+  @Deprecated
   public NamedList<Object> toNamedList() {
     final SimpleOrderedMap<Object> result = new SimpleOrderedMap<>();
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SimpleOrderedMap.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.common.util;
 
+import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.ArrayList;
@@ -24,6 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.solr.common.MapWriter;
+import org.apache.solr.common.params.SolrParams;
 
 /**
  * <code>SimpleOrderedMap</code> is a {@link NamedList} where access by key is more important than
@@ -67,7 +70,22 @@ public class SimpleOrderedMap<T> extends NamedList<T> implements Map<String, T> 
     super(nameValuePairs);
   }
 
-  // TODO override asShallowMap in Solr 10
+  /** Can convert a {@link SolrParams} and other things. */
+  public SimpleOrderedMap(MapWriter mapWriter) {
+    try {
+      mapWriter.writeMap(
+          new EntryWriter() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public EntryWriter put(CharSequence k, Object v) throws IOException {
+              SimpleOrderedMap.this.add(k.toString(), (T) v);
+              return this;
+            }
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(e); // impossible?
+    }
+  }
 
   @Override
   public SimpleOrderedMap<T> clone() {


### PR DESCRIPTION
* new SimpleOrderedMap(MapWriter)   ex: a SolrParams
* deprecate SolrParams.toNamedList
* optimize SolrParams.writeMap

Bigger picture is avoiding NamedList.

Can go to 9x