### PR TITLE
SOLR-17706 SolrJ DocumentObjectBinder, make a singleton

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -160,6 +160,9 @@ Other Changes
   thus BinaryQueryResponseWriter is gone.  Added TextQueryResponseWriter for the text ones.
   Stopped using RawResponseWriter when not needed.  (David Smiley)
 
+* SOLR-17706: SolrJ DocumentObjectBinder is now a global singleton via an INSTANCE field and that
+  which is pluggable via Java SPI/ServiceLoader.  SolrClient.getBinder is gone.  (David Smiley)
+
 ==================  9.9.0 ==================
 New Features
 ---------------------

--- a/solr/core/src/test/org/apache/solr/cloud/DistribJoinFromCollectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribJoinFromCollectionTest.java
@@ -147,7 +147,7 @@ public class DistribJoinFromCollectionTest extends SolrCloudTestCase {
               + fromQ;
       QueryRequest qr =
           new QueryRequest(params("collection", toColl, "q", joinQ, "fl", "id,get_s,score"));
-      QueryResponse rsp = new QueryResponse(client.request(qr), client);
+      QueryResponse rsp = qr.process(client);
       SolrDocumentList hits = rsp.getResults();
       assertEquals("Expected 1 doc, got " + hits, 1, hits.getNumFound());
       SolrDocument doc = hits.get(0);
@@ -173,7 +173,7 @@ public class DistribJoinFromCollectionTest extends SolrCloudTestCase {
               + fromQ;
       final QueryRequest qr =
           new QueryRequest(params("collection", toColl, "q", joinQ, "fl", "id,get_s,score"));
-      final QueryResponse rsp = new QueryResponse(client.request(qr), client);
+      final QueryResponse rsp = qr.process(client);
       final SolrDocumentList hits = rsp.getResults();
       assertEquals("Expected 1 doc", 1, hits.getNumFound());
       SolrDocument doc = hits.get(0);
@@ -195,7 +195,7 @@ public class DistribJoinFromCollectionTest extends SolrCloudTestCase {
               + " to=join_s}match_s:d";
       final QueryRequest qr =
           new QueryRequest(params("collection", toColl, "q", joinQ, "fl", "id,get_s,score"));
-      final QueryResponse rsp = new QueryResponse(client.request(qr), client);
+      final QueryResponse rsp = qr.process(client);
       final SolrDocumentList hits = rsp.getResults();
       assertEquals("Expected no hits", 0, hits.getNumFound());
     }

--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
@@ -624,7 +624,7 @@ public class TestRandomFlRTGCloud extends SolrCloudTestCase {
     return getDocsFromRTGResponse(
         expectList,
         new QueryResponse(
-            new RawCapableXMLResponseParser().processResponse(new StringReader(rsp)), null));
+            new RawCapableXMLResponseParser().processResponse(new StringReader(rsp))));
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/response/transform/TestSubQueryTransformerDistrib.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestSubQueryTransformerDistrib.java
@@ -182,8 +182,7 @@ public class TestSubQueryTransformerDistrib extends SolrCloudTestCase {
     final SolrDocumentList hits;
     {
       final QueryRequest qr = withBasicAuth(new QueryRequest(params));
-      final QueryResponse rsp = new QueryResponse();
-      rsp.setResponse(cluster.getSolrClient().request(qr, people + "," + depts));
+      final QueryResponse rsp = qr.process(cluster.getSolrClient(), people + "," + depts);
       hits = rsp.getResults();
 
       assertEquals(peopleMultiplier, hits.getNumFound());

--- a/solr/core/src/test/org/apache/solr/search/join/ShardToShardJoinAbstract.java
+++ b/solr/core/src/test/org/apache/solr/search/join/ShardToShardJoinAbstract.java
@@ -194,7 +194,7 @@ public class ShardToShardJoinAbstract extends SolrCloudTestCase {
                     + " to=id}"
                     + fromQ;
             QueryRequest qr = new QueryRequest(params("collection", toColl, "q", joinQ, "fl", "*"));
-            QueryResponse rsp = new QueryResponse(client.request(qr), client);
+            QueryResponse rsp = qr.process(client);
             SolrDocumentList hits = rsp.getResults();
             assertEquals("Expected 1 doc, got " + hits, 1, hits.getNumFound());
             SolrDocument doc = hits.get(0);
@@ -216,7 +216,7 @@ public class ShardToShardJoinAbstract extends SolrCloudTestCase {
             QueryRequest qr =
                 new QueryRequest(
                     params("collection", fromColl, "q", joinQ, "fl", "*", "rows", "20"));
-            QueryResponse rsp = new QueryResponse(client.request(qr), client);
+            QueryResponse rsp = new QueryResponse(client.request(qr));
             SolrDocumentList hits = rsp.getResults();
             assertEquals("Expected 11 doc, got " + hits, 10 + 1, hits.getNumFound());
             for (SolrDocument doc : hits) {
@@ -246,7 +246,7 @@ public class ShardToShardJoinAbstract extends SolrCloudTestCase {
               + " to=id}"
               + fromQ;
       QueryRequest qr = new QueryRequest(params("collection", toColl, "q", joinQ, "fl", "*"));
-      QueryResponse rsp = new QueryResponse(client.request(qr), client);
+      QueryResponse rsp = qr.process(client);
       SolrDocumentList hits = rsp.getResults();
       final Set<String> expect =
           new HashSet<>(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrClient.java
@@ -52,7 +52,6 @@ public abstract class SolrClient implements Serializable, Closeable {
 
   private static final long serialVersionUID = 1L;
 
-  private DocumentObjectBinder binder;
   protected String defaultCollection;
 
   /**
@@ -261,7 +260,7 @@ public abstract class SolrClient implements Serializable, Closeable {
    */
   public UpdateResponse addBean(String collection, Object obj, int commitWithinMs)
       throws IOException, SolrServerException {
-    return add(collection, getBinder().toSolrInputDocument(obj), commitWithinMs);
+    return add(collection, DocumentObjectBinder.INSTANCE.toSolrInputDocument(obj), commitWithinMs);
   }
 
   /**
@@ -277,7 +276,7 @@ public abstract class SolrClient implements Serializable, Closeable {
    */
   public UpdateResponse addBean(Object obj, int commitWithinMs)
       throws IOException, SolrServerException {
-    return add(null, getBinder().toSolrInputDocument(obj), commitWithinMs);
+    return add(null, DocumentObjectBinder.INSTANCE.toSolrInputDocument(obj), commitWithinMs);
   }
 
   /**
@@ -324,15 +323,14 @@ public abstract class SolrClient implements Serializable, Closeable {
    * @return an {@link org.apache.solr.client.solrj.response.UpdateResponse} from the server
    * @throws IOException if there is a communication error with the server
    * @throws SolrServerException if there is an error on the server
-   * @see SolrClient#getBinder()
+   * @see DocumentObjectBinder
    * @since solr 5.1
    */
   public UpdateResponse addBeans(String collection, Collection<?> beans, int commitWithinMs)
       throws SolrServerException, IOException {
-    DocumentObjectBinder binder = this.getBinder();
     ArrayList<SolrInputDocument> docs = new ArrayList<>(beans.size());
     for (Object bean : beans) {
-      docs.add(binder.toSolrInputDocument(bean));
+      docs.add(DocumentObjectBinder.INSTANCE.toSolrInputDocument(bean));
     }
     return add(collection, docs, commitWithinMs);
   }
@@ -348,7 +346,7 @@ public abstract class SolrClient implements Serializable, Closeable {
    * @return an {@link org.apache.solr.client.solrj.response.UpdateResponse} from the server
    * @throws IOException if there is a communication error with the server
    * @throws SolrServerException if there is an error on the server
-   * @see SolrClient#getBinder()
+   * @see DocumentObjectBinder
    * @since solr 3.5
    */
   public UpdateResponse addBeans(Collection<?> beans, int commitWithinMs)
@@ -380,7 +378,7 @@ public abstract class SolrClient implements Serializable, Closeable {
           public SolrInputDocument next() {
             Object o = beanIterator.next();
             if (o == null) return null;
-            return getBinder().toSolrInputDocument(o);
+            return DocumentObjectBinder.INSTANCE.toSolrInputDocument(o);
           }
 
           @Override
@@ -1193,20 +1191,6 @@ public abstract class SolrClient implements Serializable, Closeable {
   public final NamedList<Object> request(final SolrRequest<?> request)
       throws SolrServerException, IOException {
     return request(request, null);
-  }
-
-  /**
-   * Get the {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder} for this client.
-   *
-   * @return a DocumentObjectBinder
-   * @see SolrClient#addBean
-   * @see SolrClient#addBeans
-   */
-  public DocumentObjectBinder getBinder() {
-    if (binder == null) {
-      binder = new DocumentObjectBinder();
-    }
-    return binder;
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/QueryRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/QueryRequest.java
@@ -62,7 +62,7 @@ public class QueryRequest extends CollectionRequiringSolrRequest<QueryResponse> 
 
   @Override
   protected QueryResponse createResponse(SolrClient client) {
-    return new QueryResponse(client);
+    return new QueryResponse();
   }
 
   @Override

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.beans.DocumentObjectBinder;
 import org.apache.solr.client.solrj.response.json.NestableJsonFacet;
 import org.apache.solr.common.SolrDocumentList;
@@ -102,21 +101,10 @@ public class QueryResponse extends SolrResponseBase {
   private Map<String, Object> _debugMap = null;
   private Map<String, Object> _explainMap = null;
 
-  // utility variable used for automatic binding -- it should not be serialized
-  private final transient SolrClient solrClient;
+  public QueryResponse() {}
 
-  public QueryResponse() {
-    solrClient = null;
-  }
-
-  /** Utility constructor to set the solrServer and namedList */
-  public QueryResponse(NamedList<Object> res, SolrClient solrClient) {
+  public QueryResponse(NamedList<Object> res) {
     this.setResponse(res);
-    this.solrClient = solrClient;
-  }
-
-  public QueryResponse(SolrClient solrClient) {
-    this.solrClient = solrClient;
   }
 
   @Override
@@ -643,9 +631,7 @@ public class QueryResponse extends SolrResponseBase {
   }
 
   public <T> List<T> getBeans(Class<T> type) {
-    return solrClient == null
-        ? new DocumentObjectBinder().getBeans(type, _results)
-        : solrClient.getBinder().getBeans(type, _results);
+    return DocumentObjectBinder.INSTANCE.getBeans(type, _results);
   }
 
   public Map<String, FieldStatsInfo> getFieldStatsInfo() {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/beans/TestDocumentObjectBinder.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/beans/TestDocumentObjectBinder.java
@@ -38,7 +38,7 @@ public class TestDocumentObjectBinder extends SolrTestCase {
     DocumentObjectBinder binder = new DocumentObjectBinder();
     XMLResponseParser parser = new XMLResponseParser();
     NamedList<Object> nl = parser.processResponse(new StringReader(xml));
-    QueryResponse res = new QueryResponse(nl, null);
+    QueryResponse res = new QueryResponse(nl);
 
     SolrDocumentList solDocList = res.getResults();
     List<Item> l = binder.getBeans(Item.class, res.getResults());
@@ -83,7 +83,7 @@ public class TestDocumentObjectBinder extends SolrTestCase {
     DocumentObjectBinder binder = new DocumentObjectBinder();
     XMLResponseParser parser = new XMLResponseParser();
     NamedList<Object> nl = parser.processResponse(new StringReader(xml));
-    QueryResponse res = new QueryResponse(nl, null);
+    QueryResponse res = new QueryResponse(nl);
     List<Item> l = binder.getBeans(Item.class, res.getResults());
 
     assertArrayEquals(

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/response/QueryResponseTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/response/QueryResponseTest.java
@@ -55,7 +55,7 @@ public class QueryResponseTest extends SolrTestCase {
       }
     }
 
-    QueryResponse qr = new QueryResponse(response, null);
+    QueryResponse qr = new QueryResponse(response);
     assertNotNull(qr);
 
     int counter = 0;
@@ -119,7 +119,7 @@ public class QueryResponseTest extends SolrTestCase {
       }
     }
 
-    QueryResponse qr = new QueryResponse(response, null);
+    QueryResponse qr = new QueryResponse(response);
     assertNotNull(qr);
     GroupResponse groupResponse = qr.getGroupResponse();
     assertNotNull(groupResponse);
@@ -225,7 +225,7 @@ public class QueryResponseTest extends SolrTestCase {
       }
     }
 
-    QueryResponse qr = new QueryResponse(response, null);
+    QueryResponse qr = new QueryResponse(response);
     assertNotNull(qr);
     GroupResponse groupResponse = qr.getGroupResponse();
     assertNotNull(groupResponse);
@@ -267,7 +267,7 @@ public class QueryResponseTest extends SolrTestCase {
       NamedList<Object> response = parser.processResponse(in);
       in.close();
 
-      QueryResponse qr = new QueryResponse(response, null);
+      QueryResponse qr = new QueryResponse(response);
       assertNotNull(qr);
       assertNotNull(qr.getIntervalFacets());
       assertEquals(2, qr.getIntervalFacets().size());
@@ -311,7 +311,7 @@ public class QueryResponseTest extends SolrTestCase {
       }
     }
 
-    QueryResponse qr = new QueryResponse(response, null);
+    QueryResponse qr = new QueryResponse(response);
     assertNotNull(qr);
 
     Map<String, Object> explainMap = qr.getExplainMap();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestClusteringResponse.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestClusteringResponse.java
@@ -45,7 +45,7 @@ public class TestClusteringResponse extends SolrJettyTestBase {
         response = parser.processResponse(in);
       }
     }
-    QueryResponse qr = new QueryResponse(response, null);
+    QueryResponse qr = new QueryResponse(response);
     ClusteringResponse clusteringResponse = qr.getClusteringResponse();
     List<Cluster> clusters = clusteringResponse.getClusters();
     assertEquals(4, clusters.size());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17706

Remove from SolrClient, and thus update QueryResponse to not get it from there.
Use Java SPI/ServiceLoader to allow someone to customize.
Use ConcurrentHashMap.computeIfAbsent internally.