### PR TITLE
removing check which brakes update with new dynamic field

### DIFF
--- a/solr/modules/llm/src/java/org/apache/solr/llm/textvectorisation/update/processor/TextToVectorUpdateProcessorFactory.java
+++ b/solr/modules/llm/src/java/org/apache/solr/llm/textvectorisation/update/processor/TextToVectorUpdateProcessorFactory.java
@@ -70,10 +70,6 @@ public class TextToVectorUpdateProcessorFactory extends UpdateRequestProcessorFa
   public UpdateRequestProcessor getInstance(
       SolrQueryRequest req, SolrQueryResponse rsp, UpdateRequestProcessor next) {
     IndexSchema latestSchema = req.getCore().getLatestSchema();
-    if (!latestSchema.hasExplicitField(inputField)) {
-      throw new SolrException(
-          SolrException.ErrorCode.SERVER_ERROR, "undefined field: \"" + inputField + "\"");
-    }
     if (!latestSchema.hasExplicitField(outputField)) {
       throw new SolrException(
           SolrException.ErrorCode.SERVER_ERROR, "undefined field: \"" + outputField + "\"");


### PR DESCRIPTION
Using TextToVectorUpdateProcessorFactory with dynamics fields, the removed check causes an exception if no document with the input-field has been processes yet. The schema does not know the field yet.

AlsTextToVectorUpdateProcessor#isNullOrEmpty is already checking for null and if the input field does not exist it will be skipped anyway, hence I think it is safe to remove the check.

The same could happen on the with the output field check , but it might be more likely, that the output field is a field a not a dymaicField

