### PR TITLE
SOLR-17741: Remove addHttpRequestToContext option

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -130,8 +130,6 @@ public class SolrConfig implements MapSerializable {
 
   private boolean handleSelect;
 
-  private boolean addHttpRequestToContext;
-
   private final SolrRequestParsers solrRequestParsers;
 
   /**
@@ -366,7 +364,6 @@ public class SolrConfig implements MapSerializable {
       }
 
       handleSelect = get("requestDispatcher").boolAttr("handleSelect", false);
-      addHttpRequestToContext = requestParsersNode.boolAttr("addHttpRequestToContext", false);
 
       List<PluginInfo> argsInfos = getPluginInfos(InitParams.class.getName());
       if (argsInfos != null) {
@@ -961,10 +958,6 @@ public class SolrConfig implements MapSerializable {
     return handleSelect;
   }
 
-  public boolean isAddHttpRequestToContext() {
-    return addHttpRequestToContext;
-  }
-
   @Override
   public Map<String, Object> toMap(Map<String, Object> result) {
     if (znodeVersion > -1) result.put(ZNODEVER, znodeVersion);
@@ -1020,9 +1013,7 @@ public class SolrConfig implements MapSerializable {
             "multipartUploadLimitKB",
             multipartUploadLimitKB,
             "formUploadLimitKB",
-            formUploadLimitKB,
-            "addHttpRequestToContext",
-            addHttpRequestToContext));
+            formUploadLimitKB));
     if (indexConfig != null) result.put("indexConfig", indexConfig);
 
     // TODO there is more to add

--- a/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
@@ -89,7 +89,6 @@ public class SolrRequestParsers {
   private final boolean enableStreamBody;
   private StandardRequestParser standard;
   private boolean handleSelect = true;
-  private boolean addHttpRequestToContext;
 
   /**
    * Default instance for e.g. admin requests. Limits to 2 MB uploads and does not allow remote
@@ -107,7 +106,6 @@ public class SolrRequestParsers {
       enableRemoteStreams = false;
       enableStreamBody = false;
       handleSelect = false;
-      addHttpRequestToContext = false;
     } else {
       multipartUploadLimitKB = globalConfig.getMultipartUploadLimitKB();
 
@@ -119,8 +117,6 @@ public class SolrRequestParsers {
 
       // Let this filter take care of /select?xxx format
       handleSelect = globalConfig.isHandleSelect();
-
-      addHttpRequestToContext = globalConfig.isAddHttpRequestToContext();
     }
     init(multipartUploadLimitKB, formUploadLimitKB);
   }
@@ -129,7 +125,6 @@ public class SolrRequestParsers {
     enableRemoteStreams = false;
     enableStreamBody = false;
     handleSelect = false;
-    addHttpRequestToContext = false;
     init(Integer.MAX_VALUE, Integer.MAX_VALUE);
   }
 
@@ -175,10 +170,6 @@ public class SolrRequestParsers {
     // the handler could use it for RESTful URLs
     sreq.getContext().put(PATH, RequestHandlers.normalize(path));
     sreq.getContext().put("httpMethod", req.getMethod());
-
-    if (addHttpRequestToContext) {
-      sreq.getContext().put("httpRequest", req);
-    }
     return sreq;
   }
 
@@ -536,14 +527,6 @@ public class SolrRequestParsers {
 
   public void setHandleSelect(boolean handleSelect) {
     this.handleSelect = handleSelect;
-  }
-
-  public boolean isAddRequestHeadersToContext() {
-    return addHttpRequestToContext;
-  }
-
-  public void setAddRequestHeadersToContext(boolean addRequestHeadersToContext) {
-    this.addHttpRequestToContext = addRequestHeadersToContext;
   }
 
   public boolean isEnableRemoteStreams() {

--- a/solr/core/src/resources/EditableSolrConfigAttributes.json
+++ b/solr/core/src/resources/EditableSolrConfigAttributes.json
@@ -59,7 +59,5 @@
     "handleSelect":0,
     "requestParsers":{
       "multipartUploadLimitInKB":0,
-      "formdataUploadLimitInKB":0,
-      "enableRemoteStreaming":10,
-      "enableStreamBody":10}}
+      "formdataUploadLimitInKB":0}}
 }

--- a/solr/core/src/resources/EditableSolrConfigAttributes.json
+++ b/solr/core/src/resources/EditableSolrConfigAttributes.json
@@ -61,6 +61,5 @@
       "multipartUploadLimitInKB":0,
       "formdataUploadLimitInKB":0,
       "enableRemoteStreaming":10,
-      "enableStreamBody":10,
-      "addHttpRequestToContext":0}},
+      "enableStreamBody":10}}
 }

--- a/solr/core/src/test/org/apache/solr/core/TestConfigOverlay.java
+++ b/solr/core/src/test/org/apache/solr/core/TestConfigOverlay.java
@@ -48,9 +48,6 @@ public class TestConfigOverlay extends SolrTestCase {
         isEditableProp("requestDispatcher.requestParsers.multipartUploadLimitInKB", false, null));
     assertTrue(
         isEditableProp("requestDispatcher.requestParsers.formdataUploadLimitInKB", false, null));
-    assertTrue(
-        isEditableProp("requestDispatcher.requestParsers.enableRemoteStreaming", false, null));
-    assertTrue(isEditableProp("requestDispatcher.requestParsers.enableStreamBody", false, null));
 
     assertTrue(isEditableProp("requestDispatcher.handleSelect", false, null));
 

--- a/solr/core/src/test/org/apache/solr/core/TestConfigOverlay.java
+++ b/solr/core/src/test/org/apache/solr/core/TestConfigOverlay.java
@@ -51,8 +51,6 @@ public class TestConfigOverlay extends SolrTestCase {
     assertTrue(
         isEditableProp("requestDispatcher.requestParsers.enableRemoteStreaming", false, null));
     assertTrue(isEditableProp("requestDispatcher.requestParsers.enableStreamBody", false, null));
-    assertTrue(
-        isEditableProp("requestDispatcher.requestParsers.addHttpRequestToContext", false, null));
 
     assertTrue(isEditableProp("requestDispatcher.handleSelect", false, null));
 

--- a/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
@@ -160,7 +160,7 @@ public class TestSolrConfigHandler extends RestTestBase {
 
     String payload =
         "{\n"
-            + " 'set-property' : { 'updateHandler.autoCommit.maxDocs':100, 'updateHandler.autoCommit.maxTime':10 , 'requestDispatcher.requestParsers.addHttpRequestToContext':true} \n"
+            + " 'set-property' : { 'updateHandler.autoCommit.maxDocs':100, 'updateHandler.autoCommit.maxTime':10 } \n"
             + " }";
     runConfigCommand(harness, "/config", payload);
 
@@ -178,8 +178,7 @@ public class TestSolrConfigHandler extends RestTestBase {
 
     assertEquals("100", m._getStr("config/updateHandler/autoCommit/maxDocs", null));
     assertEquals("10", m._getStr("config/updateHandler/autoCommit/maxTime", null));
-    assertEquals(
-        "true", m._getStr("config/requestDispatcher/requestParsers/addHttpRequestToContext", null));
+
     payload = "{\n" + " 'unset-property' :  'updateHandler.autoCommit.maxDocs' \n" + " }";
     runConfigCommand(harness, "/config", payload);
 

--- a/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -407,36 +406,6 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
     assertTrue(e.getMessage().startsWith("Solr requires that request parameters"));
     assertEquals(500, e.code());
     verify(request).getInputStream();
-  }
-
-  @Test
-  @SuppressWarnings("JdkObsolete")
-  public void testAddHttpRequestToContext() throws Exception {
-    HttpServletRequest request = getMock("/solr/select", null, -1);
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getQueryString()).thenReturn("q=title:solr");
-    Map<String, String> headers = new HashMap<>();
-    headers.put("X-Forwarded-For", "10.0.0.1");
-    when(request.getHeaderNames()).thenReturn(new Vector<>(headers.keySet()).elements());
-    for (Map.Entry<String, String> entry : headers.entrySet()) {
-      Vector<String> v = new Vector<>();
-      v.add(entry.getValue());
-      when(request.getHeaders(entry.getKey())).thenReturn(v.elements());
-    }
-
-    SolrRequestParsers parsers = new SolrRequestParsers(h.getCore().getSolrConfig());
-    assertFalse(parsers.isAddRequestHeadersToContext());
-    SolrQueryRequest solrReq = parsers.parse(h.getCore(), "/select", request);
-    assertFalse(solrReq.getContext().containsKey("httpRequest"));
-
-    parsers.setAddRequestHeadersToContext(true);
-    solrReq = parsers.parse(h.getCore(), "/select", request);
-    assertEquals(request, solrReq.getContext().get("httpRequest"));
-    assertEquals(
-        "10.0.0.1",
-        ((HttpServletRequest) solrReq.getContext().get("httpRequest"))
-            .getHeaders("X-Forwarded-For")
-            .nextElement());
   }
 
   public void testPostMissingContentType() throws Exception {

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -526,16 +526,8 @@
          POST. You can use POST to pass request parameters not
          fitting into the URL.
 
-         addHttpRequestToContext - if set to true, it will instruct
-         the requestParsers to include the original HttpServletRequest
-         object in the context map of the SolrQueryRequest under the
-         key "httpRequest". It will not be used by any of the existing
-         Solr components, but may be useful when developing custom
-         plugins.
-
     <requestParsers multipartUploadLimitInKB="-1"
-                    formdataUploadLimitInKB="-1"
-                    addHttpRequestToContext="false"/>
+                    formdataUploadLimitInKB="-1"/>
       -->
 
     <!-- HTTP Caching

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -538,17 +538,10 @@
          POST. You can use POST to pass request parameters not
          fitting into the URL.
 
-         addHttpRequestToContext - if set to true, it will instruct
-         the requestParsers to include the original HttpServletRequest
-         object in the context map of the SolrQueryRequest under the
-         key "httpRequest". It will not be used by any of the existing
-         Solr components, but may be useful when developing custom
-         plugins.
        -->
     <requestParsers
                     multipartUploadLimitInKB="-1"
-                    formdataUploadLimitInKB="-1"
-                    addHttpRequestToContext="false"/>
+                    formdataUploadLimitInKB="-1"/>
 
     <!-- HTTP Caching
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/config-api.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/config-api.adoc
@@ -222,7 +222,6 @@ See xref:requestdispatcher.adoc[] for defaults and acceptable values for these s
 * `requestDispatcher.handleSelect`
 * `requestDispatcher.requestParsers.multipartUploadLimitInKB`
 * `requestDispatcher.requestParsers.formdataUploadLimitInKB`
-* `requestDispatcher.requestParsers.addHttpRequestToContext`
 
 ==== Examples of Common Properties
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/requestdispatcher.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/requestdispatcher.adoc
@@ -69,21 +69,11 @@ A value of `-1` means MAX_INT, which is also the system default if omitted.
 This attribute sets a limit in kilobytes on the size of form data (`application/x-www-form-urlencoded`) submitted in a HTTP POST request, which can be used to pass request parameters that will not fit in a URL.
 A value of `-1` means MAX_INT, which is also the system default if omitted.
 
-`addHttpRequestToContext`::
-+
-[%autowidth,frame=none]
-|===
-|Optional |Default: none
-|===
-+
-This attribute can be used to indicate that the original `HttpServletRequest` object should be included in the context map of the `SolrQueryRequest` using the key `httpRequest`.
-This `HttpServletRequest` is not used by any Solr component, but may be useful when developing custom plugins.
 
 [source,xml]
 ----
 <requestParsers multipartUploadLimitInKB="2048"
-                formdataUploadLimitInKB="2048"
-                addHttpRequestToContext="false" />
+                formdataUploadLimitInKB="2048" />
 ----
 
 == httpCaching Element

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -111,6 +111,8 @@ Users who that don't need to vary JAR access on a per-core basis have several op
 
 * CurrencyField has been removed.  Users should migrate to the `CurrencyFieldType` implementation.
 
+* The `addHttpRequestToContext` option in `solrconfig.xml` has been removed; it's obsolete.
+
 === Security
 
 * There is no longer a distinction between trusted and untrusted configSets; all configSets are now considered trusted. To ensure security, Solr should be properly protected using authentication and authorization mechanisms, allowing only authorized users with administrative privileges to publish them.

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -112,6 +112,7 @@ Users who that don't need to vary JAR access on a per-core basis have several op
 * CurrencyField has been removed.  Users should migrate to the `CurrencyFieldType` implementation.
 
 * The `addHttpRequestToContext` option in `solrconfig.xml` has been removed; it's obsolete.
+Nowadays, the HTTP request is available via internal APIs: `SolrQueryRequest.getHttpSolrCall().getReq()`.
 
 === Security
 


### PR DESCRIPTION
in solrconfig.xml/requestDispatcher/requestParsers. Why: Obsolete/redundant with SolrQueryRequest.getHttpSolrCall().getReq()

https://issues.apache.org/jira/browse/SOLR-17741