### PR TITLE
Force errorprone to max v2.31.0 on branch_9x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,12 @@
   "prConcurrentLimit": 100,
   "prHourlyLimit": 10,
   "branchPrefix": "renovate-9x/",
-  "commitMessageSuffix": " (branch_9x)"
+  "commitMessageSuffix": " (branch_9x)",
+  "packageRules": [
+    {
+      "description": "Skip errorprone upgrades since newer versions require JDK17",
+      "matchPackagePrefixes": ["com.google.errorprone"],
+      "enabled": false
+    }
+  ]
 }

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -35,6 +35,18 @@ if (skipReason) {
   }
 }
 
+configurations.all {
+  resolutionStrategy {
+    eachDependency { details ->
+      if (details.requested.group == "com.google.errorprone" &&
+          (details.requested.name == "error_prone_core" || details.requested.name == "error_prone_annotations")) {
+        details.useVersion("2.31.0")
+        details.because("Lock Error Prone dependencies to 2.31.0 to prevent accidental upgrades")
+      }
+    }
+  }
+}
+
 allprojects { prj ->
   plugins.withType(JavaPlugin) {
     // LUCENE-9650: Errorprone on master/gradle does not work when running as plugin

--- a/versions.props
+++ b/versions.props
@@ -10,6 +10,7 @@ com.github.ben-manes.caffeine:caffeine=3.1.8
 com.github.spotbugs:*=4.8.6
 com.github.stephenc.jcip:jcip-annotations=1.0-1
 com.google.cloud:google-cloud-bom=0.224.0
+# Errorprone must stay on 2.31.0 on 9.x to play nice with JDK11
 com.google.errorprone:*=2.31.0
 com.google.guava:guava=32.1.3-jre
 com.google.protobuf:*=3.25.8


### PR DESCRIPTION
To avoid triggering JDK17 requirement. It will select v2.31 or else fail hard during version resolution.

See #3537 where I have incorporated the same changes in addition to some other tweaks. So likely the tweak will be merged from that PR and not this. 