### PR TITLE
SOLR-17806: Recreate OTEL metric registries on core rename/swapping

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -136,7 +136,6 @@ import org.apache.solr.jersey.InjectionFactories;
 import org.apache.solr.jersey.JerseyAppHandlerCache;
 import org.apache.solr.logging.LogWatcher;
 import org.apache.solr.logging.MDCLoggingContext;
-import org.apache.solr.metrics.SolrCoreMetricManager;
 import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
@@ -2326,18 +2325,18 @@ public class CoreContainer {
     SolrIdentifierValidator.validateCoreName(toName);
     try (SolrCore core = getCore(name)) {
       if (core != null) {
-        String oldRegistryName = core.getCoreMetricManager().getRegistryName();
-        String newRegistryName = SolrCoreMetricManager.createRegistryName(core, toName);
-        metricManager.swapRegistries(oldRegistryName, newRegistryName);
         // The old coreDescriptor is obsolete, so remove it. registerCore will put it back.
         CoreDescriptor cd = core.getCoreDescriptor();
         solrCores.removeCoreDescriptor(cd);
         cd.setProperty("name", toName);
         solrCores.addCoreDescriptor(cd);
+        // Before setting the new name, delete the old metrics registry then reregister metrics
+        // under the new core name
+        metricManager.removeRegistry(core.getCoreMetricManager().getRegistryName());
         core.setName(toName);
+        core.getCoreMetricManager().reregisterCoreMetrics();
         registerCore(cd, core, true, false);
         SolrCore old = solrCores.remove(name);
-
         coresLocator.rename(this, old.getCoreDescriptor(), core.getCoreDescriptor());
       }
     }

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -553,7 +553,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
     assert this.name != null;
     assert coreDescriptor.getCloudDescriptor() == null : "Cores are not renamed in SolrCloud";
     this.name = Objects.requireNonNull(v);
-    coreMetricManager.afterCoreRename();
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/SolrCores.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCores.java
@@ -257,12 +257,8 @@ public class SolrCores {
       cores.put(n1, c0);
       c0.setName(n1);
       c1.setName(n0);
-
-      container
-          .getMetricManager()
-          .swapRegistries(
-              c0.getCoreMetricManager().getRegistryName(),
-              c1.getCoreMetricManager().getRegistryName());
+      c0.getCoreMetricManager().reregisterCoreMetrics();
+      c1.getCoreMetricManager().reregisterCoreMetrics();
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/MetricsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/MetricsHandler.java
@@ -294,7 +294,7 @@ public class MetricsHandler extends RequestHandlerBase implements PermissionName
       final String registryName = unescape(parts[0]);
       final String metricName = unescape(parts[1]);
       final String propertyName = parts.length > 2 ? unescape(parts[2]) : null;
-      if (!metricManager.hasRegistry(registryName)) {
+      if (!metricManager.hasDropwizardRegistry(registryName)) {
         errors.add(key, "registry '" + registryName + "' not found");
         continue;
       }

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -633,6 +633,13 @@ public class SolrMetricManager {
     return meterProviderAndReaders.containsKey(enforcePrefix(name));
   }
 
+  // NOCOMMIT: Used in filtering. Will remove later
+  public boolean hasDropwizardRegistry(String name) {
+    Set<String> names = registryNames();
+    name = enforcePrefix(name);
+    return names.contains(name);
+  }
+
   /**
    * Return set of existing registry names that match a regex pattern
    *

--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomRequestDistribution.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomRequestDistribution.java
@@ -281,7 +281,7 @@ public class TestRandomRequestDistribution extends AbstractFullDistribZkTestBase
 
   private Double getSelectRequestCount(SolrCore core) {
     var labels =
-        SolrMetricTestUtils.getCloudLabelsBase(core)
+        SolrMetricTestUtils.newCloudLabelsBuilder(core)
             .label("category", "QUERY")
             .label("handler", "/select")
             .label("internal", "false")

--- a/solr/core/src/test/org/apache/solr/metrics/SolrCoreMetricManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrCoreMetricManagerTest.java
@@ -19,6 +19,8 @@ package org.apache.solr.metrics;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +37,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+// NOCOMMIT: Need to fix up these tests to use the new SolrMetricTestUtils once we move off of
+// Dropwizard
 public class SolrCoreMetricManagerTest extends SolrTestCaseJ4 {
   private static final int MAX_ITERATIONS = 100;
 
@@ -167,6 +171,49 @@ public class SolrCoreMetricManagerTest extends SolrTestCaseJ4 {
       assertNotNull(actualMetric);
       assertEquals(expectedMetric, actualMetric);
     }
+  }
+
+  @Test
+  public void testReregisterMetrics() {
+    Random random = random();
+
+    Map<String, Long> initialMetrics = SolrMetricTestUtils.getRandomPrometheusMetrics(random, true);
+    var initialProducer = new SolrMetricTestUtils.TestSolrMetricProducer(coreName, initialMetrics);
+    coreMetricManager.registerMetricProducer(
+        SolrMetricTestUtils.getRandomScope(random, true), initialProducer);
+
+    var labels = SolrMetricTestUtils.newStandaloneLabelsBuilder(h.getCore()).build();
+
+    String randomMetricName = initialMetrics.entrySet().iterator().next().getKey();
+
+    long actualValue =
+        (long)
+            SolrMetricTestUtils.getCounterDatapoint(h.getCore(), randomMetricName, labels)
+                .getValue();
+    long expectedValue = initialMetrics.get(randomMetricName);
+
+    assertEquals(expectedValue, actualValue);
+
+    // Change the metric value in OTEL
+    initialProducer
+        .getCounters()
+        .get(randomMetricName)
+        .add(10L, Attributes.of(AttributeKey.stringKey("core"), coreName));
+
+    long newActualValue =
+        (long)
+            SolrMetricTestUtils.getCounterDatapoint(h.getCore(), randomMetricName, labels)
+                .getValue();
+    assertEquals(expectedValue + 10L, newActualValue);
+
+    // Reregister the core metrics which should reset the metric value back to the initial value
+    coreMetricManager.reregisterCoreMetrics();
+
+    long reregisteredValue =
+        (long)
+            SolrMetricTestUtils.getCounterDatapoint(h.getCore(), randomMetricName, labels)
+                .getValue();
+    assertEquals(expectedValue, reregisteredValue);
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricManagerTest.java
@@ -64,48 +64,6 @@ public class SolrMetricManagerTest extends SolrTestCaseJ4 {
     this.reader = metricManager.getPrometheusMetricReader(METER_PROVIDER_NAME);
   }
 
-  // NOCOMMIT: We might not be supported core swapping in 10. Maybe remove this test
-  @Test
-  public void testSwapRegistries() {
-    Random r = random();
-
-    SolrMetricManager metricManager = new SolrMetricManager();
-
-    Map<String, Counter> metrics1 = SolrMetricTestUtils.getRandomMetrics(r, true);
-    Map<String, Counter> metrics2 = SolrMetricTestUtils.getRandomMetrics(r, true);
-    String fromName = "from-" + TestUtil.randomSimpleString(r, 1, 10);
-    String toName = "to-" + TestUtil.randomSimpleString(r, 1, 10);
-    // register test metrics
-    for (Map.Entry<String, Counter> entry : metrics1.entrySet()) {
-      metricManager.registerMetric(
-          null, fromName, entry.getValue(), false, entry.getKey(), "metrics1");
-    }
-    for (Map.Entry<String, Counter> entry : metrics2.entrySet()) {
-      metricManager.registerMetric(
-          null, toName, entry.getValue(), false, entry.getKey(), "metrics2");
-    }
-    assertEquals(metrics1.size(), metricManager.registry(fromName).getMetrics().size());
-    assertEquals(metrics2.size(), metricManager.registry(toName).getMetrics().size());
-
-    // swap
-    metricManager.swapRegistries(fromName, toName);
-    // check metrics
-    Map<String, Metric> fromMetrics = metricManager.registry(fromName).getMetrics();
-    assertEquals(metrics2.size(), fromMetrics.size());
-    for (Map.Entry<String, Counter> entry : metrics2.entrySet()) {
-      Object value = fromMetrics.get(SolrMetricManager.mkName(entry.getKey(), "metrics2"));
-      assertNotNull(value);
-      assertEquals(entry.getValue(), value);
-    }
-    Map<String, Metric> toMetrics = metricManager.registry(toName).getMetrics();
-    assertEquals(metrics1.size(), toMetrics.size());
-    for (Map.Entry<String, Counter> entry : metrics1.entrySet()) {
-      Object value = toMetrics.get(SolrMetricManager.mkName(entry.getKey(), "metrics1"));
-      assertNotNull(value);
-      assertEquals(entry.getValue(), value);
-    }
-  }
-
   // NOCOMMIT: Migration of this to OTEL isn't possible. You can't register instruments to a
   // meterprovider that the provider itself didn't create
   @Test

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricTestUtils.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricTestUtils.java
@@ -17,6 +17,7 @@
 package org.apache.solr.metrics;
 
 import com.codahale.metrics.Counter;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.prometheus.PrometheusMetricReader;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
@@ -66,6 +67,42 @@ public final class SolrMetricTestUtils {
 
   public static Map<String, Counter> getRandomMetrics(Random random, boolean shouldDefineMetrics) {
     return shouldDefineMetrics ? getRandomMetricsWithReplacements(random, new HashMap<>()) : null;
+  }
+
+  /**
+   * Generate random OpenTelemetry metric names for testing Prometheus metrics. Returns a map of
+   * metric names to their expected increment values.
+   */
+  public static Map<String, Long> getRandomPrometheusMetrics(Random random) {
+    return getRandomPrometheusMetrics(random, random.nextBoolean());
+  }
+
+  public static Map<String, Long> getRandomPrometheusMetrics(
+      Random random, boolean shouldDefineMetrics) {
+    return shouldDefineMetrics
+        ? getRandomPrometheusMetricsWithReplacements(random, new HashMap<>())
+        : null;
+  }
+
+  public static Map<String, Long> getRandomPrometheusMetricsWithReplacements(
+      Random random, Map<String, Long> existing) {
+    HashMap<String, Long> metrics = new HashMap<>();
+    ArrayList<String> existingKeys = new ArrayList<>(existing.keySet());
+
+    int numMetrics = TestUtil.nextInt(random, 1, MAX_ITERATIONS);
+    for (int i = 0; i < numMetrics; ++i) {
+      boolean shouldReplaceMetric = !existing.isEmpty() && random.nextBoolean();
+      String name =
+          shouldReplaceMetric
+              ? existingKeys.get(TestUtil.nextInt(random, 0, existingKeys.size() - 1))
+              : TestUtil.randomSimpleString(random, 5, 10)
+                  + SUFFIX; // must be simple string for JMX publishing
+
+      Long incrementValue = Math.abs(random.nextLong() % 1000) + 1;
+      metrics.put(name, incrementValue);
+    }
+
+    return metrics;
   }
 
   public static final String SUFFIX = "_testing";
@@ -192,5 +229,87 @@ public final class SolrMetricTestUtils {
       SolrCore core, String metricName, Labels labels) {
     return getDatapoint(
         core, metricName, labels, HistogramSnapshot.HistogramDataPointSnapshot.class);
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getStandaloneSelectRequestsDatapoint(
+      SolrCore core) {
+    return SolrMetricTestUtils.getCounterDatapoint(
+        core,
+        "solr_core_requests",
+        SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+            .label("handler", "/select")
+            .label("category", "QUERY")
+            .label("internal", "false")
+            .build());
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getCloudSelectRequestsDatapoint(
+      SolrCore core) {
+    return SolrMetricTestUtils.getCounterDatapoint(
+        core,
+        "solr_core_requests",
+        SolrMetricTestUtils.newCloudLabelsBuilder(core)
+            .label("handler", "/select")
+            .label("category", "QUERY")
+            .label("internal", "false")
+            .build());
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getStandaloneUpdateRequestsDatapoint(
+      SolrCore core) {
+    return SolrMetricTestUtils.getCounterDatapoint(
+        core,
+        "solr_core_requests",
+        SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+            .label("handler", "/update")
+            .label("category", "QUERY")
+            .label("internal", "false")
+            .build());
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getCloudUpdateRequestsDatapoint(
+      SolrCore core) {
+    return SolrMetricTestUtils.getCounterDatapoint(
+        core,
+        "solr_core_requests",
+        SolrMetricTestUtils.newCloudLabelsBuilder(core)
+            .label("handler", "/update")
+            .label("category", "QUERY")
+            .label("internal", "false")
+            .build());
+  }
+
+  public static class TestSolrMetricProducer implements SolrMetricProducer {
+    SolrMetricsContext solrMetricsContext;
+    private final Map<String, io.opentelemetry.api.metrics.LongCounter> counters = new HashMap<>();
+    private final String coreName;
+    private final Map<String, Long> metrics;
+
+    public TestSolrMetricProducer(String coreName, Map<String, Long> metrics) {
+      this.coreName = coreName;
+      this.metrics = metrics;
+    }
+
+    @Override
+    public void initializeMetrics(
+        SolrMetricsContext parentContext, Attributes attributes, String scope) {
+      this.solrMetricsContext = parentContext.getChildContext(this);
+      for (Map.Entry<String, Long> entry : metrics.entrySet()) {
+        String metricName = entry.getKey();
+        Long incrementValue = entry.getValue();
+        var counter = solrMetricsContext.longCounter(metricName, "testing");
+        counters.put(metricName, counter);
+        counter.add(incrementValue, Attributes.of(AttributeKey.stringKey("core"), coreName));
+      }
+    }
+
+    @Override
+    public SolrMetricsContext getSolrMetricsContext() {
+      return solrMetricsContext;
+    }
+
+    public Map<String, io.opentelemetry.api.metrics.LongCounter> getCounters() {
+      return counters;
+    }
   }
 }

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricsIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricsIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.http.client.HttpClient;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
@@ -35,48 +34,19 @@ import org.apache.solr.cloud.MiniSolrCloudCluster;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.NodeConfig;
-import org.apache.solr.core.PluginInfo;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.core.SolrXmlConfig;
 import org.apache.solr.embedded.JettySolrRunner;
-import org.apache.solr.util.JmxUtil;
 import org.apache.solr.util.TestHarness;
 import org.hamcrest.number.OrderingComparison;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-// NOCOMMIT: Test fails because of the @After assert on index path. Was going to migrate to just
-// check the registry for the core is deleted but this test does a rename operation which otel has
-// not addressed yet. Need to migrate the rename operation to otel first.
-@LuceneTestCase.BadApple(bugUrl = "https://issues.apache.org/jira/browse/SOLR-17458")
 public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
-  private static final int MAX_ITERATIONS = 20;
-  private static final String CORE_NAME = "metrics_integration";
-  private static final String METRIC_NAME = "requestTimes";
-  private static final String HANDLER_NAME = "/select";
-  private static final String[] REPORTER_NAMES = {"reporter1", "reporter2"};
-  private static final String UNIVERSAL = "universal";
-  private static final String SPECIFIC = "specific";
-  private static final String MULTIGROUP = "multigroup";
-  private static final String MULTIREGISTRY = "multiregistry";
-  private static final String[] INITIAL_REPORTERS = {
-    REPORTER_NAMES[0], REPORTER_NAMES[1], UNIVERSAL, SPECIFIC, MULTIGROUP, MULTIREGISTRY
-  };
-  private static final String[] RENAMED_REPORTERS = {
-    REPORTER_NAMES[0], REPORTER_NAMES[1], UNIVERSAL, MULTIGROUP
-  };
-  private static final SolrInfoBean.Category HANDLER_CATEGORY = SolrInfoBean.Category.QUERY;
-
   private CoreContainer cc;
   private SolrMetricManager metricManager;
-  private String tag;
-  private int jmxReporter;
-
-  private void assertTagged(Map<String, SolrMetricReporter> reporters, String name) {
-    assertTrue(
-        "Reporter '" + name + "' missing in " + reporters, reporters.containsKey(name + "@" + tag));
-  }
 
   @Before
   public void beforeTest() throws Exception {
@@ -97,36 +67,7 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
                 "schema.xml"));
 
     h.coreName = DEFAULT_TEST_CORENAME;
-    jmxReporter = JmxUtil.findFirstMBeanServer() != null ? 1 : 0;
-    metricManager = cc.getMetricManager();
-    tag = h.getCore().getCoreMetricManager().getTag();
-    // initially there are more reporters, because two of them are added via a matching collection
-    // name
-    Map<String, SolrMetricReporter> reporters =
-        metricManager.getReporters("solr.core." + DEFAULT_TEST_CORENAME);
-    assertEquals(INITIAL_REPORTERS.length + jmxReporter, reporters.size());
-    for (String r : INITIAL_REPORTERS) {
-      assertTagged(reporters, r);
-    }
-    // test rename operation
-    cc.rename(DEFAULT_TEST_CORENAME, CORE_NAME);
-    h.coreName = CORE_NAME;
-    cfg = cc.getConfig();
-    PluginInfo[] plugins = cfg.getMetricsConfig().getMetricReporters();
-    assertNotNull(plugins);
-    assertEquals(10 + jmxReporter, plugins.length);
-    reporters = metricManager.getReporters("solr.node");
-    assertEquals(4 + jmxReporter, reporters.size());
-    assertTrue(
-        "Reporter '" + REPORTER_NAMES[0] + "' missing in solr.node",
-        reporters.containsKey(REPORTER_NAMES[0]));
-    assertTrue(
-        "Reporter '" + UNIVERSAL + "' missing in solr.node", reporters.containsKey(UNIVERSAL));
-    assertTrue(
-        "Reporter '" + MULTIGROUP + "' missing in solr.node", reporters.containsKey(MULTIGROUP));
-    assertTrue(
-        "Reporter '" + MULTIREGISTRY + "' missing in solr.node",
-        reporters.containsKey(MULTIREGISTRY));
+    metricManager = h.getCore().getCoreContainer().getMetricManager();
   }
 
   @After
@@ -134,12 +75,7 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
     if (null == metricManager) {
       return; // test failed to init, nothing to clean up
     }
-
-    SolrCoreMetricManager coreMetricManager = h.getCore().getCoreMetricManager();
-    Gauge<?> gauge = (Gauge<?>) coreMetricManager.getRegistry().getMetrics().get("CORE.indexDir");
-    assertNotNull(gauge.getValue());
     deleteCore(); // closes TestHarness which closes CoreContainer which closes SolrCore
-    assertEquals(metricManager.nullString(), gauge.getValue());
   }
 
   @Test
@@ -165,6 +101,7 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
     assertEquals(g.getValue(), cc.getSolrHome().toString());
   }
 
+  // NOCOMMIT: Comeback and fix this test after merging the SolrZKClient metrics migration
   @Test
   public void testZkMetrics() throws Exception {
     System.setProperty("metricsEnabled", "true");
@@ -227,6 +164,36 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
       }
     } finally {
       cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testCoreRename() {
+    String newCoreName = "renamed_core";
+    String originalRegistryName;
+
+    try (SolrCore core = cc.getCore(DEFAULT_TEST_CORENAME)) {
+      originalRegistryName = core.getCoreMetricManager().getRegistryName();
+      assertTrue("Original registry should exist", metricManager.hasRegistry(originalRegistryName));
+      assertQ(req("q", "*:*"), "//result[@numFound='0']");
+      assertEquals(
+          1.0, SolrMetricTestUtils.getStandaloneSelectRequestsDatapoint(core).getValue(), 0.0);
+    }
+
+    cc.rename(DEFAULT_TEST_CORENAME, newCoreName);
+    h.coreName = newCoreName;
+
+    try (SolrCore core = cc.getCore(newCoreName)) {
+      assertFalse(
+          "Original registry should not exist", metricManager.hasRegistry(originalRegistryName));
+      assertTrue(
+          "Renamed registry should exist",
+          metricManager.hasRegistry(core.getCoreMetricManager().getRegistryName()));
+      assertQ(req("q", "*:*"), "//result[@numFound='0']");
+      assertEquals(
+          1.0,
+          SolrMetricTestUtils.getStandaloneSelectRequestsDatapoint(h.getCore()).getValue(),
+          0.0);
     }
   }
 

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/NodesSysPropsCacher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/NodesSysPropsCacher.java
@@ -74,6 +74,9 @@ public class NodesSysPropsCacher implements NodesSysProps, AutoCloseable {
     return result;
   }
 
+  // NOCOMMIT: These properties were fetched from the /admin/metrics endpoint. These properties were
+  // stored as strings instead of numeric values. This is not possible in OTEL metrics. Need to
+  // revisit this later.
   private Map<String, Object> fetchProps(String nodeName, Collection<String> tags) {
     ModifiableSolrParams msp = new ModifiableSolrParams();
     msp.add(CommonParams.OMIT_HEADER, "true");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrJMetricTestUtils.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrJMetricTestUtils.java
@@ -20,7 +20,6 @@ package org.apache.solr.client.solrj;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.InputStreamResponseParser;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
@@ -29,7 +28,7 @@ import org.apache.solr.common.util.NamedList;
 
 public final class SolrJMetricTestUtils {
 
-  public static double getPrometheusMetricValue(CloudSolrClient solrClient, String metricName)
+  public static double getPrometheusMetricValue(SolrClient solrClient, String metricName)
       throws SolrServerException, IOException {
     var req =
         new GenericSolrRequest(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806

OTEL metrics from Meter providers are immutable. On core renaming and swapping, we delete the corresponding registry and recreate it my reinitializing the metric producers with the new core name and labels.