### PR TITLE
Only apply test failure output logic for Java tests

### DIFF
--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -23,7 +23,7 @@ def resources = scriptResources(buildscript)
 def verboseModeHookInstalled = false
 
 allprojects {
-  plugins.withType(JavaPlugin) {
+  plugins.withType(JavaPlugin).configureEach {
     project.ext {
       // This array will collect all test options, including default values and option description.
       // The actual values of these properties (defaults, project properties) are resolved lazily after evaluation
@@ -87,7 +87,7 @@ allprojects {
       }
     }
 
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
       ext {
         testOutputsDir = file("${reports.junitXml.outputLocation.get()}/outputs")
       }

--- a/gradle/testing/failed-tests-at-end.gradle
+++ b/gradle/testing/failed-tests-at-end.gradle
@@ -34,16 +34,18 @@ def genFailInfo(def task, TestDescriptor desc) {
 }
 
 allprojects {
-  tasks.withType(Test) { Test task ->
-    afterTest { desc, result ->
-      if (result.resultType == TestResult.ResultType.FAILURE) {
-        failedTests << genFailInfo(task, desc)
+  plugins.withType(JavaPlugin).configureEach {
+    tasks.withType(Test).configureEach { Test task ->
+      afterTest { desc, result ->
+        if (result.resultType == TestResult.ResultType.FAILURE) {
+          failedTests << genFailInfo(task, desc)
+        }
       }
-    }
 
-    afterSuite { desc, result ->
-      if (result.exceptions) {
-        failedTests << genFailInfo(task, desc)
+      afterSuite { desc, result ->
+        if (result.exceptions) {
+          failedTests << genFailInfo(task, desc)
+        }
       }
     }
   }


### PR DESCRIPTION
This error has been seen on some of the Jenkins runs:

```
Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'testOutputsDir' for task ':solr:ui:desktopTest' of type org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest.
```

There's no reason to (currently) add the output for fucit or develocity for these tests, so let's just keep the logic to the JavaProject modules.