### PR TITLE
Replace all with configureEach to solve configuration issues

### DIFF
--- a/gradle/hacks/dummy-outputs.gradle
+++ b/gradle/hacks/dummy-outputs.gradle
@@ -35,7 +35,7 @@ allprojects {
         "gradlewScriptsTweaked",
         "validateSourcePatterns",
         "validateLogCalls"
-    ] }.forEach { Task task ->
+    ] }.configureEach { Task task ->
     task.logger.info("Setting up ${task.path} as no-output.")
     setupDummyOutputs(task)
   }

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -25,7 +25,7 @@ allprojects {
 
     // Inject vm options into custom javadoc rendering. We can't refer
     // to the task type because it's dynamic.
-    tasks.matching { it.name in ["renderJavadoc", "renderSiteJavadoc"] }.forEach {
+    tasks.matching { it.name in ["renderJavadoc", "renderSiteJavadoc"] }.configureEach {
         extraOpts.addAll(vmOpts.collect {"-J" + it})
     }
 

--- a/gradle/testing/alternative-jdk-support.gradle
+++ b/gradle/testing/alternative-jdk-support.gradle
@@ -78,7 +78,7 @@ if (jvmGradle != jvmCurrent) {
 
     // Javadoc compilation.
     def javadocExecutable = jvmCurrent.javadocExecutable
-    tasks.matching { it.name == "renderJavadoc" || it.name == "renderSiteJavadoc" }.all {
+    tasks.matching { it.name == "renderJavadoc" || it.name == "renderSiteJavadoc" }.configureEach {
       dependsOn ":altJvmWarning"
       executable = javadocExecutable.toString()
     }


### PR DESCRIPTION
# Description

One of the current build issues we are facing is a NPE when `optimizeTask` is called on an undefined task during project configuration. This and similar issues are caused in various configurations that make use of the `TaskCollection.all` method. 

The actual root cause of these errors seems to be caused by our customization for the javadoc tasks in `render-javadoc.gradle`. I am not sure why this is happening and if similar errors could occur elsewhere.

# Solution

This PR changes the method from `all` to `configureEach` for the problematic locations. They are somewhat equivalent:

_org.gradle.api.DomainObjectCollection<T>.all_

> Executes the given closure against all objects in this collection, and any objects subsequently added to this collection. The object is passed to the closure as the closure delegate. Alternatively, it is also passed as a parameter.

 _org.gradle.api.DomainObjectCollection<T>.configureEach_

 >Configures each element in this collection using the given action, as each element is required. Actions are run in the order added.

Since the collections are not altered, it should be safe to use `configureEach`.

Additionally, during the development of the [initial PR](https://github.com/apache/solr/pull/2605), `java.lang.Iterable<T>.forEach` was used in two other places, so they are changed to `configureEach` as well.

# Tests

The NPE caused when specifying an alternative JDK via `RUNTIME_JAVA_HOME` should be fixed with this change. To test it, run the current state with the environment variable `RUNTIME_JAVA_HOME` pointing to a different JDK installation. WIthout the change it should fail to build the project when running `gradlew check -x test`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
