### PR TITLE
SOLR-17875: Rationalize bootstrap_conf, bootstrap_confdir, and -Dcollection.configName in start up scripts

### DIFF
--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -93,3 +93,17 @@ teardown() {
   solr start --jettyconfig "--module=server"
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
 }
+
+@test "bootstrap configset using bootstrap_confdir and collection.configName" {
+  local confdir_path="${SOLR_TIP}/server/solr/configsets/sample_techproducts_configs/conf"
+  
+  # Verify the source configset directory exists
+  test -d "${confdir_path}"
+  
+  # Start Solr with bootstrap_confdir pointing to techproducts configset
+  solr start -Dbootstrap_confdir="${confdir_path}" -Dcollection.configName=techproducts
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+  
+  # Verify the techproducts configset was uploaded
+  config_exists "techproducts"
+}

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -101,9 +101,15 @@ teardown() {
   test -d "${confdir_path}"
   
   # Start Solr with bootstrap_confdir pointing to techproducts configset
+  # bootstrap_confdir: path to config directory to upload
+  # collection.configName: name to give the uploaded configset (default: "configuration1")
+  # This uploads the sample_techproducts_configs/conf directory as "techproducts" configset
   solr start -Dbootstrap_confdir="${confdir_path}" -Dcollection.configName=techproducts
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
   
-  # Verify the techproducts configset was uploaded
+  # Allow time for the configset upload to complete
+  sleep 1
+  
+  # Verify the techproducts configset was uploaded to ZooKeeper
   config_exists "techproducts"
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17875


# Description

Migrate the bootstrap_conf and bootstrap_confdir properties, and deal with collection.configName.   Get some bats tests in to prove they work.

Investigate ConfigSetService and CreateCollectionCmd about their use of the system properties.

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

new bats tests

