### PR TITLE
Exclude renovate PRs from being marked as 'stale'

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   "enabled": true,
   "dependencyDashboard": false,
   "enabledManagers": ["gradle", "github-actions"],
+  "labels": ["exempt-stale"],
   "includePaths": ["gradle/libs.versions.toml", "versions.*", "build.gradle", ".github/workflows/*"],
   "postUpgradeTasks": {
     "commands": [


### PR DESCRIPTION
Making renovate PRs stale after 60 days just creates message noise with not much value. This is because it does not serve to nag an author to tend to her PR, and some of us tend to periodically list all open renovate PRs some time before a release to do a batch of upgrades.

This PR adds the `exempt-stale` label to all renovate PRs.