### PR TITLE
SOLR-17069 HttpServletRequest; use eagerly to avoid inaccessibility

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CancellableQueryTracker.java
+++ b/solr/core/src/java/org/apache/solr/core/CancellableQueryTracker.java
@@ -56,7 +56,7 @@ public class CancellableQueryTracker {
       }
     }
 
-    activeQueriesGenerated.put(queryID, req.getHttpSolrCall().getReq().getQueryString());
+    activeQueriesGenerated.put(queryID, req.getParamString());
 
     return queryID;
   }

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -209,7 +209,7 @@ public class HttpShardHandler extends ShardHandler {
     req.setMethod(SolrRequest.METHOD.POST);
     SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
     if (requestInfo != null) {
-      req.setUserPrincipal(requestInfo.getReq().getUserPrincipal());
+      req.setUserPrincipal(requestInfo.getUserPrincipal());
     }
 
     return httpShardHandlerFactory.newLBHttpSolrClientReq(req, urls);

--- a/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
+++ b/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
@@ -51,12 +51,12 @@ public class SolrRequestInfo {
   private SolrQueryRequest req;
   private SolrQueryResponse rsp;
   private Date now;
-  public HttpServletRequest httpRequest;
   private TimeZone tz;
   private ResponseBuilder rb;
   private List<AutoCloseable> closeHooks;
   private SolrDispatchFilter.Action action;
   private boolean useServerToken = false;
+  private Principal principal;
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -151,6 +151,7 @@ public class SolrRequestInfo {
   public SolrRequestInfo(SolrQueryRequest req, SolrQueryResponse rsp) {
     this.req = req;
     this.rsp = rsp;
+    this.principal = req != null ? req.getUserPrincipal() : null;
   }
 
   public SolrRequestInfo(
@@ -160,8 +161,8 @@ public class SolrRequestInfo {
   }
 
   public SolrRequestInfo(HttpServletRequest httpReq, SolrQueryResponse rsp) {
-    this.httpRequest = httpReq;
     this.rsp = rsp;
+    this.principal = httpReq != null ? httpReq.getUserPrincipal() : null;
   }
 
   public SolrRequestInfo(
@@ -171,9 +172,7 @@ public class SolrRequestInfo {
   }
 
   public Principal getUserPrincipal() {
-    if (req != null) return req.getUserPrincipal();
-    if (httpRequest != null) return httpRequest.getUserPrincipal();
-    return null;
+    return principal;
   }
 
   public Date getNOW() {

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -193,12 +193,13 @@ public class HttpSolrCall {
   }
 
   /**
-   * WARNING: While this returns a non-null ServletApiRequest (Jetty’s implementation of
-   * HttpServletRequest), any method that internally calls getRequest() — such as getAttribute(),
-   * getQueryString(), etc. — may throw NullPointerException if this is accessed outside the
-   * original servlet thread (e.g. async tasks).
+   * WARNING: This method returns a non-null {@link HttpServletRequest}, but calling certain methods
+   * on it — such as {@link HttpServletRequest#getAttribute(String)} — may throw {@link
+   * NullPointerException} if accessed outside the original servlet thread (e.g., in asynchronous
+   * tasks).
    *
-   * <p>Always cache required request state early if you plan to use it later.
+   * <p>Always cache required request data early during request handling if it needs to be accessed
+   * later.
    */
   public HttpServletRequest getReq() {
     return req;

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -192,6 +192,14 @@ public class HttpSolrCall {
     return path;
   }
 
+  /**
+   * WARNING: While this returns a non-null ServletApiRequest (Jetty’s implementation of
+   * HttpServletRequest), any method that internally calls getRequest() — such as getAttribute(),
+   * getQueryString(), etc. — may throw NullPointerException if this is accessed outside the
+   * original servlet thread (e.g. async tasks).
+   *
+   * <p>Always cache required request state early if you plan to use it later.
+   */
   public HttpServletRequest getReq() {
     return req;
   }

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -164,6 +164,8 @@ public class HttpSolrCall {
 
   protected RequestType requestType;
 
+  private Span span;
+
   public HttpSolrCall(
       SolrDispatchFilter solrDispatchFilter,
       CoreContainer cores,
@@ -173,6 +175,7 @@ public class HttpSolrCall {
     this.solrDispatchFilter = solrDispatchFilter;
     this.cores = cores;
     this.req = request;
+    this.span = TraceUtils.getSpan(req);
     this.response = response;
     this.retry = retry;
     this.requestType = RequestType.UNKNOWN;
@@ -639,12 +642,7 @@ public class HttpSolrCall {
 
   /** Get the Span for this request. Not null. */
   public Span getSpan() {
-    var s = TraceUtils.getSpan(req);
-    if (s != null) {
-      return s;
-    } else {
-      return Span.getInvalid();
-    }
+    return span != null ? span : Span.getInvalid();
   }
 
   // called after init().

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -175,7 +176,7 @@ public class HttpSolrCall {
     this.solrDispatchFilter = solrDispatchFilter;
     this.cores = cores;
     this.req = request;
-    this.span = TraceUtils.getSpan(req);
+    this.span = Optional.ofNullable(TraceUtils.getSpan(req)).orElse(Span.getInvalid());
     this.response = response;
     this.retry = retry;
     this.requestType = RequestType.UNKNOWN;
@@ -642,7 +643,7 @@ public class HttpSolrCall {
 
   /** Get the Span for this request. Not null. */
   public Span getSpan() {
-    return span != null ? span : Span.getInvalid();
+    return span;
   }
 
   // called after init().

--- a/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
@@ -169,7 +169,7 @@ public class SolrRequestParsers {
     SolrParams params = parser.parseParamsAndFillStreams(req, streams);
 
     SolrQueryRequest sreq =
-        buildRequestFrom(core, params, streams, getRequestTimer(req), req, null);
+        buildRequestFrom(core, params, streams, getRequestTimer(req), req, req.getUserPrincipal());
 
     // Handlers and login will want to know the path. If it contains a ':'
     // the handler could use it for RESTful URLs
@@ -200,7 +200,7 @@ public class SolrRequestParsers {
       Collection<ContentStream> streams, // might be added to but caller shouldn't depend on it
       RTimerTree requestTimer,
       final HttpServletRequest req,
-      final Principal principal)
+      final Principal principal) // from req, if req was provided, otherwise from elsewhere
       throws Exception {
     // ensure streams is non-null and mutable so we can easily add to it
     if (streams == null) {
@@ -267,11 +267,7 @@ public class SolrRequestParsers {
         new SolrQueryRequestBase(core, params, requestTimer) {
           @Override
           public Principal getUserPrincipal() {
-            if (principal != null) {
-              return principal;
-            } else {
-              return req == null ? null : req.getUserPrincipal();
-            }
+            return principal;
           }
 
           @Override

--- a/solr/core/src/java/org/apache/solr/update/SolrCmdDistributor.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrCmdDistributor.java
@@ -308,7 +308,7 @@ public class SolrCmdDistributor implements Closeable {
     // Copy user principal from the original request to the new update request, for later
     // authentication interceptor use
     if (SolrRequestInfo.getRequestInfo() != null) {
-      req.uReq.setUserPrincipal(SolrRequestInfo.getRequestInfo().getReq().getUserPrincipal());
+      req.uReq.setUserPrincipal(SolrRequestInfo.getRequestInfo().getUserPrincipal());
     }
 
     if (req.synchronous) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17069

[Justification](https://github.com/apache/solr/pull/2876#issuecomment-2782169134)

This was split out from #2876.

A related item https://issues.apache.org/jira/browse/SOLR-17741 "Remove addHttpRequestToContext option" but that's more about removing needless option than actually addressing a hazard/bug.