### PR TITLE
Rename CloudHttp2SolrClient.withInternalClientBuilder

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/CLIUtils.java
+++ b/solr/core/src/java/org/apache/solr/cli/CLIUtils.java
@@ -268,7 +268,7 @@ public final class CLIUtils {
   public static CloudHttp2SolrClient getCloudHttp2SolrClient(
       String zkHost, Http2SolrClient.Builder builder) {
     return new CloudHttp2SolrClient.Builder(Collections.singletonList(zkHost), Optional.empty())
-        .withInternalClientBuilder(builder)
+        .withHttpClientBuilder(builder)
         .build();
   }
 

--- a/solr/core/src/java/org/apache/solr/cli/ExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ExportTool.java
@@ -257,7 +257,7 @@ public class ExportTool extends ToolBase {
 
       solrClient =
           new CloudHttp2SolrClient.Builder(Collections.singletonList(baseurl))
-              .withInternalClientBuilder(builder)
+              .withHttpClientBuilder(builder)
               .build();
       NamedList<Object> response =
           solrClient.request(

--- a/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrClientFactory.java
+++ b/solr/prometheus-exporter/src/java/org/apache/solr/prometheus/exporter/SolrClientFactory.java
@@ -76,7 +76,7 @@ public class SolrClientFactory {
             .collect(Collectors.toList());
     CloudSolrClient client =
         new CloudHttp2SolrClient.Builder(zkHosts, Optional.ofNullable(parser.getChrootPath()))
-            .withInternalClientBuilder(newHttp2SolrClientBuilder(null, settings, configuration))
+            .withHttpClientBuilder(newHttp2SolrClientBuilder(null, settings, configuration))
             .withResponseParser(new NoOpResponseParser("json"))
             .build();
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/SolrClientCache.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/SolrClientCache.java
@@ -106,7 +106,7 @@ public class SolrClientCache implements Closeable {
     builder.canUseZkACLs(canUseACLs);
     // using internal builder to ensure the internal client gets closed
     builder =
-        builder.withInternalClientBuilder(
+        builder.withHttpClientBuilder(
             newHttp2SolrClientBuilder(null, http2SolrClient, basicAuthCredentials));
     var client = builder.build();
     try {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -405,19 +405,18 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     }
 
     /**
-     * Set the internal http client.
+     * Set the internal {@link Http2SolrClient}.
      *
-     * <p>Note: closing the httpClient instance is at the responsibility of the caller.
+     * <p>Note: closing the client instance is the responsibility of the caller.
      *
-     * @param httpClient http client
      * @return this
      */
-    public Builder withHttpClient(Http2SolrClient httpClient) {
+    public Builder withHttpClient(Http2SolrClient httpSolrClient) {
       if (this.internalClientBuilder != null) {
         throw new IllegalStateException(
             "The builder can't accept an httpClient AND an internalClientBuilder, only one of those can be provided");
       }
-      this.httpClient = httpClient;
+      this.httpClient = httpSolrClient;
       return this;
     }
 
@@ -429,13 +428,18 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
      * @param internalClientBuilder the builder to use for creating the internal http client.
      * @return this
      */
-    public Builder withInternalClientBuilder(Http2SolrClient.Builder internalClientBuilder) {
+    public Builder withHttpClientBuilder(Http2SolrClient.Builder internalClientBuilder) {
       if (this.httpClient != null) {
         throw new IllegalStateException(
             "The builder can't accept an httpClient AND an internalClientBuilder, only one of those can be provided");
       }
       this.internalClientBuilder = internalClientBuilder;
       return this;
+    }
+
+    @Deprecated(since = "9.10")
+    public Builder withInternalClientBuilder(Http2SolrClient.Builder internalClientBuilder) {
+      return withHttpClientBuilder(internalClientBuilder);
     }
 
     /**

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientBuilderTest.java
@@ -128,14 +128,14 @@ public class CloudHttp2SolrClientBuilderTest extends SolrCloudTestCase {
             new CloudHttp2SolrClient.Builder(
                     Collections.singletonList(ANY_ZK_HOST), Optional.of(ANY_CHROOT))
                 .withHttpClient(mock(Http2SolrClient.class))
-                .withInternalClientBuilder(mock(Http2SolrClient.Builder.class))
+                .withHttpClientBuilder(mock(Http2SolrClient.Builder.class))
                 .build());
     expectThrows(
         IllegalStateException.class,
         () ->
             new CloudHttp2SolrClient.Builder(
                     Collections.singletonList(ANY_ZK_HOST), Optional.of(ANY_CHROOT))
-                .withInternalClientBuilder(mock(Http2SolrClient.Builder.class))
+                .withHttpClientBuilder(mock(Http2SolrClient.Builder.class))
                 .withHttpClient(mock(Http2SolrClient.class))
                 .build());
   }
@@ -148,7 +148,7 @@ public class CloudHttp2SolrClientBuilderTest extends SolrCloudTestCase {
     CloudHttp2SolrClient.Builder clientBuilder =
         new CloudHttp2SolrClient.Builder(
                 Collections.singletonList(ANY_ZK_HOST), Optional.of(ANY_CHROOT))
-            .withInternalClientBuilder(http2ClientBuilder);
+            .withHttpClientBuilder(http2ClientBuilder);
     verify(http2ClientBuilder, never()).build();
     try (CloudHttp2SolrClient client = clientBuilder.build()) {
       assertEquals(http2Client, client.getHttpClient());
@@ -218,7 +218,7 @@ public class CloudHttp2SolrClientBuilderTest extends SolrCloudTestCase {
     if (httpClient != null) {
       clientBuilder.withHttpClient(httpClient);
     } else if (internalClientBuilder != null) {
-      clientBuilder.withInternalClientBuilder(internalClientBuilder);
+      clientBuilder.withHttpClientBuilder(internalClientBuilder);
     }
 
     try (CloudHttp2SolrClient client = clientBuilder.build()) {


### PR DESCRIPTION
to withHttpClientBuilder
(kept with deprecations)

Boring enough that I'd prefer to avoid JIRA/CHANGES.txt