### PR TITLE
SOLR-17806: Migrate SolrIndexWriter metrics to OTEL

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/SolrIndexWriter.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexWriter.java
@@ -16,9 +16,8 @@
  */
 package org.apache.solr.update;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Timer;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
@@ -37,14 +36,25 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.SuppressForbidden;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.core.DirectoryFactory.DirContext;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
+import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
+import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
 import org.apache.solr.schema.IndexSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.solr.metrics.SolrCoreMetricManager.COLLECTION_ATTR;
+import static org.apache.solr.metrics.SolrCoreMetricManager.CORE_ATTR;
+import static org.apache.solr.metrics.SolrCoreMetricManager.REPLICA_ATTR;
+import static org.apache.solr.metrics.SolrCoreMetricManager.SHARD_ATTR;
+import static org.apache.solr.metrics.SolrMetricProducer.CATEGORY_ATTR;
+import static org.apache.solr.metrics.SolrMetricProducer.TYPE_ATTR;
 
 /**
  * An IndexWriter that is configured via Solr config mechanisms.
@@ -73,12 +83,12 @@ public class SolrIndexWriter extends IndexWriter {
 
   // metrics
   private long majorMergeDocs = 512 * 1024;
-  private Timer majorMerge;
-  private Timer minorMerge;
-  private Meter majorMergedDocs;
-  private Meter majorDeletedDocs;
-  private Counter mergeErrors;
-  private Meter flushMeter; // original counter is package-private in IndexWriter
+  private AttributedLongTimer majorMerge;
+  private AttributedLongTimer minorMerge;
+  private AttributedLongCounter majorMergedDocs;
+  private AttributedLongCounter majorDeletedDocs;
+  private AttributedLongCounter mergeErrors;
+  private AttributedLongCounter flushes; // original counter is package-private in IndexWriter
   private boolean mergeTotals = false;
   private boolean mergeDetails = false;
   private final AtomicInteger runningMajorMerges = new AtomicInteger();
@@ -87,6 +97,8 @@ public class SolrIndexWriter extends IndexWriter {
   private final AtomicInteger runningMinorMergesSegments = new AtomicInteger();
   private final AtomicLong runningMajorMergesDocs = new AtomicLong();
   private final AtomicLong runningMinorMergesDocs = new AtomicLong();
+  private ObservableLongGauge majorMergeStats;
+  private ObservableLongGauge minorMergeStats;
 
   private final SolrMetricsContext solrMetricsContext;
   // merge diagnostics.
@@ -177,66 +189,93 @@ public class SolrIndexWriter extends IndexWriter {
       } else {
         mergeTotals = false;
       }
+      String coreName = core.getCoreDescriptor().getName();
+      var baseAttributesBuilder =
+          Attributes.builder()
+              .put(CATEGORY_ATTR, SolrInfoBean.Category.INDEX.toString())
+              .put(CORE_ATTR, coreName);
+      if (core.getCoreContainer().isZooKeeperAware()) {
+          String collectionName = core.getCoreDescriptor().getCollectionName();
+          baseAttributesBuilder
+              .put(COLLECTION_ATTR, collectionName)
+              .put(SHARD_ATTR, core.getCoreDescriptor().getCloudDescriptor().getShardId())
+              .put(REPLICA_ATTR, Utils.parseMetricsReplicaName(collectionName, coreName));
+      }
+      var baseAttributes = baseAttributesBuilder.build();
       if (mergeDetails) {
         mergeTotals = true; // override
         majorMergedDocs =
-            solrMetricsContext.meter(
-                "docs", SolrInfoBean.Category.INDEX.toString(), "merge", "major");
+            new AttributedLongCounter(
+                solrMetricsContext.longCounter(
+                    "solr_indexriter_major_merged_docs",
+                    "Number of documents merged while merging segments above the majorMergeDocs threshold"),
+                baseAttributes);
         majorDeletedDocs =
-            solrMetricsContext.meter(
-                "deletedDocs", SolrInfoBean.Category.INDEX.toString(), "merge", "major");
+            new AttributedLongCounter(
+                solrMetricsContext.longCounter(
+                    "solr_indexriter_major_deleted_docs",
+                    "Number of deleted documents that were expunged while merging segments above the majorMergeDocs threshold"),
+                baseAttributes);
       }
       if (mergeTotals) {
         minorMerge =
-            solrMetricsContext.timer("minor", SolrInfoBean.Category.INDEX.toString(), "merge");
+            new AttributedLongTimer(
+                solrMetricsContext.longHistogram(
+                    "solr_indexwriter_minor_merge",
+                    "Time spent merging segments below the majorMergeDocs threshold",
+                    OtelUnit.MILLISECONDS),
+                baseAttributes);
         majorMerge =
-            solrMetricsContext.timer("major", SolrInfoBean.Category.INDEX.toString(), "merge");
+            new AttributedLongTimer(
+                solrMetricsContext.longHistogram(
+                    "solr_indexwriter_major_merge",
+                    "Time spent merging segments above the majorMergeDocs threshold",
+                    OtelUnit.MILLISECONDS),
+                baseAttributes);
         mergeErrors =
-            solrMetricsContext.counter("errors", SolrInfoBean.Category.INDEX.toString(), "merge");
+            new AttributedLongCounter(
+                solrMetricsContext.longCounter(
+                    "solr_indexwriter_merge_errors",
+                    "Number of merge errors"),
+                baseAttributes);
         String tag = core.getMetricTag();
-        solrMetricsContext.gauge(
-            () -> runningMajorMerges.get(),
-            true,
-            "running",
-            SolrInfoBean.Category.INDEX.toString(),
-            "merge",
-            "major");
-        solrMetricsContext.gauge(
-            () -> runningMinorMerges.get(),
-            true,
-            "running",
-            SolrInfoBean.Category.INDEX.toString(),
-            "merge",
-            "minor");
-        solrMetricsContext.gauge(
-            () -> runningMajorMergesDocs.get(),
-            true,
-            "running.docs",
-            SolrInfoBean.Category.INDEX.toString(),
-            "merge",
-            "major");
-        solrMetricsContext.gauge(
-            () -> runningMinorMergesDocs.get(),
-            true,
-            "running.docs",
-            SolrInfoBean.Category.INDEX.toString(),
-            "merge",
-            "minor");
-        solrMetricsContext.gauge(
-            () -> runningMajorMergesSegments.get(),
-            true,
-            "running.segments",
-            SolrInfoBean.Category.INDEX.toString(),
-            "merge",
-            "major");
-        solrMetricsContext.gauge(
-            () -> runningMinorMergesSegments.get(),
-            true,
-            "running.segments",
-            SolrInfoBean.Category.INDEX.toString(),
-            "merge",
-            "minor");
-        flushMeter = solrMetricsContext.meter("flush", SolrInfoBean.Category.INDEX.toString());
+        majorMergeStats =
+            solrMetricsContext.observableLongGauge(
+                "solr_indexwriter_major_merge_stats",
+                "Metrics around currently running segment merges above the majorMergeDocs threshold",
+                (observableLongMeasurement -> {
+                  observableLongMeasurement.record(
+                      runningMajorMerges.get(),
+                      baseAttributes.toBuilder().put(TYPE_ATTR, "running").build());
+                  observableLongMeasurement.record(
+                      runningMajorMergesDocs.get(),
+                      baseAttributes.toBuilder().put(TYPE_ATTR, "running_docs").build());
+                  observableLongMeasurement.record(
+                      runningMajorMergesSegments.get(),
+                      baseAttributes.toBuilder().put(TYPE_ATTR, "running_segments").build());
+                }));
+        minorMergeStats =
+            solrMetricsContext.observableLongGauge(
+                "solr_indexwriter_minor_merge_stats",
+                "Metrics around currently running segment merges below the majorMergeDocs threshold",
+                (observableLongMeasurement -> {
+                  observableLongMeasurement.record(
+                      runningMinorMerges.get(),
+                      baseAttributes.toBuilder().put(TYPE_ATTR, "running").build());
+                  observableLongMeasurement.record(
+                      runningMinorMergesDocs.get(),
+                      baseAttributes.toBuilder().put(TYPE_ATTR, "running_docs").build());
+                  observableLongMeasurement.record(
+                      runningMinorMergesSegments.get(),
+                      baseAttributes.toBuilder().put(TYPE_ATTR, "running_segments").build());
+                }));
+        flushes =
+            new AttributedLongCounter(
+                solrMetricsContext.longCounter(
+                    "solr_indexwriter_flush",
+                    "Number of times added/deleted documents have been flushed to the Directory"),
+                baseAttributes);
+
       }
     }
   }
@@ -284,21 +323,21 @@ public class SolrIndexWriter extends IndexWriter {
     }
     boolean major = totalNumDocs > majorMergeDocs;
     int segmentsCount = merge.segments.size();
-    Timer.Context context;
+    AttributedLongTimer.MetricTimer context;
     if (major) {
       runningMajorMerges.incrementAndGet();
       runningMajorMergesDocs.addAndGet(totalNumDocs);
       runningMajorMergesSegments.addAndGet(segmentsCount);
       if (mergeDetails) {
-        majorMergedDocs.mark(totalNumDocs);
-        majorDeletedDocs.mark(deletedDocs);
+        majorMergedDocs.add(totalNumDocs);
+        majorDeletedDocs.add(deletedDocs);
       }
-      context = majorMerge.time();
+      context = majorMerge.start();
     } else {
       runningMinorMerges.incrementAndGet();
       runningMinorMergesDocs.addAndGet(totalNumDocs);
       runningMinorMergesSegments.addAndGet(segmentsCount);
-      context = minorMerge.time();
+      context = minorMerge.start();
     }
     try {
       super.merge(merge);
@@ -326,8 +365,8 @@ public class SolrIndexWriter extends IndexWriter {
 
   @Override
   protected void doAfterFlush() throws IOException {
-    if (flushMeter != null) { // this is null when writer is used only for snapshot cleanup
-      flushMeter.mark(); // or if mergeTotals == false
+    if (flushes != null) { // this is null when writer is used only for snapshot cleanup
+      flushes.inc(); // or if mergeTotals == false
     }
     super.doAfterFlush();
   }

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexWriter.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexWriter.java
@@ -223,17 +223,17 @@ public class SolrIndexWriter extends IndexWriter {
         minorMerge =
             new AttributedLongTimer(
                 solrMetricsContext.longHistogram(
-                    "solr_indexwriter_minor_merge",
+                    "solr_indexwriter_merge",
                     "Time spent merging segments below or equal to the majorMergeDocs threshold (" + majorMergeDocs + ")",
                     OtelUnit.MILLISECONDS),
-                baseAttributes);
+                baseAttributes.toBuilder().put(MERGE_TYPE_ATTR, "minor").build());
         majorMerge =
             new AttributedLongTimer(
                 solrMetricsContext.longHistogram(
-                    "solr_indexwriter_major_merge",
+                    "solr_indexwriter_merge",
                     "Time spent merging segments above the majorMergeDocs threshold (" + majorMergeDocs + ")",
                     OtelUnit.MILLISECONDS),
-                baseAttributes);
+                baseAttributes.toBuilder().put(MERGE_TYPE_ATTR, "major").build());
         mergeErrors =
             new AttributedLongCounter(
                 solrMetricsContext.longCounter(
@@ -243,7 +243,7 @@ public class SolrIndexWriter extends IndexWriter {
         String tag = core.getMetricTag();
         mergeStats =
             solrMetricsContext.observableLongGauge(
-                "solr_indexwriter_major_merge_stats",
+                "solr_indexwriter_merge_stats",
                 "Metrics around currently running segment merges; major := above the majorMergeDocs threshold (" + majorMergeDocs + "), minor := below or equal to the threshold",
                 (observableLongMeasurement -> {
                   observableLongMeasurement.record(
@@ -451,9 +451,7 @@ public class SolrIndexWriter extends IndexWriter {
       if (directoryFactory != null) {
         directoryFactory.release(directory);
       }
-      if (mergeStats != null) {
-        IOUtils.closeQuietly(mergeStats);
-      }
+      IOUtils.closeQuietly(mergeStats);
       if (solrMetricsContext != null) {
         solrMetricsContext.unregister();
       }

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-indexmetrics.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-indexmetrics.xml
@@ -31,6 +31,8 @@
     <metrics>
       <bool name="merge">${solr.tests.metrics.merge:false}</bool>
       <bool name="mergeDetails">${solr.tests.metrics.mergeDetails:false}</bool>
+      <!-- majorMergeDocs default comes from the default of SolrIndexWriter.majorMergeDocs -->
+      <long name="majorMergeDocs">${solr.tests.metrics.majorMergeDocs:524288}</long>
     </metrics>
     <!-- intentionally set very low values here to trigger multiple flushes and merges.
          DO NOT USE THESE ABSURD VALUES IN PRODUCTION. -->

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.solr.update;
 
+import static org.apache.solr.metrics.SolrMetricProducer.CATEGORY_ATTR;
+import static org.apache.solr.update.SolrIndexWriter.MERGE_TYPE_ATTR;
+
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
@@ -25,9 +28,6 @@ import org.apache.solr.metrics.SolrMetricTestUtils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.After;
 import org.junit.Test;
-
-import static org.apache.solr.metrics.SolrMetricProducer.CATEGORY_ATTR;
-import static org.apache.solr.update.SolrIndexWriter.MERGE_TYPE_ATTR;
 
 /** Test proper registration and collection of index and directory metrics. */
 public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
