### PR TITLE
SOLR-17620 Fix test failure for 9x by supplying hostContext

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
@@ -227,7 +227,8 @@ public class ZkControllerTest extends SolrCloudTestCase {
     try {
       server.run();
       CoreContainer cc = getCoreContainer();
-      CloudConfig cloudConfig = new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983).build();
+      CloudConfig cloudConfig =
+          new CloudConfig.CloudConfigBuilder("127.0.0.1", 8983, "/solr").build();
 
       ZkController zkController = new ZkController(cc, server.getZkAddress(), 10000, cloudConfig);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17620

Turns out the backport to 9x, although compiling, caused test failure due to difference in `CloudConfig` between 9x and main. In 9x it needs a `hostContext` specified. 

This could have been avoided by running tests before committing the backport (by e.g. using the PR flow).