### PR TITLE
SOLR-17700: Use core operation lock when unloading core

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -201,6 +201,9 @@ Bug Fixes
   current live nodes list is stale. CloudSolrClient now retains the initial configured list of passed URLs as backup
   used for fetching cluster state when all live nodes have failed. (Matthew Biscocho via David Smiley, Houston Putman)
 
+* SOLR-17700: Use Core Operation lock when unloading cores. This fixes errors that occur when a collection deletion and reload
+  occur at the same time. (Houston Putman)
+
 
 Dependency Upgrades
 ---------------------


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17700

The tests seem to be happy with this change. `DeleteInactiveReplicaTest` failed before I added the non-locked private `unloadWithoutCoreOp()` method, so that's a good sign.

This should fix the issues we are seeing with the `SchemaDesignerApiTest` that #3213 was attempting to fix, in which there was a race condition between concurrent collection deletion and reload operations.