@@ -80,7 +80,8 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
-      // major merge timer should have a value of 0, and because 0 values are not reported, no datapoint is available
+      // major merge timer should have a value of 0, and because 0 values are not reported, no
+      // datapoint is available
       assertNull("majorMergeTimer", majorMergeTimer);
 
       // check detailed meters
@@ -163,7 +164,8 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
-      // major merge timer should have a value of 0, and because 0 values are not reported, no datapoint is available
+      // major merge timer should have a value of 0, and because 0 values are not reported, no
+      // datapoint is available
       assertNull("majorMergeTimer", majorMergeTimer);
 
       // check detailed meters
@@ -174,7 +176,8 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .build());
-      // major merge docs should have a value of 0, and because 0 values are not reported, no datapoint is available
+      // major merge docs should have a value of 0, and because 0 values are not reported, no
+      // datapoint is available
       assertNull("majorMergeDocs", majorMergeDocs);
 
       var flushCounter =
@@ -202,8 +205,10 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
       MetricSnapshots otelMetrics = prometheusMetricReader.collect();
       assertTrue("Metrics count: " + otelMetrics.size(), otelMetrics.size() >= 18);
 
-      // addDocs() adds 1000 documents and then sends a commit.  maxBufferedDocs==100, segmentsPerTier==3,
-      //     maxMergeAtOnce==3 and majorMergeDocs==450.  Thus, new documents form segments with 100 docs, merges are
+      // addDocs() adds 1000 documents and then sends a commit.  maxBufferedDocs==100,
+      // segmentsPerTier==3,
+      //     maxMergeAtOnce==3 and majorMergeDocs==450.  Thus, new documents form segments with 100
+      // docs, merges are
       //     called for when there are 3 segments at the lowest tier, and the merges are as follows:
       //     1. 100 + 100 + 100 ==> new 300 doc segment, below the 450 threshold ==> minor merge
       //     2. 100 + 100 + 100 ==> new 300 doc segment, below the 450 threshold ==> minor merge

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
@@ -27,6 +27,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import static org.apache.solr.metrics.SolrMetricProducer.CATEGORY_ATTR;
+import static org.apache.solr.update.SolrIndexWriter.MERGE_TYPE_ATTR;
 
 /** Test proper registration and collection of index and directory metrics. */
 public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
