### PR TITLE
(minor) HttpSolrClient NPE avoidance

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClient.java
@@ -18,6 +18,7 @@ package org.apache.solr.client.solrj.impl;
 
 import static org.apache.solr.common.util.Utils.getObjectByPath;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -550,7 +551,6 @@ public class HttpSolrClient extends BaseHttpSolrClient {
     method.setConfig(requestConfigBuilder.build());
 
     HttpEntity entity = null;
-    InputStream respBody = null;
     boolean shouldClose = true;
     try {
       // Execute the method.
@@ -568,7 +568,6 @@ public class HttpSolrClient extends BaseHttpSolrClient {
 
       // Read the contents
       entity = response.getEntity();
-      respBody = entity.getContent();
       String mimeType = null;
       Charset charset = null;
       String charsetName = null;
@@ -608,6 +607,9 @@ public class HttpSolrClient extends BaseHttpSolrClient {
                 null);
           }
       }
+
+      InputStream respBody =
+          (entity == null ? new ByteArrayInputStream(new byte[0]) : entity.getContent());
       if (processor == null || processor instanceof InputStreamResponseParser) {
         // no processor specified, return raw stream
         final var rsp =


### PR DESCRIPTION
While hacking on something, I saw an NPE in HttpSolrClient that is avoidable.  Basically `entity.getContent` is being called sooner than it needs to be called, potentially resulting in an NPE.

Too minor to bother with a JIRA IMO.