### PR TITLE
Test: UpdateRequestProcessorFactoryTest, can be flaky

### DIFF
--- a/solr/core/src/test/org/apache/solr/update/processor/UpdateRequestProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpdateRequestProcessorFactoryTest.java
@@ -19,7 +19,6 @@ package org.apache.solr.update.processor;
 import static org.apache.solr.update.processor.DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,14 +26,11 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.util.LogLevel;
 import org.junit.BeforeClass;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** */
 public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -86,6 +82,7 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
     assertEquals("{name={n8=88, n9=99}}", link.args.toString());
   }
 
+  @LogLevel("org.apache.solr.update.processor.LogUpdateProcessorFactory=INFO")
   public void testUpdateDistribChainSkipping() throws IOException {
 
     // a key part of this test is verifying that LogUpdateProcessor is found in all chains because
@@ -99,7 +96,8 @@ public class UpdateRequestProcessorFactoryTest extends SolrTestCaseJ4 {
     assertTrue(
         "Tests must be run with INFO level logging "
             + "otherwise LogUpdateProcessor isn't used and can't be tested.",
-        log.isInfoEnabled());
+        LoggerFactory.getLogger(LogUpdateProcessorFactory.class)
+            .isInfoEnabled()); // nowarn_valid_logger
 
     final int EXPECTED_CHAIN_LENGTH = 5;
     SolrCore core = h.getCore();

--- a/solr/modules/s3-repository/src/test/org/apache/solr/s3/AbstractS3ClientTest.java
+++ b/solr/modules/s3-repository/src/test/org/apache/solr/s3/AbstractS3ClientTest.java
@@ -36,7 +36,7 @@ public class AbstractS3ClientTest extends SolrTestCaseJ4 {
 
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder().silent().withInitialBuckets(BUCKET_NAME).build();
+      S3MockRule.builder().withInitialBuckets(BUCKET_NAME).build();
 
   S3StorageClient client;
 

--- a/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3BackupRepositoryTest.java
+++ b/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3BackupRepositoryTest.java
@@ -53,11 +53,7 @@ public class S3BackupRepositoryTest extends AbstractBackupRepositoryTest {
 
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder()
-          .silent()
-          .withInitialBuckets(BUCKET_NAME)
-          .withSecureConnection(false)
-          .build();
+      S3MockRule.builder().withInitialBuckets(BUCKET_NAME).withSecureConnection(false).build();
 
   /**
    * Sent by {@link org.apache.solr.handler.ReplicationHandler}, ensure we don't choke on the bare

--- a/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3IncrementalBackupTest.java
+++ b/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3IncrementalBackupTest.java
@@ -38,11 +38,7 @@ public class S3IncrementalBackupTest extends AbstractIncrementalBackupTest {
 
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder()
-          .silent()
-          .withInitialBuckets(BUCKET_NAME)
-          .withSecureConnection(false)
-          .build();
+      S3MockRule.builder().withInitialBuckets(BUCKET_NAME).withSecureConnection(false).build();
 
   public static final String SOLR_XML =
       "<solr>\n"

--- a/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3InstallShardTest.java
+++ b/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3InstallShardTest.java
@@ -55,11 +55,7 @@ public class S3InstallShardTest extends AbstractInstallShardTest {
 
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder()
-          .silent()
-          .withInitialBuckets(BUCKET_NAME)
-          .withSecureConnection(false)
-          .build();
+      S3MockRule.builder().withInitialBuckets(BUCKET_NAME).withSecureConnection(false).build();
 
   @BeforeClass
   public static void setupClass() throws Exception {

--- a/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3OutputStreamTest.java
+++ b/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3OutputStreamTest.java
@@ -34,7 +34,7 @@ public class S3OutputStreamTest extends SolrTestCaseJ4 {
 
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE =
-      S3MockRule.builder().silent().withInitialBuckets(BUCKET).withSecureConnection(false).build();
+      S3MockRule.builder().withInitialBuckets(BUCKET).withSecureConnection(false).build();
 
   private S3Client s3;
 


### PR DESCRIPTION
_(already reviewed by a colleague & contributor @pmcarthur-apache )_

I'm nearly sure that `S3MockRule.builder().silent()` will change the root logger to WARN.  Maybe for JUL; not sure if such a change federates to Log4j2.  Maybe we should remove silent() but I didn't check how bad/verbose it is.