### PR TITLE
[SOLR-17837] omit PULL nodes from preferredLeader prop distribution

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ExclusiveSliceProperty.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ExclusiveSliceProperty.java
@@ -129,6 +129,10 @@ class ExclusiveSliceProperty {
     return replica.getState() == Replica.State.ACTIVE;
   }
 
+  private boolean canBeLeader(Replica replica) {
+    return replica.getType() == Replica.Type.NRT || replica.getType() == Replica.Type.TLOG;
+  }
+
   // Collect a list of all the nodes that _can_ host the indicated property. Along the way, also
   // collect any of the replicas on that node that _already_ host the property as well as any slices
   // that do _not_ have the property hosted.
@@ -149,6 +153,12 @@ class ExclusiveSliceProperty {
             // Note, we won't be committing this to ZK until later.
             removeProp(slice, replica.getName());
           }
+          continue;
+        }
+        if (SliceMutator.PREFERRED_LEADER_PROP.equals(property)
+            && !canBeLeader(
+                replica)) { // omit replicas that cannot potentially be leader from preferredLeader
+          // candidates
           continue;
         }
         allHosts.add(replica.getNodeName());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17837

# Description

For BALANCESHARDUNIQUE admin collection api setting preferredLeader property, PULL nodes should be omitted from consideration as they can never be elected leader

# Solution

* In ExclusiveSliceProperty, omit PULL type nodes when property to be set is preferredLeader

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
