### PR TITLE
SOLR-17778: Remove unused FORCEPREPAREFORLEADERSHIP operation

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -133,6 +133,8 @@ Deprecation Removals
 
 * SOLR-17698: Removed deprecated EnumField field type. (Eric Pugh, David Smiley)
 
+* SOLR-17778: Removed no-op core admin operation FORCEPREPAREFORLEADERSHIP and its SolrJ peer OverrideLastPublished. (Pierre Salagnac)
+
 Dependency Upgrades
 ---------------------
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CoreAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CoreAdminRequest.java
@@ -411,34 +411,6 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     }
   }
 
-  public static class OverrideLastPublished extends CoreAdminRequest {
-    protected String state;
-
-    public OverrideLastPublished() {
-      action = CoreAdminAction.FORCEPREPAREFORLEADERSHIP;
-    }
-
-    @Override
-    public SolrParams getParams() {
-      if (action == null) {
-        throw new RuntimeException("no action specified!");
-      }
-      ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set(CoreAdminParams.ACTION, action.toString());
-      params.set(CoreAdminParams.CORE, core);
-      params.set("state", state);
-      return params;
-    }
-
-    public String getState() {
-      return state;
-    }
-
-    public void setState(String state) {
-      this.state = state;
-    }
-  }
-
   public static class MergeIndexes extends CoreAdminRequest {
     protected List<String> indexDirs;
     protected List<String> srcCores;

--- a/solr/solrj/src/java/org/apache/solr/common/params/CoreAdminParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CoreAdminParams.java
@@ -176,8 +176,6 @@ public abstract class CoreAdminParams {
     OVERSEEROP,
     REQUESTSTATUS(true),
     REJOINLEADERELECTION,
-    // internal API used by force shard leader election
-    FORCEPREPAREFORLEADERSHIP,
     // Internal APIs to back up and restore a core
     BACKUPCORE,
     RESTORECORE,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17778


Trivial removal of dead code.
This removes a core admin operation that does nothing, but was still visible in SolrJ.
