### PR TITLE
SOLR-17891: Reorganize the DeprecatedSystemPropertyMappings file

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/util/EnvUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/EnvUtils.java
@@ -75,7 +75,7 @@ public class EnvUtils {
           CUSTOM_MAPPINGS.put(key, props.getProperty(key));
         }
         for (String key : deprecatedProps.stringPropertyNames()) {
-          DEPRECATED_MAPPINGS.put(key, deprecatedProps.getProperty(key));
+          DEPRECATED_MAPPINGS.put(deprecatedProps.getProperty(key), key);
         }
         init(false, System.getenv(), System.getProperties());
       }
@@ -218,26 +218,22 @@ public class EnvUtils {
 
     // Convert deprecated keys to non deprecated versions
     for (String key : sysProperties.stringPropertyNames()) {
-      if (DEPRECATED_MAPPINGS.containsKey(key)) {
+      if (DEPRECATED_MAPPINGS.containsKey(key) || DEPRECATED_MAPPINGS.containsKey("!" + key)) {
         String deprecatedKey = key;
+        boolean invertValue = false;
         key = DEPRECATED_MAPPINGS.get(deprecatedKey);
+        if (key == null) {
+          key = DEPRECATED_MAPPINGS.get("!" + deprecatedKey);
+          invertValue = true;
+        }
         log.warn(
             "You are passing in deprecated system property {} and should upgrade to using {} instead.  The deprecated property support will be removed in future version of Solr.",
             deprecatedKey,
             key);
 
-        if (key.endsWith(".enabled") && deprecatedKey.endsWith(".disabled")) {
+        if (invertValue) {
           log.warn(
-              "Converting from legacy system property {} to modern .enabled equivalent {} by flipping the boolean property value.",
-              deprecatedKey,
-              key);
-          setProperty(key, String.valueOf(!Boolean.getBoolean(deprecatedKey)));
-        } else if (deprecatedKey.equals("disable.config.edit")
-            || deprecatedKey.equals("disable.v2.api")
-            || deprecatedKey.equals("solr.hide.stack.trace")
-            || deprecatedKey.equals("solr.allow.unsafe.resourceloading")) {
-          log.warn(
-              "Converting from legacy system property {} to modern .enabled equivalent {} by flipping the boolean property value.",
+              "Converting from legacy system property {} to modern equivalent {} by inverting the boolean value.",
               deprecatedKey,
               key);
           setProperty(key, String.valueOf(!Boolean.getBoolean(deprecatedKey)));

--- a/solr/solrj/src/resources/DeprecatedSystemPropertyMappings.properties
+++ b/solr/solrj/src/resources/DeprecatedSystemPropertyMappings.properties
@@ -1,33 +1,40 @@
-# Mapping from legacy system property names to current system property
+# Mapping current system property name to legacy system property names
 # This file only contains non-standard mappings that do not follow the standard naming conversion convention
 # You do not need a entry for a solrMyProperty to solr.my.property conversion
-# We have changed some properties from ending in .disabled to ending as .enabled.
-# In that case we programatically flip the value.
+# We have inverted the meaning of some properties, and therefore they have a =! pattern.
 
 # To be removed in Solr 12:
 
 # To be removed in Solr 11:
-solrConfigSetForbiddenFileTypes=solr.configset.forbidden.file.types
-enable.packages=solr.packages.enabled
-solr.default.confdir=solr.configset.default.confdir
-solr.admin.ui.disabled=solr.ui.enabled
-solr.admin.ui.experimental.disabled=solr.ui.experimental.enabled
-solr.log.dir=solr.logs.dir
-solr.default.confdir=solr.configset.default.confdir
-solr.wait.for.zk=solr.cloud.wait.for.zk.seconds
-solr.enable.remote.streaming=solr.requests.streaming.remote.enabled
-solr.enable.stream.body=solr.requests.streaming.body.enabled
-solr.delete.unknown.cores=solr.cloud.startup.delete.unknown.cores.enabled
-solr.config.set.forbidden.file.types=solr.configset.forbidden.file.types
-disable.config.edit=solr.api.config.edit.enabled
-configset.upload.enabled=solr.configset.upload.enabled
-disable.v2.api=solr.api.v2.enabled
-solr.hide.stack.trace=solr.responses.stacktrace.enabled
-authentication.plugin=solr.security.auth.plugin
-basicauth=solr.security.auth.basicauth.credentials
-cloud.solr.client.max.stale.retries=solr.solrj.cloud.max.stale.retries
-configset.upload.enabled=solr.configset.upload.enabled
-solr.hidden.sys.props=solr.responses.hidden.sys.props
-max.file.store.size=solr.filestore.filesize.max
-prep.recovery.read.timeout.extra.wait=solr.cloud.prep.recovery.read.timeout.additional.ms
-solr.allow.unsafe.resourceloading=solr.resourceloading.restricted.enabled
+solr.api.config.edit.enabled=!disable.config.edit
+solr.api.v2.enabled=!disable.v2.api
+
+solr.cloud.prep.recovery.read.timeout.additional.ms=prep.recovery.read.timeout.extra.wait
+solr.cloud.startup.delete.unknown.cores.enabled=solr.delete.unknown.cores
+solr.cloud.wait.for.zk.seconds=solr.wait.for.zk
+
+solr.configset.default.confdir=solr.default.confdir
+solr.configset.forbidden.file.types=solr.config.set.forbidden.file.types
+solr.configset.forbidden.file.types=solrConfigSetForbiddenFileTypes
+solr.configset.upload.enabled=configset.upload.enabled
+
+solr.filestore.filesize.max=max.file.store.size
+
+solr.logs.dir=solr.log.dir
+
+solr.packages.enabled=enable.packages
+solr.requests.streaming.body.enabled=solr.enable.stream.body
+solr.requests.streaming.remote.enabled=solr.enable.remote.streaming
+
+solr.resourceloading.restricted.enabled=!solr.allow.unsafe.resourceloading
+
+solr.responses.hidden.sys.props=solr.hidden.sys.props
+solr.responses.stacktrace.enabled=!solr.hide.stack.trace
+
+solr.security.auth.basicauth.credentials=basicauth
+solr.security.auth.plugin=authentication.plugin
+
+solr.solrj.cloud.max.stale.retries=cloud.solr.client.max.stale.retries
+
+solr.ui.enabled=!solr.admin.ui.disabled
+solr.ui.experimental.enabled=!solr.admin.ui.experimental.disabled


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-17891

Reorganize the mapping file to put the modern property on the left and the deprecated one on the left.

Sort the file by the highlevel categories to make working with the file easier.

Lastly, introduce a new=!old syntax with the `!` to indicate the values should be inverted when reading in legacy properties.
