### PR TITLE
SOLR-17806: Use OtelUnit to create Otel insturments with units as metadata

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -117,6 +117,7 @@ import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.metrics.SolrCoreMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
 import org.apache.solr.pkg.PackageListeners;
@@ -1337,7 +1338,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
             .build();
 
     var baseSearcherTimerMetric =
-        parentContext.longHistogram("solr_searcher_timer", "Timer for opening new searchers", "ms");
+        parentContext.longHistogram(
+            "solr_searcher_timer", "Timer for opening new searchers", OtelUnit.MILLISECONDS);
 
     newSearcherCounter =
         new AttributedLongCounter(
@@ -1407,7 +1409,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
             observableLongMeasurement.record(0L, usableSpaceAttributes);
           }
         }),
-        "By");
+        OtelUnit.BYTES);
 
     parentContext.observableLongGauge(
         "solr_core_index_size",
@@ -1416,7 +1418,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
           if (!isClosed())
             observableLongMeasurement.record(getIndexSize(), baseGaugeCoreAttributes);
         }),
-        "By");
+        OtelUnit.BYTES);
 
     parentContext.observableLongGauge(
         "solr_core_segment_count",

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -43,6 +43,7 @@ import org.apache.solr.metrics.SolrDelegateRegistryMetricsContext;
 import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
 import org.apache.solr.request.SolrQueryRequest;
@@ -220,7 +221,7 @@ public abstract class RequestHandlerBase
                 "solr_node_requests_timeout", "HTTP Solr node request timeouts");
         requestTimeMetric =
             solrMetricsContext.longHistogram(
-                "solr_node_requests_times", "HTTP Solr node request times", "ms");
+                "solr_node_requests_times", "HTTP Solr node request times", OtelUnit.MILLISECONDS);
       } else {
         requestMetric =
             solrMetricsContext.longCounter("solr_core_requests", "HTTP Solr core requests");
@@ -232,7 +233,7 @@ public abstract class RequestHandlerBase
                 "solr_core_requests_timeout", "HTTP Solr core request timeouts");
         requestTimeMetric =
             solrMetricsContext.longHistogram(
-                "solr_core_requests_times", "HTTP Solr core request times", "ms");
+                "solr_core_requests_times", "HTTP Solr core request times", OtelUnit.MILLISECONDS);
       }
 
       requests = new AttributedLongCounter(requestMetric, attributes);

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -84,6 +84,7 @@ import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.logging.MDCLoggingContext;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -172,69 +173,69 @@ public class SolrMetricManager {
   }
 
   public LongCounter longCounter(
-      String registry, String counterName, String description, String unit) {
+      String registry, String counterName, String description, OtelUnit unit) {
     LongCounterBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .counterBuilder(counterName)
             .setDescription(description);
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
   public LongUpDownCounter longUpDownCounter(
-      String registry, String counterName, String description, String unit) {
+      String registry, String counterName, String description, OtelUnit unit) {
     LongUpDownCounterBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .upDownCounterBuilder(counterName)
             .setDescription(description);
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
   public DoubleUpDownCounter doubleUpDownCounter(
-      String registry, String counterName, String description, String unit) {
+      String registry, String counterName, String description, OtelUnit unit) {
     DoubleUpDownCounterBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .upDownCounterBuilder(counterName)
             .setDescription(description)
             .ofDoubles();
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
   public DoubleCounter doubleCounter(
-      String registry, String counterName, String description, String unit) {
+      String registry, String counterName, String description, OtelUnit unit) {
     DoubleCounterBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .counterBuilder(counterName)
             .setDescription(description)
             .ofDoubles();
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
   public DoubleHistogram doubleHistogram(
-      String registry, String histogramName, String description, String unit) {
+      String registry, String histogramName, String description, OtelUnit unit) {
     DoubleHistogramBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .histogramBuilder(histogramName)
             .setDescription(description);
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
   public LongHistogram longHistogram(
-      String registry, String histogramName, String description, String unit) {
+      String registry, String histogramName, String description, OtelUnit unit) {
     LongHistogramBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
@@ -242,31 +243,31 @@ public class SolrMetricManager {
             .setDescription(description)
             .ofLongs();
 
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
   public DoubleGauge doubleGauge(
-      String registry, String gaugeName, String description, String unit) {
+      String registry, String gaugeName, String description, OtelUnit unit) {
     DoubleGaugeBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .gaugeBuilder(gaugeName)
             .setDescription(description);
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
 
-  public LongGauge longGauge(String registry, String gaugeName, String description, String unit) {
+  public LongGauge longGauge(String registry, String gaugeName, String description, OtelUnit unit) {
     LongGaugeBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .gaugeBuilder(gaugeName)
             .setDescription(description)
             .ofLongs();
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.build();
   }
@@ -276,13 +277,13 @@ public class SolrMetricManager {
       String counterName,
       String description,
       Consumer<ObservableLongMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     LongCounterBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .counterBuilder(counterName)
             .setDescription(description);
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.buildWithCallback(callback);
   }
@@ -292,14 +293,14 @@ public class SolrMetricManager {
       String counterName,
       String description,
       Consumer<ObservableDoubleMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     DoubleCounterBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .counterBuilder(counterName)
             .setDescription(description)
             .ofDoubles();
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.buildWithCallback(callback);
   }
@@ -309,14 +310,14 @@ public class SolrMetricManager {
       String gaugeName,
       String description,
       Consumer<ObservableLongMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     LongGaugeBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .gaugeBuilder(gaugeName)
             .setDescription(description)
             .ofLongs();
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.buildWithCallback(callback);
   }
@@ -326,14 +327,14 @@ public class SolrMetricManager {
       String gaugeName,
       String description,
       Consumer<ObservableDoubleMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     DoubleGaugeBuilder builder =
         meterProvider(registry)
             .get(OTEL_SCOPE_NAME)
             .gaugeBuilder(gaugeName)
             .setDescription(description);
 
-    if (unit != null) builder.setUnit(unit);
+    if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder.buildWithCallback(callback);
   }

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
@@ -178,6 +178,15 @@ public class SolrMetricsContext {
     return metricManager.doubleCounter(registryName, metricName, description, unit);
   }
 
+  public DoubleUpDownCounter doubleUpDownCounter(String metricName, String description) {
+    return doubleUpDownCounter(metricName, description, null);
+  }
+
+  public DoubleUpDownCounter doubleUpDownCounter(
+      String metricName, String description, OtelUnit unit) {
+    return metricManager.doubleUpDownCounter(registryName, metricName, description, unit);
+  }
+
   public DoubleHistogram doubleHistogram(String metricName, String description) {
     return metricManager.doubleHistogram(registryName, metricName, description, null);
   }
@@ -208,15 +217,6 @@ public class SolrMetricsContext {
 
   public DoubleGauge doubleGauge(String metricName, String description, OtelUnit unit) {
     return metricManager.doubleGauge(registryName, metricName, description, unit);
-  }
-
-  public DoubleUpDownCounter doubleUpDownCounter(String metricName, String description) {
-    return doubleUpDownCounter(metricName, description, null);
-  }
-
-  public DoubleUpDownCounter doubleUpDownCounter(
-      String metricName, String description, OtelUnit unit) {
-    return metricManager.doubleUpDownCounter(registryName, metricName, description, unit);
   }
 
   public ObservableLongGauge observableLongGauge(

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
@@ -26,10 +26,12 @@ import com.codahale.metrics.Timer;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.ObservableDoubleCounter;
 import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
@@ -39,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.util.stats.MetricUtils;
 
 /**
@@ -155,7 +158,7 @@ public class SolrMetricsContext {
     return longCounter(metricName, description, null);
   }
 
-  public LongCounter longCounter(String metricName, String description, String unit) {
+  public LongCounter longCounter(String metricName, String description, OtelUnit unit) {
     return metricManager.longCounter(registryName, metricName, description, unit);
   }
 
@@ -163,7 +166,7 @@ public class SolrMetricsContext {
     return longUpDownCounter(metricName, description, null);
   }
 
-  public LongUpDownCounter longUpDownCounter(String metricName, String description, String unit) {
+  public LongUpDownCounter longUpDownCounter(String metricName, String description, OtelUnit unit) {
     return metricManager.longUpDownCounter(registryName, metricName, description, unit);
   }
 
@@ -171,7 +174,7 @@ public class SolrMetricsContext {
     return doubleCounter(metricName, description, null);
   }
 
-  public DoubleCounter doubleCounter(String metricName, String description, String unit) {
+  public DoubleCounter doubleCounter(String metricName, String description, OtelUnit unit) {
     return metricManager.doubleCounter(registryName, metricName, description, unit);
   }
 
@@ -179,7 +182,7 @@ public class SolrMetricsContext {
     return metricManager.doubleHistogram(registryName, metricName, description, null);
   }
 
-  public DoubleHistogram doubleHistogram(String metricName, String description, String unit) {
+  public DoubleHistogram doubleHistogram(String metricName, String description, OtelUnit unit) {
     return metricManager.doubleHistogram(registryName, metricName, description, unit);
   }
 
@@ -187,7 +190,7 @@ public class SolrMetricsContext {
     return metricManager.longHistogram(registryName, metricName, description, null);
   }
 
-  public LongHistogram longHistogram(String metricName, String description, String unit) {
+  public LongHistogram longHistogram(String metricName, String description, OtelUnit unit) {
     return metricManager.longHistogram(registryName, metricName, description, unit);
   }
 
@@ -195,7 +198,7 @@ public class SolrMetricsContext {
     return metricManager.longGauge(registryName, metricName, description, null);
   }
 
-  public LongGauge longGauge(String metricName, String description, String unit) {
+  public LongGauge longGauge(String metricName, String description, OtelUnit unit) {
     return metricManager.longGauge(registryName, metricName, description, unit);
   }
 
@@ -203,8 +206,17 @@ public class SolrMetricsContext {
     return metricManager.doubleGauge(registryName, metricName, description, null);
   }
 
-  public DoubleGauge doubleGauge(String metricName, String description, String unit) {
+  public DoubleGauge doubleGauge(String metricName, String description, OtelUnit unit) {
     return metricManager.doubleGauge(registryName, metricName, description, unit);
+  }
+
+  public DoubleUpDownCounter doubleUpDownCounter(String metricName, String description) {
+    return doubleUpDownCounter(metricName, description, null);
+  }
+
+  public DoubleUpDownCounter doubleUpDownCounter(
+      String metricName, String description, OtelUnit unit) {
+    return metricManager.doubleUpDownCounter(registryName, metricName, description, unit);
   }
 
   public ObservableLongGauge observableLongGauge(
@@ -216,7 +228,7 @@ public class SolrMetricsContext {
       String metricName,
       String description,
       Consumer<ObservableLongMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     return metricManager.observableLongGauge(registryName, metricName, description, callback, unit);
   }
 
@@ -229,7 +241,7 @@ public class SolrMetricsContext {
       String metricName,
       String description,
       Consumer<ObservableDoubleMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     return metricManager.observableDoubleGauge(
         registryName, metricName, description, callback, unit);
   }
@@ -243,8 +255,22 @@ public class SolrMetricsContext {
       String metricName,
       String description,
       Consumer<ObservableLongMeasurement> callback,
-      String unit) {
+      OtelUnit unit) {
     return metricManager.observableLongCounter(
+        registryName, metricName, description, callback, unit);
+  }
+
+  public ObservableDoubleCounter observableDoubleCounter(
+      String metricName, String description, Consumer<ObservableDoubleMeasurement> callback) {
+    return observableDoubleCounter(metricName, description, callback, null);
+  }
+
+  public ObservableDoubleCounter observableDoubleCounter(
+      String metricName,
+      String description,
+      Consumer<ObservableDoubleMeasurement> callback,
+      OtelUnit unit) {
+    return metricManager.observableDoubleCounter(
         registryName, metricName, description, callback, unit);
   }
 

--- a/solr/core/src/java/org/apache/solr/metrics/otel/OtelUnit.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/OtelUnit.java
@@ -17,11 +17,10 @@
 package org.apache.solr.metrics.otel;
 
 /**
- * Standard metric units for OpenTelemetry instruments based on UCUM (Unified Code
- * for Units of Measure).
+ * Standard metric units for OpenTelemetry instruments based on UCUM (Unified Code for Units of
+ * Measure).
  */
 public enum OtelUnit {
-  // Time units
   NANOSECONDS("ns"),
   MICROSECONDS("us"),
   MILLISECONDS("ms"),
@@ -30,7 +29,6 @@ public enum OtelUnit {
   HOURS("h"),
   DAYS("d"),
 
-  // Byte units
   BYTES("By"),
   KILOBYTES("kBy"),
   MEGABYTES("MBy"),

--- a/solr/core/src/java/org/apache/solr/metrics/otel/OtelUnit.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/OtelUnit.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.metrics.otel;
+
+/**
+ * Standard metric units for OpenTelemetry instruments based on UCUM (Unified Code
+ * for Units of Measure).
+ */
+public enum OtelUnit {
+  // Time units
+  NANOSECONDS("ns"),
+  MICROSECONDS("us"),
+  MILLISECONDS("ms"),
+  SECONDS("s"),
+  MINUTES("min"),
+  HOURS("h"),
+  DAYS("d"),
+
+  // Byte units
+  BYTES("By"),
+  KILOBYTES("kBy"),
+  MEGABYTES("MBy"),
+  GIGABYTES("GBy");
+
+  private final String symbol;
+
+  OtelUnit(String symbol) {
+    this.symbol = symbol;
+  }
+
+  public String getSymbol() {
+    return symbol;
+  }
+
+  @Override
+  public String toString() {
+    return symbol;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/update/PeerSync.java
+++ b/solr/core/src/java/org/apache/solr/update/PeerSync.java
@@ -49,6 +49,7 @@ import org.apache.solr.handler.component.ShardRequest;
 import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
 import org.apache.solr.request.LocalSolrQueryRequest;
@@ -163,7 +164,8 @@ public class PeerSync implements SolrMetricProducer {
             baseAttributes);
     syncTime =
         new AttributedLongTimer(
-            solrMetricsContext.longHistogram("solr_core_peer_sync_time", "Peer sync times", "ms"),
+            solrMetricsContext.longHistogram(
+                "solr_core_peer_sync_time", "Peer sync times", OtelUnit.MILLISECONDS),
             baseAttributes);
   }
 

--- a/solr/core/src/java/org/apache/solr/update/PeerSyncWithLeader.java
+++ b/solr/core/src/java/org/apache/solr/update/PeerSyncWithLeader.java
@@ -41,6 +41,7 @@ import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
 import org.slf4j.Logger;
@@ -120,7 +121,7 @@ public class PeerSyncWithLeader implements SolrMetricProducer {
     syncTime =
         new AttributedLongTimer(
             solrMetricsContext.longHistogram(
-                "solr_core_sync_with_leader_time", "leader sync times", "ms"),
+                "solr_core_sync_with_leader_time", "leader sync times", OtelUnit.MILLISECONDS),
             baseAttributes);
   }
 

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -79,6 +79,7 @@ import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.core.SolrPaths;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
@@ -658,7 +659,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
         (observableLongMeasurement -> {
           observableLongMeasurement.record(getTotalLogsSize(), baseAttributes);
         }),
-        "By");
+        OtelUnit.BYTES);
 
     // NOCOMMIT: Do we want to keep this? Metric was just state with the numeric enum value.
     // Without context this doesn't mean anything and can be very confusing. Maybe keep the numeric

--- a/solr/core/src/test/org/apache/solr/cloud/TestRandomRequestDistribution.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRandomRequestDistribution.java
@@ -281,7 +281,7 @@ public class TestRandomRequestDistribution extends AbstractFullDistribZkTestBase
 
   private Double getSelectRequestCount(SolrCore core) {
     var labels =
-        SolrMetricTestUtils.getCloudLabelsBase(core)
+        SolrMetricTestUtils.newCloudLabelsBuilder(core)
             .label("category", "QUERY")
             .label("handler", "/select")
             .label("internal", "false")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806

Created an `OtelUnit` as an enum. Otel instruments can be created with a unit type as metadata but only works with specific strings that follow [UCUM](https://ucum.org/ucum). This wasn't obvious as passing in a string to created an OtelUnit enum the constrains unit types to UCUM instead of constantly trying to pass strings.