### PR TITLE
Catch cancellation exceptions - Fix TestTolerantSearch

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -468,7 +469,13 @@ public class Http2SolrClient extends HttpSolrClientBase {
                         mdcCopyHelper.onBegin(null);
                         log.debug("response processing success");
                         future.complete(body);
-                      } catch (SolrClient.RemoteSolrException | SolrServerException e) {
+                      } catch (CancellationException e) {
+                        mdcCopyHelper.onBegin(null);
+                        log.debug("response processing cancelled", e);
+                        if (!future.isCancelled()) {
+                          future.cancel(true);
+                        }
+                      } catch (Throwable e) {
                         mdcCopyHelper.onBegin(null);
                         log.debug("response processing failed", e);
                         future.completeExceptionally(e);

--- a/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -378,6 +379,7 @@ public class ExecutorUtil {
             }
             try {
               command.run();
+            } catch (CancellationException ignored) {
             } catch (Throwable t) {
               if (t instanceof OutOfMemoryError) {
                 throw t;


### PR DESCRIPTION
Currently, `TestTolerantSearch.testAllShardsFail` fails with the following: 

```
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=312, name=httpShardExecutor-171-thread-3, state=RUNNABLE, group=TGRP-TestTolerantSearch]
	at __randomizedtesting.SeedInfo.seed([E82DD9D830F6392B:772D812CE6F65EDC]:0)
Caused by: java.util.concurrent.CancellationException
	at __randomizedtesting.SeedInfo.seed([E82DD9D830F6392B]:0)
	at java.base/java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2510)
	at org.apache.solr.client.solrj.impl.LBHttp2SolrClient.lambda$requestAsync$0(LBHttp2SolrClient.java:190)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990)
	at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:974)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2512)
	at org.apache.solr.handler.component.HttpShardHandler.cancelAll(HttpShardHandler.java:361)
```

I think ultimately, somewhere in the loop the cancellations are not being caught. And I think we can actually catch it in 2 places, ultimately in the ExecutorUtil that does this error catching logic (to log it out), but also in the place I think the error is actually stemming from (since we will likely want to cancel the future if it isn't cancelled already).