### PR TITLE
Fix missing closing apostrophe in collection reload command example

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/collection-management.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/collection-management.adoc
@@ -328,6 +328,7 @@ curl -X POST http://localhost:8983/api/collections/techproducts_v2/reload -H 'Co
   {
     "async": "someAsyncId"
   }
+'
 ----
 ====
 ======


### PR DESCRIPTION
# Description

The PR fixes a minor documentation error in the Solr Collection Management guide. The cURL command example for reloading collections was missing a closing apostrophe, which could confuse users.

# Solution

The solution involved updating the example command on the [collection management page](https://solr.apache.org/guide/solr/latest/deployment-guide/collection-management.html#reload) by adding the missing closing apostrophe to the JSON payload in the cURL command.

# Tests

Since this is a documentation-only change, no additional tests were necessary.

# Checklist

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch.
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide).