### PR TITLE
Fix flaky test TestCollapseQParserPlugin.testMultiSort

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
@@ -108,15 +108,16 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
         "//result/doc[2]/str[@name='id'][.='4']");
 
     // tie broken by index order
-    params = new ModifiableSolrParams();
-    params.add("q", "*:*");
-    params.add("fq", "{!collapse field=group_s sort='test_l desc'}");
-    params.add("sort", "id_i desc");
-    assertQ(
-        req(params),
-        "*[count(//doc)=2]",
-        "//result/doc[1]/str[@name='id'][.='6']",
-        "//result/doc[2]/str[@name='id'][.='2']");
+    // UNRELIABLE TEST; sometimes id 7 comes out on top
+    //    params = new ModifiableSolrParams();
+    //    params.add("q", "*:*");
+    //    params.add("fq", "{!collapse field=group_s sort='test_l desc'}");
+    //    params.add("sort", "id_i desc");
+    //    assertQ(
+    //        req(params),
+    //        "*[count(//doc)=2]",
+    //        "//result/doc[1]/str[@name='id'][.='6']",
+    //        "//result/doc[2]/str[@name='id'][.='2']");
 
     // score, then tiebreakers; note top level sort by score ASCENDING (just for weirdness)
     params = new ModifiableSolrParams();

--- a/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
@@ -107,18 +107,6 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
         "//result/doc[1]/str[@name='id'][.='8']",
         "//result/doc[2]/str[@name='id'][.='4']");
 
-    // tie broken by index order
-    // UNRELIABLE TEST; sometimes id 7 comes out on top
-    //    params = new ModifiableSolrParams();
-    //    params.add("q", "*:*");
-    //    params.add("fq", "{!collapse field=group_s sort='test_l desc'}");
-    //    params.add("sort", "id_i desc");
-    //    assertQ(
-    //        req(params),
-    //        "*[count(//doc)=2]",
-    //        "//result/doc[1]/str[@name='id'][.='6']",
-    //        "//result/doc[2]/str[@name='id'][.='2']");
-
     // score, then tiebreakers; note top level sort by score ASCENDING (just for weirdness)
     params = new ModifiableSolrParams();
     params.add("q", "*:* term_s:YYYY");


### PR DESCRIPTION
Relying on index order is unreliable.

http://fucit.org/solr-jenkins-reports/history-trend-of-recent-failures.html#series/org.apache.solr.search.TestCollapseQParserPlugin.testMultiSort

```
TestCollapseQParserPlugin > testMultiSort FAILED
    java.lang.AssertionError: REQUEST FAILED: xpath=//result/doc[1]/str[@name='id'][.='6']
    	xml response was: <?xml version="1.0" encoding="UTF-8"?>
    <response>
    <lst name="responseHeader"><int name="status">0</int><int name="QTime">0</int></lst><result name="response" numFound="2" start="0" numFoundExact="true"><doc><str name="id">7</str><int name="id_i">7</int><str name="group_s">group2</str><int name="test_i">5</int><long name="test_l">1000</long><str name="term_s">XXXX</str><long name="_version_">1842211920030990336</long></doc><doc><str name="id">2</str><int name="id_i">2</int><str name="group_s">group1</str><int name="test_i">5</int><long name="test_l">1000</long><long name="_version_">1842211919995338752</long></doc></result>
    </response>

    	request was:q=*:*&fq={!collapse+field%3Dgroup_s+sort%3D'test_l+desc'}&sort=id_i+desc
        at __randomizedtesting.SeedInfo.seed([72818F0507C91947:D7ECFBF8490D9EDE]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.apache.solr.SolrTestCaseJ4.assertQ(SolrTestCaseJ4.java:920)
        at org.apache.solr.SolrTestCaseJ4.assertQ(SolrTestCaseJ4.java:884)
        at org.apache.solr.search.TestCollapseQParserPlugin.testMultiSort(TestCollapseQParserPlugin.java:115)
```