### PR TITLE
SOLR-17496: Remove a warning that is no longer applicable.

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/SolrZkServer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/SolrZkServer.java
@@ -168,9 +168,6 @@ public class SolrZkServer {
       }
     }
 
-    log.warn(
-        "Embedded Zookeeper is not recommended in production environments. See Reference Guide for details.");
-
     zkThread.setDaemon(true);
     zkThread.start();
     try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17496

At smaller scale setups, running Solr in Solr Cloud mode with embedded ZooKeeper is just fine.   1 node, 2 node, it's just fine.   

For 10.0 I plan on completing #2783 which would provide more concrte details.