### PR TITLE
SOLR-17806: Migrate PeerSync and PeerSyncWithLeader metrics to OTEL

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/PeerSyncReplicationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/PeerSyncReplicationTest.java
@@ -20,8 +20,6 @@ package org.apache.solr.cloud;
 import static java.util.Collections.singletonList;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -32,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -44,7 +41,9 @@ import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.metrics.SolrMetricTestUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -186,15 +185,32 @@ public class PeerSyncReplicationTest extends AbstractFullDistribZkTestBase {
         }
       }
       assertNotNull(registry);
-      Map<String, Metric> metrics = registry.getMetrics();
-      assertTrue(
-          "REPLICATION.peerSync.time present", metrics.containsKey("REPLICATION.peerSync.time"));
-      assertTrue(
-          "REPLICATION.peerSync.errors present",
-          metrics.containsKey("REPLICATION.peerSync.errors"));
-
-      Counter counter = (Counter) metrics.get("REPLICATION.peerSync.errors");
-      assertEquals(0L, counter.getCount());
+      CoreContainer cc = nodePeerSynced.jetty.getCoreContainer();
+      String coreName =
+          cc.getAllCoreNames().stream()
+              .filter(n -> n.contains(DEFAULT_TEST_COLLECTION_NAME))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Couldn't find core for " + nodePeerSynced.coreNodeName));
+      try (SolrCore core = cc.getCore(coreName)) {
+        assertTrue(
+            SolrMetricTestUtils.getHistogramDatapoint(
+                    core,
+                    "solr_core_leader_sync_time_milliseconds",
+                    SolrMetricTestUtils.newCloudLabelsBuilder(core)
+                        .label("category", "REPLICATION")
+                        .build())
+                .hasCount());
+        assertNull(
+            SolrMetricTestUtils.getCounterDatapoint(
+                core,
+                "solr_core_leader_sync_errors",
+                SolrMetricTestUtils.newCloudLabelsBuilder(core)
+                    .label("category", "REPLICATION")
+                    .build()));
+      }
       success = true;
     } finally {
       System.clearProperty("solr.disableFingerprint");

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery.java
@@ -17,17 +17,12 @@
 
 package org.apache.solr.cloud;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.Timer;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -35,9 +30,10 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.cloud.ClusterStateUtil;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.embedded.JettySolrRunner;
-import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.metrics.SolrMetricTestUtils;
 import org.apache.solr.update.UpdateLog;
 import org.apache.solr.update.UpdateShardHandler;
 import org.apache.solr.util.TestInjection;
@@ -140,22 +136,19 @@ public class TestCloudRecovery extends SolrCloudTestCase {
 
     // check metrics
     long replicationCount = 0;
-    long errorsCount = 0;
-    long skippedCount = 0;
     for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
-      SolrMetricManager manager = jetty.getCoreContainer().getMetricManager();
-      List<String> registryNames =
-          manager.registryNames().stream()
-              .filter(s -> s.startsWith("solr.core."))
-              .collect(Collectors.toList());
-      for (String registry : registryNames) {
-        Map<String, Metric> metrics = manager.registry(registry).getMetrics();
-        Timer timer = (Timer) metrics.get("REPLICATION.peerSync.time");
-        Counter counter = (Counter) metrics.get("REPLICATION.peerSync.errors");
-        Counter skipped = (Counter) metrics.get("REPLICATION.peerSync.skipped");
-        replicationCount += timer.getCount();
-        errorsCount += counter.getCount();
-        skippedCount += skipped.getCount();
+      CoreContainer cc = jetty.getCoreContainer();
+      for (String coreName : cc.getAllCoreNames()) {
+        try (SolrCore core = cc.getCore(coreName)) {
+          var replicationDatapoint =
+              SolrMetricTestUtils.getHistogramDatapoint(
+                  core,
+                  "solr_core_peer_sync_time_milliseconds",
+                  SolrMetricTestUtils.newCloudLabelsBuilder(core)
+                      .label("category", "REPLICATION")
+                      .build());
+          replicationCount += (replicationDatapoint != null) ? replicationDatapoint.getCount() : 0;
+        }
       }
     }
     if (onlyLeaderIndexes) {

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricTestUtils.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricTestUtils.java
@@ -22,6 +22,7 @@ import io.opentelemetry.exporter.prometheus.PrometheusMetricReader;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -173,9 +174,7 @@ public final class SolrMetricTestUtils {
 
   private static <T> T getDatapoint(
       SolrCore core, String metricName, Labels labels, Class<T> snapshotType) {
-
     var reader = getPrometheusMetricReader(core);
-
     return snapshotType.cast(SolrMetricTestUtils.getDataPointSnapshot(reader, metricName, labels));
   }
 
@@ -187,5 +186,11 @@ public final class SolrMetricTestUtils {
   public static CounterSnapshot.CounterDataPointSnapshot getCounterDatapoint(
       SolrCore core, String metricName, Labels labels) {
     return getDatapoint(core, metricName, labels, CounterSnapshot.CounterDataPointSnapshot.class);
+  }
+
+  public static HistogramSnapshot.HistogramDataPointSnapshot getHistogramDatapoint(
+      SolrCore core, String metricName, Labels labels) {
+    return getDatapoint(
+        core, metricName, labels, HistogramSnapshot.HistogramDataPointSnapshot.class);
   }
 }

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricTestUtils.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricTestUtils.java
@@ -142,7 +142,7 @@ public final class SolrMetricTestUtils {
         .orElse(null);
   }
 
-  public static Labels.Builder getCloudLabelsBase(SolrCore core) {
+  public static Labels.Builder newCloudLabelsBuilder(SolrCore core) {
     return Labels.builder()
         .label("collection", core.getCoreDescriptor().getCloudDescriptor().getCollectionName())
         .label("shard", core.getCoreDescriptor().getCloudDescriptor().getShardId())


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806

Migrate PeerSync and PeerSycWithLeader metrics and remove Dropwizard initializations.

```
# TYPE solr_core_leader_sync_errors_total counter
solr_core_leader_sync_errors_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n2",otel_scope_name="org.apache.solr",replica="replica_n2",shard="shard1"} 2.0
solr_core_leader_sync_errors_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard2_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard2"} 2.0
# HELP solr_core_leader_sync_skipped_total Total number of skipped syncs with leader
# TYPE solr_core_leader_sync_skipped_total counter
solr_core_leader_sync_skipped_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n2",otel_scope_name="org.apache.solr",replica="replica_n2",shard="shard1"} 1.0
solr_core_leader_sync_skipped_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard2_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard2"} 1.0
# HELP solr_core_leader_sync_time_milliseconds leader sync times
# TYPE solr_core_leader_sync_time_milliseconds histogram
solr_core_leader_sync_time_milliseconds_bucket{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n2",otel_scope_name="org.apache.solr",replica="replica_n2",shard="shard1",le="0.0"} 1
# TYPE solr_core_peer_sync_errors_total counter
solr_core_peer_sync_errors_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n4",otel_scope_name="org.apache.solr",replica="replica_n4",shard="shard1"} 2.0
solr_core_peer_sync_errors_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard2_replica_n6",otel_scope_name="org.apache.solr",replica="replica_n6",shard="shard2"} 2.0
# HELP solr_core_peer_sync_skipped_total Total number of skipped syncs with peer
# TYPE solr_core_peer_sync_skipped_total counter
solr_core_peer_sync_skipped_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n4",otel_scope_name="org.apache.solr",replica="replica_n4",shard="shard1"} 1.0
solr_core_peer_sync_skipped_total{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard2_replica_n6",otel_scope_name="org.apache.solr",replica="replica_n6",shard="shard2"} 1.0
# HELP solr_core_peer_sync_time_milliseconds Peer sync times
# TYPE solr_core_peer_sync_time_milliseconds histogram
solr_core_peer_sync_time_milliseconds_bucket{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n4",otel_scope_name="org.apache.solr",replica="replica_n4",shard="shard1",le="0.0"} 1
```