### PR TITLE
Allow disabling new UI module during builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,8 +118,8 @@ ext {
   // For testing code
   vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22, JavaVersion.VERSION_23, JavaVersion.VERSION_24, JavaVersion.VERSION_25 ] as Set
 
-  // Flag that allows disabling the experimental UI via gradle properties
-  withUiModule = !project.hasProperty('disableUiModule') || project.findProperty('disableUiModule') != 'true'
+  // Use gradle flag in root project for further referencing
+  withUiModule = gradle.ext.withUiModule
 }
 
 // Include smaller chunks configuring dedicated build areas.

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ ext {
   vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22, JavaVersion.VERSION_23, JavaVersion.VERSION_24, JavaVersion.VERSION_25 ] as Set
 
   // Flag that allows disabling the experimental UI via gradle properties
-  withNewUiModule = !project.hasProperty('disableNewUiModule') || project.findProperty('disableNewUiModule') != 'true'
+  withUiModule = !project.hasProperty('disableUiModule') || project.findProperty('disableUiModule') != 'true'
 }
 
 // Include smaller chunks configuring dedicated build areas.

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,9 @@ ext {
 
   // For testing code
   vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22, JavaVersion.VERSION_23, JavaVersion.VERSION_24, JavaVersion.VERSION_25 ] as Set
+
+  // Flag that allows disabling the experimental UI via gradle properties
+  withNewUiModule = !project.hasProperty('disableNewUiModule') || project.findProperty('disableNewUiModule') != 'true'
 }
 
 // Include smaller chunks configuring dedicated build areas.

--- a/gradle/template.gradle.properties
+++ b/gradle/template.gradle.properties
@@ -119,3 +119,8 @@ kotlin.code.style=official
 # This property should be set to true during releases.
 # Value defaults to false if not set to reduce the impact in CI/CD and new checkouts.
 production=false
+
+# Option to disable experimental new UI module. Some operating systems or environments
+# may not support compilation of the new UI module, so they can turn it off via this
+# parameter.
+disableNewUiModule=false

--- a/gradle/template.gradle.properties
+++ b/gradle/template.gradle.properties
@@ -120,7 +120,7 @@ kotlin.code.style=official
 # Value defaults to false if not set to reduce the impact in CI/CD and new checkouts.
 production=false
 
-# Option to disable experimental new UI module. Some operating systems or environments
-# may not support compilation of the new UI module, so they can turn it off via this
+# Option to disable experimental UI module. Some operating systems or environments
+# may not support compilation of the UI module, so they can turn it off via this
 # parameter.
-disableNewUiModule=false
+disableUiModule=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,9 +67,9 @@ include "solr:distribution"
 include "solr:docker"
 include "solr:prometheus-exporter"
 
