### PR TITLE
SOLR-17741: Deprecate 'addHttpRequestToContext' (9x)

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -128,6 +128,8 @@ Other Changes
 
 * SOLR-17651: Add System.exit() in forbidden APIs, and make sure CLI unit tests never call it. (Pierre Salagnac)
 
+* SOLR-17741: Deprecated 'addHttpRequestToContext', removed in 10.  (David Smiley)
+
 ==================  9.8.1 ==================
 Bug Fixes
 ---------------------

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -69,6 +69,7 @@ import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.component.SearchComponent;
+import org.apache.solr.logging.DeprecationLog;
 import org.apache.solr.pkg.PackageListeners;
 import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
@@ -382,6 +383,9 @@ public class SolrConfig implements MapSerializable {
 
       handleSelect = get("requestDispatcher").boolAttr("handleSelect", false);
       addHttpRequestToContext = requestParsersNode.boolAttr("addHttpRequestToContext", false);
+      if (addHttpRequestToContext) {
+        DeprecationLog.log("addHttpRequestToContext", "addHttpRequestToContext is deprecated");
+      }
 
       List<PluginInfo> argsInfos = getPluginInfos(InitParams.class.getName());
       if (argsInfos != null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17741

Just the deprecation, and CHANGES.txt reference.
I don't care to create yet another JIRA to make the 9x & main distinction for merely a deprecation.