### PR TITLE
SolrJ ResponseParser API improvements, minor

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
@@ -423,14 +423,8 @@ public class TestRandomFlRTGCloud extends SolrCloudTestCase {
     }
   }
 
-  private static final ResponseParser RAW_XML_RESPONSE_PARSER = new NoOpResponseParser();
-  private static final ResponseParser RAW_JSON_RESPONSE_PARSER =
-      new NoOpResponseParser() {
-        @Override
-        public String getWriterType() {
-          return "json";
-        }
-      };
+  private static final ResponseParser RAW_XML_RESPONSE_PARSER = new NoOpResponseParser("xml");
+  private static final ResponseParser RAW_JSON_RESPONSE_PARSER = new NoOpResponseParser("json");
 
   /** Helper to convert from wt string parameter to actual SolrClient. */
   private static SolrClient getSolrClient(final String jettyBaseUrl, final String wt) {

--- a/solr/core/src/test/org/apache/solr/handler/admin/ShowFileRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ShowFileRequestHandlerTest.java
@@ -18,7 +18,7 @@ package org.apache.solr.handler.admin;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.solr.SolrJettyTestBase;
 import org.apache.solr.client.solrj.ResponseParser;
@@ -100,18 +100,15 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
           }
 
           @Override
-          public NamedList<Object> processResponse(InputStream body, String encoding) {
-            try {
-              if (body.read() >= 0) readFile.set(true);
-            } catch (IOException e) {
-              throw new RuntimeException(e);
-            }
+          public NamedList<Object> processResponse(InputStream body, String encoding)
+              throws IOException {
+            if (body.read() >= 0) readFile.set(true);
             return null;
           }
 
           @Override
-          public NamedList<Object> processResponse(Reader reader) {
-            throw new UnsupportedOperationException("TODO unimplemented"); // TODO
+          public Set<String> getContentTypes() {
+            return Set.of(); // don't enforce
           }
         });
 
@@ -148,7 +145,7 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
     QueryRequest request =
         new QueryRequest(params("file", "managed-schema", "contentType", "not/known"));
     request.setPath("/admin/file");
-    request.setResponseParser(new NoOpResponseParser());
+    request.setResponseParser(new NoOpResponseParser("xml"));
     expectThrows(SolrException.class, () -> client.request(request));
   }
 
@@ -157,7 +154,7 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
     final QueryRequest request =
         new QueryRequest(params("file", "/etc/passwd", "contentType", "text/plain; charset=utf-8"));
     request.setPath("/admin/file"); // absolute path not allowed
-    request.setResponseParser(new NoOpResponseParser());
+    request.setResponseParser(new NoOpResponseParser("xml"));
     expectThrows(SolrException.class, () -> client.request(request));
   }
 
@@ -167,7 +164,7 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
         new QueryRequest(
             params("file", "../../solr.xml", "contentType", "application/xml; charset=utf-8"));
     request.setPath("/admin/file");
-    request.setResponseParser(new NoOpResponseParser());
+    request.setResponseParser(new NoOpResponseParser("xml"));
     var ex = expectThrows(SolrException.class, () -> client.request(request));
     assertTrue(ex instanceof SolrClient.RemoteSolrException);
   }
@@ -182,7 +179,7 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
                 "contentType",
                 "text/plain; charset=utf-8"));
     request.setPath("/admin/file");
-    request.setResponseParser(new NoOpResponseParser());
+    request.setResponseParser(new NoOpResponseParser("xml"));
     expectThrows(SolrException.class, () -> client.request(request));
   }
 

--- a/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
@@ -283,12 +283,7 @@ public class TestRawTransformer extends SolrCloudTestCase {
         strResponse.contains("\"links\":[\""));
   }
 
-  private static final NoOpResponseParser XML_NOOP_RESPONSE_PARSER = new NoOpResponseParser();
+  private static final NoOpResponseParser XML_NOOP_RESPONSE_PARSER = new NoOpResponseParser("xml");
   private static final NoOpResponseParser JSON_NOOP_RESPONSE_PARSER =
-      new NoOpResponseParser() {
-        @Override
-        public String getWriterType() {
-          return "json";
-        }
-      };
+      new NoOpResponseParser("json");
 }

