### PR TITLE
SOLR-17458: Give request handler base errors its own metric

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -223,39 +223,45 @@ public abstract class RequestHandlerBase
       var baseRequestMetric =
           solrMetricsContext.longCounter("solr_metrics_core_requests", "HTTP Solr request counts");
 
+      var baseErrorRequestMetric =
+          solrMetricsContext.longCounter(
+              "solr_metrics_core_requests_errors", "HTTP Solr request error counts");
+
       var baseRequestTimeMetric =
           solrMetricsContext.longHistogram(
               "solr_metrics_core_requests_times", "HTTP Solr request times", "ms");
 
       otelRequests =
           new AttributedLongCounter(
-              baseRequestMetric,
-              Attributes.builder().putAll(attributes).put(TYPE_ATTR, "requests").build());
+              baseRequestMetric, Attributes.builder().putAll(attributes).build());
 
       otelNumServerErrors =
           new AttributedLongCounter(
-              baseRequestMetric,
+              baseErrorRequestMetric,
               Attributes.builder()
                   .putAll(attributes)
                   .put(AttributeKey.stringKey("source"), "server")
-                  .put(TYPE_ATTR, "errors")
                   .build());
 
       otelNumClientErrors =
           new AttributedLongCounter(
-              baseRequestMetric,
+              baseErrorRequestMetric,
               Attributes.builder()
                   .putAll(attributes)
                   .put(AttributeKey.stringKey("source"), "client")
-                  .put(TYPE_ATTR, "errors")
                   .build());
 
       otelNumTimeouts =
           new AttributedLongCounter(
-              baseRequestMetric,
+              baseErrorRequestMetric,
               Attributes.builder().putAll(attributes).put(TYPE_ATTR, "timeouts").build());
 
       otelRequestTimes = new AttributedLongTimer(baseRequestTimeMetric, attributes);
+      // NOCOMMIT: Temporary to see metrics
+      otelRequests.add(0L);
+      otelNumTimeouts.add(0L);
+      otelNumClientErrors.add(0L);
+      otelNumServerErrors.add(0L);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/RequestHandlerBaseTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/RequestHandlerBaseTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.handler;
 
-import static org.apache.solr.metrics.SolrMetricProducer.TYPE_ATTR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -80,11 +79,7 @@ public class RequestHandlerBaseTest extends SolrTestCaseJ4 {
 
     verify(mockLongCounter, never())
         .add(
-            eq(1L),
-            argThat(
-                attrs ->
-                    "errors".equals(attrs.get(TYPE_ATTR))
-                        && "source".equals(attrs.get(AttributeKey.stringKey("client")))));
+            eq(1L), argThat(attrs -> "source".equals(attrs.get(AttributeKey.stringKey("client")))));
   }
 
   @Test
@@ -95,19 +90,9 @@ public class RequestHandlerBaseTest extends SolrTestCaseJ4 {
     RequestHandlerBase.processErrorMetricsOnException(e, metrics);
 
     verify(mockLongCounter, never())
-        .add(
-            eq(1L),
-            argThat(
-                attrs ->
-                    "errors".equals(attrs.get(TYPE_ATTR))
-                        && "client".equals(attrs.get(SOURCE_ATTR))));
+        .add(eq(1L), argThat(attrs -> "client".equals(attrs.get(SOURCE_ATTR))));
     verify(mockLongCounter, never())
-        .add(
-            eq(1L),
-            argThat(
-                attrs ->
-                    "errors".equals(attrs.get(TYPE_ATTR))
-                        && "server".equals(attrs.get(SOURCE_ATTR))));
+        .add(eq(1L), argThat(attrs -> "server".equals(attrs.get(SOURCE_ATTR))));
   }
 
   @Test
@@ -118,20 +103,10 @@ public class RequestHandlerBaseTest extends SolrTestCaseJ4 {
     RequestHandlerBase.processErrorMetricsOnException(e, metrics);
 
     verify(mockLongCounter, times(1))
-        .add(
-            eq(1L),
-            argThat(
-                attrs ->
-                    "errors".equals(attrs.get(TYPE_ATTR))
-                        && "client".equals(attrs.get(SOURCE_ATTR))));
+        .add(eq(1L), argThat(attrs -> "client".equals(attrs.get(SOURCE_ATTR))));
 
     verify(mockLongCounter, never())
-        .add(
-            eq(1L),
-            argThat(
-                attrs ->
-                    "errors".equals(attrs.get(TYPE_ATTR))
-                        && "server".equals(attrs.get(SOURCE_ATTR))));
+        .add(eq(1L), argThat(attrs -> "server".equals(attrs.get(SOURCE_ATTR))));
   }
 
   @Test


### PR DESCRIPTION
I feel that the cardinality of `solr_metrics_core_requests_total` was already high enough with the number of handlers + cores as labels and we are  bloating it with 3 different types of errors `client/server/timeouts`. This makes things confusing and I think its justified errors has its own metric name called `solr_metrics_core_requests_errors_total`. 

Makes it very easy as well to create its own error aggregation by just querying `solr_metrics_core_requests_errors_total{}` and you get all errors without needs to specify the `type=errors` label.

```
solr_metrics_core_requests_errors_total{category="QUERY",collection="demo",core="demo_shard1_replica_n1",handler="/select",internal="false",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",source="client"} 0.0
solr_metrics_core_requests_errors_total{category="QUERY",collection="demo",core="demo_shard1_replica_n1",handler="/select",internal="false",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",source="server"} 0.0
solr_metrics_core_requests_errors_total{category="QUERY",collection="demo",core="demo_shard1_replica_n1",handler="/select",internal="true",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",source="client"} 0.0
solr_metrics_core_requests_errors_total{category="QUERY",collection="demo",core="demo_shard1_replica_n1",handler="/select",internal="true",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",source="server"} 0.0
solr_metrics_core_requests_errors_total{category="QUERY",collection="demo",core="demo_shard1_replica_n1",handler="/select",internal="false",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="timeouts"} 0.0
solr_metrics_core_requests_errors_total{category="QUERY",collection="demo",core="demo_shard1_replica_n1",handler="/select",internal="true",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="timeouts"} 0.0
```