### PR TITLE
SOLR-17776: Fix overchecking of http1 flag in Http2SolrClient

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -132,8 +132,9 @@ public class Http2SolrClient extends HttpSolrClientBase {
       if (builder.followRedirects != null
           || builder.connectionTimeoutMillis != null
           || builder.maxConnectionsPerHost != null
-          || builder.useHttp1_1
-              != builder.httpClient.getTransport() instanceof HttpClientTransportOverHTTP
+          || (builder.providedUseHttp1_1 != null
+              && builder.providedUseHttp1_1
+                  != builder.httpClient.getTransport() instanceof HttpClientTransportOverHTTP)
           || builder.proxyHost != null
           || builder.sslConfig != null
           || builder.cookieStore != null
@@ -273,7 +274,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
 
     HttpClient httpClient;
     HttpClientTransport transport;
-    if (builder.useHttp1_1) {
+    if (builder.shouldUseHttp1_1()) {
       if (log.isDebugEnabled()) {
         log.debug("Create Http2SolrClient with HTTP/1.1 transport");
       }
@@ -335,7 +336,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
       proxy = new Socks4Proxy(address, builder.proxyIsSecure);
     } else {
       final Protocol protocol;
-      if (builder.useHttp1_1) {
+      if (builder.shouldUseHttp1_1()) {
         protocol = HttpClientTransportOverHTTP.HTTP11;
       } else {
         // see HttpClientTransportOverHTTP2#newOrigin

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -119,7 +119,7 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     }
     b.executor(this.executor);
 
-    if (builder.useHttp1_1) {
+    if (builder.shouldUseHttp1_1()) {
       this.forceHttp11 = true;
       b.version(HttpClient.Version.HTTP_1_1);
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
@@ -38,7 +38,8 @@ public abstract class HttpSolrClientBuilderBase<
   protected Set<String> urlParamNames;
   protected Integer maxConnectionsPerHost;
   protected ExecutorService executor;
-  protected boolean useHttp1_1 = Boolean.getBoolean("solr.http1");
+  protected final boolean defaultUseHttp1_1 = Boolean.getBoolean("solr.http1");
+  protected Boolean providedUseHttp1_1;
   protected String proxyHost;
   protected int proxyPort;
   protected boolean proxyIsSocks4;
@@ -167,8 +168,24 @@ public abstract class HttpSolrClientBuilderBase<
    */
   @SuppressWarnings("unchecked")
   public B useHttp1_1(boolean useHttp1_1) {
-    this.useHttp1_1 = useHttp1_1;
+    this.providedUseHttp1_1 = useHttp1_1;
     return (B) this;
+  }
+
+  /**
+   * Return whether the HttpSolrClient built will prefer http1.1 over http2. This will be determined
+   * first if {@link #useHttp1_1(boolean)} is called, then by checking the "solr.http1" System
+   * Property, and otherwise will default to false.
+   *
+   * @return whether the build HttpSolrClient will prefer http1.1
+   */
+  @SuppressWarnings("unchecked")
+  public boolean shouldUseHttp1_1() {
+    if (providedUseHttp1_1 != null) {
+      return providedUseHttp1_1;
+    } else {
+      return defaultUseHttp1_1;
+    }
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17776

The http1 check should work like the rest of the custom option checks, and only fail if the user has explicitly set it to something (other than what the existing httpClient uses).