-// Do not load the new UI module if it is disabled explicitly
-def withUiModule = !rootProject.hasProperty('disableUiModule') || rootProject.findProperty('disableUiModule') != 'true'
-if (withUiModule) { // Exclude new UI from unsupported OS builds
+def disableUiModuleValue = providers.gradleProperty('disableUiModule').orNull
+gradle.ext.withUiModule = disableUiModuleValue == null || disableUiModuleValue != 'true'
+if (gradle.ext.withUiModule) {
     include(":solr:ui")
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,8 +68,8 @@ include "solr:docker"
 include "solr:prometheus-exporter"
 
 // Do not load the new UI module if it is disabled explicitly
-def withNewUiModule = !rootProject.hasProperty('disableNewUiModule') || rootProject.findProperty('disableNewUiModule') != 'true'
-if (withNewUiModule) { // Exclude new UI from unsupported OS builds
+def withUiModule = !rootProject.hasProperty('disableUiModule') || rootProject.findProperty('disableUiModule') != 'true'
+if (withUiModule) { // Exclude new UI from unsupported OS builds
     include(":solr:ui")
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -57,7 +57,6 @@ include "solr:modules:s3-repository"
 include "solr:modules:scripting"
 include "solr:modules:sql"
 include "solr:webapp"
-include "solr:ui"
 include "solr:benchmark"
 include "solr:test-framework"
 include "solr:solr-ref-guide"
@@ -67,6 +66,12 @@ include "solr:packaging"
 include "solr:distribution"
 include "solr:docker"
 include "solr:prometheus-exporter"
+
+// Do not load the new UI module if it is disabled explicitly
+def withNewUiModule = !rootProject.hasProperty('disableNewUiModule') || rootProject.findProperty('disableNewUiModule') != 'true'
+if (withNewUiModule) { // Exclude new UI from unsupported OS builds
+    include(":solr:ui")
+}
 
 // Configures development for joint Lucene/ Solr composite build.
 apply from: file('gradle/lucene-dev/lucene-dev-repo-composite.gradle')

--- a/solr/webapp/build.gradle
+++ b/solr/webapp/build.gradle
@@ -94,24 +94,24 @@ task downloadBrowserify(type: NpmTask) {
   outputs.dir("${nodeProjectDir}/node_modules/browserify")
 }
 
-tasks.register("generateUiDevFiles") {
-  description = "Generate new UI for development and add files to outputs for later referencing."
-  group = "build"
-  onlyIf { rootProject.ext.withUiModule }
-
-  // Development files are larger in size but have shorter compile times.
-  dependsOn project(":solr:ui").tasks.wasmJsBrowserDevelopmentExecutableDistribution
-  outputs.dir(project(":solr:ui").file("build/dist/wasmJs/developmentExecutable/"))
+if (gradle.ext.withUiModule) {
+  tasks.register("generateUiDevFiles") {
+    description = "Generate new UI for development and add files to outputs for later referencing."
+    group = "build"
+    dependsOn project(":solr:ui").tasks.wasmJsBrowserDevelopmentExecutableDistribution
+    outputs.dir(project(":solr:ui").file("build/dist/wasmJs/developmentExecutable/"))
+  }
 }
 
-tasks.register("generateUiProdFiles") {
-  description = "Generate new UI for production and add files to outputs for later referencing"
-  group = "build"
-  onlyIf { rootProject.ext.withUiModule }
+if (gradle.ext.withUiModule) {
+  tasks.register("generateUiProdFiles") {
+    description = "Generate new UI for production and add files to outputs for later referencing"
+    group = "build"
 
-  // Production files are smaller in size but have longer compile times.
-  dependsOn project(":solr:ui").tasks.wasmJsBrowserDistribution
-  outputs.dir(project(":solr:ui").file("build/dist/wasmJs/productionExecutable/"))
+    // Production files are smaller in size but have longer compile times.
+    dependsOn project(":solr:ui").tasks.wasmJsBrowserDistribution
+    outputs.dir(project(":solr:ui").file("build/dist/wasmJs/productionExecutable/"))
+  }
 }
 
 task generateJsClientBundle(type: NpxTask) {
@@ -153,7 +153,7 @@ war {
 
   // Include new Admin UI files in webapp
   // By default, we always build dev that does not optimize generated files for release to reduce build times.
-  if (rootProject.ext.withUiModule) {
+  if (gradle.ext.withUiModule) {
     if (rootProject.ext.development) {
       from (tasks.generateUiDevFiles) {
         into "ui"

--- a/solr/webapp/build.gradle
+++ b/solr/webapp/build.gradle
@@ -97,7 +97,7 @@ task downloadBrowserify(type: NpmTask) {
 tasks.register("generateUiDevFiles") {
   description = "Generate new UI for development and add files to outputs for later referencing."
   group = "build"
-  onlyIf { rootProject.ext.withNewUiModule }
+  onlyIf { rootProject.ext.withUiModule }
 
   // Development files are larger in size but have shorter compile times.
   dependsOn project(":solr:ui").tasks.wasmJsBrowserDevelopmentExecutableDistribution
@@ -107,7 +107,7 @@ tasks.register("generateUiDevFiles") {
 tasks.register("generateUiProdFiles") {
   description = "Generate new UI for production and add files to outputs for later referencing"
   group = "build"
-  onlyIf { rootProject.ext.withNewUiModule }
+  onlyIf { rootProject.ext.withUiModule }
 
   // Production files are smaller in size but have longer compile times.
   dependsOn project(":solr:ui").tasks.wasmJsBrowserDistribution
@@ -153,7 +153,7 @@ war {
 
   // Include new Admin UI files in webapp
   // By default, we always build dev that does not optimize generated files for release to reduce build times.
-  if (rootProject.ext.withNewUiModule) {
+  if (rootProject.ext.withUiModule) {
     if (rootProject.ext.development) {
       from (tasks.generateUiDevFiles) {
         into "ui"

--- a/solr/webapp/build.gradle
+++ b/solr/webapp/build.gradle
@@ -97,6 +97,7 @@ task downloadBrowserify(type: NpmTask) {
 tasks.register("generateUiDevFiles") {
   description = "Generate new UI for development and add files to outputs for later referencing."
   group = "build"
+  onlyIf { rootProject.ext.withNewUiModule }
 
   // Development files are larger in size but have shorter compile times.
   dependsOn project(":solr:ui").tasks.wasmJsBrowserDevelopmentExecutableDistribution
@@ -106,6 +107,7 @@ tasks.register("generateUiDevFiles") {
 tasks.register("generateUiProdFiles") {
   description = "Generate new UI for production and add files to outputs for later referencing"
   group = "build"
+  onlyIf { rootProject.ext.withNewUiModule }
 
   // Production files are smaller in size but have longer compile times.
   dependsOn project(":solr:ui").tasks.wasmJsBrowserDistribution
@@ -151,13 +153,15 @@ war {
 
   // Include new Admin UI files in webapp
   // By default, we always build dev that does not optimize generated files for release to reduce build times.
-  if (rootProject.ext.development) {
-    from (tasks.generateUiDevFiles) {
-      into "ui"
-    }
-  } else {
-    from (tasks.generateUiProdFiles) {
-      into "ui"
+  if (rootProject.ext.withNewUiModule) {
+    if (rootProject.ext.development) {
+      from (tasks.generateUiDevFiles) {
+        into "ui"
+      }
+    } else {
+      from (tasks.generateUiProdFiles) {
+        into "ui"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

The new UI module has shown some compatibilty challenges when it comes to building the project with less common operating systems like s390x or when running with alterantive JDKs (`RUNTIME_JAVA_HOME`).

# Solution

This PR adds a gradle property called `disableNewUiModule` that can be used to disable the new UI module during builds. 

This is only a termporary workaround until we properly fix the compatibility issues or decide to remove the new UI module.

# Tests

This PR can be tested by adding the following flag to the `gradle.properties`:

```properties
disableNewUiModule=true
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
