### PR TITLE
SOLR-17864: Flip solr.hideStackTrace to .enabled equivalent.

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -618,7 +618,8 @@ public class NodeConfig {
     private String defaultZkHost;
     private Set<Path> allowPaths = Collections.emptySet();
     private List<String> allowUrls = Collections.emptyList();
-    private boolean hideStackTrace = Boolean.getBoolean("solr.hideStackTrace");
+    private boolean hideStackTrace =
+        !(Boolean.parseBoolean(System.getProperty("solr.responses.stacktrace.enabled", "true")));
 
     private final Path solrHome;
     private final String nodeName;

--- a/solr/solrj/src/java/org/apache/solr/common/util/EnvUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/EnvUtils.java
@@ -232,6 +232,12 @@ public class EnvUtils {
               deprecatedKey,
               key);
           setProperty(key, String.valueOf(!Boolean.getBoolean(deprecatedKey)));
+        } else if (deprecatedKey.equals("solr.hide.stack.trace")) {
+          log.warn(
+              "Converting from legacy system property {} to modern .enabled equivalent {} by flipping the boolean property value.",
+              deprecatedKey,
+              key);
+          setProperty(key, String.valueOf(!Boolean.getBoolean(deprecatedKey)));
         } else {
           setProperty(key, sysProperties.getProperty(deprecatedKey));
         }

--- a/solr/solrj/src/resources/DeprecatedSystemPropertyMappings.properties
+++ b/solr/solrj/src/resources/DeprecatedSystemPropertyMappings.properties
@@ -19,3 +19,4 @@ solr.enable.remote.streaming=solr.requests.streaming.remote.enabled
 solr.enable.stream.body=solr.requests.streaming.body.enabled
 solr.delete.unknown.cores=solr.cloud.startup.delete.unknown.cores.enabled
 solr.config.set.forbidden.file.types=solr.configset.forbidden.file.types
+solr.hide.stack.trace=solr.responses.stacktrace.enabled


### PR DESCRIPTION
Tricky one because I didn't want to change the solr.xml name AS well, so now in solr.xml we have solr.hideStackTrace, but system is solr.responses.stacktrace.enabled.

Why is this in solr.xml?

https://issues.apache.org/jira/browse/SOLR-17864

I am going to leave this one  for just this one, unless I find other solr.xml that are also system variable equivalents..    Then maybe this grows into a whole "why do we define these in solr.xml and in system variables?" disucssion!