### PR TITLE
Solr navigable remove default

### DIFF
--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -249,7 +250,8 @@ public class PackageManager implements Closeable {
                       false) /* Making a collection request, but already baked into path */);
       packages =
           (Map<String, String>)
-              result._get("/response/params/PKG_VERSIONS", Collections.emptyMap());
+              Objects.requireNonNullElse(
+                  result._get("/response/params/PKG_VERSIONS"), Collections.emptyMap());
     } catch (PathNotFoundException ex) {
       // Don't worry if PKG_VERSION wasn't found. It just means this collection was never touched by
       // the package manager.
@@ -734,7 +736,9 @@ public class PackageManager implements Closeable {
                   .setRequiresCollection(
                       false) /* Making a collection-request, but already baked into path */);
       return (Map<String, String>)
-          response._get("/response/params/packages/" + packageName, Collections.emptyMap());
+          Objects.requireNonNullElse(
+              response._get("/response/params/packages/" + packageName), Collections.emptyMap());
+
     } catch (Exception ex) {
       // This should be because there are no parameters. Be tolerant here.
       log.warn("There are no parameters to return for package: {}", packageName);

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTest.java
@@ -1373,7 +1373,7 @@ public class CollectionsAPISolrJTest extends SolrCloudTestCase {
     assertEquals(0, response.getStatus());
 
     NamedList<?> colStatus = (NamedList<?>) response.getResponse().get(collectionName);
-    Long creationTimeMillis = (Long) colStatus._get("creationTimeMillis", null);
+    Long creationTimeMillis = (Long) colStatus._get("creationTimeMillis");
     assertNotNull("creationTimeMillis was not included in COLSTATUS response", creationTimeMillis);
 
     Instant creationTime = Instant.ofEpochMilli(creationTimeMillis);

--- a/solr/core/src/test/org/apache/solr/cloud/NodeRolesTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/NodeRolesTest.java
@@ -20,6 +20,7 @@ package org.apache.solr.cloud;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.V2Request;
 import org.apache.solr.client.solrj.response.V2Response;
@@ -90,7 +91,7 @@ public class NodeRolesTest extends SolrCloudTestCase {
             .build()
             .process(cluster.getSolrClient());
     assertFalse(
-        ((Collection) rsp._get("node-roles/overseer/" + overseerModeOnDataNode, null))
+        ((Collection) rsp._get("node-roles/overseer/" + overseerModeOnDataNode))
             .contains(j1.getNodeName()));
   }
 
@@ -104,7 +105,8 @@ public class NodeRolesTest extends SolrCloudTestCase {
       String path = nodenamePaths[i + 1];
       assertTrue(
           "Didn't find " + nodename + " at " + path + ". Full response: " + rsp.jsonStr(),
-          ((Collection) rsp._get(path, Collections.emptyList())).contains(nodename));
+          ((Collection) Objects.requireNonNullElse(rsp._get(path), Collections.emptyList()))
+              .contains(nodename));
     }
   }
 
@@ -115,8 +117,11 @@ public class NodeRolesTest extends SolrCloudTestCase {
             .GET()
             .build()
             .process(cluster.getSolrClient());
+
     Map<String, Object> l =
-        (Map<String, Object>) rsp._get("supported-roles", Collections.emptyMap());
+        (Map<String, Object>)
+            Objects.requireNonNullElse(rsp._get("supported-roles"), Collections.emptyMap());
+
     assertTrue(l.containsKey("data"));
     assertTrue(l.containsKey("overseer"));
   }

