### PR TITLE
SOLR-17746: Rollback extra argument verification for bin/solr start --jettyconfig option

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -413,7 +413,7 @@ function print_usage() {
     echo "                          you could pass: --jvm-opts \"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=18983\""
     echo "                          In most cases, you should wrap the additional parameters in double quotes."
     echo ""
-    echo "  -j <jettyParams>      Additional parameters to pass to Jetty when starting Solr."
+    echo "  -j/--jettyconfig <jettyParams> Additional parameters to pass to Jetty when starting Solr."
     echo "                          For example, to add configuration folder that jetty should read"
     echo "                          you could pass: -j \"--include-jetty-dir=/etc/jetty/custom/server/\""
     echo "                          In most cases, you should wrap the additional parameters in double quotes."

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -787,7 +787,7 @@ if [ $# -gt 0 ]; then
             shift 2
         ;;
         -j|--jettyconfig)
-            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+            if [[ -z "$2" ]]; then
               print_usage "$SCRIPT_CMD" "Jetty config is required when using the $1 option!"
               exit 1
             fi

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -324,7 +324,7 @@ goto err
 @echo                 you could pass: --jvm-opts "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=18983"
 @echo                 In most cases, you should wrap the additional parameters in double quotes.
 @echo.
-@echo   -j opts       Additional parameters to pass to Jetty when starting Solr.
+@echo   -j/--jettyconfig opts Additional parameters to pass to Jetty when starting Solr.
 @echo                 For example, to add configuration folder that jetty should read
 @echo                 you could pass: -j "--include-jetty-dir=/etc/jetty/custom/server/"
 @echo                 In most cases, you should wrap the additional parameters in double quotes.

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -80,3 +80,12 @@ teardown() {
   run cat ${SOLR_LOGS_DIR}/solr-${SOLR_PORT}-console.log
   refute_output --partial 'Exception'
 }
+
+@test "solr starts with --jettyconfig" { 
+  run solr start --jettyconfig 
+  assert_output --partial 'ERROR: Jetty config is required when using the --jettyconfig option'  
+
+  # Test that parsing works.  Note, Solr doesn't actually start as we are not referencing a real jetty configuration directory.
+  run solr start --jettyconfig "--include-jetty-dir=/etc/jetty/custom/server/"
+  refute_output --partial 'ERROR: Jetty config is required when using the --jettyconfig option'  
+}

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solr-control-script-reference.adoc
@@ -69,7 +69,7 @@ If you are passing JVM parameters that begin with `-D`, you can omit the `--jvm-
 [source,bash]
 bin/solr start --jvm-opts "-Xdebug -Xrunjdwp:transport=dt_socket, server=y,suspend=n,address=1044"
 
-`-j <jettyParams>`::
+`-j <jettyParams>` or `--jettyconfig <jettyParams>`::
 +
 [%autowidth,frame=none]
 |===


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17746

# Description

Removing extra argument check that defaults passing in an argument!  Add a test, and update some docs.

# Tests

Bats test

# Checklist

Please review the following and check all that apply:

- [x ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ x] I have created a Jira issue and added the issue ID to my pull request title.
- [ x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x ] I have developed this patch against the `main` branch.
- [ x] I have run `./gradlew check`.
- [ x] I have added tests for my changes.
- [x ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
