### PR TITLE
Equal terms DocTransformer

### DIFF
--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.Field;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
@@ -86,8 +86,8 @@ public class EqualTermsDocTransformer extends DocTransformer {
       fieldValue = list.getFirst();
     }
     if (fieldValue instanceof CharSequence) return fieldValue.toString();
-    if (fieldValue instanceof StoredField storedField) {
-      return storedField.stringValue();
+    if (fieldValue instanceof Field luceneField) {
+      return luceneField.stringValue();
     }
     return null;
   }

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
@@ -55,11 +55,6 @@ public class EqualTermsDocTransformer extends DocTransformer {
   }
 
   @Override
-  public boolean needsSolrIndexSearcher() {
-    return true;
-  }
-
-  @Override
   public String[] getExtraRequestFields() {
     return new String[] {sourceField.getName()};
   }
@@ -114,10 +109,11 @@ public class EqualTermsDocTransformer extends DocTransformer {
           return false; // More tokens in source than in comparison value
         }
 
-        // Compare the current token with the corresponding token in our pre-analyzed list
-        String currentToken = termAttr.toString();
         String compareToken = compareIter.next();
-        if (!currentToken.equals(compareToken)) {
+
+        // Compare the current token with the corresponding token in our pre-analyzed list
+        if (termAttr.length() != compareToken.length()
+            || CharSequence.compare(termAttr, compareToken) != 0) {
           return false; // Token mismatch
         }
       }

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
@@ -17,35 +17,57 @@
 package org.apache.solr.response.transform;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.StoredField;
 import org.apache.solr.common.SolrDocument;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.schema.SchemaField;
 
 /**
- * Compares a field from a document with a literal string value and adds a boolean field to the
- * document indicating if they are equal.
+ * Compares a field from a document with a literal string value using Lucene's TokenStream and adds a boolean field 
+ * to the document indicating if they are equal after analysis.
  *
- * <p>This transformer takes a source field from the index and compares it with a literal string
- * value. The output is a boolean value added to the document that indicates whether the strings are
- * equal.
+ * <p>This transformer takes a source field from the index and compares it with a literal string value,
+ * applying the field's analyzer to both. The comparison is done at the term level using TokenStream.
+ * The output is a boolean value added to the document that indicates whether the analyzed terms are equal.
  *
- * <p>Example usage in a request: fl=id,name,equal:equalterms(name,Smith)
+ * <p>Example usage in a request: fl=id,subject,isEqual:[equalterms field=subject value='John Smith']
  */
 public class EqualTermsDocTransformer extends DocTransformer {
   private final String name;
   private final String sourceField;
   private final String compareValue;
+  private final IndexSchema schema;
+  private final List<String> compareValueTerms;
 
-  public EqualTermsDocTransformer(String name, String sourceField, String compareValue) {
+  public EqualTermsDocTransformer(String name, String sourceField, String compareValue, IndexSchema schema) 
+      throws IOException {
     this.name = name;
     this.sourceField = sourceField;
     this.compareValue = compareValue;
+    this.schema = schema;
+    
+    // Analyze the comparison value up front
+    SchemaField field = schema.getField(sourceField);
+    FieldType fieldType = field.getType();
+    Analyzer analyzer = fieldType.getIndexAnalyzer();
+    
+    this.compareValueTerms = analyzeToTerms(analyzer, compareValue);
   }
 
   @Override
   public String getName() {
     return name;
+  }
+  
+  @Override
+  public boolean needsSolrIndexSearcher() {
+    return true;
   }
 
   @Override
@@ -60,11 +82,17 @@ public class EqualTermsDocTransformer extends DocTransformer {
       doc.setField(name, false);
       return;
     }
-
-    boolean isEqual = Objects.equals(fieldValue, compareValue);
+    
+    SchemaField field = schema.getField(sourceField);
+    FieldType fieldType = field.getType();
+    Analyzer analyzer = fieldType.getIndexAnalyzer();
+    
+    List<String> sourceTerms = analyzeToTerms(analyzer, fieldValue);
+    
+    boolean isEqual = compareTerms(sourceTerms, compareValueTerms);
     doc.setField(name, isEqual);
   }
-
+  
   private String getFieldValue(SolrDocument doc) {
     Object fieldValue = doc.getFieldValue(sourceField);
     if (fieldValue instanceof List<?> list) {
@@ -76,5 +104,43 @@ public class EqualTermsDocTransformer extends DocTransformer {
       return storedField.stringValue();
     }
     return null;
+  }
+  
+  /**
+   * Analyzes text using the provided analyzer and returns a list of String terms.
+   */
+  private List<String> analyzeToTerms(Analyzer analyzer, String text) throws IOException {
+    List<String> terms = new ArrayList<>();
+    
+    try (TokenStream tokenStream = analyzer.tokenStream("", text)) {
+      CharTermAttribute termAttr = tokenStream.addAttribute(CharTermAttribute.class);
+      tokenStream.reset();
+      
+      while (tokenStream.incrementToken()) {
+        // Copy the term text since CharTermAttribute will be reused
+        terms.add(termAttr.toString());
+      }
+      
+      tokenStream.end();
+    }
+    
+    return terms;
+  }
+  
+  /**
+   * Compares two lists of String terms to see if they contain the same terms in the same order.
+   */
+  private boolean compareTerms(List<String> sourceTerms, List<String> compareTerms) {
+    if (sourceTerms.size() != compareTerms.size()) {
+      return false;
+    }
+    
+    for (int i = 0; i < sourceTerms.size(); i++) {
+      if (!sourceTerms.get(i).equals(compareTerms.get(i))) {
+        return false;
+      }
+    }
+    
+    return true;
   }
 }

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
@@ -18,6 +18,7 @@ package org.apache.solr.response.transform;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -29,14 +30,15 @@ import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 
 /**
- * Compares a field from a document with a literal string value using Lucene's TokenStream and adds a boolean field 
- * to the document indicating if they are equal after analysis.
+ * Compares a field from a document with a literal string value using analyzed (tokenized) text,
+ * thus a configurable degree of matching.
  *
- * <p>This transformer takes a source field from the index and compares it with a literal string value,
- * applying the field's analyzer to both. The comparison is done at the term level using TokenStream.
- * The output is a boolean value added to the document that indicates whether the analyzed terms are equal.
+ * <p>This transformer takes a source field from the index and compares it with a literal string
+ * value, applying the field's analyzer to both. The comparison is done at the term level using
+ * TokenStream. The output is a boolean value added to the document that indicates whether the
+ * analyzed terms are equal.
  *
- * <p>Example usage in a request: fl=id,subject,isEqual:[equalterms field=subject value='John Smith']
+ * <p>Example usage in a request: fl=id,isEqual:[equalterms field=subject value='John Smith']
  */
 public class EqualTermsDocTransformer extends DocTransformer {
   private final String name;
@@ -45,18 +47,18 @@ public class EqualTermsDocTransformer extends DocTransformer {
   private final IndexSchema schema;
   private final List<String> compareValueTerms;
 
-  public EqualTermsDocTransformer(String name, String sourceField, String compareValue, IndexSchema schema) 
-      throws IOException {
+  public EqualTermsDocTransformer(
+      String name, String sourceField, String compareValue, IndexSchema schema) throws IOException {
     this.name = name;
     this.sourceField = sourceField;
     this.compareValue = compareValue;
     this.schema = schema;
-    
+
     // Analyze the comparison value up front
     SchemaField field = schema.getField(sourceField);
     FieldType fieldType = field.getType();
     Analyzer analyzer = fieldType.getIndexAnalyzer();
-    
+
     this.compareValueTerms = analyzeToTerms(analyzer, compareValue);
   }
 
@@ -64,7 +66,7 @@ public class EqualTermsDocTransformer extends DocTransformer {
   public String getName() {
     return name;
   }
-  
+
   @Override
   public boolean needsSolrIndexSearcher() {
     return true;
@@ -82,17 +84,20 @@ public class EqualTermsDocTransformer extends DocTransformer {
       doc.setField(name, false);
       return;
     }
-    
+
     SchemaField field = schema.getField(sourceField);
     FieldType fieldType = field.getType();
     Analyzer analyzer = fieldType.getIndexAnalyzer();
-    
-    List<String> sourceTerms = analyzeToTerms(analyzer, fieldValue);
-    
-    boolean isEqual = compareTerms(sourceTerms, compareValueTerms);
+
+    // Compare terms on-the-fly as we iterate through the token stream
+    // This allows early termination as soon as we find a mismatch
+    boolean isEqual = compareTokensOnTheFly(analyzer, fieldValue);
     doc.setField(name, isEqual);
   }
-  
+
+  /**
+   * Gets the string field value, or null if not present or if found a list of values other than 1.
+   */
   private String getFieldValue(SolrDocument doc) {
     Object fieldValue = doc.getFieldValue(sourceField);
     if (fieldValue instanceof List<?> list) {
@@ -105,42 +110,55 @@ public class EqualTermsDocTransformer extends DocTransformer {
     }
     return null;
   }
-  
+
   /**
-   * Analyzes text using the provided analyzer and returns a list of String terms.
+   * Compares tokens from the analyzed text with the pre-analyzed comparison tokens. Returns false
+   * as soon as a mismatch is found.
    */
-  private List<String> analyzeToTerms(Analyzer analyzer, String text) throws IOException {
-    List<String> terms = new ArrayList<>();
-    
-    try (TokenStream tokenStream = analyzer.tokenStream("", text)) {
+  private boolean compareTokensOnTheFly(Analyzer analyzer, String text) throws IOException {
+    Iterator<String> compareIter = compareValueTerms.iterator();
+
+    try (TokenStream tokenStream = analyzer.tokenStream(sourceField, text)) {
       CharTermAttribute termAttr = tokenStream.addAttribute(CharTermAttribute.class);
       tokenStream.reset();
-      
+
+      while (tokenStream.incrementToken()) {
+        // Check if we've seen more tokens than in our comparison list
+        if (!compareIter.hasNext()) {
+          return false; // More tokens in source than in comparison value
+        }
+
+        // Compare the current token with the corresponding token in our pre-analyzed list
+        String currentToken = termAttr.toString();
+        String compareToken = compareIter.next();
+        if (!currentToken.equals(compareToken)) {
+          return false; // Token mismatch
+        }
+      }
+
+      tokenStream.end();
+    }
+
+    // Check if we've seen all the tokens in our comparison list
+    return !compareIter.hasNext(); // True if no more comparison tokens remain
+  }
+
+  /** Analyzes text using the provided analyzer and returns a list of String terms. */
+  private List<String> analyzeToTerms(Analyzer analyzer, String text) throws IOException {
+    List<String> terms = new ArrayList<>();
+
+    try (TokenStream tokenStream = analyzer.tokenStream(sourceField, text)) {
+      CharTermAttribute termAttr = tokenStream.addAttribute(CharTermAttribute.class);
+      tokenStream.reset();
+
       while (tokenStream.incrementToken()) {
         // Copy the term text since CharTermAttribute will be reused
         terms.add(termAttr.toString());
       }
-      
+
       tokenStream.end();
     }
-    
+
     return terms;
-  }
-  
-  /**
-   * Compares two lists of String terms to see if they contain the same terms in the same order.
-   */
-  private boolean compareTerms(List<String> sourceTerms, List<String> compareTerms) {
-    if (sourceTerms.size() != compareTerms.size()) {
-      return false;
-    }
-    
-    for (int i = 0; i < sourceTerms.size(); i++) {
-      if (!sourceTerms.get(i).equals(compareTerms.get(i))) {
-        return false;
-      }
-    }
-    
-    return true;
   }
 }

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsDocTransformer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.response.transform;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.apache.lucene.document.StoredField;
+import org.apache.solr.common.SolrDocument;
+
+/**
+ * Compares a field from a document with a literal string value and adds a boolean field to the
+ * document indicating if they are equal.
+ *
+ * <p>This transformer takes a source field from the index and compares it with a literal string
+ * value. The output is a boolean value added to the document that indicates whether the strings are
+ * equal.
+ *
+ * <p>Example usage in a request: fl=id,name,equal:equalterms(name,Smith)
+ */
+public class EqualTermsDocTransformer extends DocTransformer {
+  private final String name;
+  private final String sourceField;
+  private final String compareValue;
+
+  public EqualTermsDocTransformer(String name, String sourceField, String compareValue) {
+    this.name = name;
+    this.sourceField = sourceField;
+    this.compareValue = compareValue;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String[] getExtraRequestFields() {
+    return new String[] {sourceField};
+  }
+
+  @Override
+  public void transform(SolrDocument doc, int docid) throws IOException {
+    String fieldValue = getFieldValue(doc);
+    if (fieldValue == null) {
+      doc.setField(name, false);
+      return;
+    }
+
+    boolean isEqual = Objects.equals(fieldValue, compareValue);
+    doc.setField(name, isEqual);
+  }
+
+  private String getFieldValue(SolrDocument doc) {
+    Object fieldValue = doc.getFieldValue(sourceField);
+    if (fieldValue instanceof List<?> list) {
+      if (list.size() != 1) return null;
+      fieldValue = list.getFirst();
+    }
+    if (fieldValue instanceof CharSequence) return fieldValue.toString();
+    if (fieldValue instanceof StoredField storedField) {
+      return storedField.stringValue();
+    }
+    return null;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
@@ -16,10 +16,13 @@
  */
 package org.apache.solr.response.transform;
 
+import java.io.IOException;
+
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.schema.IndexSchema;
 
 /**
  * Factory for {@link EqualTermsDocTransformer} instances.
@@ -49,7 +52,14 @@ public class EqualTermsTransformerFactory extends TransformerFactory {
       throw new SolrException(
           ErrorCode.BAD_REQUEST, "EqualTermsTransformer requires 'value' parameter");
     }
-
-    return new EqualTermsDocTransformer(field, sourceField, compareValue);
+    
+    IndexSchema schema = req.getSchema();
+    
+    try {
+      return new EqualTermsDocTransformer(field, sourceField, compareValue, schema);
+    } catch (IOException e) {
+      throw new SolrException(
+          ErrorCode.SERVER_ERROR, "Error creating EqualTermsDocTransformer: " + e.getMessage(), e);
+    }
   }
 }

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
@@ -17,7 +17,6 @@
 package org.apache.solr.response.transform;
 
 import java.io.IOException;
-
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.params.SolrParams;
@@ -52,9 +51,9 @@ public class EqualTermsTransformerFactory extends TransformerFactory {
       throw new SolrException(
           ErrorCode.BAD_REQUEST, "EqualTermsTransformer requires 'value' parameter");
     }
-    
+
     IndexSchema schema = req.getSchema();
-    
+
     try {
       return new EqualTermsDocTransformer(field, sourceField, compareValue, schema);
     } catch (IOException e) {

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
@@ -38,6 +38,9 @@ import org.apache.solr.request.SolrQueryRequest;
  */
 public class EqualTermsTransformerFactory extends TransformerFactory {
 
+  // TODO consider an option to choose the analyzer; not necessarily related to the input field's
+  //  analysis.
+
   @Override
   public DocTransformer create(String destField, SolrParams params, SolrQueryRequest req) {
     String sourceField = params.get("field");

--- a/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/EqualTermsTransformerFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.response.transform;
+
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.request.SolrQueryRequest;
+
+/**
+ * Factory for {@link EqualTermsDocTransformer} instances.
+ *
+ * <p>Syntax: {fieldName}:equalterms({sourceField},{compareValue})
+ *
+ * <p>Params:
+ *
+ * <ul>
+ *   <li>sourceField: The field from the document to compare
+ *   <li>compareValue: The literal string value to compare with
+ * </ul>
+ */
+public class EqualTermsTransformerFactory extends TransformerFactory {
+
+  @Override
+  public DocTransformer create(String field, SolrParams params, SolrQueryRequest req) {
+    String sourceField = params.get("field");
+    String compareValue = params.get("value");
+
+    if (sourceField == null) {
+      throw new SolrException(
+          ErrorCode.BAD_REQUEST, "EqualTermsTransformer requires 'field' parameter");
+    }
+
+    if (compareValue == null) {
+      throw new SolrException(
+          ErrorCode.BAD_REQUEST, "EqualTermsTransformer requires 'value' parameter");
+    }
+
+    return new EqualTermsDocTransformer(field, sourceField, compareValue);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/response/transform/TransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/TransformerFactory.java
@@ -105,7 +105,7 @@ public abstract class TransformerFactory implements NamedListInitializedPlugin {
     }
   }
 
-  public static final Map<String, TransformerFactory> defaultFactories = new HashMap<>(9, 1.0f);
+  public static final Map<String, TransformerFactory> defaultFactories = new HashMap<>();
 
   static {
     defaultFactories.put("explain", new ExplainAugmenterFactory());
@@ -118,5 +118,6 @@ public abstract class TransformerFactory implements NamedListInitializedPlugin {
     defaultFactories.put("xml", new RawValueTransformerFactory("xml"));
     defaultFactories.put("geo", new GeoTransformerFactory());
     defaultFactories.put("core", new CoreAugmenterFactory());
+    defaultFactories.put("equalterms", new EqualTermsTransformerFactory());
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomFlRTGCloud.java
@@ -1501,10 +1501,6 @@ public class TestRandomFlRTGCloud extends SolrCloudTestCase {
     public static final String FIXED_VALUE = "Billy";
     public static final String FIELD_NAME = "equalterms_s";
 
-    public EqualTermsValidator(final String fieldName) {
-      this(fieldName, "[" + NAME + "]");
-    }
-
     public EqualTermsValidator(final String fieldName, final String resultKey) {
       this.fieldName = fieldName;
       this.resultKey = resultKey;

--- a/solr/core/src/test/org/apache/solr/response/transform/TestEqualTermsTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestEqualTermsTransformer.java
@@ -104,11 +104,11 @@ public class TestEqualTermsTransformer extends SolrTestCaseJ4 {
     assertJQ(
         req(
             "q",
-            "*:*",
-            "sort",
-            "id asc",
+            "john   smith",
+            "df",
+            "subject",
             "fl",
-            "id,isMatch:[equalterms field=subject value='john   smith']"),
+            "id,isMatch:[equalterms field=subject value=$q]"),
         "/response/docs/[0]/id=='1'", // John Smith
         "/response/docs/[0]/isMatch==true");
   }

--- a/solr/core/src/test/org/apache/solr/response/transform/TestEqualTermsTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestEqualTermsTransformer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.response.transform;
+
+import java.io.IOException;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrDocument;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Test cases for {@link EqualTermsDocTransformer} */
+public class TestEqualTermsTransformer extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig.xml", "schema.xml");
+  }
+
+  @Before
+  public void before() {
+    clearIndex();
+    assertU(adoc("id", "1", "name", "John Smith"));
+    assertU(adoc("id", "2", "name", "Alice Jones"));
+    assertU(adoc("id", "3", "name", "Bob Miller"));
+    assertU(commit());
+  }
+
+  @Test
+  public void testBasicTransformation() throws IOException {
+    // Test with matching value
+    SolrDocument doc = new SolrDocument();
+    doc.addField("name", "John Smith");
+
+    EqualTermsDocTransformer transformer =
+        new EqualTermsDocTransformer("isJohn", "name", "John Smith");
+    transformer.transform(doc, 0);
+
+    assertEquals(true, doc.getFieldValue("isJohn"));
+
+    // Test with non-matching value
+    SolrDocument doc2 = new SolrDocument();
+    doc2.addField("name", "Alice Jones");
+
+    transformer.transform(doc2, 0);
+
+    assertEquals(false, doc2.getFieldValue("isJohn"));
+
+    // Test with null field value
+    SolrDocument doc3 = new SolrDocument();
+
+    transformer.transform(doc3, 0);
+
+    assertEquals(false, doc3.getFieldValue("isJohn"));
+  }
+
+  @Test
+  public void testQueryTimeTransformation() throws Exception {
+    // Test with matching value
+    assertJQ(
+        req("q", "*:*", "fl", "id,isJohn:[equalterms field=name value='John Smith']"),
+        "/response/docs/[0]/id=='1'",
+        "/response/docs/[0]/isJohn==true",
+        "/response/docs/[1]/isJohn==false",
+        "/response/docs/[2]/isJohn==false");
+
+    //    // Test with value not present in any documents
+    //    assertJQ(
+    //        req("q", "*:*", "fl", "id,name,isUnknown:equalterms(field=name,value='Unknown
+    // Person')"),
+    //        "/response/docs/[0]/isUnknown==false",
+    //        "/response/docs/[1]/isUnknown==false",
+    //        "/response/docs/[2]/isUnknown==false");
+  }
+}

--- a/solr/core/src/test/org/apache/solr/response/transform/TestEqualTermsTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestEqualTermsTransformer.java
@@ -50,7 +50,7 @@ public class TestEqualTermsTransformer extends SolrTestCaseJ4 {
 
     IndexSchema schema = h.getCore().getLatestSchema();
     EqualTermsDocTransformer transformer =
-        new EqualTermsDocTransformer("isJohn", "subject", "John Smith", schema);
+        new EqualTermsDocTransformer("isJohn", schema.getField("subject"), "John Smith");
     transformer.transform(doc, 0);
 
     assertEquals(true, doc.getFieldValue("isJohn"));


### PR DESCRIPTION
JIRA TODO: https://issues.apache.org/jira/browse/SOLR-XXXXX

This is a sketch of a DocTransformer  that emits a boolean field on the returned doc based on a document field being equal to an input stream, as compared by the analyzed text.
`fl=id,isEqual:[equalterms field=subject value='John Smith']`

I need this for work but looking for feedback on inclusion in Solr and naming and other things.