### PR TITLE
[backport] Bump OWASP Dependency-Check to 12.1.3 (fix CVSS v4/SAFETY crash)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ import java.time.format.DateTimeFormatter
 plugins {
   id 'base'
   id 'com.palantir.consistent-versions' version '2.16.0'
-  id 'org.owasp.dependencycheck' version '9.0.8'
+  id 'org.owasp.dependencycheck' version '12.1.3'
   id 'ca.cutterslade.analyze' version '1.10.0'
   id 'de.thetaphi.forbiddenapis' version '3.7' apply false
   id 'de.undercouch.download' version '5.5.0' apply false


### PR DESCRIPTION
./gradlew owasp failing!

https://ci-builds.apache.org/job/Solr/job/OWASP-9.x

