### PR TITLE
SOLR-17715: Deprecate SolrQuery.setRequestHandler

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrQuery.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrQuery.java
@@ -1139,12 +1139,15 @@ public class SolrQuery extends ModifiableSolrParams {
    *
    * @param qt The Request Handler name corresponding to one in solrconfig.xml on the server.
    * @return this
+   * @deprecated Use {@link SolrRequest#setPath(String)}
    */
+  @Deprecated
   public SolrQuery setRequestHandler(String qt) {
     this.set(CommonParams.QT, qt);
     return this;
   }
 
+  @Deprecated
   public String getRequestHandler() {
     return this.get(CommonParams.QT);
   }


### PR DESCRIPTION
and getRequestHandler.

Use QueryRequest.setPath instead.

https://issues.apache.org/jira/browse/SOLR-17715