### PR TITLE
SOLR-17092: Fix race condition for async request status

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -805,7 +805,9 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
 
           final NamedList<Object> status = new NamedList<>();
           if (coreContainer.getDistributedCollectionCommandRunner().isEmpty()) {
-            if (zkController.getOverseerCompletedMap().contains(requestId)) {
+            if (zkController.getOverseerRunningMap().contains(requestId)) {
+              addStatusToResponse(status, RUNNING, "found [" + requestId + "] in running tasks");
+            } else if (zkController.getOverseerCompletedMap().contains(requestId)) {
               final byte[] mapEntry = zkController.getOverseerCompletedMap().get(requestId);
               rsp.getValues()
                   .addAll(OverseerSolrResponseSerializer.deserialize(mapEntry).getResponse());
@@ -816,8 +818,6 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
               rsp.getValues()
                   .addAll(OverseerSolrResponseSerializer.deserialize(mapEntry).getResponse());
               addStatusToResponse(status, FAILED, "found [" + requestId + "] in failed tasks");
-            } else if (zkController.getOverseerRunningMap().contains(requestId)) {
-              addStatusToResponse(status, RUNNING, "found [" + requestId + "] in running tasks");
             } else if (h.overseerCollectionQueueContains(requestId)) {
               addStatusToResponse(
                   status, SUBMITTED, "found [" + requestId + "] in submitted tasks");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17092

This is only for when the Overseer is used, as compared to https://github.com/apache/solr/pull/3268 which was for the `DistributedApiAsyncTracker`. But overall, the two are similar race conditions. We need to check if the request is running first, in case the Overseer ZK operations are completed in-between the "isSuccessful" and "isRunning" checks. If we check "isRunning" first, then we should not be able to return "Not found" or "submitted" because the check will either see it in the running map or the successful map, there is no possibility that it is in neither of them.