### PR TITLE
fix-tmp-symlink

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1314,6 +1314,7 @@ function start_solr() {
   SOLR_START_OPTS=('-server' "${JAVA_MEM_OPTS[@]}" "${GC_TUNE_ARR[@]}" "${GC_LOG_OPTS[@]}" "${IP_ACL_OPTS[@]}" \
     "${REMOTE_JMX_OPTS[@]}" "${CLOUD_MODE_OPTS[@]}" -Dsolr.log.dir="$SOLR_LOGS_DIR" \
     "-Djetty.port=$SOLR_PORT" "-DSTOP.PORT=$stop_port" "-DSTOP.KEY=$STOP_KEY" \
+    "-Djava.io.tmpdir=$(cd $TMPDIR; pwd -P)" \
     # '-OmitStackTraceInFastThrow' ensures stack traces in errors,
     # users who don't care about useful error msgs can override in SOLR_OPTS with +OmitStackTraceInFastThrow
     "${SOLR_HOST_ARG[@]}" "-Duser.timezone=$SOLR_TIMEZONE" "-XX:-OmitStackTraceInFastThrow" \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-XXXXX

# Description

On Mac /tmp is a symlink and this causes issues with the Solr security manager. SOLR-16457 / https://github.com/apache/solr/pull/1282 fixed a similar issue with symlinks and the security manager. This applies the same type of solution but specifically for `java.io.tmpdir` to ensure that on Macs (and Linux) the full path is used not the symlink. This makes the security manager checking the path happy since its not trying to compare to a symlink anymore.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
