### PR TITLE
SOLR-17871: Http2SolrClient: fix idle timeout > 30 seconds

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -254,6 +254,8 @@ Bug Fixes
 
 * SOLR-17830: v1 Restore API no longer conflates backup-name and collection-name during validation. (Abhishek Umarjikar via Jason Gerlowski)
 
+* SOLR-17871: Http2SolrClient wasn't honoring idle timeout configuration above 30 seconds -- a regression. (Thomas Wöckinger, David Smiley)
+
 Dependency Upgrades
 ---------------------
 (No changes)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -296,6 +296,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
         asyncTracker.getMaxRequestsQueuedPerDestination());
     httpClient.setUserAgentField(new HttpField(HttpHeader.USER_AGENT, USER_AGENT));
     httpClient.setConnectTimeout(builder.getConnectionTimeoutMillis());
+    httpClient.setIdleTimeout(-1); // don't enforce an idle timeout at this level
     // note: idle & request timeouts are set per request
 
     var cookieStore = builder.getCookieStore();

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/BasicHttpSolrClientTest.java
@@ -104,13 +104,16 @@ public class BasicHttpSolrClientTest extends SolrJettyTestBase {
 
   public static class SlowStreamServlet extends HttpServlet {
 
+    public static final int PACKET_MS = 500;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-      IntStream.range(0, 10)
+      String countStr = req.getParameter("count");
+      IntStream.range(0, countStr == null ? 10 : Integer.parseInt(countStr))
           .forEach(
               i -> {
                 try {
-                  Thread.sleep(500);
+                  Thread.sleep(PACKET_MS);
                   resp.getOutputStream().write(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
                   resp.getOutputStream().flush();
                 } catch (IOException | InterruptedException e) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -26,6 +26,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.client.api.util.SolrVersion;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.SolrClient;
@@ -671,11 +674,13 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
       }
 
       // too little time to succeed
-      QueryRequest req = new QueryRequest();
+      int packets = LuceneTestCase.RANDOM_MULTIPLIER == 1 ? 10 : 80; // 60 crosses a default timeout
+      long timeToSendMs = packets * BasicHttpSolrClientTest.SlowStreamServlet.PACKET_MS;
+      QueryRequest req = new QueryRequest(SolrParams.of("count", "" + packets));
       req.setResponseParser(new InputStreamResponseParser(FILE_STREAM));
       assertIsTimeout(expectThrows(SolrServerException.class, () -> oldClient.request(req)));
 
-      int newIdleTimeoutMs = 10 * 1000; // enough time to succeed
+      long newIdleTimeoutMs = timeToSendMs + 1000; // enough time to succeed
       try (Http2SolrClient idleTimeoutChangedClient =
           new Http2SolrClient.Builder(url)
               .withHttpClient(oldClient)
@@ -685,7 +690,9 @@ public class Http2SolrClientTest extends HttpSolrClientTestBase {
         assertEquals(newIdleTimeoutMs, idleTimeoutChangedClient.getIdleTimeout());
         NamedList<Object> response = idleTimeoutChangedClient.request(req);
         try (InputStream is = (InputStream) response.get("stream")) {
-          assertEquals("0123456789", new String(is.readAllBytes(), StandardCharsets.UTF_8));
+          String expect =
+              IntStream.range(0, packets).mapToObj(String::valueOf).collect(Collectors.joining());
+          assertEquals(expect, new String(is.readAllBytes(), StandardCharsets.UTF_8));
         }
       }
     }


### PR DESCRIPTION
Http2SolrClient wasn't honoring idle timeout configuration above 30 seconds -- a regression.

https://issues.apache.org/jira/browse/SOLR-17871
