### PR TITLE
SOLR-17877: Introduce cluster property overseerEnabled, replacing dual booleans

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -712,7 +712,7 @@ public class Overseer implements SolrCloseable {
     this.stats = new Stats();
     this.config = config;
     this.distributedClusterStateUpdater =
-        new DistributedClusterStateUpdater(config.getDistributedClusterStateUpdates());
+        new DistributedClusterStateUpdater(reader.getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false));
 
     this.solrMetricsContext =
         new SolrMetricsContext(

--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -712,7 +712,7 @@ public class Overseer implements SolrCloseable {
     this.stats = new Stats();
     this.config = config;
     this.distributedClusterStateUpdater =
-        new DistributedClusterStateUpdater(reader.getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false));
+        new DistributedClusterStateUpdater(!"true".equals(String.valueOf(reader.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true"))));
 
     this.solrMetricsContext =
         new SolrMetricsContext(

--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -711,8 +711,7 @@ public class Overseer implements SolrCloseable {
     this.zkController = zkController;
     this.stats = new Stats();
     this.config = config;
-    this.distributedClusterStateUpdater =
-        new DistributedClusterStateUpdater(!"true".equals(String.valueOf(reader.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true"))));
+    this.distributedClusterStateUpdater = zkController.getDistributedClusterStateUpdater();
 
     this.solrMetricsContext =
         new SolrMetricsContext(

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -383,7 +383,7 @@ public class ZkController implements Closeable {
             });
 
     // Now that zkStateReader is available, read the overseer enabled setting
-    // When overseerEnabled is false, both distributed features should be enabled  
+    // When overseerEnabled is false, both distributed features should be enabled
     Object clusterProperty = zkStateReader.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, null);
     boolean overseerEnabled;
     if (clusterProperty != null) {
@@ -393,8 +393,8 @@ public class ZkController implements Closeable {
     }
     boolean useDistributedUpdates = !overseerEnabled;
     boolean useDistributedCommandRunner = !overseerEnabled;
-    
-    distributedClusterStateUpdater = new DistributedClusterStateUpdater(useDistributedUpdates);
+
+    this.distributedClusterStateUpdater = new DistributedClusterStateUpdater(useDistributedUpdates);
 
     // Initialize the distributed command runner now that we have the cluster properties
     this.distributedCommandRunner =

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DistributedCollectionCommandContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DistributedCollectionCommandContext.java
@@ -69,11 +69,12 @@ public class DistributedCollectionCommandContext implements CollectionCommandCon
     if (distributedClusterStateUpdater == null) {
       synchronized (this) {
         if (distributedClusterStateUpdater == null) {
-          // Read distributed cluster state updates setting from cluster properties
-          boolean useDistributedUpdates = false;
+          // Read overseer enabled setting from cluster properties 
+          // When overseerEnabled is false, distributed updates should be enabled
+          boolean useDistributedUpdates = true; // default if zkController not available yet
           if (coreContainer.getZkController() != null) {
-            useDistributedUpdates = coreContainer.getZkController().getZkStateReader()
-                .getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false);
+            useDistributedUpdates = !"true".equals(String.valueOf(coreContainer.getZkController().getZkStateReader()
+                .getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true")));
           }
           distributedClusterStateUpdater = new DistributedClusterStateUpdater(useDistributedUpdates);
         }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DistributedCollectionCommandContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DistributedCollectionCommandContext.java
@@ -27,15 +27,12 @@ import org.apache.solr.handler.component.ShardHandler;
 
 public class DistributedCollectionCommandContext implements CollectionCommandContext {
   private final CoreContainer coreContainer;
-  private final DistributedClusterStateUpdater distributedClusterStateUpdater;
   private final ExecutorService executorService;
 
   public DistributedCollectionCommandContext(
       CoreContainer coreContainer, ExecutorService executorService) {
     // note: coreContainer.getZkController() is not yet instantiated; don't call it right now
     this.coreContainer = coreContainer;
-    // Get the distributed cluster state updater from ZkController now that it's initialized properly
-    this.distributedClusterStateUpdater = coreContainer.getZkController().getDistributedClusterStateUpdater();
     this.executorService = executorService;
   }
 
@@ -68,7 +65,7 @@ public class DistributedCollectionCommandContext implements CollectionCommandCon
 
   @Override
   public DistributedClusterStateUpdater getDistributedClusterStateUpdater() {
-    return distributedClusterStateUpdater;
+    return this.coreContainer.getZkController().getDistributedClusterStateUpdater();
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/core/CloudConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/CloudConfig.java
@@ -49,10 +49,6 @@ public class CloudConfig {
 
   private final String pkiHandlerPublicKeyPath;
 
-  private final boolean useDistributedClusterStateUpdates;
-
-  private final boolean useDistributedCollectionConfigSetExecution;
-
   private final int minStateByteLenForCompression;
 
   private final String stateCompressorClass;
@@ -72,8 +68,6 @@ public class CloudConfig {
       boolean createCollectionCheckLeaderActive,
       String pkiHandlerPrivateKeyPath,
       String pkiHandlerPublicKeyPath,
-      boolean useDistributedClusterStateUpdates,
-      boolean useDistributedCollectionConfigSetExecution,
       int minStateByteLenForCompression,
       String stateCompressorClass) {
     this.zkHost = zkHost;
@@ -90,16 +84,8 @@ public class CloudConfig {
     this.createCollectionCheckLeaderActive = createCollectionCheckLeaderActive;
     this.pkiHandlerPrivateKeyPath = pkiHandlerPrivateKeyPath;
     this.pkiHandlerPublicKeyPath = pkiHandlerPublicKeyPath;
-    this.useDistributedClusterStateUpdates = useDistributedClusterStateUpdates;
-    this.useDistributedCollectionConfigSetExecution = useDistributedCollectionConfigSetExecution;
     this.minStateByteLenForCompression = minStateByteLenForCompression;
     this.stateCompressorClass = stateCompressorClass;
-
-    if (useDistributedCollectionConfigSetExecution && !useDistributedClusterStateUpdates) {
-      throw new SolrException(
-          SolrException.ErrorCode.SERVER_ERROR,
-          "'useDistributedCollectionConfigSetExecution' can't be true if useDistributedClusterStateUpdates is false");
-    }
 
     if (this.hostPort == -1)
       throw new SolrException(
@@ -162,14 +148,6 @@ public class CloudConfig {
     return pkiHandlerPublicKeyPath;
   }
 
-  public boolean getDistributedClusterStateUpdates() {
-    return useDistributedClusterStateUpdates;
-  }
-
-  public boolean getDistributedCollectionConfigSetExecution() {
-    return useDistributedCollectionConfigSetExecution;
-  }
-
   public int getMinStateByteLenForCompression() {
     return minStateByteLenForCompression;
   }
@@ -202,8 +180,6 @@ public class CloudConfig {
         DEFAULT_CREATE_COLLECTION_CHECK_LEADER_ACTIVE;
     private String pkiHandlerPrivateKeyPath;
     private String pkiHandlerPublicKeyPath;
-    private boolean useDistributedClusterStateUpdates = false;
-    private boolean useDistributedCollectionConfigSetExecution = false;
     private int minStateByteLenForCompression = DEFAULT_MINIMUM_STATE_SIZE_FOR_COMPRESSION;
 
     private String stateCompressorClass;
@@ -277,18 +253,6 @@ public class CloudConfig {
       return this;
     }
 
-    public CloudConfigBuilder setUseDistributedClusterStateUpdates(
-        boolean useDistributedClusterStateUpdates) {
-      this.useDistributedClusterStateUpdates = useDistributedClusterStateUpdates;
-      return this;
-    }
-
-    public CloudConfigBuilder setUseDistributedCollectionConfigSetExecution(
-        boolean useDistributedCollectionConfigSetExecution) {
-      this.useDistributedCollectionConfigSetExecution = useDistributedCollectionConfigSetExecution;
-      return this;
-    }
-
     public CloudConfigBuilder setMinStateByteLenForCompression(int minStateByteLenForCompression) {
       this.minStateByteLenForCompression = minStateByteLenForCompression;
       return this;
@@ -315,8 +279,6 @@ public class CloudConfig {
           createCollectionCheckLeaderActive,
           pkiHandlerPrivateKeyPath,
           pkiHandlerPublicKeyPath,
-          useDistributedClusterStateUpdates,
-          useDistributedCollectionConfigSetExecution,
           minStateByteLenForCompression,
           stateCompressorClass);
     }

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -570,6 +570,14 @@ public class SolrXmlConfig {
         case "stateCompressor":
           builder.setStateCompressorClass(value);
           break;
+        case "distributedClusterStateUpdates":
+          log.warn("The 'distributedClusterStateUpdates' parameter in solr.xml is deprecated. " +
+                   "Use the 'overseerEnabled' cluster property instead. This setting will be ignored.");
+          break;
+        case "distributedCollectionConfigSetExecution":
+          log.warn("The 'distributedCollectionConfigSetExecution' parameter in solr.xml is deprecated. " +
+                   "Use the 'overseerEnabled' cluster property instead. This setting will be ignored.");
+          break;
         default:
           throw new SolrException(
               SolrException.ErrorCode.SERVER_ERROR,

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -564,12 +564,6 @@ public class SolrXmlConfig {
         case "pkiHandlerPublicKeyPath":
           builder.setPkiHandlerPublicKeyPath(value);
           break;
-        case "distributedClusterStateUpdates":
-          builder.setUseDistributedClusterStateUpdates(Boolean.parseBoolean(value));
-          break;
-        case "distributedCollectionConfigSetExecution":
-          builder.setUseDistributedCollectionConfigSetExecution(Boolean.parseBoolean(value));
-          break;
         case "minStateByteLenForCompression":
           builder.setMinStateByteLenForCompression(parseInt(name, value));
           break;

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -570,14 +570,7 @@ public class SolrXmlConfig {
         case "stateCompressor":
           builder.setStateCompressorClass(value);
           break;
-        case "distributedClusterStateUpdates":
-          log.warn("The 'distributedClusterStateUpdates' parameter in solr.xml is deprecated. " +
-                   "Use the 'overseerEnabled' cluster property instead. This setting will be ignored.");
-          break;
-        case "distributedCollectionConfigSetExecution":
-          log.warn("The 'distributedCollectionConfigSetExecution' parameter in solr.xml is deprecated. " +
-                   "Use the 'overseerEnabled' cluster property instead. This setting will be ignored.");
-          break;
+
         default:
           throw new SolrException(
               SolrException.ErrorCode.SERVER_ERROR,

--- a/solr/core/src/test/org/apache/solr/cloud/CreateCollectionCleanupTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CreateCollectionCleanupTest.java
@@ -56,7 +56,6 @@ public class CreateCollectionCleanupTest extends SolrCloudTestCase {
           + "    <int name=\"distribUpdateConnTimeout\">${distribUpdateConnTimeout:45000}</int>\n"
           + "    <int name=\"distribUpdateSoTimeout\">${distribUpdateSoTimeout:340000}</int>\n"
           + "    <int name=\"createCollectionWaitTimeTillActive\">${createCollectionWaitTimeTillActive:10}</int>\n"
-          + "    <str name=\"distributedClusterStateUpdates\">${solr.distributedClusterStateUpdates:false}</str> \n"
           + "  </solrcloud>\n"
           + "  \n"
           + "</solr>\n";

--- a/solr/core/src/test/org/apache/solr/cloud/CreateCollectionCleanupTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CreateCollectionCleanupTest.java
@@ -66,7 +66,7 @@ public class CreateCollectionCleanupTest extends SolrCloudTestCase {
         .addConfig(
             "conf1", TEST_PATH().resolve("configsets").resolve("cloud-minimal").resolve("conf"))
         .withSolrXml(CLOUD_SOLR_XML_WITH_10S_CREATE_COLL_WAIT)
-        .useOtherCollectionConfigSetExecution()
+        .flipOverseerEnablement()
         .configure();
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
@@ -64,7 +64,7 @@ public class DeleteReplicaTest extends SolrCloudTestCase {
     // these tests need to be isolated, so we don't share the minicluster
     configureCluster(4)
         .addConfig("conf", configset("cloud-minimal"))
-        .useOtherCollectionConfigSetExecution()
+        .flipOverseerEnablement()
         // Some tests (this one) use "the other" cluster Collection API execution strategy to
         // increase coverage
         .configure();

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -1022,8 +1022,6 @@ public class OverseerTest extends SolrTestCaseJ4 {
               reader,
               zkController,
               new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983)
-                  .setUseDistributedClusterStateUpdates(false)
-                  .setUseDistributedCollectionConfigSetExecution(false)
                   .build());
       overseers.add(overseer);
       ElectionContext ec =
@@ -1849,7 +1847,6 @@ public class OverseerTest extends SolrTestCaseJ4 {
             reader,
             zkController,
             new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983)
-                .setUseDistributedClusterStateUpdates(false)
                 .build());
     overseers.add(overseer);
     ElectionContext ec = new OverseerElectionContext(zkClient, overseer, address.replace("/", "_"));

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -60,7 +60,6 @@ import org.apache.solr.cloud.overseer.OverseerAction;
 import org.apache.solr.cloud.overseer.ZkWriteCommand;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterState;
-import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
@@ -999,8 +998,8 @@ public class OverseerTest extends SolrTestCaseJ4 {
       reader = new ZkStateReader(zkClient);
       reader.createClusterStateWatchersAndUpdate();
 
-      // Set overseerEnabled=true to ensure tests use Overseer mode
-      new ClusterProperties(zkClient).setClusterProperties(Map.of(ZkStateReader.OVERSEER_ENABLED, "true"));
+      // Set system property to ensure tests use Overseer mode
+      System.setProperty("solr.cloud.overseer.enabled", "true");
 
       mockController =
           new MockZKController(server.getZkAddress(), "127.0.0.1:8983_solr", overseers);
@@ -1842,12 +1841,8 @@ public class OverseerTest extends SolrTestCaseJ4 {
     ZkController zkController = createMockZkController(address, null, reader);
     zkControllers.add(zkController);
     
-    // Set overseerEnabled=true to ensure tests use Overseer mode
-    try {
-      new ClusterProperties(zkClient).setClusterProperties(Map.of(ZkStateReader.OVERSEER_ENABLED, "true"));
-    } catch (Exception e) {
-      // Cluster properties may already be set
-    }
+    // Set system property to ensure tests use Overseer mode
+    System.setProperty("solr.cloud.overseer.enabled", "true");
     
     // Create an Overseer with associated configuration to NOT USE distributed state update. Tests
     // in this class really test the Overseer.

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -208,7 +208,6 @@ public class OverseerTest extends SolrTestCaseJ4 {
               "");
       final Overseer overseer = MiniSolrCloudCluster.getOpenOverseer(overseers);
       // This being an Overseer test, we force it to use the Overseer based cluster state update.
-      // Look for "new Overseer" calls in this class.
       assertFalse(overseer.getDistributedClusterStateUpdater().isDistributedStateUpdate());
       ZkDistributedQueue q = overseer.getStateUpdateQueue();
       q.offer(m);
@@ -1024,8 +1023,7 @@ public class OverseerTest extends SolrTestCaseJ4 {
               "/admin/cores",
               reader,
               zkController,
-              new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983)
-                  .build());
+              new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983).build());
       overseers.add(overseer);
       ElectionContext ec =
           new OverseerElectionContext(zkClient, overseer, server.getZkAddress().replace("/", "_"));
@@ -1838,12 +1836,12 @@ public class OverseerTest extends SolrTestCaseJ4 {
     httpShardHandlerFactory.init(new PluginInfo("shardHandlerFactory", Collections.emptyMap()));
     httpShardHandlerFactorys.add(httpShardHandlerFactory);
 
-    ZkController zkController = createMockZkController(address, null, reader);
-    zkControllers.add(zkController);
-    
     // Set system property to ensure tests use Overseer mode
     System.setProperty("solr.cloud.overseer.enabled", "true");
-    
+
+    ZkController zkController = createMockZkController(address, null, reader);
+    zkControllers.add(zkController);
+
     // Create an Overseer with associated configuration to NOT USE distributed state update. Tests
     // in this class really test the Overseer.
     Overseer overseer =
@@ -1853,8 +1851,7 @@ public class OverseerTest extends SolrTestCaseJ4 {
             "/admin/cores",
             reader,
             zkController,
-            new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983)
-                .build());
+            new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983).build());
     overseers.add(overseer);
     ElectionContext ec = new OverseerElectionContext(zkClient, overseer, address.replace("/", "_"));
     overseerElector.setup(ec);
@@ -1914,6 +1911,8 @@ public class OverseerTest extends SolrTestCaseJ4 {
     when(zkController.getCoreContainer()).thenReturn(mockAlwaysUpCoreContainer);
     when(zkController.getZkClient()).thenReturn(zkClient);
     when(zkController.getZkStateReader()).thenReturn(reader);
+    when(zkController.getDistributedClusterStateUpdater())
+        .thenReturn(new DistributedClusterStateUpdater(false));
     // primitive support for CC.runAsync
     doAnswer(
             invocable -> {

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -60,6 +60,7 @@ import org.apache.solr.cloud.overseer.OverseerAction;
 import org.apache.solr.cloud.overseer.ZkWriteCommand;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterState;
+import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
@@ -998,6 +999,9 @@ public class OverseerTest extends SolrTestCaseJ4 {
       reader = new ZkStateReader(zkClient);
       reader.createClusterStateWatchersAndUpdate();
 
+      // Set overseerEnabled=true to ensure tests use Overseer mode
+      new ClusterProperties(zkClient).setClusterProperties(Map.of(ZkStateReader.OVERSEER_ENABLED, "true"));
+
       mockController =
           new MockZKController(server.getZkAddress(), "127.0.0.1:8983_solr", overseers);
 
@@ -1837,6 +1841,14 @@ public class OverseerTest extends SolrTestCaseJ4 {
 
     ZkController zkController = createMockZkController(address, null, reader);
     zkControllers.add(zkController);
+    
+    // Set overseerEnabled=true to ensure tests use Overseer mode
+    try {
+      new ClusterProperties(zkClient).setClusterProperties(Map.of(ZkStateReader.OVERSEER_ENABLED, "true"));
+    } catch (Exception e) {
+      // Cluster properties may already be set
+    }
+    
     // Create an Overseer with associated configuration to NOT USE distributed state update. Tests
     // in this class really test the Overseer.
     Overseer overseer =

--- a/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
@@ -20,6 +20,7 @@ package org.apache.solr.cloud;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterProperties;
+import org.apache.solr.common.cloud.ZkStateReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -51,5 +52,31 @@ public class TestClusterProperties extends SolrCloudTestCase {
     String propertyName = "pluginA.propertyA";
     CollectionAdminRequest.setClusterProperty(propertyName, "valueA")
         .process(cluster.getSolrClient());
+  }
+
+  @Test
+  public void testDistributedClusterStateUpdatesProperty() throws Exception {
+    // Test setting and getting the distributed cluster state updates property
+    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, "true")
+        .process(cluster.getSolrClient());
+    assertEquals(Boolean.TRUE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false));
+
+    // Test default value
+    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, null)
+        .process(cluster.getSolrClient());
+    assertEquals(Boolean.FALSE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false));
+  }
+
+  @Test
+  public void testDistributedCollectionConfigSetExecutionProperty() throws Exception {
+    // Test setting and getting the distributed collection config set execution property
+    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, "true")
+        .process(cluster.getSolrClient());
+    assertEquals(Boolean.TRUE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, false));
+
+    // Test default value
+    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, null)
+        .process(cluster.getSolrClient());
+    assertEquals(Boolean.FALSE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, false));
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
@@ -54,17 +54,5 @@ public class TestClusterProperties extends SolrCloudTestCase {
         .process(cluster.getSolrClient());
   }
 
-  @Test
-  public void testOverseerEnabledProperty() throws Exception {
-    // Test setting and getting the overseer enabled property
-    CollectionAdminRequest.setClusterProperty(ZkStateReader.OVERSEER_ENABLED, "false")
-        .process(cluster.getSolrClient());
-    // When property is set as string, it returns as string
-    assertEquals("false", props.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true"));
 
-    // Test default value when property is removed (should return the default)
-    CollectionAdminRequest.setClusterProperty(ZkStateReader.OVERSEER_ENABLED, null)
-        .process(cluster.getSolrClient());
-    assertEquals("true", props.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true"));
-  }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
@@ -55,28 +55,16 @@ public class TestClusterProperties extends SolrCloudTestCase {
   }
 
   @Test
-  public void testDistributedClusterStateUpdatesProperty() throws Exception {
-    // Test setting and getting the distributed cluster state updates property
-    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, "true")
+  public void testOverseerEnabledProperty() throws Exception {
+    // Test setting and getting the overseer enabled property
+    CollectionAdminRequest.setClusterProperty(ZkStateReader.OVERSEER_ENABLED, "false")
         .process(cluster.getSolrClient());
-    assertEquals(Boolean.TRUE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false));
+    // When property is set as string, it returns as string
+    assertEquals("false", props.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true"));
 
-    // Test default value
-    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, null)
+    // Test default value when property is removed (should return the default)
+    CollectionAdminRequest.setClusterProperty(ZkStateReader.OVERSEER_ENABLED, null)
         .process(cluster.getSolrClient());
-    assertEquals(Boolean.FALSE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_CLUSTER_STATE_UPDATES, false));
-  }
-
-  @Test
-  public void testDistributedCollectionConfigSetExecutionProperty() throws Exception {
-    // Test setting and getting the distributed collection config set execution property
-    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, "true")
-        .process(cluster.getSolrClient());
-    assertEquals(Boolean.TRUE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, false));
-
-    // Test default value
-    CollectionAdminRequest.setClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, null)
-        .process(cluster.getSolrClient());
-    assertEquals(Boolean.FALSE, props.getClusterProperty(ZkStateReader.DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION, false));
+    assertEquals("true", props.getClusterProperty(ZkStateReader.OVERSEER_ENABLED, "true"));
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestClusterProperties.java
@@ -20,7 +20,6 @@ package org.apache.solr.cloud;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterProperties;
-import org.apache.solr.common.cloud.ZkStateReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -53,6 +52,4 @@ public class TestClusterProperties extends SolrCloudTestCase {
     CollectionAdminRequest.setClusterProperty(propertyName, "valueA")
         .process(cluster.getSolrClient());
   }
-
-
 }

--- a/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
@@ -261,9 +261,7 @@ public class ZkControllerTest extends SolrCloudTestCase {
       ZkController zkController = null;
 
       try {
-        CloudConfig cloudConfig =
-            new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983)
-                .build();
+        CloudConfig cloudConfig = new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983).build();
         zkController =
             new ZkController(cc, cluster.getZkServer().getZkAddress(), TIMEOUT, cloudConfig);
         zkControllerRef.set(zkController);

--- a/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
@@ -263,10 +263,6 @@ public class ZkControllerTest extends SolrCloudTestCase {
       try {
         CloudConfig cloudConfig =
             new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983)
-                .setUseDistributedClusterStateUpdates(
-                    Boolean.getBoolean("solr.distributedClusterStateUpdates"))
-                .setUseDistributedCollectionConfigSetExecution(
-                    Boolean.getBoolean("solr.distributedCollectionConfigSetExecution"))
                 .build();
         zkController =
             new ZkController(cc, cluster.getZkServer().getZkAddress(), TIMEOUT, cloudConfig);

--- a/solr/server/solr/solr.xml
+++ b/solr/server/solr/solr.xml
@@ -49,8 +49,6 @@
     <str name="zkCredentialsProvider">${zkCredentialsProvider:org.apache.solr.common.cloud.DefaultZkCredentialsProvider}</str>
     <str name="zkACLProvider">${zkACLProvider:org.apache.solr.common.cloud.DefaultZkACLProvider}</str>
     <str name="zkCredentialsInjector">${zkCredentialsInjector:org.apache.solr.common.cloud.DefaultZkCredentialsInjector}</str>
-    <bool name="distributedClusterStateUpdates">${distributedClusterStateUpdates:false}</bool>
-    <bool name="distributedCollectionConfigSetExecution">${distributedCollectionConfigSetExecution:false}</bool>
     <int name="minStateByteLenForCompression">${minStateByteLenForCompression:-1}</int>
     <str name="stateCompressor">${stateCompressor:org.apache.solr.common.util.ZLibCompressor}</str>
 

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -138,8 +138,7 @@ public class ZkStateReader implements SolrCloseable {
   public static final String NRT_REPLICAS = "nrtReplicas";
   public static final String TLOG_REPLICAS = "tlogReplicas";
   public static final String READ_ONLY = "readOnly";
-  public static final String DISTRIBUTED_CLUSTER_STATE_UPDATES = "distributedClusterStateUpdates";
-  public static final String DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION = "distributedCollectionConfigSetExecution";
+  public static final String OVERSEER_ENABLED = "overseerEnabled";
 
   public static final String CONFIGS_ZKNODE = "/configs";
   public static final String CONFIGNAME_PROP = "configName";
@@ -383,7 +382,8 @@ public class ZkStateReader implements SolrCloseable {
           SOLR_ENVIRONMENT,
           CollectionAdminParams.DEFAULTS,
           CONTAINER_PLUGINS,
-          PLACEMENT_PLUGIN);
+          PLACEMENT_PLUGIN,
+          OVERSEER_ENABLED);
 
   private final SolrZkClient zkClient;
 

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -138,6 +138,8 @@ public class ZkStateReader implements SolrCloseable {
   public static final String NRT_REPLICAS = "nrtReplicas";
   public static final String TLOG_REPLICAS = "tlogReplicas";
   public static final String READ_ONLY = "readOnly";
+  public static final String DISTRIBUTED_CLUSTER_STATE_UPDATES = "distributedClusterStateUpdates";
+  public static final String DISTRIBUTED_COLLECTION_CONFIG_SET_EXECUTION = "distributedCollectionConfigSetExecution";
 
   public static final String CONFIGS_ZKNODE = "/configs";
   public static final String CONFIGNAME_PROP = "configName";

--- a/solr/solrj/src/test/org/apache/solr/common/cloud/PerReplicaStatesIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/cloud/PerReplicaStatesIntegrationTest.java
@@ -286,7 +286,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
     String PRS_COLL = "prs_test_coll2";
     MiniSolrCloudCluster cluster =
         configureCluster(3)
-            .withDistributedClusterStateUpdates(false, false)
+            .withOverseer(true)
             .addConfig(
                 "conf",
                 getFile("solrj")

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudTestCase.java
@@ -114,18 +114,14 @@ public class SolrCloudTestCase extends SolrTestCaseJ4 {
    */
   protected static MiniSolrCloudCluster.Builder configureCluster(int nodeCount) {
     // By default the MiniSolrCloudCluster being built will randomly (seed based) decide which
-    // collection API strategy to use (distributed or Overseer based) and which cluster update
-    // strategy to use (distributed if collection API is distributed, but Overseer based or
-    // distributed randomly chosen if Collection API is Overseer based), and whether to use PRS
+    // collection API strategy to use (distributed or Overseer based) and whether to use PRS
 
     configurePrsDefault();
 
-    boolean useDistributedCollectionConfigSetExecution = LuceneTestCase.random().nextInt(2) == 0;
-    boolean useDistributedClusterStateUpdate =
-        useDistributedCollectionConfigSetExecution || LuceneTestCase.random().nextInt(2) == 0;
     return new MiniSolrCloudCluster.Builder(nodeCount, createTempDir())
-        .withDistributedClusterStateUpdates(
-            useDistributedCollectionConfigSetExecution, useDistributedClusterStateUpdate);
+        .withOverseer(
+            EnvUtils.getPropertyAsBool(
+                "solr.cloud.overseer.enabled", LuceneTestCase.random().nextBoolean()));
   }
 
   public static void configurePrsDefault() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17877

This PR removes the dual booleans.  They weren't advertised before thus no backwards compatibility consideration is needed.  The ability to toggle just the distributed cluster state update part is not needed.  Now there's an "overseerEnabled" cluster property.  There's also an EnvUtil fallback on "solr.cloud.overseer.enabled".

Upgrade guide notes should be added to at least advise someone who divined the secret setting.

A follow-on change will change the default setting to consider the cluster version.

Tests pass (ran locally).