### PR TITLE
Adding dependency graph submission workflow

### DIFF
--- a/.github/workflows/dependency-graph-submission.yml
+++ b/.github/workflows/dependency-graph-submission.yml
@@ -17,17 +17,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-
-      - uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-url: https://develocity.apache.org
-
+          
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
-        with:
-          build-scan-publish: true
-          develocity-access-key: ${{ secrets.SOLR_DEVELOCITY_ACCESS_KEY }}
-
         env:
           DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: "(?i)(^|:)(compileClasspath|runtimeClasspath|testCompileClasspath|testRuntimeClasspath)$"
           DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: "(?i)(^|:)(classpath|.*PluginClasspath|kotlinCompilerClasspath|kaptClasspath|annotationProcessor|detachedConfiguration.*)$"

--- a/.github/workflows/dependency-graph-submission.yml
+++ b/.github/workflows/dependency-graph-submission.yml
@@ -1,0 +1,21 @@
+name: Dependency Graph Submission
+
+on:
+  push:
+    branches: [ 'main' ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/dependency-graph-submission.yml
+++ b/.github/workflows/dependency-graph-submission.yml
@@ -1,8 +1,8 @@
-name: Dependency Graph Submission
+name: Dependency Submission
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ main ]
 
 permissions:
   contents: write
@@ -11,11 +11,25 @@ jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 21
+      - uses: actions/checkout@v4
 
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-url: https://develocity.apache.org
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
+        with:
+          build-scan-publish: true
+          develocity-access-key: ${{ secrets.SOLR_DEVELOCITY_ACCESS_KEY }}
+
+        env:
+          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: "(?i)(^|:)(compileClasspath|runtimeClasspath|testCompileClasspath|testRuntimeClasspath)$"
+          DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: "(?i)(^|:)(classpath|.*PluginClasspath|kotlinCompilerClasspath|kaptClasspath|annotationProcessor|detachedConfiguration.*)$"
+          DEPENDENCY_GRAPH_RUNTIME_INCLUDE_CONFIGURATIONS: "(?i)(^|:)runtimeClasspath$"
+          DEPENDENCY_GRAPH_RUNTIME_EXCLUDE_CONFIGURATIONS: "(?i)(^|:)testRuntimeClasspath$"


### PR DESCRIPTION
Inspired by: [Lucene issue #15114](https://github.com/apache/lucene/issues/15114)

This adds GitHub’s dependency graph setup so it’s easier for us to keep an eye on dependencies.

- Submits a full dependency graph (including transitives) that shows up under Insights → Dependency graph, so we can quickly check what we’re pulling in.

- [Future PR] Runs dependency review on each PR, comparing against main and flagging any unexpected changes.

- Hooks in Dependabot alerts so we get notified about High/Critical CVEs right away.

Overall, this makes troubleshooting, checking vulnerability status, and acting on alerts a lot smoother within the GitHub ecosystem. There’s plenty more potential here as we explore the feature further and as GitHub keeps expanding its toolkit.
