### PR TITLE
Run github PR tests on branch_9x with JDK17

### DIFF
--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
     # Setup
     - uses: actions/checkout@v5
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
         java-package: jdk
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
     # Setup
     - uses: actions/checkout@v5
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
         java-package: jdk
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -19,11 +19,11 @@ jobs:
     # Setup
     - uses: actions/checkout@v5
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
         java-package: jdk
 
     - name: Setup Gradle

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
     # Setup
     - uses: actions/checkout@v5
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
         java-package: jdk
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
Workaround for errors like

```
> Task :solr:api:compileJava FAILED
compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.28, {1}, {2}, {3}, {4}, {5}, {6}, {7}
java.lang.UnsupportedClassVersionError: com/google/errorprone/ErrorProneJavacPlugin has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
```