### PR TITLE
remove some stray backticks in Solr Ref Guide

### DIFF
--- a/solr/solr-ref-guide/modules/deployment-guide/pages/rate-limiters.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/rate-limiters.adoc
@@ -28,7 +28,7 @@ There is future work planned to have finer grained execution here (https://issue
 
 The rate-limiting bucket of a request is determined by the value of the unique `Solr-Request-Type` HTTP header of
 that request. Requests with no `Solr-Request-Type` header will be accepted and processed with no rate-limiting.
-`"Slot borrowing" and "guaranteed slots" are defined with respect to the specified rate-limiting bucket.
+"Slot borrowing" and "guaranteed slots" are defined with respect to the specified rate-limiting bucket.
 
 NOTE: currently there is only one `Solr-Request-Type` value recognized for rate-limiting: the literal
 string value `QUERY`. So only requests that specify header `Solr-Request-Type: QUERY` will be rate-limited (and

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-films.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-films.adoc
@@ -301,7 +301,7 @@ The `curl` command below will return facet counts for the `genre_str` field:
 
 [,console]
 ----
-$ curl "http://localhost:8983/solr/films/select?q=\*:*&rows=0&facet=true&facet.field=genre_str"`
+$ curl "http://localhost:8983/solr/films/select?q=\*:*&rows=0&facet=true&facet.field=genre_str"
 ----
 
 In your terminal, you'll see something like:

--- a/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-nested-documents.adoc
+++ b/solr/solr-ref-guide/modules/indexing-guide/pages/indexing-nested-documents.adoc
@@ -243,7 +243,7 @@ Preferably, you will also define `\_nest_path_` which adds features and ease-of-
 [source,xml]
 ----
 <fieldType name="_nest_path_" class="solr.NestPathField" />
-<field name="_nest_path_" type="_nest_path_" />`
+<field name="_nest_path_" type="_nest_path_" />
 ----
 
 * Solr automatically populates this field for any child document but not root documents.

--- a/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
@@ -267,7 +267,7 @@ Note that in the above example, the `/` characters in the `\_nest_path_` were "d
 
 === Combining Block Join Query Parsers with Child Doc Transformer
 
-The combination of these two parsers with the `[child] transformer enables seamless creation of very powerful queries.
+The combination of these two parsers with the `[child]` transformer enables seamless creation of very powerful queries.
 
 Here for example is a query where:
 


### PR DESCRIPTION
Stumbled across one of them for real and then

```
git grep -n "\`" *.adoc | grep -v "\`.*\`"
```

prospected for more with small #2401 deja vu sense.