### PR TITLE
SOLR-17879: Fail to start if it's major version is smaller than the cluster

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -384,10 +384,10 @@ public class ZkController implements Closeable {
               if (cc != null) cc.securityNodeChanged();
             });
 
+    init();
+
     // Check version compatibility with other live nodes
     checkVersionCompatibility();
-
-    init();
 
     if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
       this.overseerJobQueue = null;

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -970,7 +969,8 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
         true);
 
     var lowestVersion1 = reader.fetchLowestSolrVersion();
-    assertTrue("Expected lowest version to be present for high version node", lowestVersion1.isPresent());
+    assertTrue(
+        "Expected lowest version to be present for high version node", lowestVersion1.isPresent());
     assertEquals("after high node", SolrVersion.valueOf("888.0.0"), lowestVersion1.get());
 
     String node2 = "node2_solr";

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -46,7 +47,6 @@ import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
-import java.util.Optional;
 import org.apache.solr.client.api.util.SolrVersion;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider;
@@ -873,19 +873,20 @@ public class ZkStateReader implements SolrCloseable {
   }
 
   /**
-   * Returns the lowest Solr version among all live nodes in the cluster.
-   * If older Solr nodes have joined that don't declare their version, the result won't be
-   * accurate, but it's at least an upper bound on the possible version it might be.
+   * Returns the lowest Solr version among all live nodes in the cluster. If older Solr nodes have
+   * joined that don't declare their version, the result won't be accurate, but it's at least an
+   * upper bound on the possible version it might be.
    *
-   * @return an Optional containing the lowest Solr version of nodes in the cluster, or empty
-   *     if no live nodes exist or all nodes return 9.9.0 for unspecified versions
+   * @return an Optional containing the lowest Solr version of nodes in the cluster, or empty if no
+   *     live nodes exist or all nodes return 9.9.0 for unspecified versions
    */
-  public Optional<SolrVersion> fetchLowestSolrVersion() throws KeeperException, InterruptedException {
+  public Optional<SolrVersion> fetchLowestSolrVersion()
+      throws KeeperException, InterruptedException {
     List<String> liveNodeNames = zkClient.getChildren(LIVE_NODES_ZKNODE, null, true);
     SolrVersion lowest = null;
     // the last version to not specify its version in live nodes
     final SolrVersion UNSPECIFIED_VERSION = SolrVersion.valueOf("9.9.0");
-    
+
     for (String nodeName : liveNodeNames) {
       String path = LIVE_NODES_ZKNODE + "/" + nodeName;
       byte[] data = zkClient.getData(path, null, null, true);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -873,12 +873,12 @@ public class ZkStateReader implements SolrCloseable {
   }
 
   /**
-   * Returns the lowest Solr version among all other live nodes in the cluster (excluding current
-   * node). If older Solr nodes have joined that don't declare their version, the result won't be
+   * Returns the lowest Solr version among all live nodes in the cluster.
+   * If older Solr nodes have joined that don't declare their version, the result won't be
    * accurate, but it's at least an upper bound on the possible version it might be.
    *
-   * @return an Optional containing the lowest Solr version of other nodes in the cluster, or empty
-   *     if no other live nodes exist or no versions can be determined
+   * @return an Optional containing the lowest Solr version of nodes in the cluster, or empty
+   *     if no live nodes exist or all nodes return 9.9.0 for unspecified versions
    */
   public Optional<SolrVersion> fetchLowestSolrVersion() throws KeeperException, InterruptedException {
     List<String> liveNodeNames = zkClient.getChildren(LIVE_NODES_ZKNODE, null, true);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17879

The test is marked Ignored because the failure occurs in a way that does not close objects that the ZkController created midway through it's construction (like SolrZkClient).  So there's a suite failure but I can see the test otherwise passes.  Maybe I should just remove it.

Maybe the BATS tests can work with docker?  Or do we add to the docker module's tests, which only run on certain buildds.  Regardless, imagine this is backported to Solr 9, and we later add a test that runs a branch_9x snapshot (published where?) and then runs the current docker version, then we can test the behavior here.  Such a thing would need to be a separate PR.