### PR TITLE
[NO JIRA]: Fix BasicDistributedZkTest test failure

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractBasicDistributedZkTestBase.java
@@ -17,7 +17,9 @@
 package org.apache.solr.cloud;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,9 +44,9 @@ import org.apache.solr.JSONTestUtil;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.InputStreamResponseParser;
 import org.apache.solr.client.solrj.request.AbstractUpdateRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest.Create;
@@ -73,6 +75,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.UpdateParams;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.NamedList;
@@ -1271,7 +1274,6 @@ public abstract class AbstractBasicDistributedZkTestBase extends AbstractFullDis
                     .setAction(AbstractUpdateRequest.ACTION.COMMIT, true, true));
 
     long endCommits = getNumCommits((HttpSolrClient) clients.get(0));
-
     assertEquals(startCommits + 1L, endCommits);
   }
 
@@ -1282,22 +1284,30 @@ public abstract class AbstractBasicDistributedZkTestBase extends AbstractFullDis
             .withConnectionTimeout(15000, TimeUnit.MILLISECONDS)
             .withSocketTimeout(60000, TimeUnit.MILLISECONDS)
             .build()) {
-      ModifiableSolrParams params = new ModifiableSolrParams();
-      // params.set("qt", "/admin/metrics?prefix=UPDATE.updateHandler&registry=solr.core." +
-      // collection);
-      params.set("prefix", "UPDATE.updateHandler");
-      params.set("registry", "solr.core." + collection);
-      // use generic request to avoid extra processing of queries
       var req =
           new GenericSolrRequest(
-              SolrRequest.METHOD.GET, "/admin/metrics", SolrRequestType.ADMIN, params);
+              SolrRequest.METHOD.GET,
+              "/admin/metrics",
+              SolrRequest.SolrRequestType.ADMIN,
+              SolrParams.of("wt", "prometheus"));
+      req.setResponseParser(new InputStreamResponseParser("prometheus"));
+
       NamedList<Object> resp = client.request(req);
-      NamedList<?> metrics = (NamedList<?>) resp.get("metrics");
-      NamedList<?> uhandlerCat = (NamedList<?>) metrics.getVal(0);
-      @SuppressWarnings({"unchecked"})
-      Map<String, Object> commits =
-          (Map<String, Object>) uhandlerCat.get("UPDATE.updateHandler.commits");
-      return (Long) commits.get("count");
+      try (InputStream in = (InputStream) resp.get("stream")) {
+        String output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        String metricName = "solr_core_update_commit_ops";
+
+        return (long)
+            output
+                .lines()
+                .filter(
+                    l ->
+                        l.startsWith(metricName)
+                            && l.contains("collection=\"" + collection + "\"")
+                            && l.contains("ops=\"commits\""))
+                .mapToDouble(s -> Double.parseDouble(s.substring(s.lastIndexOf(" "))))
+                .sum();
+      }
     }
   }
 


### PR DESCRIPTION
No Jira. BasicDistributedZkTest has been failing since I migrated `DirectUpdateHandler2`. This is because it would call the /admin/metrics handler and look for the Dropwizard/Json format of these metrics. Migrated it to look for prometheus format instead.