### PR TITLE
SOLR-17756: Parallelize calculation of index fingerprint across segments

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -241,6 +241,8 @@ Optimizations
 
 * SOLR-17669: Reduced memory usage in SolrJ getBeans() method when handling dynamic fields with wildcards. (Martin Anzinger)
 
+* SOLR-17756: Parallelize index fingerprint computation across segments via a dedicated thread pool (Matthew Biscocho, Luke Kot-Zaniewski)
+
 Bug Fixes
 ---------------------
 * SOLR-17629: If SQLHandler failed to open the underlying stream (e.g. Solr returns an error; could be user/syntax problem),

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1307,7 +1307,7 @@ public class CoreContainer {
 
     ExecutorUtil.shutdownAndAwaitTermination(coreContainerAsyncTaskExecutor);
     ExecutorUtil.shutdownAndAwaitTermination(indexSearcherExecutor);
-    indexFingerprintExecutor.shutdownNow();
+    ExecutorUtil.shutdownNowAndAwaitTermination(indexFingerprintExecutor);
     ExecutorService customThreadPool =
         ExecutorUtil.newMDCAwareCachedThreadPool(new SolrNamedThreadFactory("closeThreadPool"));
 

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -458,8 +458,10 @@ public class CoreContainer {
     this.indexSearcherExecutor = SolrIndexSearcher.initCollectorExecutor(cfg);
 
     this.indexFingerprintExecutor =
-        ExecutorUtil.newMDCAwareFixedThreadPool(
-            EXECUTOR_MAX_CPU_THREADS, new SolrNamedThreadFactory("IndexFingerprintPool"));
+        ExecutorUtil.newMDCAwareCachedThreadPool(
+            EXECUTOR_MAX_CPU_THREADS,
+            Integer.MAX_VALUE,
+            new SolrNamedThreadFactory("IndexFingerprintPool"));
   }
 
   @SuppressWarnings({"unchecked"})

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -26,6 +26,7 @@ import static org.apache.solr.common.params.CommonParams.INFO_HANDLER_PATH;
 import static org.apache.solr.common.params.CommonParams.METRICS_PATH;
 import static org.apache.solr.common.params.CommonParams.ZK_PATH;
 import static org.apache.solr.common.params.CommonParams.ZK_STATUS_PATH;
+import static org.apache.solr.search.SolrIndexSearcher.EXECUTOR_MAX_CPU_THREADS;
 import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGIN_PROP;
 
 import com.github.benmanes.caffeine.cache.Interner;
@@ -187,6 +188,10 @@ public class CoreContainer {
     return indexSearcherExecutor;
   }
 
+  public ExecutorService getIndexFingerprintExecutor() {
+    return indexFingerprintExecutor;
+  }
+
   public static class CoreLoadFailure {
 
     public final CoreDescriptor cd;
@@ -291,6 +296,8 @@ public class CoreContainer {
   public final NodeRoles nodeRoles = new NodeRoles(System.getProperty(NodeRoles.NODE_ROLES_PROP));
 
   private final ExecutorService indexSearcherExecutor;
+
+  private final ExecutorService indexFingerprintExecutor;
 
   private final ClusterSingletons clusterSingletons =
       new ClusterSingletons(
@@ -449,6 +456,10 @@ public class CoreContainer {
     this.allowListUrlChecker = AllowListUrlChecker.create(config);
 
     this.indexSearcherExecutor = SolrIndexSearcher.initCollectorExecutor(cfg);
+
+    this.indexFingerprintExecutor =
+        ExecutorUtil.newMDCAwareFixedThreadPool(
+            EXECUTOR_MAX_CPU_THREADS, new SolrNamedThreadFactory("IndexFingerprintPool"));
   }
 
   @SuppressWarnings({"unchecked"})
@@ -678,6 +689,7 @@ public class CoreContainer {
     allowPaths = null;
     allowListUrlChecker = null;
     indexSearcherExecutor = null;
+    indexFingerprintExecutor = null;
   }
 
   public static CoreContainer createAndLoad(Path solrHome) {
@@ -1293,6 +1305,7 @@ public class CoreContainer {
 
     ExecutorUtil.shutdownAndAwaitTermination(coreContainerAsyncTaskExecutor);
     ExecutorUtil.shutdownAndAwaitTermination(indexSearcherExecutor);
+    indexFingerprintExecutor.shutdownNow();
     ExecutorService customThreadPool =
         ExecutorUtil.newMDCAwareCachedThreadPool(new SolrNamedThreadFactory("closeThreadPool"));
 

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2204,6 +2204,11 @@ public class SolrCore implements SolrInfoBean, Closeable {
     return f;
   }
 
+  /** Clear the per‐segment fingerprint cache. */
+  public void clearPerSegmentFingerprintCache() {
+    perSegmentFingerprintCache.clear();
+  }
+
   /**
    * Returns the current registered searcher with its reference count incremented, or null if none
    * are registered.

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2204,11 +2204,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
     return f;
   }
 
-  /** Clear the per‐segment fingerprint cache. */
-  public void clearPerSegmentFingerprintCache() {
-    perSegmentFingerprintCache.clear();
-  }
-
   /**
    * Returns the current registered searcher with its reference count incremented, or null if none
    * are registered.

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -401,7 +400,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
             + "]"
             + (name != null ? " " + name : "");
     log.debug("Opening [{}]", this.name);
-    this.fingerprintExecutor = ExecutorUtil.newMDCAwareFixedThreadPool(EXECUTOR_MAX_CPU_THREADS, new SolrNamedThreadFactory("IndexFingerprintPool"));
+    this.fingerprintExecutor =
+        ExecutorUtil.newMDCAwareFixedThreadPool(
+            EXECUTOR_MAX_CPU_THREADS, new SolrNamedThreadFactory("IndexFingerprintPool"));
 
     if (directoryFactory.searchersReserveCommitPoints()) {
       // reserve commit point for life of searcher
@@ -2558,9 +2559,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
             .map(
                 ctx ->
                     (Callable<IndexFingerprint>)
-                        () -> searcher
-                                .getCore()
-                                .getIndexFingerprint(searcher, ctx, maxVersion))
+                        () -> searcher.getCore().getIndexFingerprint(searcher, ctx, maxVersion))
             .collect(Collectors.toList());
     return ExecutorUtil.submitAllAndAwaitAggregatingExceptions(fingerprintExecutor, tasks).stream()
         .reduce(new IndexFingerprint(maxVersion), IndexFingerprint::reduce);

--- a/solr/core/src/java/org/apache/solr/update/IndexFingerprint.java
+++ b/solr/core/src/java/org/apache/solr/update/IndexFingerprint.java
@@ -137,19 +137,17 @@ public class IndexFingerprint implements MapSerializable {
     return f;
   }
 
-  public static IndexFingerprint reduce(IndexFingerprint acc, IndexFingerprint other) {
-    // The resulting IndexFingerprint will inherit maxVersionSpecified from
-    // acc already set in it using IndexFingerprint(long maxVersionSpecified) constructor
-    IndexFingerprint result = new IndexFingerprint(acc.maxVersionSpecified);
+  public static IndexFingerprint reduce(IndexFingerprint acc, IndexFingerprint f2) {
+    // acc should have maxVersionSpecified already set in it using IndexFingerprint(long
+    // maxVersionSpecified) constructor
+    acc.maxDoc = Math.max(acc.maxDoc, f2.maxDoc);
+    acc.numDocs += f2.numDocs;
+    acc.maxVersionEncountered = Math.max(acc.maxVersionEncountered, f2.maxVersionEncountered);
+    acc.maxInHash = Math.max(acc.maxInHash, f2.maxInHash);
+    acc.versionsHash += f2.versionsHash;
+    acc.numVersions += f2.numVersions;
 
-    result.maxVersionEncountered = Math.max(acc.maxVersionEncountered, other.maxVersionEncountered);
-    result.maxInHash = Math.max(acc.maxInHash, other.maxInHash);
-    result.versionsHash = acc.versionsHash + other.versionsHash;
-    result.numVersions = acc.numVersions + other.numVersions;
-    result.numDocs = acc.numDocs + other.numDocs;
-    result.maxDoc = Math.max(acc.maxDoc, other.maxDoc);
-
-    return result;
+    return acc;
   }
 
   /** returns 0 for equal, negative if f1 is less recent than f2, positive if more recent */

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexFingerprintTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexFingerprintTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.search.SolrIndexSearcher;
-import org.apache.solr.util.RefCounted;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -52,8 +51,7 @@ public class SolrIndexFingerprintTest extends SolrTestCaseJ4 {
     assertU(adoc("id", "109"));
     assertU(commit());
 
-    final RefCounted<SolrIndexSearcher> searcherRef = core.openNewSearcher(true, true);
-    final SolrIndexSearcher searcher = searcherRef.get();
+    final SolrIndexSearcher searcher = core.openNewSearcher(true, true).get();
 
     // Compute fingerprint sequentially to compare with parallel computation
     IndexFingerprint expectedFingerprint =

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexFingerprintTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexFingerprintTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update;
+
+import java.io.IOException;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.search.SolrIndexSearcher;
+import org.apache.solr.util.RefCounted;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SolrIndexFingerprintTest extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeTests() throws Exception {
+    initCore("solrconfig.xml", "schema.xml");
+  }
+
+  @Test
+  public void testSequentialVsParallelFingerprint() throws Exception {
+    long maxVersion = Long.MAX_VALUE;
+    SolrCore core = h.getCore();
+
+    // Create a set of 3 segments
+    assertU(adoc("id", "101"));
+    assertU(adoc("id", "102"));
+    assertU(adoc("id", "103"));
+    assertU(commit());
+
+    assertU(adoc("id", "104"));
+    assertU(adoc("id", "105"));
+    assertU(adoc("id", "106"));
+    assertU(commit());
+
+    assertU(adoc("id", "107"));
+    assertU(adoc("id", "108"));
+    assertU(adoc("id", "109"));
+    assertU(commit());
+
+    final RefCounted<SolrIndexSearcher> searcherRef = core.openNewSearcher(true, true);
+    final SolrIndexSearcher searcher = searcherRef.get();
+
+    // Compute fingerprint sequentially to compare with parallel computation
+    IndexFingerprint expectedFingerprint =
+        searcher.getTopReaderContext().leaves().stream()
+            .map(
+                ctx -> {
+                  try {
+                    return core.getIndexFingerprint(searcher, ctx, maxVersion);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .reduce(new IndexFingerprint(maxVersion), IndexFingerprint::reduce);
+
+    IndexFingerprint actualFingerprint = searcher.getIndexFingerprint(maxVersion);
+
+    assertEquals(expectedFingerprint, actualFingerprint);
+    searcher.close();
+  }
+}

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexFingerprintTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexFingerprintTest.java
@@ -17,7 +17,6 @@
 package org.apache.solr.update;
 
 import java.io.IOException;
-
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.solr.SolrTestCaseJ4;
@@ -61,18 +60,20 @@ public class SolrIndexFingerprintTest extends SolrTestCaseJ4 {
             .map(
                 ctx -> {
                   try {
-                    LeafReader noCacheLeafReader = new FilterLeafReader(ctx.reader()) {
-                      @Override
-                      public CacheHelper getReaderCacheHelper() {
-                        return null;
-                      }
+                    LeafReader noCacheLeafReader =
+                        new FilterLeafReader(ctx.reader()) {
+                          @Override
+                          public CacheHelper getReaderCacheHelper() {
+                            return null;
+                          }
 
-                      @Override
-                      public CacheHelper getCoreCacheHelper() {
-                        return null;
-                      }
-                    };
-                    return core.getIndexFingerprint(searcher, noCacheLeafReader.getContext(), maxVersion);
+                          @Override
+                          public CacheHelper getCoreCacheHelper() {
+                            return null;
+                          }
+                        };
+                    return core.getIndexFingerprint(
+                        searcher, noCacheLeafReader.getContext(), maxVersion);
                   } catch (IOException e) {
                     throw new RuntimeException(e);
                   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17756

# Description

The index fingerprint is currently being calculated on each segment sequentially. While this works fine, the index fingerprint calculation was noticed to be a very slow process and on leader election is blocking.

This proposes to have this calculation parallelized across segments instead. Since the fingerprint is just a cumulative sum of a hash on versions, the order in which it is added to the running sum should not matter.

# Solution

Create a dedicated threadpool (`IndexFingerprintPool`) to calculate the indexfingerprint. Created a separate theadpool instead of the common `ForkJoinPool` as this can be an expensive operation calculating across a large index

# Tests

Created `testSequentialVsParallelFingerprint` test to confirm the fingerprint is the same.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
