### PR TITLE
SOLR-17775: optimize ValueSourceAugmenter

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -251,6 +251,8 @@ Optimizations
 
 * SOLR-17756: Parallelize index fingerprint computation across segments via a dedicated thread pool (Matthew Biscocho, Luke Kot-Zaniewski)
 
+* SOLR-17775: Optimize ValueSourceAugmenter by pre-calculating function values. (Yura Korolov)
+
 Bug Fixes
 ---------------------
 * SOLR-17629: If SQLHandler failed to open the underlying stream (e.g. Solr returns an error; could be user/syntax problem),

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -251,7 +251,7 @@ Optimizations
 
 * SOLR-17756: Parallelize index fingerprint computation across segments via a dedicated thread pool (Matthew Biscocho, Luke Kot-Zaniewski)
 
-* SOLR-17775: Speed up returning fields ("fl" param) with DocValues referenced directly or indirectly via function queries. (Yura Korolov)
+* SOLR-17775: Speed up function queries in 'fl' param. (Yura Korolov)
 
 Bug Fixes
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -251,7 +251,7 @@ Optimizations
 
 * SOLR-17756: Parallelize index fingerprint computation across segments via a dedicated thread pool (Matthew Biscocho, Luke Kot-Zaniewski)
 
-* SOLR-17775: Optimize ValueSourceAugmenter by pre-calculating function values. (Yura Korolov)
+* SOLR-17775: Speed up returning fields ("fl" param) with DocValues referenced directly or indirectly via function queries. (Yura Korolov)
 
 Bug Fixes
 ---------------------


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17775

# Description
Optimize ValueSourceAugmenter performance by pre-calculating function values during setContext() instead of calculating them on-demand for each document.

# Solution
Collect all document IDs from DocList during setContext(), sort them, and calculate function values sequentially by reader segment. Store results in a map for fast lookup during transform(). Include fallback for documents not in the pre-calculated set.

# Tests
Existing test suite covers ValueSourceAugmenter functionality and all tests pass. Tested in Solr Cloud setup with function queries as pseudo-fields (e.g., &fl=sum(x,y),id,score) and verified performance improvement 

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
