### PR TITLE
SOLR-17806: switch ReplicationHandler metrics to OTEL

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -82,6 +82,7 @@ import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ExecutorUtil;
+import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
@@ -156,7 +157,7 @@ public class ReplicationHandler extends RequestHandlerBase
   SolrCore core;
   private ObservableLongGauge indexSizeGauge;
   private ObservableLongGauge indexVersionGauge;
-  private ObservableLongGauge generationGauge;
+  private ObservableLongGauge indexGenerationGauge;
   private ObservableLongGauge isLeaderGauge;
   private ObservableLongGauge isFollowerGauge;
   private ObservableLongGauge replicationEnabledGauge;
@@ -879,9 +880,9 @@ public class ReplicationHandler extends RequestHandlerBase
               }
             });
 
-    generationGauge =
+    indexGenerationGauge =
         solrMetricsContext.observableLongGauge(
-            "solr_replication_generation",
+            "solr_replication_index_generation",
             "Current index generation",
             gauge -> {
               if (core != null && !core.isClosed()) {
@@ -926,7 +927,7 @@ public class ReplicationHandler extends RequestHandlerBase
 
     ObservableLongMeasurement bytesDownloaded =
         solrMetricsContext.longMeasurement(
-            "solr_replication_bytes_downloaded",
+            "solr_replication_downloaded_size",
             "Total bytes downloaded during replication",
             OtelUnit.BYTES);
 
@@ -961,28 +962,13 @@ public class ReplicationHandler extends RequestHandlerBase
 
   @Override
   public void close() throws IOException {
-    if (indexSizeGauge != null) {
-      indexSizeGauge.close();
-    }
-    if (indexVersionGauge != null) {
-      indexVersionGauge.close();
-    }
-    if (generationGauge != null) {
-      generationGauge.close();
-    }
-    if (isLeaderGauge != null) {
-      isLeaderGauge.close();
-    }
-    if (isFollowerGauge != null) {
-      isFollowerGauge.close();
-    }
-    if (replicationEnabledGauge != null) {
-      replicationEnabledGauge.close();
-    }
-    if (fetcherMetricsBatch != null) {
-      fetcherMetricsBatch.close();
-    }
-
+    IOUtils.closeQuietly(indexSizeGauge);
+    IOUtils.closeQuietly(indexVersionGauge);
+    IOUtils.closeQuietly(indexGenerationGauge);
+    IOUtils.closeQuietly(isLeaderGauge);
+    IOUtils.closeQuietly(isFollowerGauge);
+    IOUtils.closeQuietly(replicationEnabledGauge);
+    IOUtils.closeQuietly(fetcherMetricsBatch);
     super.close();
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -903,34 +903,34 @@ public class ReplicationHandler extends RequestHandlerBase
 
     replicationEnabledGauge =
         solrMetricsContext.observableLongGauge(
-            "solr_replication_enabled",
+            "solr_replication_is_enabled",
             "Whether replication is enabled (1) or not (0)",
             gauge ->
                 gauge.record(
                     (isLeader && replicationEnabled.get()) ? 1 : 0, replicationAttributes));
 
     // Create measurements for fetcher metrics in a batch to ensure consistent fetcher reference
-    ObservableLongMeasurement isPollingDisabledGauge =
+    ObservableLongMeasurement isPollingDisabled =
         solrMetricsContext.longMeasurement(
             "solr_replication_is_polling_disabled", "Whether polling is disabled (1) or not (0)");
 
-    ObservableLongMeasurement isReplicatingGauge =
+    ObservableLongMeasurement isReplicating =
         solrMetricsContext.longMeasurement(
             "solr_replication_is_replicating", "Whether replication is in progress (1) or not (0)");
 
-    ObservableLongMeasurement timeElapsedGauge =
+    ObservableLongMeasurement timeElapsed =
         solrMetricsContext.longMeasurement(
             "solr_replication_time_elapsed",
             "Time elapsed during replication in seconds",
             OtelUnit.SECONDS);
 
-    ObservableLongMeasurement bytesDownloadedGauge =
+    ObservableLongMeasurement bytesDownloaded =
         solrMetricsContext.longMeasurement(
             "solr_replication_bytes_downloaded",
             "Total bytes downloaded during replication",
             OtelUnit.BYTES);
 
-    ObservableLongMeasurement downloadSpeedGauge =
+    ObservableLongMeasurement downloadSpeed =
         solrMetricsContext.longMeasurement(
             "solr_replication_download_speed", "Download speed in bytes per second");
 
@@ -940,23 +940,23 @@ public class ReplicationHandler extends RequestHandlerBase
             () -> {
               IndexFetcher fetcher = currentIndexFetcher;
               if (fetcher != null) {
-                isPollingDisabledGauge.record(isPollingDisabled() ? 1 : 0, replicationAttributes);
-                isReplicatingGauge.record(isReplicating() ? 1 : 0, replicationAttributes);
+                isPollingDisabled.record(isPollingDisabled() ? 1 : 0, replicationAttributes);
+                isReplicating.record(isReplicating() ? 1 : 0, replicationAttributes);
 
                 long elapsed = fetcher.getReplicationTimeElapsed();
                 long val = fetcher.getTotalBytesDownloaded();
                 if (elapsed > 0) {
-                  timeElapsedGauge.record(elapsed, replicationAttributes);
-                  bytesDownloadedGauge.record(val, replicationAttributes);
-                  downloadSpeedGauge.record(val / elapsed, replicationAttributes);
+                  timeElapsed.record(elapsed, replicationAttributes);
+                  bytesDownloaded.record(val, replicationAttributes);
+                  downloadSpeed.record(val / elapsed, replicationAttributes);
                 }
               }
             },
-            isPollingDisabledGauge,
-            isReplicatingGauge,
-            timeElapsedGauge,
-            bytesDownloadedGauge,
-            downloadSpeedGauge);
+            isPollingDisabled,
+            isReplicating,
+            timeElapsed,
+            bytesDownloaded,
+            downloadSpeed);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
+import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.DoubleCounterBuilder;
 import io.opentelemetry.api.metrics.DoubleGauge;
@@ -50,6 +51,7 @@ import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+import io.opentelemetry.api.metrics.ObservableMeasurement;
 import io.opentelemetry.exporter.prometheus.PrometheusMetricReader;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
@@ -261,15 +263,7 @@ public class SolrMetricManager {
   }
 
   public LongGauge longGauge(String registry, String gaugeName, String description, OtelUnit unit) {
-    LongGaugeBuilder builder =
-        meterProvider(registry)
-            .get(OTEL_SCOPE_NAME)
-            .gaugeBuilder(gaugeName)
-            .setDescription(description)
-            .ofLongs();
-    if (unit != null) builder.setUnit(unit.getSymbol());
-
-    return builder.build();
+    return longGaugeBuilder(registry, gaugeName, description, unit).build();
   }
 
   public ObservableLongCounter observableLongCounter(
@@ -311,15 +305,7 @@ public class SolrMetricManager {
       String description,
       Consumer<ObservableLongMeasurement> callback,
       OtelUnit unit) {
-    LongGaugeBuilder builder =
-        meterProvider(registry)
-            .get(OTEL_SCOPE_NAME)
-            .gaugeBuilder(gaugeName)
-            .setDescription(description)
-            .ofLongs();
-    if (unit != null) builder.setUnit(unit.getSymbol());
-
-    return builder.buildWithCallback(callback);
+    return longGaugeBuilder(registry, gaugeName, description, unit).buildWithCallback(callback);
   }
 
   public ObservableDoubleGauge observableDoubleGauge(
@@ -370,6 +356,34 @@ public class SolrMetricManager {
     if (unit != null) builder.setUnit(unit);
 
     return builder.buildWithCallback(callback);
+  }
+
+  ObservableLongMeasurement longMeasurement(
+      String registry, String gaugeName, String description, OtelUnit unit) {
+    return longGaugeBuilder(registry, gaugeName, description, unit).buildObserver();
+  }
+
+  BatchCallback batchCallback(
+      String registry,
+      Runnable callback,
+      ObservableMeasurement measurement,
+      ObservableMeasurement... additionalMeasurements) {
+    return meterProvider(registry)
+        .get(OTEL_SCOPE_NAME)
+        .batchCallback(callback, measurement, additionalMeasurements);
+  }
+
+  private LongGaugeBuilder longGaugeBuilder(
+      String registry, String gaugeName, String description, OtelUnit unit) {
+    LongGaugeBuilder builder =
+        meterProvider(registry)
+            .get(OTEL_SCOPE_NAME)
+            .gaugeBuilder(gaugeName)
+            .setDescription(description)
+            .ofLongs();
+    if (unit != null) builder.setUnit(unit.getSymbol());
+
+    return builder;
   }
 
   // for unit tests

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.DoubleHistogram;
@@ -37,6 +38,7 @@ import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableMeasurement;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -272,6 +274,22 @@ public class SolrMetricsContext {
       OtelUnit unit) {
     return metricManager.observableDoubleCounter(
         registryName, metricName, description, callback, unit);
+  }
+
+  public ObservableLongMeasurement longMeasurement(String metricName, String description) {
+    return longMeasurement(metricName, description, null);
+  }
+
+  public ObservableLongMeasurement longMeasurement(
+      String metricName, String description, OtelUnit unit) {
+    return metricManager.longMeasurement(registryName, metricName, description, unit);
+  }
+
+  public BatchCallback batchCallback(
+      Runnable callback,
+      ObservableMeasurement measurement,
+      ObservableMeasurement... additionalMeasurements) {
+    return metricManager.batchCallback(registryName, callback, measurement, additionalMeasurements);
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17458

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Added OTEL metrics to ReplicationHandler. This is what they look like:

```
# HELP solr_replication_download_speed Download speed in bytes per second
# TYPE solr_replication_download_speed gauge
solr_replication_download_speed{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 3.7073146E7
# HELP solr_replication_downloaded_size_bytes Total bytes downloaded during replication
# TYPE solr_replication_downloaded_size_bytes gauge
solr_replication_downloaded_size_bytes{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 1.408779582E9
# HELP solr_replication_index_generation Current index generation
# TYPE solr_replication_index_generation gauge
solr_replication_index_generation{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 9.0
# HELP solr_replication_index_version Current index version
# TYPE solr_replication_index_version gauge
solr_replication_index_version{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 1.756417815232E12
# HELP solr_replication_is_enabled Whether replication is enabled (1) or not (0)
# TYPE solr_replication_is_enabled gauge
solr_replication_is_enabled{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 1.0
# HELP solr_replication_is_follower Whether this node is a follower (1) or not (0)
# TYPE solr_replication_is_follower gauge
solr_replication_is_follower{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 0.0
# HELP solr_replication_is_leader Whether this node is a leader (1) or not (0)
# TYPE solr_replication_is_leader gauge
solr_replication_is_leader{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 1.0
# HELP solr_replication_is_polling_disabled Whether polling is disabled (1) or not (0)
# TYPE solr_replication_is_polling_disabled gauge
solr_replication_is_polling_disabled{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 0.0
# HELP solr_replication_is_replicating Whether replication is in progress (1) or not (0)
# TYPE solr_replication_is_replicating gauge
solr_replication_is_replicating{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 1.0
# HELP solr_replication_time_elapsed_seconds Time elapsed during replication in seconds
# TYPE solr_replication_time_elapsed_seconds gauge
solr_replication_time_elapsed_seconds{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 38.0
# HELP ssolr_replication_index_size_bytes Size of the index in bytes
# TYPE ssolr_replication_index_size_bytes gauge
solr_replication_index_size_bytes{category="REPLICATION",collection="gettingstarted",core="gettingstarted_shard1_replica_n9",handler="/replication",otel_scope_name="org.apache.solr",replica="replica_n9",shard="shard1"} 3.91604846E8
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
