### PR TITLE
SOLR-17582: Fix ClusterState serializing for older SolrJ versions

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -1193,7 +1193,13 @@ public class HttpSolrCall {
       return null;
     }
     try {
-      return SolrVersion.valueOf(header.substring(header.lastIndexOf(' ') + 1));
+      String userAgent = header.substring(header.lastIndexOf(' ') + 1);
+      if ("1.0".equals(userAgent)) {
+        userAgent = "1.0.0";
+      } else if ("2.0".equals(userAgent)) {
+        userAgent = "2.0.0";
+      }
+      return SolrVersion.valueOf(userAgent);
     } catch (Exception e) {
       // unexpected but let's not freak out
       assert false : e.toString();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
@@ -233,6 +233,34 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
       assertThat(
           clusterStateZk.getCollection("col2"), equalTo(clusterStateHttp.getCollection("col2")));
     }
+
+    try (var cspZk = zkClientClusterStateProvider();
+        var cspHttp = http2ClusterStateProvider()) {
+      // Even older SolrJ versionsg for non streamed response
+      cspHttp
+          .getHttpClient()
+          .getHttpClient()
+          .setUserAgentField(
+              new HttpField(
+                  HttpHeader.USER_AGENT,
+                  "Solr[" + MethodHandles.lookup().lookupClass().getName() + "] " + "2.0"));
+
+      assertThat(cspHttp.getCollection("col1"), equalTo(cspZk.getCollection("col1")));
+
+      final var clusterStateZk = cspZk.getClusterState();
+      final var clusterStateHttp = cspHttp.getClusterState();
+      assertThat(
+          clusterStateHttp.getLiveNodes(),
+          containsInAnyOrder(clusterStateHttp.getLiveNodes().toArray()));
+      assertEquals(2, clusterStateZk.size());
+      assertEquals(clusterStateZk.size(), clusterStateHttp.size());
+      assertThat(
+          clusterStateHttp.collectionStream().collect(Collectors.toList()),
+          containsInAnyOrder(clusterStateHttp.collectionStream().toArray()));
+
+      assertThat(
+          clusterStateZk.getCollection("col2"), equalTo(clusterStateHttp.getCollection("col2")));
+    }
   }
 
   @Test

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
@@ -255,7 +255,7 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
       assertEquals(2, clusterStateZk.size());
       assertEquals(clusterStateZk.size(), clusterStateHttp.size());
       assertThat(
-          clusterStateHttp.collectionStream().collect(Collectors.toList()),
+          clusterStateHttp.collectionStream().toList(),
           containsInAnyOrder(clusterStateHttp.collectionStream().toArray()));
 
       assertThat(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17582

User Agent versions < 9.9.0 work, but not the old 1.0 or 2.0 agent versions used by Solr. We should catch these versions and just change them to be semVer compliant.