### PR TITLE
SOLR-17684: SolrJ Reference Guide (Ping) - Incorrect Status Retrieval

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/examples/UsingPingRefGuideExamplesTest.java
+++ b/solr/solr-ref-guide/modules/deployment-guide/examples/UsingPingRefGuideExamplesTest.java
@@ -1,0 +1,128 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.beans.Field;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.SolrPing;
+import org.apache.solr.client.solrj.response.CollectionAdminResponse;
+import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.util.ExternalPaths;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Example Ping usage.
+ *
+ * <p>Snippets surrounded by "tag" and "end" comments are extracted and used in the Solr Reference
+ * Guide.
+ */
+public class UsingPingRefGuideExamplesTest extends SolrCloudTestCase {
+
+  private static final int NUM_LIVE_NODES = 1;
+
+  @BeforeClass
+  public static void setUpCluster() throws Exception {
+    configureCluster(NUM_LIVE_NODES)
+        .addConfig("conf", new File(ExternalPaths.TECHPRODUCTS_CONFIGSET).toPath())
+        .configure();
+
+    CollectionAdminResponse response =
+        CollectionAdminRequest.createCollection("techproducts", "conf", 1, 1)
+            .process(cluster.getSolrClient());
+    cluster.waitForActiveCollection("techproducts", 1, 1);
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    final SolrClient client = getSolrClient();
+
+    final List<TechProduct> products = new ArrayList<>();
+    products.add(new TechProduct("1", "Fitbit Alta"));
+    products.add(new TechProduct("2", "Sony Walkman"));
+    products.add(new TechProduct("3", "Garmin GPS"));
+
+    client.addBeans("techproducts", products);
+    client.commit("techproducts");
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+
+    final SolrClient client = getSolrClient();
+    client.deleteByQuery("techproducts", "*:*");
+    client.commit("techproducts");
+  }
+
+  private SolrClient getSolrClient() {
+    return cluster.getSolrClient();
+  }
+
+  @Test
+  public void solrJExampleWithSolrPing() throws Exception {
+
+    final SolrClient solrClient = getSolrClient();
+    String collectionName = "techproducts";
+
+    // tag::solrj-example-with-solrping[]
+    SolrPing ping = new SolrPing();
+    ping.getParams()
+        .add("distrib", "true"); // To make it a distributed request against a collection
+    SolrPingResponse rsp = ping.process(solrClient, collectionName);
+    String status = (String) rsp.getResponse().get("status");
+    // end::solrj-example-with-solrping[]
+
+    assertEquals("OK", status);
+  }
+
+  @Test
+  public void solrJExampleWithSolrClient() throws Exception {
+
+    String collectionName = "techproducts";
+
+    // tag::solrj-example-with-solrclient[]
+    final SolrClient solrClient = getSolrClient();
+    SolrPingResponse pingResponse = solrClient.ping(collectionName);
+    String status = (String) pingResponse.getResponse().get("status");
+    // end::solrj-example-with-solrclient[]
+
+    assertEquals("OK", status);
+  }
+
+  public static class TechProduct {
+    @Field public String id;
+    @Field public String name;
+
+    public TechProduct(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    public TechProduct() {}
+  }
+}

--- a/solr/solr-ref-guide/modules/deployment-guide/examples/UsingPingRefGuideExamplesTest.java
+++ b/solr/solr-ref-guide/modules/deployment-guide/examples/UsingPingRefGuideExamplesTest.java
@@ -17,18 +17,12 @@
  */
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.beans.Field;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.SolrPing;
-import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.util.ExternalPaths;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -48,35 +42,9 @@ public class UsingPingRefGuideExamplesTest extends SolrCloudTestCase {
         .addConfig("conf", new File(ExternalPaths.TECHPRODUCTS_CONFIGSET).toPath())
         .configure();
 
-    CollectionAdminResponse response =
-        CollectionAdminRequest.createCollection("techproducts", "conf", 1, 1)
-            .process(cluster.getSolrClient());
+    CollectionAdminRequest.createCollection("techproducts", "conf", 1, 1)
+        .process(cluster.getSolrClient());
     cluster.waitForActiveCollection("techproducts", 1, 1);
-  }
-
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    final SolrClient client = getSolrClient();
-
-    final List<TechProduct> products = new ArrayList<>();
-    products.add(new TechProduct("1", "Fitbit Alta"));
-    products.add(new TechProduct("2", "Sony Walkman"));
-    products.add(new TechProduct("3", "Garmin GPS"));
-
-    client.addBeans("techproducts", products);
-    client.commit("techproducts");
-  }
-
-  @After
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-
-    final SolrClient client = getSolrClient();
-    client.deleteByQuery("techproducts", "*:*");
-    client.commit("techproducts");
   }
 
   private SolrClient getSolrClient() {
@@ -112,17 +80,5 @@ public class UsingPingRefGuideExamplesTest extends SolrCloudTestCase {
     // end::solrj-example-with-solrclient[]
 
     assertEquals("OK", status);
-  }
-
-  public static class TechProduct {
-    @Field public String id;
-    @Field public String name;
-
-    public TechProduct(String id, String name) {
-      this.id = id;
-      this.name = name;
-    }
-
-    public TechProduct() {}
   }
 }

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/ping.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/ping.adoc
@@ -74,19 +74,14 @@ A status=OK indicates that the nodes are responding.
 
 *SolrJ Example with SolrPing*
 
-[source,java]
+[source,java,indent=0]
 ----
-SolrPing ping = new SolrPing();
-ping.getParams().add("distrib", "true"); //To make it a distributed request against a collection
-rsp = ping.process(solrClient, collectionName);
-int status = rsp.getStatus();
+include::example$UsingPingRefGuideExamplesTest.java[tag=solrj-example-with-solrping]
 ----
 
 *SolrJ Example with SolrClient*
 
-[source,java]
+[source,java,indent=0]
 ----
-SolrClient client = new HttpSolrClient.Builder(solrUrl).build();
-SolrPingResponse pingResponse = client.ping(collectionName);
-int status = pingResponse.getStatus();
+include::example$UsingPingRefGuideExamplesTest.java[tag=solrj-example-with-solrclient]
 ----


### PR DESCRIPTION


- Update ping.adoc with references from unit test.
- Add unit test to illustrate the usage of the ping response.

https://issues.apache.org/jira/browse/SOLR-17684


# Description

The SolrJ Reference Guide provides incorrect examples for retrieving the ping status of a collection.

https://solr.apache.org/guide/solr/9_8/deployment-guide/ping.html 

# Solution

pingResponse.getStatus() returns the status of the ping request itself (status=0), not the collection's ping status ("OK").
Since getResponse() returns a NamedList<Object>, the value must be explicitly cast to a String or converted using .toString().

# Tests

Created a new test class named: UsingPingRefGuideExamplesTest

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [  ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)