### PR TITLE
SOLR-17756: Explicit cast on IndexFingerprint for Java 11

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/IndexFingerprint.java
+++ b/solr/core/src/java/org/apache/solr/update/IndexFingerprint.java
@@ -224,7 +224,8 @@ public class IndexFingerprint implements MapSerializable {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof IndexFingerprint other)) return false;
+    if (!(o instanceof IndexFingerprint)) return false;
+    IndexFingerprint other = (IndexFingerprint) o;
     return maxVersionSpecified == other.maxVersionSpecified
         && this.maxVersionEncountered == other.maxVersionEncountered
         && this.maxInHash == other.maxInHash


### PR DESCRIPTION
IndexFingerprint needs a separate explicit cast on Java 11 after instanceof check.