--- a/solr/core/src/test/org/apache/solr/search/TestSmileRequest.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSmileRequest.java
@@ -99,13 +99,9 @@ public class TestSmileRequest extends SolrTestCaseJ4 {
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public NamedList<Object> processResponse(InputStream body, String encoding) {
-      try {
-        Map m = (Map) SmileWriterTest.decodeSmile(body);
-        return new NamedList(m);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+    public NamedList<Object> processResponse(InputStream body, String encoding) throws IOException {
+      Map m = (Map) SmileWriterTest.decodeSmile(body);
+      return new NamedList(m);
     }
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/ResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/ResponseParser.java
@@ -37,7 +37,8 @@ public abstract class ResponseParser {
   /**
    * A well-behaved ResponseParser will return the content-types it supports.
    *
-   * @return the content-type values that this parser is capable of parsing. Never null.
+   * @return the content-type values that this parser is capable of parsing. Never null. Empty means
+   *     no enforcement.
    */
   public abstract Collection<String> getContentTypes();
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/ResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/ResponseParser.java
@@ -16,45 +16,30 @@
  */
 package org.apache.solr.client.solrj;
 
+import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
 import java.util.Collection;
-import java.util.Set;
 import org.apache.solr.common.util.NamedList;
 
 /**
+ * SolrJ Solr response parser.
+ *
  * @since solr 1.3
  */
 public abstract class ResponseParser {
+
+  /** The writer type placed onto the request as the {@code wt} param. */
   public abstract String getWriterType(); // for example: wt=XML, JSON, etc
 
-  public abstract NamedList<Object> processResponse(InputStream body, String encoding);
-
-  public abstract NamedList<Object> processResponse(Reader reader);
-
-  /**
-   * A well-behaved ResponseParser will return its content-type.
-   *
-   * @return the content-type this parser expects to parse
-   * @deprecated use {@link #getContentTypes()} instead
-   */
-  @Deprecated
-  public String getContentType() {
-    return null;
-  }
+  public abstract NamedList<Object> processResponse(InputStream body, String encoding)
+      throws IOException;
 
   /**
    * A well-behaved ResponseParser will return the content-types it supports.
    *
-   * @return the content-type values that this parser is capable of parsing.
+   * @return the content-type values that this parser is capable of parsing. Never null.
    */
-  public Collection<String> getContentTypes() {
-    final String contentType = getContentType();
-    if (contentType == null) {
-      return Set.of();
-    }
-    return Set.of(getContentType());
-  }
+  public abstract Collection<String> getContentTypes();
 
   /**
    * @return the version param passed to solr

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BinaryResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BinaryResponseParser.java
@@ -18,11 +18,9 @@ package org.apache.solr.client.solrj.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
 import java.util.Collection;
 import java.util.Set;
 import org.apache.solr.client.solrj.ResponseParser;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
 
@@ -47,21 +45,12 @@ public class BinaryResponseParser extends ResponseParser {
 
   @Override
   @SuppressWarnings({"unchecked"})
-  public NamedList<Object> processResponse(InputStream body, String encoding) {
-    try {
-      return (NamedList<Object>) createCodec().unmarshal(body);
-    } catch (IOException e) {
-      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "parsing error", e);
-    }
+  public NamedList<Object> processResponse(InputStream body, String encoding) throws IOException {
+    return (NamedList<Object>) createCodec().unmarshal(body);
   }
 
   protected JavaBinCodec createCodec() {
     return new JavaBinCodec(null, stringCache);
-  }
-
-  @Override
-  public String getContentType() {
-    return BINARY_CONTENT_TYPE;
   }
 
   @Override
@@ -72,10 +61,5 @@ public class BinaryResponseParser extends ResponseParser {
   @Override
   public String getVersion() {
     return "2";
-  }
-
-  @Override
-  public NamedList<Object> processResponse(Reader reader) {
-    throw new RuntimeException("Cannot handle character stream");
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -622,7 +622,7 @@ public class HttpSolrClient extends BaseHttpSolrClient {
       }
 
       final Collection<String> processorSupportedContentTypes = processor.getContentTypes();
-      if (processorSupportedContentTypes != null && !processorSupportedContentTypes.isEmpty()) {
+      if (!processorSupportedContentTypes.isEmpty()) {
         final Collection<String> processorMimeTypes =
             processorSupportedContentTypes.stream()
                 .map(ct -> ContentType.parse(ct).getMimeType().trim().toLowerCase(Locale.ROOT))

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
@@ -322,7 +322,7 @@ public abstract class HttpSolrClientBase extends SolrClient {
       return;
     }
     final Collection<String> processorSupportedContentTypes = processor.getContentTypes();
-    if (processorSupportedContentTypes != null && !processorSupportedContentTypes.isEmpty()) {
+    if (!processorSupportedContentTypes.isEmpty()) {
       boolean processorAcceptsMimeType =
           processorAcceptsMimeType(processorSupportedContentTypes, mimeType);
       if (!processorAcceptsMimeType) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/InputStreamResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/InputStreamResponseParser.java
@@ -17,7 +17,7 @@
 package org.apache.solr.client.solrj.impl;
 
 import java.io.InputStream;
-import java.io.Reader;
+import java.util.Set;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
@@ -44,13 +44,13 @@ public class InputStreamResponseParser extends ResponseParser {
   }
 
   @Override
-  public NamedList<Object> processResponse(Reader reader) {
+  public NamedList<Object> processResponse(InputStream body, String encoding) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public NamedList<Object> processResponse(InputStream body, String encoding) {
-    throw new UnsupportedOperationException();
+  public Set<String> getContentTypes() {
+    return Set.of(); // don't enforce
   }
 
   public static NamedList<Object> createInputStreamNamedList(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/JsonMapResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/JsonMapResponseParser.java
@@ -20,8 +20,9 @@ package org.apache.solr.client.solrj.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
@@ -37,14 +38,14 @@ public class JsonMapResponseParser extends ResponseParser {
 
   @Override
   @SuppressWarnings({"unchecked"})
-  public NamedList<Object> processResponse(InputStream body, String encoding) {
+  public NamedList<Object> processResponse(InputStream body, String encoding) throws IOException {
     @SuppressWarnings({"rawtypes"})
     Map map = null;
     try (InputStreamReader reader =
         new InputStreamReader(body, encoding == null ? "UTF-8" : encoding)) {
       ObjectBuilder builder = new ObjectBuilder(new JSONParser(reader));
       map = (Map) builder.getObject();
-    } catch (IOException | JSONParser.ParseException e) {
+    } catch (JSONParser.ParseException e) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "JSON parsing error", e);
     }
     NamedList<Object> list = new NamedList<>();
@@ -53,13 +54,8 @@ public class JsonMapResponseParser extends ResponseParser {
   }
 
   @Override
-  public NamedList<Object> processResponse(Reader reader) {
-    throw new RuntimeException("Cannot handle character stream");
-  }
-
-  @Override
-  public String getContentType() {
-    return "application/json";
+  public Collection<String> getContentTypes() {
+    return Set.of("application/json");
   }
 
   @Override

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/JsonMapResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/JsonMapResponseParser.java
@@ -29,7 +29,9 @@ import org.apache.solr.common.util.NamedList;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 
-/** ResponseParser for JsonMaps. */
+/**
+ * Parses the input as a JSON {@link Map}, and puts the entries onto the response {@link NamedList}.
+ */
 public class JsonMapResponseParser extends ResponseParser {
   @Override
   public String getWriterType() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/NoOpResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/NoOpResponseParser.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Set;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
@@ -30,24 +32,22 @@ import org.apache.solr.common.util.NamedList;
  */
 public class NoOpResponseParser extends ResponseParser {
 
-  private String writerType = "xml";
-
-  public NoOpResponseParser() {}
+  private final String writerType;
 
   public NoOpResponseParser(String writerType) {
     this.writerType = writerType;
   }
 
   @Override
-  public String getWriterType() {
+  public final String getWriterType() {
     return writerType;
   }
 
-  public void setWriterType(String writerType) {
-    this.writerType = writerType;
+  @Override
+  public Collection<String> getContentTypes() {
+    return Set.of();
   }
 
-  @Override
   public NamedList<Object> processResponse(Reader reader) {
     try {
       StringWriter writer = new StringWriter();
@@ -62,16 +62,12 @@ public class NoOpResponseParser extends ResponseParser {
   }
 
   @Override
-  public NamedList<Object> processResponse(InputStream body, String encoding) {
-    try {
-      StringWriter writer = new StringWriter();
-      new InputStreamReader(body, encoding == null ? "UTF-8" : encoding).transferTo(writer);
-      String output = writer.toString();
-      NamedList<Object> list = new NamedList<>();
-      list.add("response", output);
-      return list;
-    } catch (IOException e) {
-      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "parsing error", e);
-    }
+  public NamedList<Object> processResponse(InputStream body, String encoding) throws IOException {
+    StringWriter writer = new StringWriter();
+    new InputStreamReader(body, encoding == null ? "UTF-8" : encoding).transferTo(writer);
+    String output = writer.toString();
+    NamedList<Object> list = new NamedList<>();
+    list.add("response", output);
+    return list;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/StreamingBinaryResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/StreamingBinaryResponseParser.java
@@ -23,7 +23,6 @@ import org.apache.solr.client.solrj.FastStreamingDocsCallback;
 import org.apache.solr.client.solrj.StreamingResponseCallback;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.DataEntry;
 import org.apache.solr.common.util.DataEntry.EntryListener;
 import org.apache.solr.common.util.DataInputInputStream;
@@ -53,15 +52,11 @@ public class StreamingBinaryResponseParser extends BinaryResponseParser {
   }
 
   @Override
-  public NamedList<Object> processResponse(InputStream body, String encoding) {
+  public NamedList<Object> processResponse(InputStream body, String encoding) throws IOException {
     if (callback != null) {
       return streamDocs(body);
     } else {
-      try {
-        return fastStreamDocs(body, fastCallback);
-      } catch (IOException e) {
-        throw new RuntimeException("Unable to parse", e);
-      }
+      return fastStreamDocs(body, fastCallback);
     }
   }
 
@@ -116,7 +111,7 @@ public class StreamingBinaryResponseParser extends BinaryResponseParser {
   private EntryListener docListener;
 
   @SuppressWarnings({"unchecked"})
-  private NamedList<Object> streamDocs(InputStream body) {
+  private NamedList<Object> streamDocs(InputStream body) throws IOException {
     try (JavaBinCodec codec =
         new JavaBinCodec() {
 
@@ -164,8 +159,6 @@ public class StreamingBinaryResponseParser extends BinaryResponseParser {
         }; ) {
 
       return (NamedList<Object>) codec.unmarshal(body);
-    } catch (IOException e) {
-      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "parsing error", e);
     }
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/XMLResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/XMLResponseParser.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Function;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -81,11 +82,10 @@ public class XMLResponseParser extends ResponseParser {
   }
 
   @Override
-  public String getContentType() {
-    return XML_CONTENT_TYPE;
+  public Set<String> getContentTypes() {
+    return Set.of(XML_CONTENT_TYPE);
   }
 
-  @Override
   public NamedList<Object> processResponse(Reader in) {
     XMLStreamReader parser = null;
     try {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/DelegationTokenRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/DelegationTokenRequest.java
@@ -130,7 +130,7 @@ public abstract class DelegationTokenRequest<
     public Cancel(String token) {
       super(METHOD.PUT);
       this.token = token;
-      setResponseParser(new NoOpResponseParser());
+      setResponseParser(new NoOpResponseParser("xml"));
       setQueryParams(new TreeSet<>(Arrays.asList(OP_KEY, TOKEN_KEY)));
     }
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleCborTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleCborTest.java
@@ -289,7 +289,7 @@ public class SolrExampleCborTest extends SolrExampleTests {
 
       @Override
       public Set<String> getContentTypes() {
-        return Set.of("application/cbor");
+        return Set.of("application/cbor", "application/octet-stream");
       }
 
       @Override

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleCborTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleCborTest.java
@@ -22,18 +22,17 @@ import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.solr.client.solrj.impl.BinaryRequestWriter;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.RequestWriter;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.junit.BeforeClass;
@@ -289,27 +288,28 @@ public class SolrExampleCborTest extends SolrExampleTests {
       }
 
       @Override
+      public Set<String> getContentTypes() {
+        return Set.of("application/cbor");
+      }
+
+      @Override
       @SuppressWarnings({"rawtypes", "unchecked"})
-      public NamedList<Object> processResponse(InputStream b, String encoding) {
+      public NamedList<Object> processResponse(InputStream b, String encoding) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper(new CBORFactory());
-        try {
-          Map m = (Map) objectMapper.readValue(b, Object.class);
-          NamedList nl = new NamedList();
-          m.forEach(
-              (k, v) -> {
-                if (v instanceof Map map) {
-                  if ("response".equals(k)) {
-                    v = convertResponse((Map) v);
-                  } else {
-                    v = new NamedList(map);
-                  }
+        Map m = (Map) objectMapper.readValue(b, Object.class);
+        NamedList nl = new NamedList();
+        m.forEach(
+            (k, v) -> {
+              if (v instanceof Map map) {
+                if ("response".equals(k)) {
+                  v = convertResponse((Map) v);
+                } else {
+                  v = new NamedList(map);
                 }
-                nl.add(k.toString(), v);
-              });
-          return nl;
-        } catch (IOException e) {
-          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "parsing error", e);
-        }
+              }
+              nl.add(k.toString(), v);
+            });
+        return nl;
       }
 
       @SuppressWarnings({"rawtypes", "unchecked"})
@@ -331,11 +331,6 @@ public class SolrExampleCborTest extends SolrExampleTests {
           }
         }
         return sdl;
-      }
-
-      @Override
-      public NamedList<Object> processResponse(Reader reader) {
-        return null;
       }
     };
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class HttpSolrClientBuilderTest extends SolrTestCase {
   private static final String ANY_BASE_SOLR_URL = "ANY_BASE_SOLR_URL";
   private static final HttpClient ANY_HTTP_CLIENT = HttpClientBuilder.create().build();
-  private static final ResponseParser ANY_RESPONSE_PARSER = new NoOpResponseParser();
+  private static final ResponseParser ANY_RESPONSE_PARSER = new NoOpResponseParser("xml");
 
   @Test(expected = IllegalArgumentException.class)
   public void testBaseSolrUrlIsRequired() {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttpSolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/LBHttpSolrClientBuilderTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class LBHttpSolrClientBuilderTest extends SolrTestCase {
   private static final String ANY_BASE_SOLR_URL = "ANY_BASE_SOLR_URL";
   private static final HttpClient ANY_HTTP_CLIENT = HttpClientBuilder.create().build();
-  private static final ResponseParser ANY_RESPONSE_PARSER = new NoOpResponseParser();
+  private static final ResponseParser ANY_RESPONSE_PARSER = new NoOpResponseParser("xml");
 
   @Test
   public void providesHttpClientToClient() {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/response/NoOpResponseParserTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/response/NoOpResponseParserTest.java
@@ -73,7 +73,7 @@ public class NoOpResponseParserTest extends SolrJettyTestBase {
     try (SolrClient client =
         new HttpSolrClient.Builder(getBaseUrl())
             .withDefaultCollection(DEFAULT_TEST_CORENAME)
-            .withResponseParser(new NoOpResponseParser())
+            .withResponseParser(new NoOpResponseParser("xml"))
             .build()) {
       SolrQuery query = new SolrQuery("id:1234");
       QueryRequest req = new QueryRequest(query);
@@ -99,7 +99,7 @@ public class NoOpResponseParserTest extends SolrJettyTestBase {
   /** Parse response from java.io.Reader. */
   @Test
   public void testReaderResponse() throws Exception {
-    NoOpResponseParser parser = new NoOpResponseParser();
+    NoOpResponseParser parser = new NoOpResponseParser("xml");
     try (final InputStream is = getResponse()) {
       assertNotNull(is);
       Reader in = new InputStreamReader(is, StandardCharsets.UTF_8);
@@ -113,7 +113,7 @@ public class NoOpResponseParserTest extends SolrJettyTestBase {
   /** Parse response from java.io.InputStream. */
   @Test
   public void testInputStreamResponse() throws Exception {
-    NoOpResponseParser parser = new NoOpResponseParser();
+    NoOpResponseParser parser = new NoOpResponseParser("xml");
     try (final InputStream is = getResponse()) {
       assertNotNull(is);
       NamedList<Object> response = parser.processResponse(is, "UTF-8");


### PR DESCRIPTION
* processResponse should declare to throw IOException since it reads data
* processResponse(Reader) -- remove
* getContentType() -- remove (deprecated)
* getContentTypes() -- make abstract

NoOpResponseParser: must specify writer type; do not default to XML

10.0 only