### PR TITLE
SOLR-17678: Change matchScore to originalScore, make it a fake-function

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -208,7 +208,7 @@ New Features
 
 * SOLR-17714: Added a FuzzyQParser to enable all FuzzyQuery customizations. (Houston Putman, Siju Varghese)
 
-* SOLR-17678: ReRank queries can now return the matchScore (original score) in addition to the re-ranked score. (Siju Varghese, Houston Putman)
+* SOLR-17678: ReRank queries can now return the originalScore (original score) in addition to the re-ranked score. (Siju Varghese, Houston Putman)
 
 * SOLR-17447: Support terminating a search early based on maxHitsAllowed per shard. (Siju Varghese, Houston Putman, David Smiley, Gus Heck)
 

--- a/solr/core/src/java/org/apache/solr/response/DocsStreamer.java
+++ b/solr/core/src/java/org/apache/solr/response/DocsStreamer.java
@@ -60,8 +60,6 @@ public class DocsStreamer implements Iterator<SolrDocument> {
   private final org.apache.solr.response.ResultContext rctx;
   private final SolrDocumentFetcher docFetcher; // a collaborator of SolrIndexSearcher
   private final DocList docs;
-  private boolean doScore;
-  private boolean doMatchScore;
 
   private final DocTransformer transformer;
   private final DocIterator docIterator;

--- a/solr/core/src/java/org/apache/solr/response/transform/OriginalScoreAugmenter.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/OriginalScoreAugmenter.java
@@ -20,14 +20,14 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.search.DocIterationInfo;
 
 /**
- * Simple Augmenter that adds the matchScore
+ * Simple Augmenter that adds the originalScore
  *
  * @since solr 4.0
  */
-public class MatchScoreAugmenter extends DocTransformer {
+public class OriginalScoreAugmenter extends DocTransformer {
   final String name;
 
-  public MatchScoreAugmenter(String display) {
+  public OriginalScoreAugmenter(String display) {
     this.name = display;
   }
 
@@ -38,6 +38,6 @@ public class MatchScoreAugmenter extends DocTransformer {
 
   @Override
   public void transform(SolrDocument doc, int docid, DocIterationInfo docInfo) {
-    doc.setField(name, docInfo.matchScore());
+    doc.setField(name, docInfo.originalScore());
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/DocIterationInfo.java
+++ b/solr/core/src/java/org/apache/solr/search/DocIterationInfo.java
@@ -30,11 +30,11 @@ public interface DocIterationInfo {
   float score();
 
   /**
-   * Returns the query match score in case of rerank queries
+   * Returns the original query match score in case of rerank queries
    *
-   * @return the query match score in case of a rerank query, null otherwise.
+   * @return the original query match score in case of a rerank query, null otherwise.
    */
-  default Float matchScore() {
+  default Float originalScore() {
     return null;
   }
 

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -271,11 +271,11 @@ public class ReRankCollector extends TopDocsCollector<ScoreDoc> {
   }
 
   static class RescoreDoc extends ScoreDoc {
-    public float matchScore;
+    public float originalScore;
 
-    public RescoreDoc(ScoreDoc scoreDoc, float matchScore) {
+    public RescoreDoc(ScoreDoc scoreDoc, float originalScore) {
       super(scoreDoc.doc, scoreDoc.score, scoreDoc.shardIndex);
-      this.matchScore = matchScore;
+      this.originalScore = originalScore;
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/TopDocsSlice.java
+++ b/solr/core/src/java/org/apache/solr/search/TopDocsSlice.java
@@ -79,9 +79,9 @@ public class TopDocsSlice extends DocSlice {
 
   @Override
   public DocIterator iterator() {
-    boolean hasMatchScore =
+    boolean hasOriginalScore =
         topDocs.scoreDocs.length > 0 && topDocs.scoreDocs[0] instanceof ReRankCollector.RescoreDoc;
-    if (hasMatchScore) {
+    if (hasOriginalScore) {
       return new ReRankedTopDocsIterator();
     } else {
       return new TopDocsIterator();
@@ -123,9 +123,9 @@ public class TopDocsSlice extends DocSlice {
   class ReRankedTopDocsIterator extends TopDocsIterator {
 
     @Override
-    public Float matchScore() {
+    public Float originalScore() {
       try {
-        return ((ReRankCollector.RescoreDoc) topDocs.scoreDocs[pos - 1]).matchScore;
+        return ((ReRankCollector.RescoreDoc) topDocs.scoreDocs[pos - 1]).originalScore;
       } catch (ClassCastException e) {
         return null;
       }

--- a/solr/core/src/test/org/apache/solr/search/DistributedReRankExplainTest.java
+++ b/solr/core/src/test/org/apache/solr/search/DistributedReRankExplainTest.java
@@ -160,18 +160,18 @@ public class DistributedReRankExplainTest extends SolrCloudTestCase {
                     CommonParams.Q,
                     "test_s:hello",
                     "fl",
-                    "id,test_s,score,originalScore:matchScore,matchScore")));
+                    "id,test_s,score,matchScore:originalScore(),originalScore()")));
 
     final QueryResponse queryResponse = queryRequest.process(client, COLLECTIONORALIAS);
     for (SolrDocument doc : queryResponse.getResults()) {
       assertNotNull("test_s", doc.getFieldValue("test_s"));
+      assertNotNull("originalScore()", doc.getFieldValue("originalScore()"));
+      assertTrue(queryResponse.toString(), doc.getFieldValue("originalScore()") instanceof Float);
       assertNotNull("matchScore", doc.getFieldValue("matchScore"));
-      assertTrue(queryResponse.toString(), doc.getFieldValue("matchScore") instanceof Float);
-      assertNotNull("originalScore", doc.getFieldValue("originalScore"));
       assertTrue(
-          doc.getFieldValue("originalScore").toString(),
-          doc.getFieldValue("originalScore") instanceof Float);
-      assertEquals(doc.getFieldValue("matchScore"), doc.getFieldValue("originalScore"));
+          doc.getFieldValue("matchScore").toString(),
+          doc.getFieldValue("matchScore") instanceof Float);
+      assertEquals(doc.getFieldValue("originalScore()"), doc.getFieldValue("matchScore"));
     }
     return queryResponse;
   }

--- a/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
@@ -65,7 +65,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRerankReturnMatchScore() throws Exception {
+  public void testRerankReturnOriginalScore() throws Exception {
 
     assertU(delQ("*:*"));
     assertU(commit());
@@ -121,17 +121,17 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("start", "0");
     params.add("rows", "6");
     params.add("df", "text");
-    params.add("fl", "id,test_ti,score,matchScore");
+    params.add("fl", "id,test_ti,score,originalScore()");
 
     assertQ(
         req(params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='3']",
         "//result/doc[1]/float[@name='score'][.>'10000.03']",
-        "//result/doc[1]/float[@name='matchScore'][.>'0.03']",
+        "//result/doc[1]/float[@name='originalScore()'][.>'0.03']",
         "//result/doc[2]/str[@name='id'][.='4']",
         "//result/doc[2]/float[@name='score'][.>'1000.03']",
-        "//result/doc[2]/float[@name='matchScore'][.>'0.03']",
+        "//result/doc[2]/float[@name='originalScore()'][.>'0.03']",
         "//result/doc[3]/str[@name='id'][.='2']",
         "//result/doc[4]/str[@name='id'][.='6']",
         "//result/doc[5]/str[@name='id'][.='1']",
@@ -139,7 +139,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testRerankReturnMatchScoreNotRequested() throws Exception {
+  public void testRerankReturnOriginalScoreNotRequested() throws Exception {
 
     assertU(delQ("*:*"));
     assertU(commit());
@@ -198,7 +198,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,test_ti,score");
 
     String response = JQ(req(params));
-    assertFalse(response.contains("matchScore"));
+    assertFalse(response.contains("originalScore()"));
   }
 
   @Test

--- a/solr/solr-ref-guide/modules/query-guide/pages/query-re-ranking.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/query-re-ranking.adoc
@@ -107,13 +107,13 @@ q=greetings&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=3}&rqq=(hi
 ----
 
 If a document matches the original query, but does not match the re-ranking query, the document's original score will remain.
-For reranked documents, an additional `matchScore` field in the response will indicate the original score for a reranked doc. This
-is the score for the document prior to rerank being applied. For documents that were not reranked, the matchScore and score fields
-will have the same value. For the example above, you would use the following to return the match score:
+For reranked documents, an additional `originalScore()` function in the response will indicate the original score for a reranked doc. This
+is the score for the document prior to rerank being applied. For documents that were not reranked, the `originalScore()` and `score` fields
+will have the same value. For the example above, you would use the following to return the original score:
 
 [source,text]
 ----
-q=greetings&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=3}&rqq=(hi+hello+hey+hiya)&fl=id,matchScore
+q=greetings&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=3}&rqq=(hi+hello+hey+hiya)&fl=id,originalScore()
 ----
 
 Setting `reRankOperator` to `multiply` will multiply the three numbers instead. This means that other multiplying operations such as xref:edismax-query-parser.adoc#extended-dismax-parameters[eDisMax `boost` functions] can be converted to Re-Rank operations.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17678

The functionality was already added in https://github.com/apache/solr/pull/3222, but this is making the following changes before any release has been made:

- Rename from `matchScore` to `originalScore`, since that is the name that LTR queries already use for this feature. And eventually, the two implementations can hopefully be merged.
- Make the return field `originalScore()` to resemble a function. It is not currently a function, but in the future we want to use a real ValueSource function instead of hardcoding this option in Solr. The ticket that covers this is [SOLR-17784](https://issues.apache.org/jira/browse/SOLR-17784).