### PR TITLE
SOLR-17716: Handle interrupted exception in SolrCores.waitAddPendingCoreOps.

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -2323,16 +2323,14 @@ public class CoreContainer {
     // TestConfigSetsAPI and TestLazyCores
     if (desc == null || zkSys.getZkController() != null) return null;
 
-    // This will put an entry in pending core ops if the core isn't loaded. Here's where moving the
-    // waitAddPendingCoreOps to createFromDescriptor would introduce a race condition.
-    core = solrCores.waitAddPendingCoreOps(name);
-
-    if (isShutDown) {
-      // We're quitting, so stop. This needs to be after the wait above since we may come off the
-      // wait as a consequence of shutting down.
-      return null;
-    }
     try {
+      // This will put an entry in pending core ops if the core isn't loaded. Here's where moving
+      // the waitAddPendingCoreOps to createFromDescriptor would introduce a race condition.
+      core = solrCores.waitAddPendingCoreOps(name);
+      if (isShutDown) {
+        // We're quitting, so stop.
+        return null;
+      }
       if (core == null) {
         if (zkSys.getZkController() != null) {
           zkSys.getZkController().throwErrorIfReplicaReplaced(desc);

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1078,19 +1078,23 @@ public class CoreContainer {
           coreLoadExecutor.execute(
               () -> {
                 SolrCore core;
+                boolean pendingCoreOpAdded = false;
                 try {
                   if (zkSys.getZkController() != null) {
                     zkSys.getZkController().throwErrorIfReplicaReplaced(cd);
                   }
                   MDCLoggingContext.setCoreDescriptor(this, cd);
                   solrCores.waitAddPendingCoreOps(cd.getName());
+                  pendingCoreOpAdded = true;
                   core = createFromDescriptor(cd, false, false);
                 } catch (Exception e) {
                   log.error("SolrCore failed to load on startup", e);
                   MDCLoggingContext.clear();
                   return;
                 } finally {
-                  solrCores.removeFromPendingOps(cd.getName());
+                  if (pendingCoreOpAdded) {
+                    solrCores.removeFromPendingOps(cd.getName());
+                  }
                   if (asyncSolrCoreLoad) {
                     solrCores.markCoreAsNotLoading(cd);
                   }
@@ -1610,8 +1614,8 @@ public class CoreContainer {
         coresLocator.create(this, cd);
 
         SolrCore core;
+        solrCores.waitAddPendingCoreOps(cd.getName());
         try {
-          solrCores.waitAddPendingCoreOps(cd.getName());
           core = createFromDescriptor(cd, true, newCollection);
           // Write out the current core properties in case anything changed when the core was
           // created
@@ -2047,8 +2051,8 @@ public class CoreContainer {
       CoreDescriptor cd = reloadCoreDescriptor(core.getCoreDescriptor());
       solrCores.addCoreDescriptor(cd);
       boolean success = false;
+      solrCores.waitAddPendingCoreOps(cd.getName());
       try {
-        solrCores.waitAddPendingCoreOps(cd.getName());
         ConfigSet coreConfig = coreConfigService.loadConfigSet(cd);
         if (log.isInfoEnabled()) {
           log.info(
@@ -2105,8 +2109,8 @@ public class CoreContainer {
       if (coreId != null) return; // yeah, this core is already reloaded/unloaded return right away
       CoreLoadFailure clf = coreInitFailures.get(name);
       if (clf != null) {
+        solrCores.waitAddPendingCoreOps(clf.cd.getName());
         try {
-          solrCores.waitAddPendingCoreOps(clf.cd.getName());
           createFromDescriptor(clf.cd, true, false);
         } finally {
           solrCores.removeFromPendingOps(clf.cd.getName());
@@ -2149,8 +2153,8 @@ public class CoreContainer {
    */
   public void unload(
       String name, boolean deleteIndexDir, boolean deleteDataDir, boolean deleteInstanceDir) {
+    solrCores.waitAddPendingCoreOps(name);
     try {
-      solrCores.waitAddPendingCoreOps(name);
       unloadWithoutCoreOp(name, deleteIndexDir, deleteDataDir, deleteInstanceDir);
     } finally {
       solrCores.removeFromPendingOps(name);
@@ -2323,14 +2327,16 @@ public class CoreContainer {
     // TestConfigSetsAPI and TestLazyCores
     if (desc == null || zkSys.getZkController() != null) return null;
 
+    // This will put an entry in pending core ops if the core isn't loaded. Here's where moving the
+    // waitAddPendingCoreOps to createFromDescriptor would introduce a race condition.
+    core = solrCores.waitAddPendingCoreOps(name);
+
+    if (isShutDown) {
+      // We're quitting, so stop. This needs to be after the wait above since we may come off the
+      // wait as a consequence of shutting down.
+      return null;
+    }
     try {
-      // This will put an entry in pending core ops if the core isn't loaded. Here's where moving
-      // the waitAddPendingCoreOps to createFromDescriptor would introduce a race condition.
-      core = solrCores.waitAddPendingCoreOps(name);
-      if (isShutDown) {
-        // We're quitting, so stop.
-        return null;
-      }
       if (core == null) {
         if (zkSys.getZkController() != null) {
           zkSys.getZkController().throwErrorIfReplicaReplaced(desc);

--- a/solr/core/src/java/org/apache/solr/core/SolrCores.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCores.java
@@ -346,7 +346,12 @@ public class SolrCores {
             }
           }
         }
-        if (container.isShutDown()) return null; // Just stop already.
+        if (container.isShutDown()) {
+          // Just stop already.
+          // Seems best to throw a SolrException if shutting down, because returning any value,
+          // including null, would mean the waiting is complete.
+          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Server is shutting down");
+        }
 
         if (pending) {
           try {

--- a/solr/core/src/java/org/apache/solr/core/SolrCores.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCores.java
@@ -352,7 +352,10 @@ public class SolrCores {
           try {
             modifyLock.wait();
           } catch (InterruptedException e) {
-            return null; // Seems best not to do anything at all if the thread is interrupted
+            // Seems best to throw a SolrException if interrupted, because returning any value,
+            // including null, would mean the waiting is complete.
+            Thread.currentThread().interrupt();
+            throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
           }
         }
       } while (pending);

--- a/solr/core/src/java/org/apache/solr/core/SolrCores.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCores.java
@@ -365,15 +365,12 @@ public class SolrCores {
         }
       } while (pending);
       // We _really_ need to do this within the synchronized block!
-      if (!container.isShutDown()) {
-        if (!pendingCoreOps.add(name)) {
-          log.warn("Replaced an entry in pendingCoreOps {}, we should not be doing this", name);
-        }
-        // we might have been _unloading_ the core, so return the core if it was loaded.
-        return getCoreFromAnyList(name, false);
+      if (!pendingCoreOps.add(name)) {
+        log.warn("Replaced an entry in pendingCoreOps {}, we should not be doing this", name);
       }
+      // we might have been _unloading_ the core, so return the core if it was loaded.
+      return getCoreFromAnyList(name, false);
     }
-    return null;
   }
 
   // We should always be removing the first thing in the list with our name! The idea here is to NOT


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17716

SolrCores.waitAddPendingCoreOps is the main locking mechanism for operations on cores like creation/loading/removal.

In the current code, if an InterruptedException is caught while waiting for the lock, the method returns null. However returning null means basically that the waiting is complete and the caller got the lock. So the caller code proceeds normally with its critical operation on the core.

We should handle differently an InterruptedException to prevent the caller from taking the lock while another pending op is on the core. The proposal is to throw a SolrException.