### PR TITLE
Bump OWASP Dependency-Check to 12.1.3 (fix CVSS v4/SAFETY crash)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -178,7 +178,7 @@ osgi-annotation = "8.1.0"
 oshai-logging = "7.0.3"
 # @keep for version alignment
 ow2-asm = "9.7.1"
-owasp-dependencycheck = "12.0.2"
+owasp-dependencycheck = "12.1.3"
 # @keep for version alignment
 perfmark = "0.27.0"
 prometheus-metrics = "1.1.0"


### PR DESCRIPTION
Upgrades the owasp-dependencycheck to 12.1.3 so it handles NVD’s CVSS v4 data.

```
Caused by: com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data$ModifiedCiaType`, problem: SAFETY
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5913764] (through reference chain: io.github.jeremylong.openvulnerability.client.nvd.CveApiJson20["vulnerabilities"]->java.util.ArrayList[1471]->io.github.jeremylong.openvulnerability.client.nvd.DefCveItem["cve"]->io.github.jeremylong.openvulnerability.client.nvd.CveItem["metrics"]->io.github.jeremylong.openvulnerability.client.nvd.Metrics["cvssMetricV40"]->java.util.ArrayList[0]->io.github.jeremylong.openvulnerability.client.nvd.CvssV4["cvssData"]->io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data["modifiedSubIntegrityImpact"])
	at com.fasterxml.jackson.databind.exc.ValueInstantiationException.from(ValueInstantiationException.java:47)
	at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:2015)
	at 

```
https://ci-builds.apache.org/job/Solr/job/OWASP-main/