### PR TITLE
(branch_9x) start Learned Sparse Retrieval (LSR) tutorial page

### DIFF
--- a/solr/example/exampledocs/three_bees.json
+++ b/solr/example/exampledocs/three_bees.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id" : "1",
+    "text_ws" : "bumble bee",
+    "text_drtf" : "bee|3 bumble|2"
+  }
+,
+  {
+    "id" : "2",
+    "text_ws" : "honey bee",
+    "text_drtf" : "bee|3 honey|2 sugar|1"
+  }
+,
+  {
+    "id" : "3",
+    "text_ws" : "solitary bee",
+    "text_drtf" : "bee|3 solitary|2 alone|1"
+  }
+]

--- a/solr/server/solr/configsets/_default/conf/managed-schema.xml
+++ b/solr/server/solr/configsets/_default/conf/managed-schema.xml
@@ -164,6 +164,9 @@
     <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
     <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
 
+    <!-- delimited raw term-frequency dynamic field(s) -->
+    <dynamicField name="*_drtf" type="delimited_rawtf" indexed="true" stored="true" omitPositions="true"/>
+
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Field to use to determine and enforce document uniqueness.
@@ -561,6 +564,17 @@
         <tokenizer name="whitespace"/>
         <filter name="delimitedPayload" encoder="identity"/>
       </analyzer>
+    </fieldType>
+
+    <fieldType name="delimited_rawtf" stored="false" indexed="true" class="solr.TextField">
+      <analyzer>
+        <tokenizer name="whitespace"/>
+        <filter name="delimitedTermFrequency"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer name="whitespace"/>
+      </analyzer>
+      <similarity class="solr.RawTFSimilarityFactory"/>
     </fieldType>
 
     <!-- some examples for different languages (generally ordered by ISO code) -->

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-lsr.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-lsr.adoc
@@ -1,0 +1,171 @@
+= Exercise 6: Using Learned Sparse Retrieval (LSR)
+:experimental:
+:tabs-sync-option:
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+[[exercise-6]]
+== Exercise 6: Using Learned Sparse Retrieval (LSR) in Solr
+
+...
+
+=== Getting Ready
+
+[,console]
+----
+bin/solr start -noprompt -e cloud
+----
+
+...
+
+[,console]
+----
+bin/solr create -c buzz
+----
+
+
+=== Indexing
+
+...
+
+[,console]
+----
+bin/solr post -c buzz example/exampledocs/three_bees.json
+----
+
+=== Searching
+
+...
+
+
+[,console]
+----
+curl 'http://localhost:8983/solr/buzz/select?fl=text_*,score&q=text_ws:bee'
+----
+
+As can be seen the scores are the same for all documents.
+
+```
+...
+    "docs":[{
+      "text_ws":"bumble bee",
+      "text_drtf":"bee|3 bumble|2",
+      "score":0.06069608
+    },{
+      "text_ws":"honey bee",
+      "text_drtf":"bee|3 honey|2 sugar|1",
+      "score":0.06069608
+    },{
+      "text_ws":"solitary bee",
+      "text_drtf":"bee|3 solitary|2 alone|1",
+      "score":0.06069608
+    }]
+...
+```
+
+=== Searching with the raw term frequency similarity field
+
+...
+
+
+[,console]
+----
+curl 'http://localhost:8983/solr/buzz/select?fl=text_*,score&q=text_drtf:bee'
+----
+
+As can be seen the scores are as supplied after the pipe delimiter for the `bee` term.
+
+```
+...
+   "docs":[{
+      "text_ws":"bumble bee",
+      "text_drtf":"bee|3 bumble|2",
+      "score":3.0
+    },{
+      "text_ws":"honey bee",
+      "text_drtf":"bee|3 honey|2 sugar|1",
+      "score":3.0
+    },{
+      "text_ws":"solitary bee",
+      "text_drtf":"bee|3 solitary|2 alone|1",
+      "score":3.0
+    }]
+...
+```
+
+[,console]
+----
+curl 'http://localhost:8983/solr/buzz/select?fl=text_*,score&q=text_drtf:(honey+bee)'
+----
+
+As can be seen the scores are as supplied after the pipe delimiter, summed for the matching terms.
+
+```
+...
+    "docs":[{
+      "text_ws":"honey bee",
+      "text_drtf":"bee|3 honey|2 sugar|1",
+      "score":5.0
+    },{
+      "text_ws":"bumble bee",
+      "text_drtf":"bee|3 bumble|2",
+      "score":3.0
+    },{
+      "text_ws":"solitary bee",
+      "text_drtf":"bee|3 solitary|2 alone|1",
+      "score":3.0
+    }]
+...
+```
+
+...
+
+[,console]
+----
+curl 'http://localhost:8983/solr/buzz/select?fl=text_*,score&q=text_drtf:(bumble^10+honey^2+bee)'
+----
+
+As can be seen the scores are as supplied after the pipe delimiter, summed for the matching terms and boosted as per the query.
+
+
+```
+...
+    "docs":[{
+      "text_ws":"bumble bee",
+      "text_drtf":"bee|3 bumble|2",
+      "score":23.0
+    },{
+      "text_ws":"honey bee",
+      "text_drtf":"bee|3 honey|2 sugar|1",
+      "score":7.0
+    },{
+      "text_ws":"solitary bee",
+      "text_drtf":"bee|3 solitary|2 alone|1",
+      "score":3.0
+    }]
+...
+```
+
+...
+
+=== Searching with payloaded fields
+
+...
+
+=== Searching with ??? fields
+
+...


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17626 added the `RawTFSimilarityFactory` class targeting the (not yet released) Solr 9.9 version.

Lots of still things still TODO here, input and collaboration very welcome, e.g.
- [X] Making a start with something.
- [ ] In a paragraph or two, what is LSR and links to a paper or two.
- [ ] Content re: training and evaluation.
- [ ] Content re: indexing.
- [ ] Content re: searching.
- [ ] Content w.r.t. the different options within Solr i.e. raw term frequency is one, payload is(?) another, what else and how to trade-off and choose?
- [ ] Tutorial test-driving
- [ ] Relocation from `branch_9x` to `main` branch.
