### PR TITLE
SOLR-17870 - UnsupportedOperationException Fix - Return Partial Results collations when query Limit exceeded in SpellCheckCollator 

### DIFF
--- a/changelog/unreleased/SOLR-17870-partial-spellcheck-collator-results.yml
+++ b/changelog/unreleased/SOLR-17870-partial-spellcheck-collator-results.yml
@@ -1,0 +1,10 @@
+title: >
+  SpellCheckCollator now returns the partial (mutable) list of collations it had gathered so far,
+  instead of throwing an UnsupportedOperationException, when the query time limit is exceeded
+  while collating results.
+type: fixed
+authors:
+  - name: Puneet Sharma
+links:
+  - name: SOLR-17870
+    url: https://issues.apache.org/jira/browse/SOLR-17870

--- a/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
+++ b/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
@@ -96,7 +96,7 @@ public class SpellCheckCollator {
     while (tryNo < maxTries && collNo < maxCollations && possibilityIter.hasNext()) {
 
       if (queryLimits.maybeExitWithPartialResults("SpellCheck collator")) {
-        return List.of();
+        return new ArrayList<>();
       }
 
       PossibilityIterator.RankedSpellPossibility possibility = possibilityIter.next();

--- a/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
+++ b/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
@@ -96,7 +96,7 @@ public class SpellCheckCollator {
     while (tryNo < maxTries && collNo < maxCollations && possibilityIter.hasNext()) {
 
       if (queryLimits.maybeExitWithPartialResults("SpellCheck collator")) {
-        return new ArrayList<>();
+        return collations;
       }
 
       PossibilityIterator.RankedSpellPossibility possibility = possibilityIter.next();

--- a/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
@@ -38,6 +38,7 @@ import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.handler.component.SpellCheckComponent;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequestBase;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
@@ -809,7 +810,7 @@ public class SpellCheckCollatorTest extends SolrTestCaseJ4 {
       params.add(CommonParams.Q, "test query");
       params.add(CommonParams.DF, "teststop");
 
-      SolrQueryRequest req = new LocalSolrQueryRequest(core, params);
+      SolrQueryRequest req = new SolrQueryRequestBase(core, params);
       SolrQueryResponse response = new SolrQueryResponse();
       response.addResponseHeader(new SimpleOrderedMap<>());
 


### PR DESCRIPTION
UnsupportedOperationException Fix - Return Partial Results collations when query Limit exceeded in SpellCheckCollator

https://issues.apache.org/jira/browse/SOLR-17870
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

When a search query with spellcheck enabled (spellcheck=true) exceeds the specified timeAllowed, Solr throws a java.lang.UnsupportedOperationException. This occurs because in the timeout scenario, the SpellCheckCollator returns an immutable list. The SpellCheckComponent later attempts to sort this list of collations, which is an unsupported operation on an immutable list and results in the exception.

# Solution

The fix modifies the SpellCheckCollator to return a new mutable collections with partial results instead of an immutable list when the query time limit is exceeded. This allows the SpellCheckComponent to successfully sort the collations list without throwing an UnsupportedOperationException, enabling Solr to gracefully handle the timeout and return a partial response.

# Tests

To validate the fix, a unit test was added for the SpellCheckComponent. This test simulates a timeout condition by executing a spellcheck query with a very short timeAllowed value. The test asserts that the query completes successfully without throwing an UnsupportedOperationException and that the response is handled correctly.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
