### PR TITLE
SOLR-17859: Restore the use of TimeLimitingBulkScorer.

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
+++ b/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
@@ -67,6 +67,7 @@ public class TestQueryLimits extends SolrCloudTestCase {
           "SearchHandler.handleRequestBody",
           "QueryComponent",
           "QueryComponent.process",
+          "TimeLimitingBulkScorer.score",
           "FacetComponent.process:2"
         };
     for (String matchingExpr : matchingExprTests) {

--- a/solr/test-framework/src/java/org/apache/solr/search/CallerSpecificQueryLimit.java
+++ b/solr/test-framework/src/java/org/apache/solr/search/CallerSpecificQueryLimit.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -53,10 +54,10 @@ public class CallerSpecificQueryLimit implements QueryLimit {
   // className -> set of method names
   private final Map<String, Set<String>> interestingCallers = new HashMap<>();
   // expr -> initial count
-  private final Map<String, Integer> maxCounts = new HashMap<>();
+  private final Map<String, Integer> maxCounts = new ConcurrentHashMap<>();
   // expr -> current count
-  private final Map<String, AtomicInteger> callCounts = new HashMap<>();
-  private Set<String> trippedBy = new LinkedHashSet<>();
+  private final Map<String, AtomicInteger> callCounts = new ConcurrentHashMap<>();
+  private Set<String> trippedBy = ConcurrentHashMap.newKeySet();
 
   /**
    * Signal a timeout in places that match the calling classes (and methods).


### PR DESCRIPTION
During the upgrade to Lucene 10 due to the Lucene API changes the `SolrIndexSearcher.search(List<LeafReaderContext>, Weight, Collector)` became obsolete and was commented out.

However, this removed Solr's ability to trigger the use of `TimeLimitingBulkScorer` in Lucene when `QueryLimits` are in use. This PR fixes it and adds a unit test to make sure that this scorer is in fact used when limits are active.