### PR TITLE
(no intended to be merged to branch_9_8) SOLR-17626: add RawTFSimilarity[Factory] class(es)

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/similarities/RawTFSimilarity.java
+++ b/solr/core/src/java/org/apache/solr/search/similarities/RawTFSimilarity.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.similarities;
+
+import org.apache.lucene.index.FieldInvertState;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.search.CollectionStatistics;
+import org.apache.lucene.search.TermStatistics;
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.util.SmallFloat;
+
+/** Similarity that returns the raw TF as score. */
+public class RawTFSimilarity extends Similarity {
+  private final boolean discountOverlaps;
+
+  /** Default constructor: parameter-free */
+  public RawTFSimilarity() {
+    this(true);
+  }
+
+  /** Primary constructor. */
+  public RawTFSimilarity(boolean discountOverlaps) {
+    this.discountOverlaps = discountOverlaps;
+  }
+
+  /** Returns true if overlap tokens are discounted from the document's length. */
+  public boolean getDiscountOverlaps() {
+    return discountOverlaps;
+  }
+
+  @Override
+  public SimScorer scorer(
+      float boost, CollectionStatistics collectionStats, TermStatistics... termStats) {
+    return new SimScorer() {
+      @Override
+      public float score(float freq, long norm) {
+        return boost * freq;
+      }
+    };
+  }
+
+  @Override
+  public final long computeNorm(FieldInvertState state) {
+    final int numTerms;
+    if (state.getIndexOptions() == IndexOptions.DOCS && state.getIndexCreatedVersionMajor() >= 8) {
+      numTerms = state.getUniqueTermCount();
+    } else if (discountOverlaps) {
+      numTerms = state.getLength() - state.getNumOverlap();
+    } else {
+      numTerms = state.getLength();
+    }
+    return SmallFloat.intToByte4(numTerms);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/similarities/RawTFSimilarityFactory.java
+++ b/solr/core/src/java/org/apache/solr/search/similarities/RawTFSimilarityFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.similarities;
+
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.schema.SimilarityFactory;
+
+/**
+ * Factory for RawTFSimilarity.
+ *
+ * <p>Parameters:
+ *
+ * <ul>
+ *   <li>discountOverlaps (bool): True if overlap tokens (tokens with a position of increment of
+ *       zero) are discounted from the document's length. The default is <code>true</code>
+ * </ul>
+ *
+ * @lucene.experimental
+ * @since 9.9.0
+ */
+public class RawTFSimilarityFactory extends SimilarityFactory {
+  private RawTFSimilarity similarity;
+
+  @Override
+  public void init(SolrParams params) {
+    super.init(params);
+    boolean discountOverlaps = params.getBool("discountOverlaps", true);
+    similarity = new RawTFSimilarity(discountOverlaps);
+  }
+
+  @Override
+  public Similarity getSimilarity() {
+    return similarity;
+  }
+}

--- a/solr/core/src/test-files/solr/collection1/conf/schema-rawtf.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-rawtf.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- Test schema file for RawTFSimilarityFactory -->
+
+<schema name="test" version="1.7">
+  <fieldType name="string" class="solr.StrField" omitNorms="true" positionIncrementGap="0"/>
+
+  <!-- default parameters -->
+  <fieldType name="text" class="solr.TextField">
+    <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+    <similarity class="solr.RawTFSimilarityFactory"/>
+  </fieldType>
+
+  <!-- with parameters -->
+  <fieldType name="text_params_0" class="solr.TextField">
+    <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+    <similarity class="solr.RawTFSimilarityFactory">
+      <bool name="discountOverlaps">false</bool>
+    </similarity>
+  </fieldType>
+  <fieldType name="text_params_1" class="solr.TextField">
+    <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+    <similarity class="solr.RawTFSimilarityFactory">
+      <bool name="discountOverlaps">true</bool>
+    </similarity>
+  </fieldType>
+
+  <field name="id" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
+  <field name="text" type="text" indexed="true" stored="false"/>
+  <field name="text_params_0" type="text_params_0" indexed="true" stored="false"/>
+  <field name="text_params_1" type="text_params_1" indexed="true" stored="false"/>
+
+  <uniqueKey>id</uniqueKey>
+
+</schema>

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestRawTFSimilarity.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestRawTFSimilarity.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.similarities;
+
+import java.io.IOException;
+import java.util.Random;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.search.similarities.BaseSimilarityTestCase;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.IOUtils;
+
+public class TestRawTFSimilarity extends BaseSimilarityTestCase {
+
+  private Directory directory;
+  private IndexReader indexReader;
+  private IndexSearcher indexSearcher;
+
+  @Override
+  protected Similarity getSimilarity(Random random) {
+    return new RawTFSimilarity();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    directory = newDirectory();
+    try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+      final Document document1 = new Document();
+      final Document document2 = new Document();
+      final Document document3 = new Document();
+      document1.add(LuceneTestCase.newTextField("test", "one", Field.Store.YES));
+      document2.add(LuceneTestCase.newTextField("test", "two two", Field.Store.YES));
+      document3.add(LuceneTestCase.newTextField("test", "three three three", Field.Store.YES));
+      indexWriter.addDocument(document1);
+      indexWriter.addDocument(document2);
+      indexWriter.addDocument(document3);
+      indexWriter.commit();
+    }
+    indexReader = DirectoryReader.open(directory);
+    indexSearcher = newSearcher(indexReader);
+    indexSearcher.setSimilarity(new RawTFSimilarity());
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    IOUtils.close(indexReader, directory);
+    super.tearDown();
+  }
+
+  public void testOne() throws IOException {
+    implTest("one", 1f);
+  }
+
+  public void testTwo() throws IOException {
+    implTest("two", 2f);
+  }
+
+  public void testThree() throws IOException {
+    implTest("three", 3f);
+  }
+
+  private void implTest(String text, float expectedScore) throws IOException {
+    Query query = new TermQuery(new Term("test", text));
+    TopDocs topDocs = indexSearcher.search(query, 1);
+    assertEquals(1, topDocs.totalHits.value);
+    assertEquals(1, topDocs.scoreDocs.length);
+    assertEquals(expectedScore, topDocs.scoreDocs[0].score, 0.0);
+  }
+
+  public void testBoostQuery() throws IOException {
+    Query query = new TermQuery(new Term("test", "three"));
+    float boost = 14f;
+    TopDocs topDocs = indexSearcher.search(new BoostQuery(query, boost), 1);
+    assertEquals(1, topDocs.totalHits.value);
+    assertEquals(1, topDocs.scoreDocs.length);
+    assertEquals(42f, topDocs.scoreDocs[0].score, 0.0);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/similarities/TestRawTFSimilarityFactory.java
+++ b/solr/core/src/test/org/apache/solr/search/similarities/TestRawTFSimilarityFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.similarities;
+
+import org.apache.lucene.search.similarities.Similarity;
+import org.junit.BeforeClass;
+
+/** Tests {@link RawTFSimilarityFactory} */
+public class TestRawTFSimilarityFactory extends BaseSimilarityTestCase {
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig-basic.xml", "schema-rawtf.xml");
+  }
+
+  public void test() {
+    Similarity sim = getSimilarity("text");
+    assertEquals(RawTFSimilarity.class, sim.getClass());
+    RawTFSimilarity rtfSim = (RawTFSimilarity) sim;
+    assertTrue(rtfSim.getDiscountOverlaps());
+  }
+
+  public void testParameters0() {
+    Similarity sim = getSimilarity("text_params_0");
+    assertEquals(RawTFSimilarity.class, sim.getClass());
+    RawTFSimilarity rtfSim = (RawTFSimilarity) sim;
+    assertFalse(rtfSim.getDiscountOverlaps());
+  }
+
+  public void testParameters1() {
+    Similarity sim = getSimilarity("text_params_1");
+    assertEquals(RawTFSimilarity.class, sim.getClass());
+    RawTFSimilarity rtfSim = (RawTFSimilarity) sim;
+    assertTrue(rtfSim.getDiscountOverlaps());
+  }
+}


### PR DESCRIPTION
The `RawTFSimilarityFactory` from (not yet released) Solr 9.9 backported to 9.8 branch with a local `RawTFSimilarity` variant since Solr 9.8's Lucene version does not have the `RawTFSimilarity` class.

https://issues.apache.org/jira/browse/SOLR-17626