### PR TITLE
SOLR-17819: Disable http2 request cancellation for Jetty 10

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -181,6 +181,8 @@ Bug Fixes
 
 * GITHUB#3426: Improving check in TextToVectorUpdateProcessorFactory, which breaks update for new dynamic fields. (Renato Haeberli via Alessandro Benedetti)
 
+* SOLR-17819: Disable http2 request cancellation for Jetty 10, the cancellation can bleed across to other requestsg. (Houston Putman)
+
 Dependency Upgrades
 ---------------------
 * SOLR-17795: Upgrade Lucene to 9.12.2. (Pierre Salagnac, Christine Poerschke, Houston Putman)

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
@@ -409,29 +409,35 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
     query.set("debug", "true");
     query.set("distrib", "true");
     query.setFields("id", "text");
-    query.set("shards", shard1 + "," + shard2 + "," + badShard);
+    // When the badShard is placed first, we are more likely to hit errors
+    query.set("shards", badShard + "," + shard2 + "," + shard1);
 
-    // verify that the request would fail if shards.tolerant=false
-    ignoreException("Server refused connection");
-    expectThrows(SolrException.class, () -> collection1.query(query));
+    // Submit the requests enough times to get failures when code is buggy
+    for (int i = 0; i < (TEST_NIGHTLY ? 500 : 200); i++) {
+      // verify that the request would fail if shards.tolerant=false
+      query.set(ShardParams.SHARDS_TOLERANT, "false");
+      ignoreException("Server refused connection");
+      expectThrows(SolrException.class, () -> collection1.query(query));
 
-    query.set(ShardParams.SHARDS_TOLERANT, "true");
-    QueryResponse response = collection1.query(query);
-    assertTrue(
-        (Boolean)
-            response
-                .getResponseHeader()
-                .get(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY));
-    @SuppressWarnings("unchecked")
-    NamedList<String> badShardTrack =
-        (((NamedList<NamedList<NamedList<String>>>) response.getDebugMap().get("track"))
-                .get("EXECUTE_QUERY"))
-            .get(badShard);
-    assertEquals("Unexpected response size for shard", 1, badShardTrack.size());
-    Entry<String, String> exception = badShardTrack.iterator().next();
-    assertEquals("Expected key 'Exception' not found", "Exception", exception.getKey());
-    assertNotNull("Exception message should not be null", exception.getValue());
-    unIgnoreException("Server refused connection");
+      // verify that the request would succeed if shards.tolerant=true
+      query.set(ShardParams.SHARDS_TOLERANT, "true");
+      QueryResponse response = collection1.query(query);
+      assertTrue(
+          (Boolean)
+              response
+                  .getResponseHeader()
+                  .get(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY));
+      @SuppressWarnings("unchecked")
+      NamedList<String> badShardTrack =
+          (((NamedList<NamedList<NamedList<String>>>) response.getDebugMap().get("track"))
+                  .get("EXECUTE_QUERY"))
+              .get(badShard);
+      assertEquals("Unexpected response size for shard", 1, badShardTrack.size());
+      Entry<String, String> exception = badShardTrack.iterator().next();
+      assertEquals("Expected key 'Exception' not found", "Exception", exception.getKey());
+      assertNotNull("Exception message should not be null", exception.getValue());
+      unIgnoreException("Server refused connection");
+    }
   }
 
   /** Compares the same section on the two query responses */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -567,11 +567,15 @@ public class Http2SolrClient extends HttpSolrClientBase {
                     new SolrServerException(failure.getMessage(), failure));
               }
             });
-    future.exceptionally(
-        (error) -> {
-          mrrv.request.abort(error);
-          return null;
-        });
+
+    // SOLR-17819: Disabling request aborting for Solr 9.x (Jetty 10).
+    // Not disabled for Solr 10.x because Jetty 12 does not have the same issue.
+    //
+    // future.exceptionally(
+    //     (error) -> {
+    //       mrrv.request.abort(error);
+    //       return null;
+    //     });
 
     if (mrrv.contentWriter != null) {
       try (var output = mrrv.requestContent.getOutputStream()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17819

Jetty 10 apparently has a bug that the Http2 clients can bleed cancellations across requests. So when we send a non-tolerant search, the HttpShardHandler will cancel outstanding requests. When we then send a tolerant search next, very occasionally, the good shards will fail with `java.io.IOException: cancel_stream_error/unexpected_data_frame`, meaning that they have been cancelled. I debugged and checked that these requests do not fail because they are being cancelled. And when the non-tolerant request is commented out, they never fail. So it is the cancellation from one request bleeding to other requests.

This does not fail on main (10.x), which uses Jetty 12, so we only need to disable this for Solr 9. I will add the test into main, just to make sure in the future that this is not an issue.