### PR TITLE
Explicitly disable dev/prod tasks based on flag

### DIFF
--- a/solr/ui/build.gradle.kts
+++ b/solr/ui/build.gradle.kts
@@ -174,3 +174,21 @@ tasks.matching { task ->
     // and you will see the test tasks being listed there as well, but they will be skipped as
     // expected
 }
+
+// Explicitly enable or disable development tasks based on the build variant
+// This prevents any invalid task dependencies on assemble task execution
+tasks.matching {
+    val taskName = it.name.lowercase()
+    taskName.contains("wasmjs") && taskName.contains("development")
+}.configureEach {
+    onlyIf { rootProject.ext["development"] as Boolean }
+}
+
+// Explicitly enable or disable production tasks based on the build variant
+// This prevents any invalid task dependencies on assemble task execution
+tasks.matching {
+    val taskName = it.name.lowercase()
+    taskName.contains("wasmjs") && taskName.contains("production")
+}.configureEach {
+    onlyIf { !(rootProject.ext["development"] as Boolean) }
+}


### PR DESCRIPTION
# Description

With the `production` build flag set to `false`, gradle may fail when running `gradlew assemble` with an error due to some invalid task dependencies coming from the Compose MP plugin. The reported message is similar to the below:

See also discussion in https://lists.apache.org/thread/1l25p9cd9h8ch32jt2ljpmdt3fc9bctq

```
...
> Task :solr:ui:wasmJsProductionExecutableCompileSync FAILED

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':solr:ui:wasmJsProductionExecutableCompileSync' (type 'DefaultIncrementalSyncTask').
  - Gradle detected a problem with the following location: '/Users/christos/workspace/apache/solr/build/js/packages/composeApp/kotlin'.
    
    Reason: Task ':solr:ui:wasmJsBrowserDevelopmentWebpack' uses this output of task ':solr:ui:wasmJsProductionExecutableCompileSync' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':solr:ui:wasmJsProductionExecutableCompileSync' as an input of ':solr:ui:wasmJsBrowserDevelopmentWebpack'.
      2. Declare an explicit dependency on ':solr:ui:wasmJsProductionExecutableCompileSync' from ':solr:ui:wasmJsBrowserDevelopmentWebpack' using Task#dependsOn.
      3. Declare an explicit dependency on ':solr:ui:wasmJsProductionExecutableCompileSync' from ':solr:ui:wasmJsBrowserDevelopmentWebpack' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.10/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

The error is likely thrown because by default both development and production artifacts are generated on `assemble`. In the `webapp` module, we explicitly depend on tasks and include their outputs based on the variant configured by the `production` flag, leading to potentially different artifacts being included based on execution order.

The current workaround was to set the `production` flag to `true`.

# Solution

This PR solves the issue of the invalid task dependencies and allows the `production` flag to be set to `false` again without failing on `gradlew assemble`.

The `production` flag can be set to `false` again on our build servers after merging this.

# Tests

_No tests written for gradle execution_

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
