### PR TITLE
SOLR-17875:  Redo of Rationalize bootstrap_conf, bootstrap_confdir, and -Dcollection.configName in start up scripts

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1091,11 +1091,6 @@ if [ "${SOLR_MODE:-}" == 'solrcloud' ]; then
     CLOUD_MODE_OPTS+=("-DcreateZkChroot=$ZK_CREATE_CHROOT")
   fi
 
-  # and if collection1 needs to be bootstrapped
-  if [ -e "$SOLR_HOME/collection1/core.properties" ]; then
-    CLOUD_MODE_OPTS+=('-Dbootstrap_confdir=./solr/collection1/conf' '-Dcollection.configName=myconf' '-DnumShards=1')
-  fi
-
   if [ "${SOLR_SOLRXML_REQUIRED:-false}" == "true" ]; then
     CLOUD_MODE_OPTS+=("-Dsolr.solrxml.required=true")
   fi

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -936,10 +936,6 @@ IF "%SOLR_MODE%"=="solrcloud" (
     set "CLOUD_MODE_OPTS=!CLOUD_MODE_OPTS! -Dsolr.solrxml.required=true"
   )
 
-  IF EXIST "%SOLR_HOME%\collection1\core.properties" set "CLOUD_MODE_OPTS=!CLOUD_MODE_OPTS! -Dbootstrap_confdir=./solr/collection1/conf -Dcollection.configName=myconf -DnumShards=1"
-) ELSE (
-  REM change Cloud mode to User Managed mode with flag
-  set "CLOUD_MODE_OPTS="
   IF NOT EXIST "%SOLR_HOME%\solr.xml" (
     IF "%SOLR_SOLRXML_REQUIRED%"=="true" (
       set "SCRIPT_ERROR=Solr home directory %SOLR_HOME% must contain solr.xml!"

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -93,3 +93,17 @@ teardown() {
   solr start --jettyconfig "--module=server"
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
 }
+
+@test "bootstrap configset using bootstrap_confdir and collection.configName" {
+  local confdir_path="${SOLR_TIP}/server/solr/configsets/sample_techproducts_configs/conf"
+  
+  # Verify the source configset directory exists
+  test -d "${confdir_path}"
+
+  # Start Solr with bootstrap_confdir pointing to techproducts configset
+  solr start -Dbootstrap_confdir="${confdir_path}" -Dcollection.configName=techproducts
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+  
+  # Verify the techproducts configset was uploaded
+  config_exists "techproducts"
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17875

This is a more limited version of https://github.com/apache/solr/pull/3512.   We are aiming to remove the dead bootstrapping of a core into a solr cloud, add a test for bootstrapping, and rename the variables.   The boolean `bootstrap_conf` will hopefully be removed to as dead code.

We are accepting fully qualified paths instead of relative in the bats test, and hoping not to trigger the Java Security Manager issues with the benchmarking tests.