### PR TITLE
Reimplement CancellableQueryTracker

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CancellableQueryTracker.java
+++ b/solr/core/src/java/org/apache/solr/core/CancellableQueryTracker.java
@@ -16,90 +16,177 @@
  */
 package org.apache.solr.core;
 
-import static org.apache.solr.common.params.CommonParams.QUERY_UUID;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.search.CancellableCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import org.apache.solr.request.SolrQueryRequest;
-import org.apache.solr.search.CancellableCollector;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
-/** Tracks metadata for active queries and provides methods for access */
+import static org.apache.solr.common.params.CommonParams.QUERY_UUID;
+
+/**
+ * Tracks metadata for active queries and provides methods for access
+ */
 public class CancellableQueryTracker {
-  // TODO: This needs to become a time aware storage model
-  private final Map<String, CancellableCollector> activeCancellableQueries =
-      new ConcurrentHashMap<>();
-  private final Map<String, String> activeQueriesGenerated = new ConcurrentHashMap<>();
+    /**
+     * expiryTimeInSeconds is the amount of time before a key will be regarded as
+     * stale and discarded. It can be set with the solr.cancellableQueryTracker.expiryTime
+     * property.
+     */
+    static protected int expiryTimeInSeconds = Integer.parseInt(System.getProperty("solr.cancellableQueryTracker.expiryTime", "3600"));
+    /**
+     * maxSize is the maximum number of tasks to track before discarding the least recently used.
+     * It can be set using the solr.cancellableQueryTracker.maxSize property.
+     */
+    static protected int maxSize = Integer.parseInt(System.getProperty("solr.cancellableQueryTracker.maxSize", "10000"));
+    /**
+     * cleanupTime is the tick time for the cleanup for the caches
+     */
+    static protected int cleanupTime = Integer.parseInt(System.getProperty("solr.cancellableQueryTracker.cleanupTime", "60"));
 
-  /**
-   * Generates a UUID for the given query or if the user provided a UUID for this query, uses that.
-   */
-  public String generateQueryID(SolrQueryRequest req) {
-    String queryID;
-    String customQueryUUID = req.getParams().get(QUERY_UUID, null);
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    protected final Cache<String, CancellableCollector> activeCancellableQueries;
+    protected final Cache<String, String> activeQueriesGenerated;
 
-    if (customQueryUUID != null) {
-      queryID = customQueryUUID;
-    } else {
-      // TODO: Use a different generator
-      queryID = UUID.randomUUID().toString();
+    public CancellableQueryTracker() {
+        activeQueriesGenerated = CacheBuilder.
+                newBuilder().maximumSize(maxSize).
+                expireAfterWrite(expiryTimeInSeconds, TimeUnit.SECONDS).
+                removalListener(notification -> {
+                    if (log.isTraceEnabled() && notification.wasEvicted()) {
+                        log.trace("CQT: Removed task {} from activeQueriesGenerated due to {}", notification.getKey(), notification.getCause()); //nowarn
+                    }
+                }).build();
+        activeCancellableQueries = CacheBuilder.
+                newBuilder().
+                maximumSize(maxSize).
+                expireAfterWrite(expiryTimeInSeconds, TimeUnit.SECONDS).
+                removalListener(notification -> {
+                    if (notification.wasEvicted()) {
+                        if (log.isWarnEnabled()) {
+                            log.warn("CQT: Cancelling stalled task {} as evicted from query tracker due to {}", notification.getKey(), notification.getCause()); //nowarn
+                        }
+                        assert notification.getValue() != null;
+                        CancellableCollector asCC = (CancellableCollector) notification.getValue();
+                        asCC.cancel();
+                    }
+                }).build();
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        exec.scheduleAtFixedRate(() -> {
+            long beforeACQ = 0;
+            long beforeAQG = 0;
+            if (log.isTraceEnabled()) {
+                beforeACQ = activeCancellableQueries.size();
+                beforeAQG = activeQueriesGenerated.size();
+            }
+            activeCancellableQueries.cleanUp();
+            activeQueriesGenerated.cleanUp();
+            if (log.isTraceEnabled()) {
+                log.trace("CQT: Ran cleanup. ACQ before {} now {}. AQG before {} now {}.",
+                        beforeACQ, activeCancellableQueries.size(), beforeAQG, activeQueriesGenerated.size());
+            }
+        }, cleanupTime, cleanupTime, TimeUnit.SECONDS);
     }
 
-    if (activeQueriesGenerated.containsKey(queryID)) {
-      if (customQueryUUID != null) {
-        throw new IllegalArgumentException("Duplicate query UUID given");
-      } else {
-        while (activeQueriesGenerated.get(queryID) != null) {
-          queryID = UUID.randomUUID().toString();
+    /**
+     * Generates a UUID for the given query or if the user provided a UUID for this query, uses that.
+     */
+    public String generateQueryID(SolrQueryRequest req) {
+        String queryID;
+        String customQueryUUID = req.getParams().get(QUERY_UUID, null);
+
+        if (customQueryUUID != null) {
+            queryID = customQueryUUID;
+        } else {
+            // TODO: Use a different generator
+            queryID = UUID.randomUUID().toString();
         }
-      }
+
+        if (activeQueriesGenerated.getIfPresent(queryID) != null) {
+            if (customQueryUUID != null) {
+                throw new IllegalArgumentException("Duplicate query UUID given");
+            } else {
+                while (activeQueriesGenerated.getIfPresent(queryID) != null) {
+                    queryID = UUID.randomUUID().toString();
+                }
+            }
+        }
+        String qs = "";
+        if (req.getHttpSolrCall() != null) {
+            qs = req.getHttpSolrCall().getReq().getQueryString();
+        }
+        activeQueriesGenerated.put(queryID, qs);
+
+        return queryID;
     }
 
-    activeQueriesGenerated.put(queryID, req.getHttpSolrCall().getReq().getQueryString());
+    /**
+     * Releases a queryID allocated by generateQueryID()
+     */
+    public void releaseQueryID(String inputQueryID) {
+        if (inputQueryID == null) {
+            return;
+        }
 
-    return queryID;
-  }
-
-  public void releaseQueryID(String inputQueryID) {
-    if (inputQueryID == null) {
-      return;
+        activeQueriesGenerated.invalidate(inputQueryID);
     }
 
-    activeQueriesGenerated.remove(inputQueryID);
-  }
-
-  public boolean isQueryIdActive(String queryID) {
-    return activeQueriesGenerated.containsKey(queryID);
-  }
-
-  public void addShardLevelActiveQuery(String queryID, CancellableCollector collector) {
-    if (queryID == null) {
-      return;
+    /**
+     * Determines if a queryID allocated by generateQueryID() is currently present
+     */
+    public boolean isQueryIdActive(String queryID) {
+        return activeQueriesGenerated.getIfPresent(queryID) != null;
     }
 
-    activeCancellableQueries.put(queryID, collector);
-  }
+    /**
+     * Adds a queryID to the list of cancellable queries
+     */
+    public void addShardLevelActiveQuery(String queryID, CancellableCollector collector) {
+        log.trace("CQT: Marking query {} as cancellable", queryID);
+        if (queryID == null) {
+            return;
+        }
 
-  public CancellableCollector getCancellableTask(String queryID) {
-    if (queryID == null) {
-      throw new IllegalArgumentException("Input queryID is null");
+        activeCancellableQueries.put(queryID, collector);
     }
 
-    return activeCancellableQueries.get(queryID);
-  }
+    /**
+     * Gets the cancellation task for a cancellable queryID
+     */
+    public CancellableCollector getCancellableTask(String queryID) {
+        if (queryID == null) {
+            throw new IllegalArgumentException("Input queryID is null");
+        }
 
-  public void removeCancellableQuery(String queryID) {
-    if (queryID == null) {
-      // Some components, such as CaffeineCache, use the searcher to fire internal queries which are
-      // not tracked
-      return;
+        return activeCancellableQueries.getIfPresent(queryID);
     }
 
-    activeCancellableQueries.remove(queryID);
-  }
+    /**
+     * Removes a cancellable query from the list of outstanding cancellable queries
+     */
+    public void removeCancellableQuery(String queryID) {
+        if (queryID == null) {
+            // Some components, such as CaffeineCache, use the searcher to fire internal queries which are
+            // not tracked
+            return;
+        }
 
-  public Iterator<Map.Entry<String, String>> getActiveQueriesGenerated() {
-    return activeQueriesGenerated.entrySet().iterator();
-  }
+        activeCancellableQueries.invalidate(queryID);
+    }
+
+    /**
+     * Returns the list of allocated and unreleased queryIDs allocated by generateQueryID()
+     */
+    public Iterator<Map.Entry<String, String>> getActiveQueriesGenerated() {
+        return activeQueriesGenerated.asMap().entrySet().iterator();
+    }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -142,7 +142,6 @@ public class QueryComponent extends SearchComponent {
 
     if (rb.isDistrib) {
       boolean isCancellableQuery = params.getBool(CommonParams.IS_QUERY_CANCELLABLE, false);
-
       if (isCancellableQuery) {
         // Generate Query ID
         rb.queryID = generateQueryID(req);
@@ -386,7 +385,7 @@ public class QueryComponent extends SearchComponent {
 
     if (isCancellableQuery) {
       // Set the queryID for the searcher to consume
-      String queryID = params.get(ShardParams.QUERY_ID);
+      String queryID = params.get(ShardParams.QUERY_ID, params.get(CommonParams.QUERY_UUID));
 
       cmd.setQueryCancellable(true);
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -424,6 +424,11 @@ public class SearchHandler extends RequestHandlerBase
 
     processComponents(req, rsp, rb, timer, components);
 
+    if (rb.queryID != null) {
+      // Remove the current queryID from the active list
+      rb.req.getCore().getCancellableQueryTracker().releaseQueryID(rb.queryID);
+    }
+
     // SOLR-5550: still provide shards.info if requested even for a short-circuited distrib request
     if (!rb.isDistrib
         && req.getParams().getBool(ShardParams.SHARDS_INFO, false)

--- a/solr/core/src/test/org/apache/solr/core/CancellableQueryTrackerTest.java
+++ b/solr/core/src/test/org/apache/solr/core/CancellableQueryTrackerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core;
+
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.request.LocalSolrQueryRequest;
+import org.apache.solr.search.CancellableCollector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.apache.solr.SolrTestCaseJ4.assumeWorkingMockito;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class CancellableQueryTrackerTest {
+    private static int expiry;
+
+    @Before
+    public void setUp() {
+        assumeWorkingMockito();
+        expiry = CancellableQueryTracker.expiryTimeInSeconds;
+        CancellableQueryTracker.expiryTimeInSeconds = 3;
+    }
+
+    @After
+    public void tearDown() {
+        CancellableQueryTracker.expiryTimeInSeconds = expiry;
+    }
+
+    @Test
+    public void TestGenerateQueryID() {
+        CancellableQueryTracker tracker = new CancellableQueryTracker();
+        Map<String, String[]> args = new HashMap<>();
+        LocalSolrQueryRequest sr = new LocalSolrQueryRequest(null, args);
+        // if we generate a UUID it shouldn't be our test string
+        String uuid1 = tracker.generateQueryID(sr);
+        assertNotEquals("myQueryID", uuid1);
+        // if we generate another UUID it also should be our test string, or the first UUID
+        String uuid2 = tracker.generateQueryID(sr);
+        assertNotEquals("myQueryID", uuid2);
+        assertNotEquals(uuid1, uuid2);
+        // if we set an explicit ID it should be used
+        args.put("queryUUID", new String[]{"myQueryID"});
+        sr = new LocalSolrQueryRequest(null, args);
+        assertEquals("myQueryID", tracker.generateQueryID(sr));
+        // but if we try to use it again, it should throw an exception
+        Consumer<LocalSolrQueryRequest> localSolrQueryRequestConsumer = (LocalSolrQueryRequest sq) -> {
+            try {
+                tracker.generateQueryID(sq);
+            } catch (IllegalArgumentException e) {
+                assertEquals("Duplicate query UUID given", e.getMessage());
+                return;
+            }
+            fail("Should have thrown IllegalArgumentException");
+        };
+        localSolrQueryRequestConsumer.accept(sr);
+        // unless we mark it complete
+        tracker.releaseQueryID("myQueryID");
+        assertEquals("myQueryID", tracker.generateQueryID(sr));
+    }
+
+    @Test
+    public void activeCancellableQueryTimesOut() throws InterruptedException {
+        CancellableQueryTracker tracker = new CancellableQueryTracker();
+        CancellableCollector cc = mock(CancellableCollector.class);
+        tracker.addShardLevelActiveQuery("myQueryID", cc);
+        assertNotNull(tracker.activeCancellableQueries.getIfPresent("myQueryID"));
+        TimeUnit.SECONDS.sleep(5);
+        assertNull(tracker.activeCancellableQueries.getIfPresent("myQueryID"));
+        tracker.activeCancellableQueries.cleanUp();
+        Mockito.verify(cc, Mockito.times(1)).cancel();
+    }
+
+    @Test
+    public void queryIDIsReleased() {
+        CancellableQueryTracker tracker = new CancellableQueryTracker();
+        SolrParams mockParams = mock(SolrParams.class);
+        Mockito.when(mockParams.get("queryUUID")).thenReturn("myQueryID");
+        LocalSolrQueryRequest req = mock(LocalSolrQueryRequest.class);
+        Mockito.when(req.getParams()).thenReturn(mockParams);
+        String queryID = tracker.generateQueryID(req);
+        assertNotNull(tracker.activeQueriesGenerated.getIfPresent(queryID));
+        tracker.releaseQueryID(queryID);
+        assertNull(tracker.activeQueriesGenerated.getIfPresent(queryID));
+    }
+
+    @Test
+    public void canFetchCancellableQuery() {
+        CancellableQueryTracker tracker = new CancellableQueryTracker();
+        CancellableCollector cc = mock(CancellableCollector.class);
+        tracker.addShardLevelActiveQuery("myQueryID", cc);
+        assertNotNull(tracker.activeCancellableQueries.getIfPresent("myQueryID"));
+        assertEquals(cc, tracker.getCancellableTask("myQueryID"));
+    }
+
+    @Test
+    public void canFetchQueryList() {
+        CancellableQueryTracker tracker = new CancellableQueryTracker();
+        String[] queries = new String[5];
+        SolrParams mockParams = mock(SolrParams.class);
+        LocalSolrQueryRequest req = mock(LocalSolrQueryRequest.class);
+        for (int i = 0; i < 5; i++) {
+            Mockito.when(req.getParams()).thenReturn(mockParams);
+            queries[i]= tracker.generateQueryID(req);
+        }
+        Iterator<Map.Entry<String, String>> iterator = tracker.getActiveQueriesGenerated();
+        int count = 0;
+        String[] results = new String[5];
+        while (iterator.hasNext()) {
+            results[count] = iterator.next().getKey();
+            count++;
+        }
+        Arrays.sort(results);
+        Arrays.sort(queries);
+        assertArrayEquals(queries, results);
+    }
+}


### PR DESCRIPTION
I don't have access to JIRA to create a ticket but please see below. I've posted in the users list but not received any replies to I've attempted to fix myself.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

We noticed increasing memory usage over long periods of time in our Solr Clouds. Running some synthetic tests against such showed that it was directly linked to the number of abnormally terminated requests received - either exceeding resource limits or client timeout closed connection.

Investigation showed that the length of the response received to the tasks/list endpoints was growing. The resource leak was minimal but the time spent processing them was rising therefore a cleanup mechanism was needed.

Further investigation of why they were not being removed showed that when code ran out of time to run the calls to `checkLimitsBefore` would cause them to return before the finaliser that removes the active query from the list runs. This issue only appears to affect 
1. Explicitly set query IDs
2. Queries sent to shards which get the node name prepended to the generated query ID when adding to the list but not when being removed

# Solution

1. Prevent CancellableQueryTracker from filling with abnormally terminated requests by adding a timeout mechanism and making it configurable
3. Improve logging in that class
4. Add tests for that class
5. Add an additional release for activeQueries when the request has been finished early

Additionally there are clearly issues with the cancellation mechanism more generally that I'm not going to tackle now but am more than happy to look at in more depth later. Namely:

1. Multithreaded queries are not cancellable
2. Cancellability is dependent on the cancellation being sent to the same node that created the task to be cancelled. It also seems there's something weird with shard selection going on here too but I've not got to the bottom of it.
3. activeTaskList is again node dependent so the same UUID can be simultaneously sent to two nodes

# Tests

I've added tests for the class and run nearly half a million "broken" and half a million non broken requests against a cloud of four nodes 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [n/a] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
