### PR TITLE
SOLR-16903: Nightly test failures from Path migration

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/MissingSegmentRecoveryTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MissingSegmentRecoveryTest.java
@@ -114,7 +114,9 @@ public class MissingSegmentRecoveryTest extends SolrCloudTestCase {
         cluster.getReplicaJetty(replica).getCoreContainer().getCore(replica.getCoreName())) {
       Path indexDir = Path.of(core.getDataDir(), "index");
       try (Stream<Path> files = Files.list(indexDir)) {
-        return files.filter((file) -> file.getFileName().startsWith("segments_")).toList();
+        return files
+            .filter((file) -> file.getFileName().toString().startsWith("segments_"))
+            .toList();
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -1038,7 +1038,9 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
       return (int)
           files
               .filter(
-                  (file) -> Files.isDirectory(file) && !file.getFileName().startsWith("snapshot"))
+                  (file) ->
+                      Files.isDirectory(file)
+                          && !file.getFileName().toString().startsWith("snapshot"))
               .count();
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestStressThreadBackup.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Term;
@@ -288,7 +289,7 @@ public class TestStressThreadBackup extends SolrCloudTestCase {
           numBackupsToCheck);
       try (Stream<Path> files = Files.list(backupDir)) {
         // insure consistent (arbitrary) ordering before shuffling
-        final List<Path> allBackups = files.sorted().toList();
+        final List<Path> allBackups = files.sorted().collect(Collectors.toList());
         Collections.shuffle(allBackups, random());
         for (int i = 0; i < numBackupsToCheck; i++) {
           final Path backup = allBackups.get(i);

--- a/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
@@ -19,13 +19,9 @@ package org.apache.solr.update;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-
-import com.carrotsearch.randomizedtesting.RandomizedContext;
 import org.apache.lucene.tests.mockfile.FilterPath;
-import org.apache.lucene.tests.mockfile.WindowsFS;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;

--- a/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
@@ -19,9 +19,13 @@ package org.apache.solr.update;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
 import org.apache.lucene.tests.mockfile.FilterPath;
+import org.apache.lucene.tests.mockfile.WindowsFS;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
@@ -53,7 +57,7 @@ public class CustomTLogDirTest extends SolrTestCaseJ4 {
 
     Path instanceDir = FilterPath.unwrap(coreRootDir.resolve(collectionName));
 
-    Path ulogDir = LuceneTestCase.createTempDir();
+    Path ulogDir = FilterPath.unwrap(LuceneTestCase.createTempDir());
     // absolute path spec that falls outside of the instance and data dirs for the
     // associated core, is assumed to already by namespaced by purpose (tlog). We
     // expect it to be further namespaced by core name.

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -1172,7 +1172,7 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
    * is in place.
    */
   protected void seedSolrHome(Path jettyHome) throws IOException {
-    PathUtils.copyDirectory(getSolrHome(), jettyHome);
+    PathUtils.copyDirectory(getSolrHome(), jettyHome, StandardCopyOption.REPLACE_EXISTING);
     String solrxml = getSolrXml();
     if (solrxml != null) {
       Files.copy(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16903

# Description

Tests on nightly failing.

# Solution

- `TestReplicationHandler` needs to check fileName from string
- `TestStressThreadBackup.java` `toList()` is immutable. Collect with `.collect(Collectors.toList())`
- `BaseDistributedSearchTestCase.java` seems with a nightly test, the file/directory already exists. Use `StandardCopyOption.REPLACE_EXISTING` to overwrite as `FileUtils.copyDirectory` does
- CustomTLogDirTest.java When using `LuceneTestCase.createTempDir()`, certain seeds generate a [WindowsFS](https://github.com/apache/lucene/blob/main/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java#L34) and this causes try-with-resources failing to [close the file stream](https://github.com/apache/solr/blob/470ae762b883b259da6f127844855395e9eedf9f/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java#L166). Unwrap it to just get a generic NIO Path so stream can close


# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