--- a/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
@@ -169,9 +169,9 @@ public class TestSolrConfigHandler extends RestTestBase {
     assertEquals("10", m._getStr("overlay/props/updateHandler/autoCommit/maxTime", null));
 
     m = getRespMap("/config/updateHandler", harness);
-    assertNotNull(m._get("config/updateHandler/commitWithin/softCommit", null));
-    assertNotNull(m._get("config/updateHandler/autoCommit/maxDocs", null));
-    assertNotNull(m._get("config/updateHandler/autoCommit/maxTime", null));
+    assertNotNull(m._get("config/updateHandler/commitWithin/softCommit"));
+    assertNotNull(m._get("config/updateHandler/autoCommit/maxDocs"));
+    assertNotNull(m._get("config/updateHandler/autoCommit/maxTime"));
 
     m = getRespMap("/config", harness);
     assertNotNull(m);
@@ -183,7 +183,7 @@ public class TestSolrConfigHandler extends RestTestBase {
     runConfigCommand(harness, "/config", payload);
 
     m = getRespMap("/config/overlay", harness);
-    assertNull(m._get("overlay/props/updateHandler/autoCommit/maxDocs", null));
+    assertNull(m._get("overlay/props/updateHandler/autoCommit/maxDocs"));
     assertEquals("10", m._getStr("overlay/props/updateHandler/autoCommit/maxTime", null));
   }
 
@@ -197,13 +197,13 @@ public class TestSolrConfigHandler extends RestTestBase {
     runConfigCommand(harness, "/config", payload);
 
     MapWriter m = getRespMap("/config/overlay", harness); // .get("overlay");
-    assertEquals(m._get("overlay/userProps/my.custom.variable.a", null), "MODIFIEDA");
-    assertEquals(m._get("overlay/userProps/my.custom.variable.b", null), "MODIFIEDB");
+    assertEquals(m._get("overlay/userProps/my.custom.variable.a"), "MODIFIEDA");
+    assertEquals(m._get("overlay/userProps/my.custom.variable.b"), "MODIFIEDB");
 
     m = getRespMap("/dump?json.nl=map&initArgs=true", harness); // .get("initArgs");
 
-    assertEquals("MODIFIEDA", m._get("initArgs/defaults/a", null));
-    assertEquals("MODIFIEDB", m._get("initArgs/defaults/b", null));
+    assertEquals("MODIFIEDA", m._get("initArgs/defaults/a"));
+    assertEquals("MODIFIEDB", m._get("initArgs/defaults/b"));
   }
 
   public void testReqHandlerAPIs() throws Exception {

--- a/solr/core/src/test/org/apache/solr/handler/TestContainerPlugin.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestContainerPlugin.java
@@ -183,7 +183,7 @@ public class TestContainerPlugin extends SolrCloudTestCase {
 
     // verify it is removed
     rsp = readPluginState.call();
-    assertNull(rsp._get("/plugin/testplugin/class", null));
+    assertNull(rsp._get("/plugin/testplugin/class"));
 
     try (ErrorLogMuter errors = ErrorLogMuter.substring("TestContainerPlugin$C4")) {
       // test with a class  @EndPoint methods. This also uses a template in the path name

--- a/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerConcurrent.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerConcurrent.java
@@ -150,7 +150,7 @@ public class TestSolrConfigHandlerConcurrent extends AbstractFullDistribZkTestBa
         Thread.sleep(100);
         errmessages.clear();
         MapWriter respMap = getAsMap(url + "/config/overlay", cloudClient);
-        MapWriter m = (MapWriter) respMap._get("overlay/props", null);
+        MapWriter m = (MapWriter) respMap._get("overlay/props");
         if (m == null) {
           errmessages.add(
               StrUtils.formatString(

--- a/solr/core/src/test/org/apache/solr/handler/admin/LoggingHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/LoggingHandlerTest.java
@@ -104,7 +104,7 @@ public class LoggingHandlerTest extends SolrTestCaseJ4 {
 
     { // GET
       @SuppressWarnings({"unchecked"})
-      List<Map<String, Object>> loggers = (List<Map<String, Object>>) rsp._get("loggers", null);
+      List<Map<String, Object>> loggers = (List<Map<String, Object>>) rsp._get("loggers");
 
       // check expected log levels returned by handler
       assertLoggerLevel(loggers, PARENT_LOGGER_NAME, "DEBUG", true);
@@ -122,7 +122,7 @@ public class LoggingHandlerTest extends SolrTestCaseJ4 {
               new GenericSolrRequest(SolrRequest.METHOD.GET, "/admin/info/logging", mparams));
       @SuppressWarnings({"unchecked"})
       List<Map<String, Object>> updatedLoggerLevel =
-          (List<Map<String, Object>>) rsp._get("loggers", null);
+          (List<Map<String, Object>>) rsp._get("loggers");
 
       // check new log levels returned by handler
       assertLoggerLevel(updatedLoggerLevel, PARENT_LOGGER_NAME, "DEBUG", true);
@@ -153,7 +153,7 @@ public class LoggingHandlerTest extends SolrTestCaseJ4 {
 
       @SuppressWarnings({"unchecked"})
       List<Map<String, Object>> removedLoggerLevel =
-          (List<Map<String, Object>>) rsp._get("loggers", null);
+          (List<Map<String, Object>>) rsp._get("loggers");
 
       // check new log levels returned by handler
       assertLoggerLevel(removedLoggerLevel, PARENT_LOGGER_NAME, "DEBUG", true);

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -121,15 +121,15 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertNotNull(o); // counter type
     assertTrue(o instanceof MapWriter);
     // response wasn't serialized, so we get here whatever MetricUtils produced instead of NamedList
-    assertNotNull(((MapWriter) o)._get("count", null));
-    assertEquals(0L, ((MapWriter) nl.get("SEARCHER.new.errors"))._get("count", null));
+    assertNotNull(((MapWriter) o)._get("count"));
+    assertEquals(0L, ((MapWriter) nl.get("SEARCHER.new.errors"))._get("count"));
     assertNotNull(nl.get("INDEX.segments")); // int gauge
-    assertTrue((int) ((MapWriter) nl.get("INDEX.segments"))._get("value", null) >= 0);
+    assertTrue((int) ((MapWriter) nl.get("INDEX.segments"))._get("value") >= 0);
     assertNotNull(nl.get("INDEX.sizeInBytes")); // long gauge
-    assertTrue((long) ((MapWriter) nl.get("INDEX.sizeInBytes"))._get("value", null) >= 0);
+    assertTrue((long) ((MapWriter) nl.get("INDEX.sizeInBytes"))._get("value") >= 0);
     nl = (NamedList<?>) values.get("solr.node");
     assertNotNull(nl.get("CONTAINER.cores.loaded")); // int gauge
-    assertEquals(1, ((MapWriter) nl.get("CONTAINER.cores.loaded"))._get("value", null));
+    assertEquals(1, ((MapWriter) nl.get("CONTAINER.cores.loaded"))._get("value"));
     assertNotNull(nl.get("ADMIN./admin/authorization.clientErrors")); // timer type
     Map<String, Object> map = new HashMap<>();
     ((MapWriter) nl.get("ADMIN./admin/authorization.clientErrors")).toMap(map);
@@ -326,7 +326,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertEquals(1, values.size());
     MapWriter writer = (MapWriter) values.get("CACHE.core.fieldCache");
     assertNotNull(writer);
-    assertNotNull(writer._get("entries_count", null));
+    assertNotNull(writer._get("entries_count"));
 
     resp = new SolrQueryResponse();
     handler.handleRequestBody(
@@ -496,7 +496,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
             MetricsHandler.KEY_PARAM,
             key2),
         resp);
-    val = resp.getValues()._get("metrics/" + key2, null);
+    val = resp.getValues()._get("metrics/" + key2);
     assertNotNull(val);
     assertTrue(val instanceof Number);
 
@@ -512,7 +512,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
             key3),
         resp);
 
-    val = resp.getValues()._get("metrics/" + key3, null);
+    val = resp.getValues()._get("metrics/" + key3);
     assertNotNull(val);
     assertTrue(val instanceof Number);
     assertEquals(3, ((Number) val).intValue());
@@ -533,11 +533,11 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
             key3),
         resp);
 
-    val = resp.getValues()._get("metrics/" + key1, null);
+    val = resp.getValues()._get("metrics/" + key1);
     assertNotNull(val);
-    val = resp.getValues()._get("metrics/" + key2, null);
+    val = resp.getValues()._get("metrics/" + key2);
     assertNotNull(val);
-    val = resp.getValues()._get("metrics/" + key3, null);
+    val = resp.getValues()._get("metrics/" + key3);
     assertNotNull(val);
 
     String key4 = "solr.core.collection1:QUERY./select.requestTimes:1minRate";

--- a/solr/core/src/test/org/apache/solr/handler/admin/ThreadDumpHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ThreadDumpHandlerTest.java
@@ -313,8 +313,7 @@ public class ThreadDumpHandlerTest extends SolrTestCaseJ4 {
   }
 
   private NamedList<?> getThreadInfo(NamedList<?> rsp, String threadName) {
-    for (Map.Entry<String, ?> threadInfoEntry :
-        (NamedList<?>) rsp._get("system/threadDump", null)) {
+    for (Map.Entry<String, ?> threadInfoEntry : (NamedList<?>) rsp._get("system/threadDump")) {
       NamedList<?> thread = (NamedList<?>) threadInfoEntry.getValue();
       if (thread._getStr("name", "").contains(threadName)) {
         return thread;

--- a/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
@@ -245,7 +245,7 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
             assertTrue(o instanceof MapWriter);
             MapWriter writer = (MapWriter) o;
             assertEquals(1, writer._size());
-            assertEquals("bar", writer._get("foo", null));
+            assertEquals("bar", writer._get("foo"));
           } else {
             assertTrue(o instanceof MapWriter);
             Map<String, Object> v = new HashMap<>();

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/NodesSysPropsCacher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/NodesSysPropsCacher.java
@@ -91,8 +91,8 @@ public class NodesSysPropsCacher implements NodesSysProps, AutoCloseable {
           solrClient
               .requestWithBaseUrl(zkStateReader.getBaseUrlForNodeName(nodeName), null, req)
               .getResponse();
-      var metrics = NavigableObject.wrap(response._get("metrics", null));
-      keys.forEach((tag, key) -> result.put(tag, metrics._get(key, null)));
+      var metrics = NavigableObject.wrap(response._get("metrics"));
+      keys.forEach((tag, key) -> result.put(tag, metrics._get(key)));
       return result;
     } catch (Exception e) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);

--- a/solr/solrj/src/java/org/apache/solr/common/LinkedHashMapWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/LinkedHashMapWriter.java
@@ -45,9 +45,9 @@ public class LinkedHashMapWriter<V> extends LinkedHashMap<String, V> implements 
 
   @Override
   @SuppressWarnings({"unchecked"})
-  public Object _get(String path, Object def) {
-    if (path.indexOf('/') == -1) return getOrDefault(path, (V) def);
-    return MapWriter.super._get(path, def);
+  public Object _get(String path) {
+    if (path.indexOf('/') == -1) return get(path);
+    return MapWriter.super._get(path);
   }
 
   @Override

--- a/solr/solrj/src/java/org/apache/solr/common/MapWriterMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/MapWriterMap.java
@@ -35,9 +35,9 @@ public class MapWriterMap implements MapWriter {
   }
 
   @Override
-  public Object _get(String path, Object def) {
-    if (path.indexOf('/') == -1) return delegate.getOrDefault(path, def);
-    return MapWriter.super._get(path, def);
+  public Object _get(String path) {
+    if (path.indexOf('/') == -1) return delegate.get(path);
+    return MapWriter.super._get(path);
   }
 
   @Override

--- a/solr/solrj/src/java/org/apache/solr/common/NavigableObject.java
+++ b/solr/solrj/src/java/org/apache/solr/common/NavigableObject.java
@@ -41,11 +41,6 @@ public interface NavigableObject {
     return v;
   }
 
-  default Object _get(String path, Object def) {
-    Object v = Utils.getObjectByPath(this, false, path);
-    return v == null ? def : v;
-  }
-
   /**
    * get the value as a String. useful in tests
    *

--- a/solr/solrj/src/java/org/apache/solr/common/NavigableObject.java
+++ b/solr/solrj/src/java/org/apache/solr/common/NavigableObject.java
@@ -34,9 +34,13 @@ public interface NavigableObject {
    * list of strings where performance is important
    *
    * @param path the full path to that object such as a/b/c[4]/d etc
-   * @param def the default
    * @return the found value or default
    */
+  default Object _get(String path) {
+    Object v = Utils.getObjectByPath(this, false, path);
+    return v;
+  }
+
   default Object _get(String path, Object def) {
     Object v = Utils.getObjectByPath(this, false, path);
     return v == null ? def : v;

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestV2Request.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestV2Request.java
@@ -54,7 +54,7 @@ public class TestV2Request extends SolrCloudTestCase {
             .withMethod(SolrRequest.METHOD.GET)
             .build()
             .process(cluster.getSolrClient());
-    List<?> l = (List<?>) rsp._get("nodes", null);
+    List<?> l = (List<?>) rsp._get("nodes");
     assertNotNull(l);
     assertFalse(l.isEmpty());
   }

--- a/solr/solrj/src/test/org/apache/solr/common/cloud/PerReplicaStatesIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/cloud/PerReplicaStatesIntegrationTest.java
@@ -198,20 +198,16 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
 
         assertNull(
             rsp._get(
-                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node2/leader",
-                null));
+                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node2/leader"));
         assertNull(
             rsp._get(
-                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node2/state",
-                null));
+                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node2/state"));
         assertNull(
             rsp._get(
-                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node4/leader",
-                null));
+                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node4/leader"));
         assertNull(
             rsp._get(
-                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node4/state",
-                null));
+                "cluster/collections/prs_restart_test/shards/shard1/replicas/core_node4/state"));
 
         jsr.start();
         cluster.waitForActiveCollection(testCollection, 1, 2);

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -1866,7 +1866,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
           if (o instanceof String) {
             assertEquals(o, rsp.getResponse()._getStr(s, null));
           } else {
-            assertEquals(o, rsp.getResponse()._get(s, null));
+            assertEquals(o, rsp.getResponse()._get(s));
           }
         });
   }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractIncrementalBackupTest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractIncrementalBackupTest.java
@@ -298,14 +298,14 @@ public abstract class AbstractIncrementalBackupTest extends SolrCloudTestCase {
               .setRepositoryName(BACKUP_REPO_NAME)
               .setLocation(backupLocation)
               .process(cluster.getSolrClient());
-      assertEquals(1, resp.getResponse()._get("deleted[0]/backupId", null));
+      assertEquals(1, resp.getResponse()._get("deleted[0]/backupId"));
 
       resp =
           CollectionAdminRequest.deleteBackupById(backupName, 3)
               .setRepositoryName(BACKUP_REPO_NAME)
               .setLocation(backupLocation)
               .process(cluster.getSolrClient());
-      assertEquals(3, resp.getResponse()._get("deleted[0]/backupId", null));
+      assertEquals(3, resp.getResponse()._get("deleted[0]/backupId"));
 
       simpleRestoreAndCheckDocCount(solrClient, backupLocation, backupName);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-NavigableRemoveDeafult




# Description

_get(T t1,T t2) is replaced _get(T t1) in Navigable Object.All the classes which make call to this method get replaced

# Solution

Analyze and Refactor feature of IntelliJ Idea were used to carry out the task

# Tests

No tests developed.Tests Passed.

