### PR TITLE
SOLR-17749: linear function support for RankQParserPlugin

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -207,6 +207,8 @@ New Features
 
 * SSOLR-17447 : Support terminating a search early based on maxHitsAllowed per shard. (Siju Varghese, Houston Putman, David Smiley, Gus Heck)
 
+* SOLR-17749: Added linear function support for RankField via RankQParserPlugin. (Christine Poerschke)
+
 Improvements
 ---------------------
 * SOLR-15751: The v2 API now has parity with the v1 "COLSTATUS" and "segments" APIs, which can be used to fetch detailed information about

--- a/solr/core/src/java/org/apache/solr/search/RankQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/RankQParserPlugin.java
@@ -73,6 +73,17 @@ public class RankQParserPlugin extends QParserPlugin {
         }
       }
     },
+    LINEAR {
+      @Override
+      public Query createQuery(String fieldName, SolrParams params) throws SyntaxError {
+        float weight = params.getFloat(WEIGHT, 1f);
+        try {
+          return FeatureField.newLinearQuery(RankField.INTERNAL_RANK_FIELD_NAME, fieldName, weight);
+        } catch (IllegalArgumentException iae) {
+          throw new SyntaxError(iae.getMessage());
+        }
+      }
+    },
     LOG {
       @Override
       public Query createQuery(String fieldName, SolrParams params) throws SyntaxError {

--- a/solr/core/src/test/org/apache/solr/search/RankQParserPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/search/RankQParserPluginTest.java
@@ -82,6 +82,20 @@ public class RankQParserPluginTest extends SolrTestCaseJ4 {
         () -> getRankQParser(params(FIELD, "id"), req()).parse());
   }
 
+  public void testBadLinearParameters() {
+    assertSyntaxError(
+        "Expecting bad weight",
+        "weight must be in",
+        () ->
+            getRankQParser(
+                    params(
+                        FIELD, "rank_1",
+                        FUNCTION, "linear",
+                        WEIGHT, "0"),
+                    req())
+                .parse());
+  }
+
   public void testBadLogParameters() {
     assertSyntaxError(
         "Expecting bad weight",
@@ -208,6 +222,36 @@ public class RankQParserPluginTest extends SolrTestCaseJ4 {
                 .parse());
   }
 
+  public void testParseLinear() throws IOException, SyntaxError {
+    assertValidRankQuery(
+        expectedFeatureQueryToString("rank_1", expectedLinearToString(), 1),
+        params(
+            FIELD, "rank_1",
+            FUNCTION, "linear",
+            WEIGHT, "1"));
+
+    assertValidRankQuery(
+        expectedFeatureQueryToString("rank_1", expectedLinearToString(), 1),
+        params(
+            FIELD, "rank_1",
+            FUNCTION, "linear",
+            WEIGHT, "1"));
+
+    assertValidRankQuery(
+        expectedFeatureQueryToString("rank_1", expectedLinearToString(), 2.5f),
+        params(
+            FIELD, "rank_1",
+            FUNCTION, "linear",
+            WEIGHT, "2.5"));
+
+    assertValidRankQuery(
+        expectedFeatureQueryToString("rank_1", expectedLinearToString(), 2.5f),
+        params(
+            FIELD, "rank_1",
+            FUNCTION, "Linear", // use different case
+            WEIGHT, "2.5"));
+  }
+
   public void testParseLog() throws IOException, SyntaxError {
     assertValidRankQuery(
         expectedFeatureQueryToString("rank_1", expectedLogToString(1), 1),
@@ -328,6 +372,10 @@ public class RankQParserPluginTest extends SolrTestCaseJ4 {
       return featureQueryStr;
     }
     return "(" + featureQueryStr + ")^" + boost;
+  }
+
+  private String expectedLinearToString() {
+    return "LinearFunction";
   }
 
   private String expectedLogToString(float scalingFactor) {


### PR DESCRIPTION
* Solr 8.6 added RankField support: https://issues.apache.org/jira/browse/SOLR-14590
* Lucene/Solr 8.8 added linear function support on the Lucene level only: https://issues.apache.org/jira/browse/LUCENE-9594

https://issues.apache.org/jira/browse/SOLR-17749