### PR TITLE
Fix reference in collapse and expand docs

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/collapse-and-expand-results.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/collapse-and-expand-results.adoc
@@ -128,7 +128,7 @@ Setting the size above the number of results expected in the result set will eli
 |Optional |Default: `true`
 |===
 +
-In combination with the <<Collapsing Query Parser>> all elevated docs are visible at the beginning of the result set.
+In combination with the xref:query-elevation-component.adoc[Query Elevation Component] all elevated docs are visible at the beginning of the result set.
 If this parameter is `false`, only the representative is visible if the elevated docs has the same collapse key.
 
 


### PR DESCRIPTION
The [Collapse and Expand Results documentation](https://solr.apache.org/guide/solr/latest/query-guide/collapse-and-expand-results.html#collapsing-query-parser) references itself below the `collectElevatedDocsWhenCollapsing` parameter which doesn't really make any sense. I adjusted it to reference the [Query Elevation Component](https://solr.apache.org/guide/solr/latest/query-guide/query-elevation-component.html) which I assume was the intention.