### PR TITLE
SOLR-17851: Deprecate BlobHandler and related V2 APIs

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/BlobHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/BlobHandler.java
@@ -74,6 +74,10 @@ import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated Please use {@link org.apache.solr.filestore.FileStore}.
+ */
+@Deprecated(since = "9.10")
 public class BlobHandler extends RequestHandlerBase
     implements PluginInfoInitialized, PermissionNameProvider {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/GetBlobInfoAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/GetBlobInfoAPI.java
@@ -30,7 +30,10 @@ import org.apache.solr.response.SolrQueryResponse;
  *
  * <p>These APIs (GET /v2/collections/.system/blob/*) is analogous to the v1 GET
  * /solr/.system/blob/* APIs.
+ *
+ * @deprecated Please use {@link org.apache.solr.client.api.endpoint.ClusterFileStoreApis}.
  */
+@Deprecated(since = "9.10")
 public class GetBlobInfoAPI {
   private BlobHandler blobHandler;
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/UploadBlobAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/UploadBlobAPI.java
@@ -30,7 +30,10 @@ import org.apache.solr.response.SolrQueryResponse;
  *
  * <p>This API (POST /v2/collections/.system/blob/blobName) is analogous to the v1 POST
  * /solr/.system/blob/blobName API.
+ *
+ * @deprecated Please use {@link org.apache.solr.client.api.endpoint.ClusterFileStoreApis}.
  */
+@Deprecated(since = "9.10")
 public class UploadBlobAPI {
   private final BlobHandler blobHandler;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17851


# Description

Add deprecation notices to BlobHandler and related v2 api's that are being removed in Solr 10.

# Solution

Add appropriate tags.

# Tests

n/a

# Checklist

Please review the following and check all that apply:

- [x ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ x] I have created a Jira issue and added the issue ID to my pull request title.
- [ x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [ x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
