### PR TITLE
Optimize consumeInputFully, don't loop read single byte

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -19,7 +19,6 @@ package org.apache.solr.servlet;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -41,6 +40,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import org.apache.http.HttpHeaders;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.util.tracing.TraceUtils;
 import org.slf4j.Logger;
@@ -252,12 +252,7 @@ public abstract class ServletUtils {
   // connection - see SOLR-8453 and SOLR-8683
   static void consumeInputFully(HttpServletRequest req, HttpServletResponse response) {
     try {
-      ServletInputStream is = req.getInputStream();
-      if (!is.isFinished() && is.read() != -1) {
-        is.skipNBytes(Long.MAX_VALUE); // throws EOF
-      }
-    } catch (EOFException e) {
-      // ignore / expected for skipNBytes
+      Utils.readFully(req.getInputStream());
     } catch (IOException e) {
       if (req.getHeader(HttpHeaders.EXPECT) != null && response.isCommitted()) {
         log.debug("No input stream to consume from client");

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -665,7 +665,7 @@ public class Utils {
    * @throws IOException on problem with IO
    */
   public static void readFully(InputStream is) throws IOException {
-    if (is.read() != -1) { // not needed but avoids a buffer allocation soon if found data
+    if (is.read() != -1) { // not needed but avoids skipNBytes's internal buffer allocation
       try {
         is.skipNBytes(Long.MAX_VALUE); // throws EOF
       } catch (EOFException e) {

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -24,6 +24,7 @@ import static org.apache.solr.common.SolrException.ErrorCode.SERVER_ERROR;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -664,8 +665,13 @@ public class Utils {
    * @throws IOException on problem with IO
    */
   public static void readFully(InputStream is) throws IOException {
-    is.skip(is.available());
-    while (is.read() != -1) {}
+    if (is.read() != -1) { // not needed but avoids a buffer allocation soon if found data
+      try {
+        is.skipNBytes(Long.MAX_VALUE); // throws EOF
+      } catch (EOFException e) {
+        // ignore / expected for skipNBytes
+      }
+    }
   }
 
   public static final Pattern ARRAY_ELEMENT_INDEX = Pattern.compile("(\\S*?)\\[([-]?\\d+)\\]");


### PR DESCRIPTION
Do not read a single byte in a loop -- a performance anti-pattern.

I just happened to notice this during a debugging session that had me looking closely at single-byte reads.