### PR TITLE
SOLR-16951: Add PKI Auth Caching for both generation and validation

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -229,6 +229,9 @@ Improvements
 
 * SOLR-17732: Score-based return fields other than "score" can now be returned in distributed queries. (Houston Putman)
 
+* SOLR-16951: Add PKI Auth Caching for both generation of the PKI Auth Tokens and validation of received tokens.
+  The default PKI Auth validity TTL has been increased from 5 seconds to 10 seconds. (Houston Putman)
+
 Optimizations
 ---------------------
 * SOLR-17578: Remove ZkController internal core supplier, for slightly faster reconnection after Zookeeper session loss. (Pierre Salagnac)

--- a/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
@@ -19,6 +19,8 @@ package org.apache.solr.security;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.solr.client.solrj.SolrRequest.METHOD.GET;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -34,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -94,7 +97,10 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
   private final Map<String, PublicKey> keyCache = new ConcurrentHashMap<>();
   private final PublicKeyHandler publicKeyHandler;
   private final CoreContainer cores;
-  private static final int MAX_VALIDITY = Integer.getInteger("pkiauth.ttl", 5000);
+  private final LoadingCache<String, PKIHeaderData> validatedHeaderCache;
+  private final LoadingCache<String, String> generatedV1TokenCache;
+  private final LoadingCache<String, String> generatedV2TokenCache;
+  private static final int MAX_VALIDITY = Integer.getInteger("pkiauth.ttl", 10000);
   private final String myNodeName;
   private final HttpHeaderClientInterceptor interceptor = new HttpHeaderClientInterceptor();
   private boolean interceptorRegistered = false;
@@ -113,6 +119,38 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
     this.publicKeyHandler = publicKeyHandler;
     this.cores = cores;
     myNodeName = nodeName;
+
+    // Don't expire after read, because there is no reason to add the overhead of updating expiry
+    // information after each read. The expiration time here doesn't matter too much, because we
+    // still check the PKI Token TTL after fetching from the cache. We just want to make sure cache
+    // entries are cleaned up regularly.
+    validatedHeaderCache =
+        Caffeine.newBuilder()
+            .maximumSize(1000)
+            .expireAfterWrite(MAX_VALIDITY, TimeUnit.MILLISECONDS)
+            .build(this::decipherHeaderV2);
+    // We must expire much earlier than the max validity, because these cached Auth tokens still
+    // need to be sent to the server, which will validate the TTL. If we expire at maxValidity, the
+    // TTL check will always fail before the cache entry is expired.
+    long expireAfterTime = Math.min(1000, MAX_VALIDITY / 5);
+    // Refreshing is done asynchronously, so we want to do it before expiration. This means that
+    // requests are not synchronously blocked when generating new Auth tokens. However, the refresh
+    // will only happen when the cached header is requested. Therefore, we want to give a long-ish
+    // runway for requests to come in to trigger an asynchronous-refresh before expiry causes a
+    // synchronous-refresh.
+    long shouldRefreshTime = Math.max(1, expireAfterTime / 2);
+    generatedV1TokenCache =
+        Caffeine.newBuilder()
+            .maximumSize(100)
+            .refreshAfterWrite(shouldRefreshTime, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(expireAfterTime, TimeUnit.MILLISECONDS)
+            .build(this::generateToken);
+    generatedV2TokenCache =
+        Caffeine.newBuilder()
+            .maximumSize(100)
+            .refreshAfterWrite(shouldRefreshTime, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(expireAfterTime, TimeUnit.MILLISECONDS)
+            .build(this::generateTokenV2);
 
     Set<String> knownPkiVersions = Set.of("v1", "v2");
     // We always accept v2 even if it is not specified
@@ -155,7 +193,7 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
         return sendError(response, true, "Could not parse node name from SolrAuthV2 header.");
       }
 
-      headerData = decipherHeaderV2(headerV2, headerV2.substring(0, nodeNameEnd));
+      headerData = validatedHeaderCache.get(headerV2);
     } else if (headerV1 != null && acceptPkiV1) {
       List<String> authInfo = StrUtils.splitWS(headerV1, false);
       if (authInfo.size() != 2) {
@@ -223,7 +261,8 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
     return key;
   }
 
-  private PKIHeaderData decipherHeaderV2(String header, String nodeName) {
+  private PKIHeaderData decipherHeaderV2(String header) {
+    String nodeName = header.substring(0, header.indexOf(' '));
     PublicKey key = getOrFetchPublicKey(nodeName);
 
     int sigStart = header.lastIndexOf(' ');
@@ -414,11 +453,11 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
             final Optional<String> preFetchedUser = getUserFromJettyRequest(request);
             if ("v1".equals(System.getProperty(SEND_VERSION))) {
               preFetchedUser
-                  .map(PKIAuthenticationPlugin.this::generateToken)
+                  .map(generatedV1TokenCache::get)
                   .ifPresent(token -> request.header(HEADER, token));
             } else {
               preFetchedUser
-                  .map(PKIAuthenticationPlugin.this::generateTokenV2)
+                  .map(generatedV2TokenCache::get)
                   .ifPresent(token -> request.header(HEADER_V2, token));
             }
           }
@@ -519,10 +558,12 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
 
   void setHeader(HttpRequest httpRequest) {
     if ("v1".equals(System.getProperty(SEND_VERSION))) {
-      getUser().map(this::generateToken).ifPresent(token -> httpRequest.setHeader(HEADER, token));
+      getUser()
+          .map(generatedV1TokenCache::get)
+          .ifPresent(token -> httpRequest.setHeader(HEADER, token));
     } else {
       getUser()
-          .map(this::generateTokenV2)
+          .map(generatedV2TokenCache::get)
           .ifPresent(token -> httpRequest.setHeader(HEADER_V2, token));
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16951

- Default PKI TTL has been increased to 10 seconds
- The PKI Generation cache will expire cached tokens after 1/4 of the TTL time, to give a minimum 3/4 of the TTL time for transportation.
- The PKI Generation cache will start refreshing cached tokens 1/2 of the expiration time (1/8 of the TTL time), to give time for the asynchronous refresh to complete before the token is expired. I would set this to `expirationTime - 50ms`, but CaffeineCache requires a `get()` in order to trigger the async refresh, so we want to give time between `refreshTime` and `expireTime` for a request to come in to trigger the refresh. 1/2 of the expiration time should be fine here.
- I don't expect to get more than 100 users that often, so I think this is a safe cache limit for generation. For validation, the node name is included in the token, so we need an order of magnitude bigger cache. I chose 1000 here, but this can probably be changed if we need to. The validation cache isn't as important as the generation cache, so it shouldn't be a huge deal.