### PR TITLE
QueryRequest should only be for SearchHandler

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/ReindexCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/ReindexCollectionCmd.java
@@ -33,9 +33,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.cloud.DistribStateManager;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.DistributedClusterStateUpdater;
@@ -854,12 +856,14 @@ public class ReindexCollectionCmd implements CollApiCmds.CollectionApiCommand {
     final var solrClient = ccc.getCoreContainer().getDefaultHttpSolrClient();
 
     final var solrParams = new ModifiableSolrParams();
-    solrParams.set(CommonParams.QT, "/stream");
     solrParams.set("action", action);
     solrParams.set(CommonParams.ID, daemonName);
     solrParams.set(CommonParams.DISTRIB, false);
 
-    final var req = new QueryRequest(solrParams);
+    final var req =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.POST, "/stream", SolrRequest.SolrRequestType.ADMIN, solrParams)
+            .setRequiresCollection(true);
     final var solrResponse =
         solrClient.requestWithBaseUrl(daemonReplica.getBaseUrl(), daemonReplica.getCoreName(), req);
     return solrResponse.getResponse();

--- a/solr/core/src/java/org/apache/solr/handler/admin/ColStatus.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ColStatus.java
@@ -26,9 +26,10 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.solr.client.api.model.GetSegmentDataResponse;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
@@ -36,7 +37,6 @@ import org.apache.solr.common.cloud.RoutingRule;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
@@ -190,7 +190,6 @@ public class ColStatus {
         if (getSegments) {
           try {
             ModifiableSolrParams params = new ModifiableSolrParams();
-            params.add(CommonParams.QT, "/admin/segments");
             params.add(FIELD_INFO_PROP, "true");
             params.add(CORE_INFO_PROP, String.valueOf(withCoreInfo));
             params.add(SIZE_INFO_PROP, String.valueOf(withSizeInfo));
@@ -200,7 +199,13 @@ public class ColStatus {
             if (samplingPercent != null) {
               params.add(RAW_SIZE_SAMPLING_PERCENT_PROP, String.valueOf(samplingPercent));
             }
-            QueryRequest req = new QueryRequest(params);
+            var req =
+                new GenericSolrRequest(
+                        SolrRequest.METHOD.GET,
+                        "/admin/segments",
+                        SolrRequest.SolrRequestType.ADMIN,
+                        params)
+                    .setRequiresCollection(true);
             NamedList<Object> rsp = solrClient.requestWithBaseUrl(url, null, req).getResponse();
             final var segmentResponse =
                 SolrJacksonMapper.getObjectMapper().convertValue(rsp, GetSegmentDataResponse.class);

--- a/solr/core/src/java/org/apache/solr/update/PeerSyncWithLeader.java
+++ b/solr/core/src/java/org/apache/solr/update/PeerSyncWithLeader.java
@@ -31,8 +31,7 @@ import java.util.Set;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
-import org.apache.solr.client.solrj.request.QueryRequest;
-import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -260,13 +259,12 @@ public class PeerSyncWithLeader implements SolrMetricProducer {
     }
 
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set("qt", "/get");
     params.set(DISTRIB, false);
     params.set("getUpdates", missedUpdatesRequest.versionsAndRanges);
     params.set("onlyIfActive", false);
     params.set("skipDbq", true);
 
-    return request(params, "Failed on getting missed updates from the leader");
+    return doRtgRequest(params, "Failed on getting missed updates from the leader");
   }
 
   private boolean handleUpdates(
@@ -331,10 +329,12 @@ public class PeerSyncWithLeader implements SolrMetricProducer {
     return true;
   }
 
-  private NamedList<Object> request(ModifiableSolrParams params, String onFail) {
+  private NamedList<Object> doRtgRequest(ModifiableSolrParams params, String onFail) {
     try {
-      QueryRequest request = new QueryRequest(params, SolrRequest.METHOD.POST);
-      QueryResponse rsp = clientToLeader.requestWithBaseUrl(leaderBaseUrl, coreName, request);
+      var request =
+          new GenericSolrRequest(
+              SolrRequest.METHOD.GET, "/get", SolrRequest.SolrRequestType.QUERY, params).setRequiresCollection(true);
+      var rsp = clientToLeader.requestWithBaseUrl(leaderBaseUrl, coreName, request);
       Exception exception = rsp.getException();
       if (exception != null) {
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, onFail);
@@ -347,21 +347,19 @@ public class PeerSyncWithLeader implements SolrMetricProducer {
 
   private NamedList<Object> getVersions() {
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set("qt", "/get");
     params.set(DISTRIB, false);
     params.set("getVersions", nUpdates);
     params.set("fingerprint", doFingerprint);
 
-    return request(params, "Failed to get recent versions from leader");
+    return doRtgRequest(params, "Failed to get recent versions from leader");
   }
 
   private boolean alreadyInSync() {
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set("qt", "/get");
     params.set(DISTRIB, false);
     params.set("getFingerprint", String.valueOf(Long.MAX_VALUE));
 
-    NamedList<Object> rsp = request(params, "Failed to get fingerprint from leader");
+    NamedList<Object> rsp = doRtgRequest(params, "Failed to get fingerprint from leader");
     IndexFingerprint leaderFingerprint = getFingerprint(rsp);
     return compareFingerprint(leaderFingerprint);
   }

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderVoteWaitTimeoutTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderVoteWaitTimeoutTest.java
@@ -31,11 +31,13 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkStateReader;
@@ -335,8 +337,13 @@ public class LeaderVoteWaitTimeoutTest extends SolrCloudTestCase {
 
   private NamedList<Object> realTimeGetDocId(SolrClient solr, String docId)
       throws SolrServerException, IOException {
-    QueryRequest qr = new QueryRequest(params("qt", "/get", "id", docId, "distrib", "false"));
-    return solr.request(qr);
+    return solr.request(
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/get",
+                SolrRequestType.QUERY,
+                params("id", docId, "distrib", "false"))
+            .setRequiresCollection(true));
   }
 
   protected SolrClient getSolrClient(Replica replica, String coll) {

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudConsistency.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudConsistency.java
@@ -29,11 +29,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.util.NamedList;
@@ -343,8 +345,13 @@ public class TestCloudConsistency extends SolrCloudTestCase {
 
   private NamedList<Object> realTimeGetDocId(SolrClient solr, String docId)
       throws SolrServerException, IOException {
-    QueryRequest qr = new QueryRequest(params("qt", "/get", "id", docId, "distrib", "false"));
-    return solr.request(qr);
+    return solr.request(
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/get",
+                SolrRequestType.QUERY,
+                params("id", docId, "distrib", "false"))
+            .setRequiresCollection(true));
   }
 
   protected SolrClient getHttpSolrClient(Replica replica, String coll) {

--- a/solr/core/src/test/org/apache/solr/cloud/TestTlogReplayVsRecovery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTlogReplayVsRecovery.java
@@ -29,11 +29,12 @@ import java.util.concurrent.TimeoutException;
 import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.SocketProxy;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.request.QueryRequest;
-import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.Replica;
@@ -274,11 +275,14 @@ public class TestTlogReplayVsRecovery extends SolrCloudTestCase {
    */
   private void assertDocExists(final String clientName, final SolrClient client, final String docId)
       throws Exception {
-    final QueryResponse rsp =
-        (new QueryRequest(
-                params("qt", "/get", "id", docId, "_trace", clientName, "distrib", "false")))
+    final var rsp =
+        (new GenericSolrRequest(
+                    SolrRequest.METHOD.GET,
+                    "/get",
+                    SolrRequestType.QUERY,
+                    params("qt", "/get", "id", docId, "_trace", clientName, "distrib", "false"))
+                .setRequiresCollection(true))
             .process(client, COLLECTION);
-    assertEquals(0, rsp.getStatus());
 
     String match = JSONTestUtil.matchObj("/id", rsp.getResponse().get("doc"), docId);
     assertNull(

--- a/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
+++ b/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
@@ -34,9 +34,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
@@ -128,10 +130,12 @@ public final class ReplicationTestHelper {
 
     // check vs /replication?command=indexversion call
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set("qt", ReplicationHandler.PATH);
     params.set("_trace", "assertVersions");
     params.set("command", "indexversion");
-    QueryRequest req = new QueryRequest(params);
+    var req =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET, ReplicationHandler.PATH, SolrRequestType.ADMIN, params)
+            .setRequiresCollection(true);
     NamedList<Object> resp = client1.request(req);
     assertReplicationResponseSucceeded(resp);
     Long version = (Long) resp.get("indexversion");
@@ -205,8 +209,10 @@ public final class ReplicationTestHelper {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("command", "details");
     params.set("_trace", "getDetails");
-    params.set("qt", ReplicationHandler.PATH);
-    QueryRequest req = new QueryRequest(params);
+    var req =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET, ReplicationHandler.PATH, SolrRequestType.ADMIN, params)
+            .setRequiresCollection(true);
 
     NamedList<Object> res = s.request(req);
     assertReplicationResponseSucceeded(res);

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -51,10 +51,10 @@ import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CoresApi;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
-import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SimpleSolrResponse;
@@ -201,8 +201,10 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("command", "details");
     params.set("_trace", "getDetails");
-    params.set("qt", ReplicationHandler.PATH);
-    QueryRequest req = new QueryRequest(params);
+    var req =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET, ReplicationHandler.PATH, SolrRequestType.ADMIN, params)
+            .setRequiresCollection(true);
 
     NamedList<Object> res = s.request(req);
     assertReplicationResponseSucceeded(res);
@@ -220,9 +222,10 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("command", "indexversion");
     params.set("_trace", "getIndexVersion");
-    params.set("qt", ReplicationHandler.PATH);
-    QueryRequest req = new QueryRequest(params);
-
+    var req =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET, ReplicationHandler.PATH, SolrRequestType.ADMIN, params)
+            .setRequiresCollection(true);
     NamedList<Object> res = s.request(req);
     assertReplicationResponseSucceeded(res);
 
@@ -234,8 +237,9 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("action", "reload");
     params.set("core", core);
-    params.set("qt", "/admin/cores");
-    QueryRequest req = new QueryRequest(params);
+    var req =
+        new GenericSolrRequest(
+            SolrRequest.METHOD.POST, "/admin/cores", SolrRequestType.ADMIN, params);
 
     try (SolrClient adminClient = adminClient(jettySolrRunner)) {
       NamedList<Object> res = adminClient.request(req);

--- a/solr/core/src/test/org/apache/solr/handler/admin/ShowFileRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ShowFileRequestHandlerTest.java
@@ -23,11 +23,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.solr.SolrJettyTestBase;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.NoOpResponseParser;
-import org.apache.solr.client.solrj.request.QueryRequest;
-import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.SolrCore;
@@ -51,8 +53,13 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
 
   public void test404ViaHttp() {
     SolrClient client = getSolrClient();
-    QueryRequest request = new QueryRequest(params("file", "does-not-exist-404.txt"));
-    request.setPath("/admin/file");
+    var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                params("file", "does-not-exist-404.txt"))
+            .setRequiresCollection(true);
     SolrException e = expectThrows(SolrException.class, () -> request.process(client));
     assertEquals(404, e.code());
   }
@@ -77,10 +84,14 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
     SolrClient client = getSolrClient();
     // assertQ(req("qt", "/admin/file")); TODO file bug that SolrJettyTestBase extends
     // SolrTestCaseJ4
-    QueryRequest request = new QueryRequest();
-    request.setPath("/admin/file");
-    QueryResponse resp = request.process(client);
-    assertEquals(0, resp.getStatus());
+    var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                new ModifiableSolrParams())
+            .setRequiresCollection(true);
+    var resp = request.process(client);
     assertTrue(((NamedList) resp.getResponse().get("files")).size() > 0); // some files
   }
 
@@ -88,8 +99,13 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
     SolrClient client = getSolrClient();
     // assertQ(req("qt", "/admin/file"));
     // TODO file bug that SolrJettyTestBase extends SolrTestCaseJ4
-    QueryRequest request = new QueryRequest(params("file", "managed-schema.xml"));
-    request.setPath("/admin/file");
+    var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                params("file", "managed-schema.xml"))
+            .setRequiresCollection(true);
     final AtomicBoolean readFile = new AtomicBoolean();
     request.setResponseParser(
         new ResponseParser() {
@@ -142,28 +158,39 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
 
   public void testIllegalContentType() {
     SolrClient client = getSolrClient();
-    QueryRequest request =
-        new QueryRequest(params("file", "managed-schema", "contentType", "not/known"));
-    request.setPath("/admin/file");
+    var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                params("file", "managed-schema", "contentType", "not/known"))
+            .setRequiresCollection(true);
     request.setResponseParser(new NoOpResponseParser("xml"));
     expectThrows(SolrException.class, () -> client.request(request));
   }
 
   public void testAbsoluteFilename() {
     SolrClient client = getSolrClient();
-    final QueryRequest request =
-        new QueryRequest(params("file", "/etc/passwd", "contentType", "text/plain; charset=utf-8"));
-    request.setPath("/admin/file"); // absolute path not allowed
+    final var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                params("file", "/etc/passwd", "contentType", "text/plain; charset=utf-8"))
+            .setRequiresCollection(true);
     request.setResponseParser(new NoOpResponseParser("xml"));
     expectThrows(SolrException.class, () -> client.request(request));
   }
 
   public void testEscapeConfDir() {
     SolrClient client = getSolrClient();
-    final QueryRequest request =
-        new QueryRequest(
-            params("file", "../../solr.xml", "contentType", "application/xml; charset=utf-8"));
-    request.setPath("/admin/file");
+    final var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                params("file", "../../solr.xml", "contentType", "application/xml; charset=utf-8"))
+            .setRequiresCollection(true);
     request.setResponseParser(new NoOpResponseParser("xml"));
     var ex = expectThrows(SolrException.class, () -> client.request(request));
     assertTrue(ex instanceof SolrClient.RemoteSolrException);
@@ -171,14 +198,17 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
 
   public void testPathTraversalFilename() {
     SolrClient client = getSolrClient();
-    final QueryRequest request =
-        new QueryRequest(
-            params(
-                "file",
-                "../../../../../../etc/passwd",
-                "contentType",
-                "text/plain; charset=utf-8"));
-    request.setPath("/admin/file");
+    final var request =
+        new GenericSolrRequest(
+                SolrRequest.METHOD.GET,
+                "/admin/file",
+                SolrRequestType.ADMIN,
+                params(
+                    "file",
+                    "../../../../../../etc/passwd",
+                    "contentType",
+                    "text/plain; charset=utf-8"))
+            .setRequiresCollection(true);
     request.setResponseParser(new NoOpResponseParser("xml"));
     expectThrows(SolrException.class, () -> client.request(request));
   }

--- a/solr/core/src/test/org/apache/solr/search/TestTaskManagement.java
+++ b/solr/core/src/test/org/apache/solr/search/TestTaskManagement.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
@@ -219,8 +220,10 @@ public class TestTaskManagement extends SolrCloudTestCase {
           ModifiableSolrParams params = new ModifiableSolrParams();
 
           params.set("queryUUID", queryID);
-          SolrRequest<?> request = new QueryRequest(params);
-          request.setPath("/tasks/cancel");
+          var request =
+              new GenericSolrRequest(
+                      SolrRequest.METHOD.POST, "/tasks/cancel", SolrRequestType.ADMIN, params)
+                  .setRequiresCollection(true);
 
           try {
             NamedList<Object> queryResponse;

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/MetricsQuery.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/MetricsQuery.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
-import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.DOMUtil;
 import org.apache.solr.common.util.NamedList;
@@ -110,9 +109,6 @@ public class MetricsQuery {
           }
         }
       }
-
-      QueryRequest queryRequest = new QueryRequest(params);
-      queryRequest.setPath(path);
 
       List<JsonQuery> compiledQueries = new ArrayList<>();
       if (jsonQueries != null) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/QueryRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/QueryRequest.java
@@ -23,6 +23,9 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 
 /**
+ * For use with Solr's {@code SearchHandler}, generally at "/select". For other handlers, try {@link
+ * GenericSolrRequest}.
+ *
  * @since solr 1.3
  */
 public class QueryRequest extends CollectionRequiringSolrRequest<QueryResponse> {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java
@@ -39,6 +39,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -664,12 +665,14 @@ public class CloudHttp2SolrClientTest extends SolrCloudTestCase {
             .withSocketTimeout(60000, TimeUnit.MILLISECONDS)
             .build()) {
       ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set("qt", "/admin/mbeans");
       params.set("stats", "true");
       params.set("key", key);
       params.set("cat", category);
       // use generic request to avoid extra processing of queries
-      QueryRequest req = new QueryRequest(params);
+      var req =
+          new GenericSolrRequest(
+                  SolrRequest.METHOD.GET, "/admin/mbeans", SolrRequestType.ADMIN, params)
+              .setRequiresCollection(true);
       resp = client.request(req);
     }
     String name;
@@ -734,10 +737,10 @@ public class CloudHttp2SolrClientTest extends SolrCloudTestCase {
 
           ModifiableSolrParams params = new ModifiableSolrParams();
           params.set("action", "foobar"); // this should cause an error
-          params.set("qt", adminPath);
 
           var request =
-              new GenericSolrRequest(METHOD.GET, adminPath, SolrRequestType.ADMIN, params);
+              new GenericSolrRequest(METHOD.GET, adminPath, SolrRequestType.ADMIN, params)
+                  .setRequiresCollection(true);
           try {
             NamedList<Object> resp = client.request(request);
             fail("call to foo for admin path " + adminPath + " should have failed");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
@@ -39,6 +39,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -599,12 +600,14 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
             .withSocketTimeout(60000, TimeUnit.MILLISECONDS)
             .build()) {
       ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set("qt", "/admin/mbeans");
       params.set("stats", "true");
       params.set("key", key);
       params.set("cat", category);
       // use generic request to avoid extra processing of queries
-      QueryRequest req = new QueryRequest(params);
+      var req =
+          new GenericSolrRequest(
+                  SolrRequest.METHOD.GET, "/admin/mbeans", SolrRequestType.ADMIN, params)
+              .setRequiresCollection(true);
       resp = client.request(req);
     }
     String name;
@@ -672,7 +675,8 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
           params.set("action", "foobar"); // this should cause an error
 
           var request =
-              new GenericSolrRequest(METHOD.GET, adminPath, SolrRequestType.ADMIN, params);
+              new GenericSolrRequest(METHOD.GET, adminPath, SolrRequestType.ADMIN, params)
+                  .setRequiresCollection(true);
           try {
             NamedList<Object> resp = client.request(request);
             fail("call to foo for admin path " + adminPath + " should have failed");


### PR DESCRIPTION
Internal refactoring.  There are many places where QueryRequest is being used for requests that are *not* to a SearchHandler.  That is an abuse/misuse.  It explains some portion of the use of "qt" that can be sidestepped via explicit path to `GenericSolrRequest`.

This PR also adds javadoc to QueryRequest to make it's intended use explicit.