### PR TITLE
SOLR-17792: Fix error handling for shard requests

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -343,7 +343,7 @@ public class HttpShardHandler extends ShardHandler {
             // Otherwise return the last response that we processed.
             return previousResponse.getShardRequest().responses.stream()
                 .filter(sr -> sr.getException() != null)
-                .findAny()
+                .findFirst()
                 .orElse(previousResponse);
           }
         } else {

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -267,7 +267,7 @@ public class HttpShardHandler extends ShardHandler {
     // Synchronize on canceled, so that we know precisely whether to add it to the responseFutureMap
     // or not.
     synchronized (canceled) {
-      if (canceled.get()) {
+      if (canceled.get() && !future.isDone()) {
         future.cancel(true);
         return;
       } else {
@@ -335,7 +335,17 @@ public class HttpShardHandler extends ShardHandler {
           responses.clear();
 
           // We want to return the last response we received, if possible
-          return previousResponse;
+          if (previousResponse == null) {
+            return null;
+          } else {
+            // If we have been canceled, return a response from this request that has an exception,
+            // since that is the contract of the method.
+            // Otherwise return the last response that we processed.
+            return previousResponse.getShardRequest().responses.stream()
+                .filter(sr -> sr.getException() != null)
+                .findAny()
+                .orElse(previousResponse);
+          }
         } else {
           responseFutureMap.remove(rsp);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17792

https://github.com/apache/solr/pull/3398 accidentally broke the error handling in HttpShardHandler, by accepting already received requests after cancelling. So instead of throwing those responses away, the HttpShardHandler will find a response with an error after cancelling, since that is the contract that `take()` has. And even then, for tolerant requests, the `SearchHandler` needs to find any responses that have errors to know if the results are partial or not. (because tolerant requests don't guarantee that the response returned is the one with the error)