### PR TITLE
SOLR-17754 Fix race condition in overseer main loop.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -190,7 +190,7 @@ Other Changes
 New Features
 ---------------------
 * SOLR-17582: The CLUSTERSTATUS API will now stream each collection's status to the response,
-  fetching and computing it on the fly.  To avoid a backwards compatibilty concern, this won't work
+  fetching and computing it on the fly.  To avoid a backwards compatibility concern, this won't work
   for wt=javabin.  (Matthew Biscocho, David Smiley)
 
 * SOLR-17626: Add RawTFSimilarityFactory class. (Christine Poerschke)
@@ -278,6 +278,9 @@ Bug Fixes
 * SOLR-17638: Some CLI errors not logged when starting prometheus exporter (Alex Deparvu)
 
 * SOLR-17745: Cancel leader election was being skipped on core container shutdown due to incorrect zkClient check (Matthew Biscocho, Luke Kot-Zaniewski)
+
+* SOLR-17754: Fix rare bug in overseer main loop in case of high load, that may cause the overseer be fully stuck until
+  server restart. (Pierre Salagnac)
 
 Dependency Upgrades
 ---------------------

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTaskQueueTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTaskQueueTest.java
@@ -92,7 +92,7 @@ public class OverseerTaskQueueTest extends DistributedQueueTest {
     }
     assertNotNull("Didn't find event with requestid " + requestId2, requestId2Event);
     requestId2Event.setBytes("foo bar".getBytes(StandardCharsets.UTF_8));
-    tq.remove(requestId2Event);
+    tq.remove(requestId2Event, true);
 
     // Make sure this call to check if requestId exists doesn't barf with Json parse exception
     assertTrue(


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-17754


# Description

Stuck overseer that sometimes happens under high load, when the overseer has at least 100 running tasks.

See [Jira](https://issues.apache.org/jira/browse/SOLR-17754) for the full scenario as description is pretty long.

# Solution

This fixes the overseer main loop so we never submit more than 100 concurrent tasks to the thread pool. Instead of manually tracking when a task is complete, we check the status using a standard java `Future`.

The changes also makes sure we don't write the result to ZK response node when we should not (see [comment](https://issues.apache.org/jira/browse/SOLR-17754?focusedCommentId=17951216&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17951216)), removing the erroneous occurrences of log `"Response ZK path: <node> doesn't exist. Requestor may have disconnected from ZooKeeper"`

# Tests

Add a new test to make sure we don't fail anymore with lot of tasks.

