### PR TITLE
Minor refactoring of the TextToVectorQParserPlugin

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -57,6 +57,8 @@ Improvements
 
 * SOLR-17867: Export tool should properly output exported documents in json, json w/ lines, and javabin formats. (Eric Pugh)
 
+* Minor refactoring of the TextToVectorQParserPlugin (Ilaria Petreti via Alessandro Benedetti)
+
 Optimizations
 ---------------------
 * SOLR-17568: The CLI bin/solr export tool now contacts the appropriate nodes directly for data instead of proxying through one.

--- a/solr/core/src/java/org/apache/solr/search/neural/AbstractVectorQParserBase.java
+++ b/solr/core/src/java/org/apache/solr/search/neural/AbstractVectorQParserBase.java
@@ -40,7 +40,7 @@ public abstract class AbstractVectorQParserBase extends QParser {
   static final String INCLUDE_TAGS = "includeTags";
 
   private final String denseVectorFieldName;
-  private final String vectorToSearch;
+  protected String vectorToSearch;
 
   public AbstractVectorQParserBase(
       String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req) {


### PR DESCRIPTION
# Description

Just a minor refactoring of the `TextToVectorQParserPlugin` to use the superclass parse method.

The method `checkVectorDimension ` has been removed because it is already present in `org/apache/solr/util/vector/DenseVectorParser.java`.