### PR TITLE
SOLR-16391: Fix CoresAPI integration in V2HttpCall

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
+++ b/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
@@ -175,7 +175,7 @@ public class V2HttpCall extends HttpSolrCall {
             }
           }
         }
-      } else if ("cores".equals(prefix)) {
+      } else if ("cores".equals(prefix) && pathSegments.size() > 1) {
         origCorename = pathSegments.get(1);
         core = cores.getCore(origCorename);
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16391

We might be able to move this else if statement entirely, if all cores APIs are handled by JaxRS, but I may be wrong about that. It's just a guess.