### PR TITLE
SOLR-17893: Use caching to remove Remote Proxy bottleneck

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -228,6 +228,8 @@ Improvements
 ---------------------
 * SOLR-17860: DocBasedVersionConstraintsProcessorFactory now supports PULL replicas. (Houston Putman)
 
+* SOLR-17893: Speed up Remote Proxy for high QPS, utilizing ClusterState caching. (Houston Putman)
+
 Optimizations
 ---------------------
 (No changes)

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -327,7 +327,7 @@ public class HttpSolrCall {
     }
     ZkStateReader zkStateReader = cores.getZkController().getZkStateReader();
     Supplier<DocCollection> logic =
-        () -> zkStateReader.getClusterState().getCollectionOrNull(collectionName);
+        () -> zkStateReader.getClusterState().getCollectionOrNull(collectionName, true);
 
     DocCollection docCollection = logic.get();
     if (docCollection != null) {
@@ -930,7 +930,7 @@ public class HttpSolrCall {
 
   protected String getRemoteCoreUrl(String collectionName) throws SolrException {
     ClusterState clusterState = cores.getZkController().getClusterState();
-    final DocCollection docCollection = clusterState.getCollectionOrNull(collectionName);
+    final DocCollection docCollection = clusterState.getCollectionOrNull(collectionName, true);
     if (docCollection == null) {
       return null;
     }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -762,6 +762,7 @@ public class ZkStateReader implements SolrCloseable {
           Stat freshStats = null;
           try {
             freshStats = zkClient.exists(DocCollection.getCollectionPath(collName), null, true);
+            lastUpdateTime = System.nanoTime();
           } catch (Exception e) {
           }
           if (freshStats != null


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17893

- Both `clusterState.getCollectionOrNull()` calls in HttpSolrCall should allow for cached values. There's no reason to fetch live versions every time here.
- The `lastUpdateTime` needs to be updated after getting the stats. If there is no change, that is an "update". We don't want to check every call after 2 seconds, if the ClusterState hasn't changed. We want to check once every 2 seconds.