@@ -65,17 +66,19 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
       var minorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
-              "solr_indexwriter_minor_merge_milliseconds",
+              "solr_indexwriter_merge_milliseconds",
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
+                  .label(MERGE_TYPE_ATTR.toString(), "minor")
                   .build());
       assertTrue("minorMerge: " + minorMergeTimer.getCount(), minorMergeTimer.getCount() >= 3);
       var majorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
-              "solr_indexwriter_major_merge_milliseconds",
+              "solr_indexwriter_merge_milliseconds",
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
+                  .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
       // major merge timer should have a value of 0, and because 0 values are not reported, no datapoint is available
       assertNull("majorMergeTimer", majorMergeTimer);
@@ -146,17 +149,19 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
       var minorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
-              "solr_indexwriter_minor_merge_milliseconds",
+              "solr_indexwriter_merge_milliseconds",
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
+                  .label(MERGE_TYPE_ATTR.toString(), "minor")
                   .build());
       assertTrue("minorMergeTimer: " + minorMergeTimer.getCount(), minorMergeTimer.getCount() >= 3);
       var majorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
-              "solr_indexwriter_major_merge_milliseconds",
+              "solr_indexwriter_merge_milliseconds",
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
+                  .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
       // major merge timer should have a value of 0, and because 0 values are not reported, no datapoint is available
       assertNull("majorMergeTimer", majorMergeTimer);
