### PR TITLE
Close OTEL Observable instruments

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
+++ b/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
@@ -50,6 +50,7 @@ import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.SolrConfig.UpdateHandlerInfo;
 import org.apache.solr.core.SolrCore;
@@ -1014,8 +1015,9 @@ public class DirectUpdateHandler2 extends UpdateHandler
 
     commitTracker.close();
     softCommitTracker.close();
-    commitStats.close();
-
+    IOUtils.closeQuietly(commitStats);
+    IOUtils.closeQuietly(updateStats);
+    IOUtils.closeQuietly(softAutoCommits);
     numDocsPending.reset();
     try {
       super.close();

--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -117,23 +117,21 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
   @Test
   public void testSomeStuff() {
-    clearIndex();
+    try (SolrCore core = h.getCoreContainer().getCore("collection1")) {
+      // test that we got the expected config, not just hardcoded defaults
+      assertNotNull(core.getRequestHandler("/mock"));
 
-    SolrCore core = h.getCore();
-
-    // test that we got the expected config, not just hardcoded defaults
-    assertNotNull(core.getRequestHandler("/mock"));
-
-    // test stats call
-    var refCount =
-        SolrMetricTestUtils.getGaugeDatapoint(
-            core,
-            "solr_core_ref_count",
-            SolrMetricTestUtils.newStandaloneLabelsBuilder(core).label("category", "CORE").build());
-    assertNotNull(refCount);
-
-    assertTrue(refCount.getValue() > 0);
-
+      // test stats call
+      var refCount =
+          SolrMetricTestUtils.getGaugeDatapoint(
+              core,
+              "solr_core_ref_count",
+              SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+                  .label("category", "CORE")
+                  .build());
+      assertNotNull(refCount);
+      assertTrue(refCount.getValue() > 0);
+    }
     assertQ(
         "test query on empty index",
         req("qlkciyopsbgzyvkylsjhchghjrdf"),

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Timer;
 import java.util.Map;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.metrics.SolrMetricTestUtils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.After;
@@ -89,30 +90,25 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
     System.setProperty("solr.tests.metrics.merge", "false");
     System.setProperty("solr.tests.metrics.mergeDetails", "false");
     initCore("solrconfig-indexmetrics.xml", "schema.xml");
-
     addDocs();
-
-    MetricRegistry registry =
-        h.getCoreContainer()
-            .getMetricManager()
-            .registry(h.getCore().getCoreMetricManager().getRegistryName());
-    assertNotNull(registry);
-    var indexSize =
-        SolrMetricTestUtils.getGaugeDatapoint(
-            h.getCore(),
-            "solr_core_index_size_bytes",
-            SolrMetricTestUtils.newStandaloneLabelsBuilder(h.getCore())
-                .label("category", "CORE")
-                .build());
-    var segmentSize =
-        SolrMetricTestUtils.getGaugeDatapoint(
-            h.getCore(),
-            "solr_core_segment_count",
-            SolrMetricTestUtils.newStandaloneLabelsBuilder(h.getCore())
-                .label("category", "CORE")
-                .build());
-    assertNotNull(indexSize);
-    assertNotNull(segmentSize);
+    try (SolrCore core = h.getCoreContainer().getCore("collection1")) {
+      var indexSize =
+          SolrMetricTestUtils.getGaugeDatapoint(
+              core,
+              "solr_core_index_size_bytes",
+              SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+                  .label("category", "CORE")
+                  .build());
+      var segmentSize =
+          SolrMetricTestUtils.getGaugeDatapoint(
+              core,
+              "solr_core_segment_count",
+              SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+                  .label("category", "CORE")
+                  .build());
+      assertNotNull(indexSize);
+      assertNotNull(segmentSize);
+    }
   }
 
   @Test


### PR DESCRIPTION
No JIRA. Observable instruments `Gauge/Counters` closeable unlike synchronous instruments which aren't. They will close in the case of the `Meter Providers` closing but we should close them as well when we can.