### PR TITLE
Refactor: remove coreContainerWorkExecutor

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1347,7 +1347,7 @@ public class CoreContainer {
         zkSys.zkController.tryCancelAllElections();
       }
 
-      ExecutorUtil.shutdownAndAwaitTermination(coreLoadExecutor);
+      ExecutorUtil.shutdownAndAwaitTermination(coreLoadExecutor); // actually already shutdown
 
       // First wake up the closer thread, it'll terminate almost immediately since it checks
       // isShutDown.

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1086,14 +1086,15 @@ public class CoreContainer {
     }
 
     // setup executor to load cores in parallel
-    coreLoadExecutor = MetricUtils.instrumentedExecutorService(
-        ExecutorUtil.newMDCAwareFixedThreadPool(
-            cfg.getCoreLoadThreadCount(isZooKeeperAware()),
-            new SolrNamedThreadFactory("coreLoadExecutor")),
-        null,
-        metricManager.registry(SolrMetricManager.getRegistryName(SolrInfoBean.Group.node)),
-        SolrMetricManager.mkName(
-            "coreLoadExecutor", SolrInfoBean.Category.CONTAINER.toString(), "threadPool"));
+    coreLoadExecutor =
+        MetricUtils.instrumentedExecutorService(
+            ExecutorUtil.newMDCAwareFixedThreadPool(
+                cfg.getCoreLoadThreadCount(isZooKeeperAware()),
+                new SolrNamedThreadFactory("coreLoadExecutor")),
+            null,
+            metricManager.registry(SolrMetricManager.getRegistryName(SolrInfoBean.Group.node)),
+            SolrMetricManager.mkName(
+                "coreLoadExecutor", SolrInfoBean.Category.CONTAINER.toString(), "threadPool"));
 
     coreSorter =
         loader.newInstance(

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -276,9 +276,8 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertEquals(1, values.size());
     assertNotNull(values.get("solr.node"));
     values = (NamedList<?>) values.get("solr.node");
-    assertEquals(27, values.size());
+    assertEquals(15, values.size());
     assertNotNull(values.get("CONTAINER.cores.lazy")); // this is a gauge node
-    assertNotNull(values.get("CONTAINER.threadPool.coreContainerWorkExecutor.completed"));
     assertNotNull(values.get("CONTAINER.threadPool.coreLoadExecutor.completed"));
 
     resp = new SolrQueryResponse();
@@ -300,8 +299,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     values = (NamedList<?>) values.get("metrics");
     assertNotNull(values.get("solr.node"));
     values = (NamedList<?>) values.get("solr.node");
-    assertEquals(7, values.size());
-    assertNotNull(values.get("CONTAINER.threadPool.coreContainerWorkExecutor.completed"));
+    assertEquals(5, values.size());
     assertNotNull(values.get("CONTAINER.threadPool.coreLoadExecutor.completed"));
 
     resp = new SolrQueryResponse();


### PR DESCRIPTION
It's only used for one silly thing:
It's needless to create an executor just to asynchronously wait for another executor (coreLoadExecutor) to close.  We can instead call shutdownAndAwaitTermination on coreLoadExecutor when the container shuts down.