### PR TITLE
SOLR-17655: Mark ExternalFileField as deprecated

### DIFF
--- a/solr/core/src/java/org/apache/solr/schema/ExternalFileField.java
+++ b/solr/core/src/java/org/apache/solr/schema/ExternalFileField.java
@@ -65,7 +65,9 @@ import org.apache.solr.uninverting.UninvertingReader.Type;
  * fl=id,field(inventory_count)</code>.
  *
  * @see ExternalFileFieldReloader
+ * @deprecated ExternalFileField is an old capability of Solr that pre-dated in-place partial updates of numeric DocValue fields.
  */
+@Deprecated(since = "9.9")
 public class ExternalFileField extends FieldType implements SchemaAware {
   private String keyFieldName;
   private IndexSchema schema;

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/external-files-processes.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/external-files-processes.adoc
@@ -21,6 +21,12 @@ It can also consume a stream of tokens that have already undergone analysis with
 
 == The ExternalFileField Type
 
+.ExternalFileField has been Deprecated
+[WARNING]
+====
+ExternalFileField has been deprecated and will be removed in a future release.
+====
+
 The `ExternalFileField` type makes it possible to specify the values for a field in a file outside the Solr index.
 For such a field, the file contains mappings from a key field to the field value.
 Another way to think of this is that, instead of specifying the field in documents as they are indexed, Solr finds values for this field in the external file.

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/external-files-processes.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/external-files-processes.adoc
@@ -24,7 +24,8 @@ It can also consume a stream of tokens that have already undergone analysis with
 .ExternalFileField has been Deprecated
 [WARNING]
 ====
-ExternalFileField has been deprecated and will be removed in a future release.
+ExternalFileField has been deprecated and will be removed in a future release.  
+Please use xref:partial-document-updates.adoc#in-place-updates[in-place updates] for numeric fields.
 ====
 
 The `ExternalFileField` type makes it possible to specify the values for a field in a file outside the Solr index.

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/field-types-included-with-solr.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/field-types-included-with-solr.adoc
@@ -99,6 +99,8 @@ This shortcoming may be addressed in a future release.
 
 |EnumField |Use EnumFieldType instead.
 
+|ExternalFileField | This field is deprecated and will be removed in Solr 10.
+
 |TrieDateField |Use DatePointField instead.
 
 |TrieDoubleField |Use DoublePointField instead.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17655


# Description

Mark ExternalFileField as deprecated.

# Solution

This pairs with https://github.com/apache/solr/pull/3244, and is meant to go on `branch_9x` to mark this as deprecated.  Then #3244 can be committed to `main`.

# Tests

no change.
