### PR TITLE
SOLR-17721 - null pointer fix in the doAddDistinct method

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -218,6 +218,8 @@ Bug Fixes
 
 * SOLR-17824: RecoveryStrategy.pingLeader could NPE when there's no shard leader (David Smiley)
 
+* SOLR-17721: NPE can occur when doing Atomic Update using Add Distinct on documents with a null field value. (puneetSharma via Eric Pugh)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java
@@ -545,8 +545,11 @@ public class AtomicUpdateDocumentMerger {
     final String name = sif.getName();
     SolrInputField existingField = toDoc.get(name);
 
-    Collection<Object> original =
-        existingField != null ? existingField.getValues() : new ArrayList<>();
+    Collection<Object> original = existingField != null ? existingField.getValues() : null;
+
+    if (original == null) {
+      original = new ArrayList<>();
+    }
 
     int initialSize = original.size();
     if (fieldVal instanceof Collection) {

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java
@@ -1704,4 +1704,27 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
         "*[count(//result/doc[1]/arr[@name='intRemove']/int)=1]",
         "//result/doc[1]/arr[@name='intRemove']/int[1][.=333]");
   }
+
+  @Test
+  public void testAddDistinctToNullField() {
+    // Test that add-distinct works correctly when the field value is null
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", 9999);
+    doc.setField("cat", null); // Set field to null
+    assertU(adoc(doc));
+    assertU(commit());
+
+    // Now try to add-distinct to the null field
+    doc = new SolrInputDocument();
+    doc.setField("id", 9999);
+    doc.setField("cat", Map.of("add-distinct", "new_value"));
+    assertU(adoc(doc));
+    assertU(commit());
+
+    // Verify the value was added
+    assertQ(
+        req("q", "id:9999", "indent", "true"),
+        "//result[@numFound = '1']",
+        "//doc/arr[@name='cat']/str[.='new_value']");
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17721

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

This issue is very intermittent and depending on a number of factors.Fixed a NullPointerException in Solr's atomic update functionality when performing add-distinct operations on fields that exist in the document but have null values. The error "Cannot invoke 'java.util.Collection.size()' because 'original' is null" was occurring in the doAddDistinct method of AtomicUpdateDocumentMerger when getValues() returned null for fields with null values.

# Solution

Added a null check in the doAddDistinct method to handle the case where existingField.getValues() returns null. When a field exists in the document but has a null value, getValues() returns null, but the code was trying to call size() on this null collection. The fix initializes an empty ArrayList when getValues() returns null, ensuring the atomic update operation can proceed without throwing a NullPointerException.
Code Changes:
Modified solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java in the doAddDistinct method
Added null check: if (original == null) { original = new ArrayList<>(); }

# Tests

Added a test case testAddDistinctToNullField() in solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java that reproduces the exact scenario where:
A field exists in the document (existingField != null)
The field has a null value (getValues() returns null)
An add-distinct atomic update operation is performed on that field
The test verifies that the operation completes successfully without throwing a NullPointerException and that the new value is correctly added to the field. The test suite was run to ensure no existing functionality was broken, with all 28 tests passing (1 skipped).

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
