### PR TITLE
SOLR-17445 Update Docker base image to eclipse-temurin:21-jre-noble

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -156,6 +156,8 @@ Dependency Upgrades
 
 * SOLR-17631: Upgrade to Lucene 10.2.1 (Ishan Chattopadhyaya, noble, Jason Gerlowski, Eric Pugh, janhoy, Christine Poerschke)
 
+* SOLR-17445: The base docker image has been upgraded from Ubuntu 22 (Jammy) to Ubuntu 24 (Noble). (Jan Høydahl)
+
 Other Changes
 ---------------------
 

--- a/solr/docker/README.md
+++ b/solr/docker/README.md
@@ -47,7 +47,7 @@ When building the image, Solr accepts arguments for customization. Currently onl
 - `BASE_IMAGE`: Change the base java image for Solr. This can be used to change java versions, jvms, etc.
 
 ```bash
-docker build --build-arg BASE_IMAGE=custom/jdk:17-slim -f solr-X.Y.Z/docker/Dockerfile https://www.apache.org/dyn/closer.lua/solr/X.Y.Z/solr-X.Y.Z.tgz
+docker build --build-arg BASE_IMAGE=custom/jdk:21-slim -f solr-X.Y.Z/docker/Dockerfile https://www.apache.org/dyn/closer.lua/solr/X.Y.Z/solr-X.Y.Z.tgz
 ```
 
 Official Image Management

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -33,7 +33,7 @@ def dockerImageTagSuffix = "${ -> propertyOrEnvOrDefault("solr.docker.imageTagSu
 def dockerImageRepo = "${ -> propertyOrEnvOrDefault("solr.docker.imageRepo", "SOLR_DOCKER_IMAGE_REPO", "apache/solr") }"
 def dockerImageTag = "${ -> propertyOrEnvOrDefault("solr.docker.imageTag", "SOLR_DOCKER_IMAGE_TAG", project.version + dockerImageDistSuffix) }"
 def dockerImageName = "${ -> propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}:${dockerImageTag}${dockerImageTagSuffix}") }"
-def baseDockerImage = "${ -> propertyOrEnvOrDefault("solr.docker.baseImage", "SOLR_DOCKER_BASE_IMAGE", 'eclipse-temurin:' + javaVersion + '-jre-jammy') }"
+def baseDockerImage = "${ -> propertyOrEnvOrDefault("solr.docker.baseImage", "SOLR_DOCKER_BASE_IMAGE", 'eclipse-temurin:' + javaVersion + '-jre-noble') }"
 def officialDockerImageName = {String dist -> "${ -> propertyOrEnvOrDefault("solr.docker.imageName", "SOLR_DOCKER_IMAGE_NAME", "${dockerImageRepo}-official:${dockerImageTag}${distToSuffix(dist)}${dockerImageTagSuffix}") }" }
 
 def releaseGpgFingerprint = "${ -> propertyOrDefault('signing.gnupg.keyName',propertyOrDefault('signing.keyId','')) }"
@@ -277,9 +277,9 @@ task createBodySnippetDockerfile(type: Copy) {
   outputs.file("$buildDir/snippets/Dockerfile.body.snippet")
   rename { name -> name.replace("template","snippet") }
   filteringCharset 'UTF-8'
-  
+
   // NOTE: The only "templating" the Dockerfile.body supports is removing comments.
-  // 
+  //
   // Any situation where it feel appropriate to add variable substitution should be reconsidered, and probably
   // implemented as either a build-arg or as a variable expanded in the header snippets (or both)
   filter( commentFilter )
@@ -289,14 +289,14 @@ ext {
   // NOTE: 'props' are variables that will be replaced in the respective templates,
   // and they must consist solely of characters matching the regex '(_|\\p{Upper})+'.
   // They may only be used in ARG and FROM lines, via the syntax: '_REPLACE_FOO_'
-  // where 'FOO' is the key used in 'props' (NOTE the leading and trailing literal '_' characters) 
+  // where 'FOO' is the key used in 'props' (NOTE the leading and trailing literal '_' characters)
   dfLocalDetails = [
     name: 'Local',
     template: 'local',
     desc: 'Dockerfile used to create local Solr docker images directly from Solr release tgz file',
 
     // NOTE: There should be no reason for Dockerfile.local to include unique values
-    // 
+    //
     // Values identical in both Dockerfiles should use consistent names in both templates and
     // be defined in the task creation.
     props: [:]
@@ -576,7 +576,7 @@ abstract class TestDockerImageTask extends DefaultTask {
 
   @Input
   SetProperty<String> testCasesExclude = project.objects.setProperty(String)
-  
+
   @OutputDirectory
   abstract public DirectoryProperty getOutputDir()
 

--- a/solr/docker/gradle-help.txt
+++ b/solr/docker/gradle-help.txt
@@ -17,7 +17,7 @@ gradlew dockerBuild
 The docker build task accepts the following inputs, all accepted via both Environment Variables and Gradle Properties.
 
 Base Docker Image: (The docker image used for the "FROM" in the Solr Dockerfile)
-   Default: "eclipse-temurin:17-jre-jammy"
+   Default: "eclipse-temurin:21-jre-noble"
    EnvVar: SOLR_DOCKER_BASE_IMAGE
    Gradle Property: -Psolr.docker.baseImage
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -119,7 +119,7 @@ Nowadays, the HTTP request is available via internal APIs: `SolrQueryRequest.get
 
 * The ConcurrentMergeScheduler's autoIOThrottle default changed to `false` but `true` may be configured to retain prior behaviour. (SOLR-17631).
 
-* BlobHandler and the `.system` collection have been removed in favour of FileStore API.  (SOLR-17851). 
+* BlobHandler and the `.system` collection have been removed in favour of FileStore API.  (SOLR-17851).
 
 
 === Security
@@ -128,6 +128,10 @@ Nowadays, the HTTP request is available via internal APIs: `SolrQueryRequest.get
 
 === Upgrade to Jetty 12.x
 Solr upgraded to Jetty 12.x from 10.x as Jetty 10 and 11 have reached end-of-life support. Jetty 12.x requires Java 17 or newer and is fully compatible with Solr's new minimum requirement of Java 21. This upgrade brings support for modern HTTP protocols and adopts the Jakarta EE 10 namespace. For more details, see https://webtide.com/jetty-12-has-arrived/.
+
+=== Docker
+
+The OS version of the official Docker image and provided Dockerfile has been upgraded to Ubuntu 24 (noble) from Ubuntu 22 (jammy).
 
 === Analysis and Tokenizers
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17445

Bump base OS version to latest LTS (Noble) before 10.x release.