### PR TITLE
SOLR-17702: Move ZK ConnectionListener logic out of SolrZkClient

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -77,6 +77,7 @@ import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.DocCollectionWatcher;
 import org.apache.solr.common.cloud.LiveNodesListener;
 import org.apache.solr.common.cloud.NodesSysPropsCacher;
+import org.apache.solr.common.cloud.OnDisconnect;
 import org.apache.solr.common.cloud.OnReconnect;
 import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.cloud.PerReplicaStatesOps;
@@ -201,6 +202,12 @@ public class ZkController implements Closeable {
 
   private CloudHttp2SolrClient cloudSolrClient;
 
+  private final ExecutorService zkConnectionListenerCallbackExecutor =
+      ExecutorUtil.newMDCAwareSingleThreadExecutor(
+          new SolrNamedThreadFactory("zkConnectionListenerCallback"));
+  private final OnReconnect onReconnect = this::onReconnect;
+  private final OnDisconnect onDisconnect = this::onDisconnect;
+
   private final String zkServerAddress; // example: 127.0.0.1:54062/solr
 
   private final int localHostPort; // example: 54065
@@ -249,7 +256,7 @@ public class ZkController implements Closeable {
   // keeps track of a list of objects that need to know a new ZooKeeper session was created after
   // expiration occurred ref is held as a HashSet since we clone the set before notifying to avoid
   // synchronizing too long
-  private HashSet<OnReconnect> reconnectListeners = new HashSet<>();
+  private final HashSet<OnReconnect> reconnectListeners = new HashSet<>();
 
   private class RegisterCoreAsync implements Callable<Object> {
 
@@ -271,22 +278,6 @@ public class ZkController implements Closeable {
       }
       register(descriptor.getName(), descriptor, recoverReloadedCores, afterExpiration, false);
       return descriptor;
-    }
-  }
-
-  // notifies registered listeners after the ZK reconnect in the background
-  private static class OnReconnectNotifyAsync implements Callable<Object> {
-
-    private final OnReconnect listener;
-
-    OnReconnectNotifyAsync(OnReconnect listener) {
-      this.listener = listener;
-    }
-
-    @Override
-    public Object call() throws Exception {
-      listener.command();
-      return null;
     }
   }
 
@@ -360,12 +351,19 @@ public class ZkController implements Closeable {
             .withUrl(zkServerAddress)
             .withTimeout(clientTimeout, TimeUnit.MILLISECONDS)
             .withConnTimeOut(zkClientConnectTimeout, TimeUnit.MILLISECONDS)
-            .withReconnectListener(this::onReconnect)
-            .withDisconnectListener((sessionExpired) -> onDisconnect(sessionExpired))
             .withAclProvider(zkACLProvider)
             .withClosedCheck(cc::isShutDown)
             .withCompressor(compressor)
             .build();
+
+    zkClient
+        .getCuratorFramework()
+        .getConnectionStateListenable()
+        .addListener(onReconnect, zkConnectionListenerCallbackExecutor);
+    zkClient
+        .getCuratorFramework()
+        .getConnectionStateListenable()
+        .addListener(onDisconnect, zkConnectionListenerCallbackExecutor);
     // Refuse to start if ZK has a non empty /clusterstate.json or a /solr.xml file
     checkNoOldClusterstate(zkClient);
 
@@ -487,6 +485,9 @@ public class ZkController implements Closeable {
           } else {
             register(descriptor.getName(), descriptor, true, true, false);
           }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw e;
         } catch (Exception e) {
           log.error("Error registering SolrCore", e);
         }
@@ -502,11 +503,22 @@ public class ZkController implements Closeable {
       for (OnReconnect listener : clonedListeners) {
         try {
           if (executorService != null) {
-            executorService.submit(new OnReconnectNotifyAsync(listener));
+            executorService.execute(
+                () -> {
+                  try {
+                    listener.onReconnect();
+                  } catch (Throwable exc) {
+                    // not much we can do here other than warn in the log
+                    log.warn(
+                        "Error when notifying OnReconnect listener {} after session re-connected.",
+                        listener,
+                        exc);
+                  }
+                });
           } else {
-            listener.command();
+            listener.onReconnect();
           }
-        } catch (Exception exc) {
+        } catch (Throwable exc) {
           // not much we can do here other than warn in the log
           log.warn(
               "Error when notifying OnReconnect listener {} after session re-connected.",
@@ -689,6 +701,16 @@ public class ZkController implements Closeable {
 
   public void preClose() {
     this.isClosed = true;
+    try {
+      // We do not want to react to connection state changes after we have started to close
+      zkClient.getCuratorFramework().getConnectionStateListenable().removeListener(onReconnect);
+      zkClient.getCuratorFramework().getConnectionStateListenable().removeListener(onDisconnect);
+      ExecutorUtil.shutdownNowAndAwaitTermination(zkConnectionListenerCallbackExecutor);
+    } catch (Exception e) {
+      log.warn(
+          "Error stopping and shutting down zkConnectionListenerCallbackExecutor. Continue closing the ZkController",
+          e);
+    }
 
     try {
       if (getZkClient().isConnected()) {

--- a/solr/core/src/java/org/apache/solr/core/ZkContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/ZkContainer.java
@@ -237,16 +237,16 @@ public class ZkContainer {
   public void close() {
 
     try {
-      if (zkController != null) {
-        zkController.close();
-      }
+      ExecutorUtil.shutdownAndAwaitTermination(coreZkRegister);
     } finally {
       try {
+        if (zkController != null) {
+          zkController.close();
+        }
+      } finally {
         if (zkServer != null) {
           zkServer.stop();
         }
-      } finally {
-        ExecutorUtil.shutdownAndAwaitTermination(coreZkRegister);
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
@@ -344,7 +344,7 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
 
     /** Called after a ZooKeeper session expiration occurs */
     @Override
-    public void command() {
+    public void onReconnect() {
       // we need to re-establish the watcher on the collections list after session expires
       synchronized (this) {
         cachedCollections = null;

--- a/solr/core/src/java/org/apache/solr/schema/ZkIndexSchemaReader.java
+++ b/solr/core/src/java/org/apache/solr/schema/ZkIndexSchemaReader.java
@@ -225,7 +225,7 @@ public class ZkIndexSchemaReader implements OnReconnect {
    * the current schema from ZooKeeper.
    */
   @Override
-  public void command() {
+  public void onReconnect() {
     try {
       // setup a new watcher to get notified when the managed schema changes
       schemaWatcher = createSchemaWatcher();

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
@@ -114,8 +114,10 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
               .withUrl(server.getZkAddress())
               .withTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
               .withConnTimeOut(TIMEOUT, TimeUnit.MILLISECONDS)
-              .withReconnectListener(onReconnect)
               .build();
+      if (onReconnect != null) {
+        zkClient.getCuratorFramework().getConnectionStateListenable().addListener(onReconnect);
+      }
       zkStateReader = new ZkStateReader(zkClient);
       elector = new LeaderElector(zkClient);
       zkController = MockSolrSource.makeSimpleMock(null, zkStateReader, zkClient);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/OnDisconnect.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/OnDisconnect.java
@@ -21,12 +21,12 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 
 public interface OnDisconnect extends ConnectionStateListener {
-  public void command(boolean sessionExpired);
+  void onDisconnect(boolean sessionExpired);
 
   @Override
   default void stateChanged(CuratorFramework client, ConnectionState newState) {
     if (newState == ConnectionState.LOST || newState == ConnectionState.SUSPENDED) {
-      command(newState == ConnectionState.LOST);
+      onDisconnect(newState == ConnectionState.LOST);
     }
   }
 }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/OnReconnect.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/OnReconnect.java
@@ -28,12 +28,12 @@ import org.apache.curator.framework.state.ConnectionStateListener;
  * to be notified of ZK reconnection events.
  */
 public interface OnReconnect extends ConnectionStateListener {
-  void command();
+  void onReconnect();
 
   @Override
   default void stateChanged(CuratorFramework client, ConnectionState newState) {
     if (ConnectionState.RECONNECTED.equals(newState)) {
-      command();
+      onReconnect();
     }
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17702

This will fix the flaky `org.apache.solr.cloud.BasicDistributedZk2Test` (class method) failures.

But in general this is a better way of taking down Solr. There's no reason for SolrZkClient to own this logic anymore. The classes that want to watch on connection state can decide if they want to be async or sync, and how to handle closing the executor themselves.