### PR TITLE
SOLR-17695: Don't warn user about solrUrl format when they do not supply it

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/RunExampleTool.java
@@ -311,7 +311,7 @@ public class RunExampleTool extends ToolBase {
             cli.getOptionValue(PORT_OPTION, System.getenv().getOrDefault("SOLR_PORT", "8983")));
     Map<String, Object> nodeStatus = startSolr(solrHomeDir, isCloudMode, cli, port, zkHost, 30);
 
-    String solrUrl = CLIUtils.normalizeSolrUrl((String) nodeStatus.get("baseUrl"));
+    String solrUrl = CLIUtils.normalizeSolrUrl((String) nodeStatus.get("baseUrl"), false);
 
     // If the example already exists then let the user know they should delete it, or
     // they may get unusual behaviors.


### PR DESCRIPTION
The user didn't supply this url, so don't warn them about the formatting.  Bit of polish to the `bin/solr start -e techproducts` example command.

https://issues.apache.org/jira/browse/SOLR-17695