### PR TITLE
Remove unused method SolrCloudManager.request() and cleanup DelegatingCloudManager

### DIFF
--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/DelegatingCloudManager.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/DelegatingCloudManager.java
@@ -17,8 +17,6 @@
 package org.apache.solr.client.solrj.cloud;
 
 import java.io.IOException;
-import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.ClusterStateProvider;
 import org.apache.solr.common.util.ObjectCache;
@@ -27,10 +25,11 @@ import org.apache.solr.common.util.TimeSource;
 /** Base class for overriding some behavior of {@link SolrCloudManager}. */
 public class DelegatingCloudManager implements SolrCloudManager {
   protected final SolrCloudManager delegate;
-  private ObjectCache objectCache = new ObjectCache();
-  private TimeSource timeSource = TimeSource.NANO_TIME;
 
   public DelegatingCloudManager(SolrCloudManager delegate) {
+    if (delegate == null) {
+      throw new IllegalArgumentException("delegate cannot be null");
+    }
     this.delegate = delegate;
   }
 
@@ -56,7 +55,7 @@ public class DelegatingCloudManager implements SolrCloudManager {
 
   @Override
   public ObjectCache getObjectCache() {
-    return delegate == null ? objectCache : delegate.getObjectCache();
+    return delegate.getObjectCache();
   }
 
   @Override
@@ -66,12 +65,7 @@ public class DelegatingCloudManager implements SolrCloudManager {
 
   @Override
   public TimeSource getTimeSource() {
-    return delegate == null ? timeSource : delegate.getTimeSource();
-  }
-
-  @Override
-  public <T extends SolrResponse> T request(SolrRequest<T> req) throws IOException {
-    return delegate.request(req);
+    return delegate.getTimeSource();
   }
 
   @Override

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/SolrCloudManager.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/cloud/SolrCloudManager.java
@@ -18,8 +18,6 @@
 package org.apache.solr.client.solrj.cloud;
 
 import java.io.IOException;
-import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.ClusterStateProvider;
 import org.apache.solr.common.SolrCloseable;
@@ -51,7 +49,4 @@ public interface SolrCloudManager extends SolrCloseable {
   ObjectCache getObjectCache();
 
   TimeSource getTimeSource();
-
-  @Deprecated
-  <T extends SolrResponse> T request(SolrRequest<T> req) throws IOException;
 }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientCloudManager.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientCloudManager.java
@@ -17,11 +17,7 @@
 
 package org.apache.solr.client.solrj.impl;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.SolrResponse;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.DistribStateManager;
 import org.apache.solr.client.solrj.cloud.NodeStateProvider;
 import org.apache.solr.client.solrj.cloud.SolrCloudManager;
@@ -102,17 +98,6 @@ public class SolrClientCloudManager implements SolrCloudManager {
   public DistribStateManager getDistribStateManager() {
     return stateManager;
   }
-
-  @Override
-  public <T extends SolrResponse> T request(SolrRequest<T> req) throws IOException {
-    try {
-      return req.process(cloudSolrClient);
-    } catch (SolrServerException e) {
-      throw new IOException(e);
-    }
-  }
-
-  private static final byte[] EMPTY = new byte[0];
 
   public SolrZkClient getZkClient() {
     return zkClient;


### PR DESCRIPTION
This removes `SolrCloudManager.request()` and implementations in Solr 10.

@dsmiley tagging you as reviewer since you removed callers in SOLR-17630 and marked the method deprecated.

