### PR TITLE
Fix failing MiniClusterBenchStateTest

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
@@ -171,10 +171,10 @@ public abstract class ConfigSetService {
     Path path = Path.of(pathStr);
 
     // Convert to absolute path if it's relative
-//    if (!path.isAbsolute()) {
-//      String installDir = EnvUtils.getProperty(SolrDispatchFilter.SOLR_INSTALL_DIR_ATTRIBUTE);
-//      path = Path.of(installDir).resolve(path).normalize();
-//    }
+    //    if (!path.isAbsolute()) {
+    //      String installDir = EnvUtils.getProperty(SolrDispatchFilter.SOLR_INSTALL_DIR_ATTRIBUTE);
+    //      path = Path.of(installDir).resolve(path).normalize();
+    //    }
 
     return path;
   }

--- a/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
@@ -171,10 +171,10 @@ public abstract class ConfigSetService {
     Path path = Path.of(pathStr);
 
     // Convert to absolute path if it's relative
-    if (!path.isAbsolute()) {
-      String installDir = EnvUtils.getProperty(SolrDispatchFilter.SOLR_INSTALL_DIR_ATTRIBUTE);
-      path = Path.of(installDir).resolve(path).normalize();
-    }
+//    if (!path.isAbsolute()) {
+//      String installDir = EnvUtils.getProperty(SolrDispatchFilter.SOLR_INSTALL_DIR_ATTRIBUTE);
+//      path = Path.of(installDir).resolve(path).normalize();
+//    }
 
     return path;
   }


### PR DESCRIPTION
Draft PR that skips the code that makes configset path absolute, which does not fly with security manager.