### PR TITLE
Utils: pretty-printed JSON, add trailing newline

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/util/SolrJSONWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/SolrJSONWriter.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
  * Use this to serialize an object into Json. This only supports standard Objects and not the
  * server-side Objects
  */
-public class SolrJSONWriter implements JsonTextWriter {
+class SolrJSONWriter implements JsonTextWriter {
   // indent up to 40 spaces
   static final char[] indentChars = new char[81];
 
@@ -48,8 +48,13 @@ public class SolrJSONWriter implements JsonTextWriter {
     this.namedListStyle = namedListStyle;
   }
 
+  /**
+   * Writes out the passed object as JSON. This is this principal entrypoint into JSON writing.
+   * {@code this} is returned.
+   */
   public SolrJSONWriter writeObj(Object o) throws IOException {
     writeVal(null, o);
+    if (doIndent()) writer.write('\n');
     return this;
   }
 


### PR DESCRIPTION
SolrJ `org.apache.solr.common.util.Utils#writeJson(java.lang.Object, java.io.Writer, boolean)` is used internally, particularly in tests to print cluster state or other JSON.  I noticed that the pretty-printed JSON typically has subsequent log statements slammed onto the end without an intervening newline.  So I enhanced this utility method to add the newline if we're pretty printing.

This utility method uses SolrJSONWriter and which is the only user of that class.  I reduced its visibility accordingly.

No JIRA/CHANGES.txt