@@ -209,17 +214,19 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
       var minorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
-              "solr_indexwriter_minor_merge_milliseconds",
+              "solr_indexwriter_merge_milliseconds",
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
+                  .label(MERGE_TYPE_ATTR.toString(), "minor")
                   .build());
       assertTrue("minorMergeTimer: " + minorMergeTimer.getCount(), minorMergeTimer.getCount() == 2);
       var majorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
-              "solr_indexwriter_major_merge_milliseconds",
+              "solr_indexwriter_merge_milliseconds",
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
+                  .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
       assertTrue("majorMergeTimer: " + majorMergeTimer.getCount(), majorMergeTimer.getCount() == 2);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806

Migrate SolrIndexWriter metrics from Dropwizard to OTEL.

```text
# HELP solr_indexwriter_flush_total Number of times added/deleted documents have been flushed to the Directory
# TYPE solr_indexwriter_flush_total counter
solr_indexwriter_flush_total{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 67.0
# HELP solr_indexwriter_major_merge_milliseconds Time spent merging segments above the majorMergeDocs threshold (524288)
# TYPE solr_indexwriter_major_merge_milliseconds histogram
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="0.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="5.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="10.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="25.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="50.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="75.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="100.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="250.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="500.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="750.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="1000.0"} 0
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="2500.0"} 2
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="5000.0"} 2
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="7500.0"} 2
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="10000.0"} 2
solr_indexwriter_major_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="+Inf"} 2
solr_indexwriter_major_merge_milliseconds_count{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 2
solr_indexwriter_major_merge_milliseconds_sum{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 3854.0
# HELP solr_indexwriter_major_merge_stats Metrics around currently running segment merges; major := above the majorMergeDocs threshold (524288), minor := below or equal to the threshold
# TYPE solr_indexwriter_major_merge_stats gauge
solr_indexwriter_major_merge_stats{category="INDEX",collection="test",core="test_shard1_replica_n1",merge_type="major",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="running"} 0.0
solr_indexwriter_major_merge_stats{category="INDEX",collection="test",core="test_shard1_replica_n1",merge_type="major",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="running_docs"} 0.0
solr_indexwriter_major_merge_stats{category="INDEX",collection="test",core="test_shard1_replica_n1",merge_type="major",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="running_segments"} 0.0
solr_indexwriter_major_merge_stats{category="INDEX",collection="test",core="test_shard1_replica_n1",merge_type="minor",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="running"} 0.0
solr_indexwriter_major_merge_stats{category="INDEX",collection="test",core="test_shard1_replica_n1",merge_type="minor",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="running_docs"} 0.0
solr_indexwriter_major_merge_stats{category="INDEX",collection="test",core="test_shard1_replica_n1",merge_type="minor",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",type="running_segments"} 0.0
# HELP solr_indexwriter_minor_merge_milliseconds Time spent merging segments below or equal to the majorMergeDocs threshold (524288)
# TYPE solr_indexwriter_minor_merge_milliseconds histogram
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="0.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="5.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="10.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="25.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="50.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="75.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="100.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="250.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="500.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="750.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="1000.0"} 0
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="2500.0"} 1
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="5000.0"} 1
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="7500.0"} 1
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="10000.0"} 1
solr_indexwriter_minor_merge_milliseconds_bucket{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1",le="+Inf"} 1
solr_indexwriter_minor_merge_milliseconds_count{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 1
solr_indexwriter_minor_merge_milliseconds_sum{category="INDEX",collection="test",core="test_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 1415.0
```