### PR TITLE
SOLR-17804: re-create SolrClient if closed.

### DIFF
--- a/solr/cross-dc-manager/build.gradle
+++ b/solr/cross-dc-manager/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation libs.dropwizard.metrics.servlets
   implementation libs.eclipse.jetty.server
   implementation libs.eclipse.jetty.ee10.servlet
+  implementation libs.google.guava
   implementation libs.slf4j.api
   runtimeOnly libs.google.protobuf.javautils
   runtimeOnly libs.commonscodec.commonscodec

--- a/solr/cross-dc-manager/build.gradle
+++ b/solr/cross-dc-manager/build.gradle
@@ -32,7 +32,6 @@ dependencies {
   implementation libs.dropwizard.metrics.servlets
   implementation libs.eclipse.jetty.server
   implementation libs.eclipse.jetty.ee10.servlet
-  implementation libs.google.guava
   implementation libs.slf4j.api
   runtimeOnly libs.google.protobuf.javautils
   runtimeOnly libs.commonscodec.commonscodec

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
@@ -118,6 +118,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
           .build();
     }
 
+    @Override
     public CloudSolrClient get() {
       CloudSolrClient existingClient = solrClientRef.get();
       if (existingClient == null) {

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
@@ -19,6 +19,9 @@ package org.apache.solr.crossdc.manager.consumer;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.google.common.annotations.VisibleForTesting;
+
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Arrays;
@@ -88,8 +91,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
   private final int maxCollapseRecords;
   private final SolrMessageProcessor messageProcessor;
 
-  protected final Supplier<CloudSolrClient> solrClientSupplier;
-  protected final AtomicReference<CloudSolrClient> solrClientRef = new AtomicReference<>();
+  protected SolrClientSupplier solrClientSupplier;
 
   private final ThreadPoolExecutor executor;
 
@@ -98,6 +100,60 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
   private final PartitionManager partitionManager;
 
   private final BlockingQueue<Runnable> queue = new BlockingQueue<>(10);
+
+  public static class SolrClientSupplier implements Supplier<CloudSolrClient>, AutoCloseable {
+    private final AtomicReference<CloudSolrClient> solrClientRef = new AtomicReference<>();
+    private final String zkConnectString;
+
+    public SolrClientSupplier(String zkConnectString) {
+      this.zkConnectString = zkConnectString;
+    }
+
+    @Override
+    public void close() {
+      IOUtils.closeQuietly(solrClientRef.get());
+    }
+
+    protected CloudSolrClient createSolrClient() {
+      log.info("-- creating new SolrClient...");
+      return new CloudSolrClient.Builder(
+          Collections.singletonList(zkConnectString),
+          Optional.empty())
+          .build();
+    }
+
+    public CloudSolrClient get() {
+      CloudSolrClient existingClient = solrClientRef.get();
+      if (existingClient == null) {
+        synchronized (solrClientRef) {
+          if (solrClientRef.get() == null) {
+            log.info("- initializing Solr client");
+            solrClientRef.set(createSolrClient());
+          }
+          return solrClientRef.get();
+        }
+      }
+      if (existingClient.getClusterStateProvider().isClosed()) {
+        // lock out other threads and re-open the client if its ClusterStateProvider was closed
+        synchronized (solrClientRef) {
+          // refresh and check again
+          existingClient = solrClientRef.get();
+          if (existingClient.getClusterStateProvider().isClosed()) {
+            log.info("- re-creating Solr client because its CSP was closed");
+            CloudSolrClient newClient = createSolrClient();
+            solrClientRef.set(newClient);
+            IOUtils.closeQuietly(existingClient);
+            return newClient;
+          } else {
+            return existingClient;
+          }
+        }
+      } else {
+        return existingClient;
+      }
+    }
+
+  }
 
   /**
    * @param conf The Kafka consumer configuration
@@ -161,34 +217,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
             r -> new Thread(r, "KafkaCrossDcConsumerWorker"));
     executor.prestartAllCoreThreads();
 
-    solrClientSupplier =
-        () -> {
-          CloudSolrClient existingClient = solrClientRef.get();
-          if (existingClient != null) {
-            if (existingClient.getClusterStateProvider().isClosed()) {
-              // re-open the client if it was closed
-              synchronized (solrClientRef) {
-                existingClient = solrClientRef.get();
-                if (existingClient != null && existingClient.getClusterStateProvider().isClosed()) {
-                  log.info("- re-creating Solr client because the previous one was closed");
-                  CloudSolrClient newClient = createSolrClient(conf);
-                  solrClientRef.set(newClient);
-                  return newClient;
-                } else {
-                  return existingClient;
-                }
-              }
-            } else {
-              return existingClient;
-            }
-          } else {
-            synchronized (solrClientRef) {
-              CloudSolrClient newClient = createSolrClient(conf);
-              solrClientRef.set(newClient);
-              return newClient;
-            }
-          }
-        };
+    solrClientSupplier = createSolrClientSupplier(conf);
 
     messageProcessor = createSolrMessageProcessor();
 
@@ -201,6 +230,10 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
     log.info("Created Kafka resubmit producer");
   }
 
+  protected SolrClientSupplier createSolrClientSupplier(KafkaCrossDcConf conf) {
+    return new SolrClientSupplier(conf.get(KafkaCrossDcConf.ZK_CONNECT_STRING));
+  }
+
   protected SolrMessageProcessor createSolrMessageProcessor() {
     return new SolrMessageProcessor(solrClientSupplier, resubmitRequest -> 0L);
   }
@@ -208,6 +241,15 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
   public KafkaConsumer<String, MirroredSolrRequest<?>> createKafkaConsumer(Properties properties) {
     return new KafkaConsumer<>(
         properties, new StringDeserializer(), new MirroredSolrRequestSerializer());
+  }
+
+  protected KafkaMirroringSink createKafkaMirroringSink(KafkaCrossDcConf conf) {
+    return new KafkaMirroringSink(conf);
+  }
+
+  @VisibleForTesting
+  public SolrClientSupplier getSolrClientSupplier() {
+    return solrClientSupplier;
   }
 
   /**
@@ -250,7 +292,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
         log.warn("Failed to close kafka mirroring sink", e);
       }
     } finally {
-      IOUtils.closeQuietly(solrClientRef.get());
+      IOUtils.closeQuietly(solrClientSupplier);
     }
   }
 
@@ -537,7 +579,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
         offsetCheckExecutor.shutdown();
         offsetCheckExecutor.awaitTermination(30, TimeUnit.SECONDS);
       }
-      IOUtils.closeQuietly(solrClientRef.get());
+      IOUtils.closeQuietly(solrClientSupplier);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       log.warn("Interrupted while waiting for executor to shutdown");
@@ -546,21 +588,5 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
     } finally {
       Util.logMetrics(metrics);
     }
-  }
-
-  @VisibleForTesting
-  public Supplier<CloudSolrClient> getSolrClientSupplier() {
-    return solrClientSupplier;
-  }
-
-  protected CloudSolrClient createSolrClient(KafkaCrossDcConf conf) {
-    return new CloudSolrClient.Builder(
-            Collections.singletonList(conf.get(KafkaCrossDcConf.ZK_CONNECT_STRING)),
-            Optional.empty())
-        .build();
-  }
-
-  protected KafkaMirroringSink createKafkaMirroringSink(KafkaCrossDcConf conf) {
-    return new KafkaMirroringSink(conf);
   }
 }

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
@@ -19,9 +19,6 @@ package org.apache.solr.crossdc.manager.consumer;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.google.common.annotations.VisibleForTesting;
-
-import java.io.Closeable;
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Arrays;
@@ -117,8 +114,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
     protected CloudSolrClient createSolrClient() {
       log.info("-- creating new SolrClient...");
       return new CloudSolrClient.Builder(
-          Collections.singletonList(zkConnectString),
-          Optional.empty())
+              Collections.singletonList(zkConnectString), Optional.empty())
           .build();
     }
 
@@ -152,7 +148,6 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
         return existingClient;
       }
     }
-
   }
 
   /**

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
@@ -18,7 +18,6 @@ package org.apache.solr.crossdc.manager.consumer;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
-import com.google.common.annotations.VisibleForTesting;
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Arrays;
@@ -241,11 +240,6 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
 
   protected KafkaMirroringSink createKafkaMirroringSink(KafkaCrossDcConf conf) {
     return new KafkaMirroringSink(conf);
-  }
-
-  @VisibleForTesting
-  public SolrClientSupplier getSolrClientSupplier() {
-    return solrClientSupplier;
   }
 
   /**

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumer.java
@@ -98,12 +98,13 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
   private final BlockingQueue<Runnable> queue = new BlockingQueue<>(10);
 
   /**
-   * Supplier for creating and managing a working CloudSolrClient instance.
-   * This class ensures that the CloudSolrClient instance doesn't try to use its {@link org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider}
-   * in a closed state, which may happen if e.g. the ZooKeeper connection is lost. When this happens the
-   * CloudSolrClient is re-created to ensure it can continue to function properly.
+   * Supplier for creating and managing a working CloudSolrClient instance. This class ensures that
+   * the CloudSolrClient instance doesn't try to use its {@link
+   * org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider} in a closed state, which may
+   * happen if e.g. the ZooKeeper connection is lost. When this happens the CloudSolrClient is
+   * re-created to ensure it can continue to function properly.
    *
-   * <p>TODO: this functionality should be moved to the CloudSolrClient itself.</p>
+   * <p>TODO: this functionality should be moved to the CloudSolrClient itself.
    */
   public static class SolrClientSupplier implements Supplier<CloudSolrClient>, AutoCloseable {
     private final AtomicReference<CloudSolrClient> solrClientRef = new AtomicReference<>();

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -65,7 +64,8 @@ public class SolrMessageProcessor extends MessageProcessor
 
   private static final String VERSION_FIELD = "_version_";
 
-  public SolrMessageProcessor(Supplier<CloudSolrClient> clientSupplier, ResubmitBackoffPolicy resubmitBackoffPolicy) {
+  public SolrMessageProcessor(
+      Supplier<CloudSolrClient> clientSupplier, ResubmitBackoffPolicy resubmitBackoffPolicy) {
     super(resubmitBackoffPolicy);
     this.clientSupplier = clientSupplier;
   }

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
@@ -23,6 +23,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -59,13 +61,13 @@ public class SolrMessageProcessor extends MessageProcessor
   private final MetricRegistry metrics =
       SharedMetricRegistries.getOrCreate(Consumer.METRICS_REGISTRY);
 
-  final CloudSolrClient client;
+  final Supplier<CloudSolrClient> clientSupplier;
 
   private static final String VERSION_FIELD = "_version_";
 
-  public SolrMessageProcessor(CloudSolrClient client, ResubmitBackoffPolicy resubmitBackoffPolicy) {
+  public SolrMessageProcessor(Supplier<CloudSolrClient> clientSupplier, ResubmitBackoffPolicy resubmitBackoffPolicy) {
     super(resubmitBackoffPolicy);
-    this.client = client;
+    this.clientSupplier = clientSupplier;
   }
 
   @Override
@@ -190,14 +192,14 @@ public class SolrMessageProcessor extends MessageProcessor
     if (log.isDebugEnabled()) {
       log.debug(
           "Sending request to Solr at ZK address={} with params {}",
-          ZkStateReader.from(client).getZkClient().getZkServerAddress(),
+          ZkStateReader.from(clientSupplier.get()).getZkClient().getZkServerAddress(),
           request.getParams());
     }
     Result<MirroredSolrRequest<?>> result;
     SolrResponseBase response;
     Timer.Context ctx = metrics.timer(MetricRegistry.name(type.name(), "outputTime")).time();
     try {
-      response = (SolrResponseBase) request.process(client);
+      response = (SolrResponseBase) request.process(clientSupplier.get());
     } finally {
       ctx.stop();
     }
@@ -216,7 +218,7 @@ public class SolrMessageProcessor extends MessageProcessor
     if (log.isDebugEnabled()) {
       log.debug(
           "Finished sending request to Solr at ZK address={} with params {} status_code={}",
-          ZkStateReader.from(client).getZkClient().getZkServerAddress(),
+          ZkStateReader.from(clientSupplier.get()).getZkClient().getZkServerAddress(),
           request.getParams(),
           status);
     }
@@ -352,7 +354,7 @@ public class SolrMessageProcessor extends MessageProcessor
     boolean connected = false;
     while (!connected) {
       try {
-        client.connect(); // volatile null-check if already connected
+        clientSupplier.get().connect(); // volatile null-check if already connected
         connected = true;
       } catch (Exception e) {
         log.error("Unable to connect to solr server. Not consuming.", e);

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/DeleteByQueryToIdTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/DeleteByQueryToIdTest.java
@@ -164,7 +164,7 @@ public class DeleteByQueryToIdTest extends SolrCloudTestCase {
             return new KafkaCrossDcConsumer(conf, startLatch) {
               @Override
               protected SolrMessageProcessor createSolrMessageProcessor() {
-                return new SolrMessageProcessor(solrClient, resubmitRequest -> 0L) {
+                return new SolrMessageProcessor(solrClientSupplier, resubmitRequest -> 0L) {
                   @Override
                   public Result<MirroredSolrRequest<?>> handleItem(
                       MirroredSolrRequest<?> mirroredSolrRequest) {

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SimpleSolrIntegrationTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SimpleSolrIntegrationTest.java
@@ -51,7 +51,7 @@ public class SimpleSolrIntegrationTest extends SolrCloudTestCase {
 
     CloudSolrClient cloudClient1 = cluster1.getSolrClient();
 
-    processor = new SolrMessageProcessor(cloudClient1, null);
+    processor = new SolrMessageProcessor(() -> cloudClient1, null);
 
     CollectionAdminRequest.Create create =
         CollectionAdminRequest.createCollection(COLLECTION, 1, 1);

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
@@ -98,13 +98,14 @@ public class KafkaCrossDcConsumerTest {
     kafkaMirroringSinkMock = mock(KafkaMirroringSink.class);
     messageProcessorMock = mock(SolrMessageProcessor.class);
     conf = testCrossDCConf();
-    KafkaCrossDcConsumer.SolrClientSupplier supplier = new KafkaCrossDcConsumer.SolrClientSupplier(null) {
-      @Override
-      protected CloudSolrClient createSolrClient() {
-        solrClientCounter.incrementAndGet();
-        return solrClientMock;
-      }
-    };
+    KafkaCrossDcConsumer.SolrClientSupplier supplier =
+        new KafkaCrossDcConsumer.SolrClientSupplier(null) {
+          @Override
+          protected CloudSolrClient createSolrClient() {
+            solrClientCounter.incrementAndGet();
+            return solrClientMock;
+          }
+        };
 
     // Set necessary configurations
 

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
@@ -76,6 +76,7 @@ public class KafkaCrossDcConsumerTest {
   private CloudSolrClient solrClientMock;
   private KafkaMirroringSink kafkaMirroringSinkMock;
   private ClusterStateProvider clusterStateProviderMock;
+  private KafkaCrossDcConsumer.SolrClientSupplier supplier;
   private AtomicInteger solrClientCounter = new AtomicInteger(0);
   private boolean clusterStateProviderIsClosed = false;
 
@@ -98,7 +99,7 @@ public class KafkaCrossDcConsumerTest {
     kafkaMirroringSinkMock = mock(KafkaMirroringSink.class);
     messageProcessorMock = mock(SolrMessageProcessor.class);
     conf = testCrossDCConf();
-    KafkaCrossDcConsumer.SolrClientSupplier supplier =
+    supplier =
         new KafkaCrossDcConsumer.SolrClientSupplier(null) {
           @Override
           protected CloudSolrClient createSolrClient() {
@@ -205,10 +206,10 @@ public class KafkaCrossDcConsumerTest {
 
   @Test
   public void testSolrClientSupplier() throws Exception {
-    kafkaCrossDcConsumer.getSolrClientSupplier().get();
+    supplier.get();
     assertEquals(1, solrClientCounter.get());
     clusterStateProviderIsClosed = true;
-    kafkaCrossDcConsumer.getSolrClientSupplier().get();
+    supplier.get();
     assertEquals(2, solrClientCounter.get());
   }
 

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
@@ -98,6 +98,14 @@ public class KafkaCrossDcConsumerTest {
     kafkaMirroringSinkMock = mock(KafkaMirroringSink.class);
     messageProcessorMock = mock(SolrMessageProcessor.class);
     conf = testCrossDCConf();
+    KafkaCrossDcConsumer.SolrClientSupplier supplier = new KafkaCrossDcConsumer.SolrClientSupplier(null) {
+      @Override
+      protected CloudSolrClient createSolrClient() {
+        solrClientCounter.incrementAndGet();
+        return solrClientMock;
+      }
+    };
+
     // Set necessary configurations
 
     kafkaCrossDcConsumer =
@@ -114,9 +122,8 @@ public class KafkaCrossDcConsumerTest {
           }
 
           @Override
-          protected CloudSolrClient createSolrClient(KafkaCrossDcConf conf) {
-            solrClientCounter.incrementAndGet();
-            return solrClientMock;
+          protected SolrClientSupplier createSolrClientSupplier(KafkaCrossDcConf conf) {
+            return supplier;
           }
 
           @Override

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
@@ -44,7 +44,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -67,7 +66,6 @@ import org.apache.solr.crossdc.manager.messageprocessor.SolrMessageProcessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
@@ -94,8 +92,7 @@ public class KafkaCrossDcConsumerTest {
   public void setUp() {
     kafkaConsumerMock = mock(KafkaConsumer.class);
     clusterStateProviderMock = mock(ClusterStateProvider.class);
-    doAnswer(inv -> clusterStateProviderIsClosed)
-        .when(clusterStateProviderMock).isClosed();
+    doAnswer(inv -> clusterStateProviderIsClosed).when(clusterStateProviderMock).isClosed();
     solrClientMock = mock(CloudSolrClient.class);
     doReturn(clusterStateProviderMock).when(solrClientMock).getClusterStateProvider();
     kafkaMirroringSinkMock = mock(KafkaMirroringSink.class);

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessorTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessorTest.java
@@ -55,7 +55,7 @@ public class SolrMessageProcessorTest {
   public void setUp() {
     client = mock(CloudSolrClient.class);
     resubmitBackoffPolicy = mock(ResubmitBackoffPolicy.class);
-    solrMessageProcessor = new SolrMessageProcessor(client, resubmitBackoffPolicy);
+    solrMessageProcessor = new SolrMessageProcessor(() -> client, resubmitBackoffPolicy);
   }
 
   /** Should handle MirroredSolrRequest and return a failed result with no retry */

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/messageprocessor/TestMessageProcessor.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/messageprocessor/TestMessageProcessor.java
@@ -70,7 +70,7 @@ public class TestMessageProcessor {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    processor = Mockito.spy(new SolrMessageProcessor(solrClient, backoffPolicy));
+    processor = Mockito.spy(new SolrMessageProcessor(() -> solrClient, backoffPolicy));
     Mockito.doNothing().when(processor).uncheckedSleep(anyLong());
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17804

Use a `Supplier<CloudSolrClient>` that automatically re-creates the client if its `ClusterStateProvider` is closed. Unfortunately SolrClient doesn't implement `SolrCloseable`.