### PR TITLE
SOLR-17910: Fix left behind restore index directory

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -49,7 +49,7 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin, Cl
       new IOContext(new FlushInfo(10 * 1000 * 1000, 100L * 1000 * 1000 * 1000));
 
   protected static final String INDEX_W_TIMESTAMP_REGEX =
-      "index\\.[0-9]{17}"; // see SnapShooter.DATE_FMT
+      "(index|restore)\\.[0-9]{17}"; // see SnapShooter.DATE_FMT
 
   // May be set by subclasses as data root, in which case getDataHome will use it as base.
   // Absolute.

--- a/solr/core/src/java/org/apache/solr/handler/RestoreCore.java
+++ b/solr/core/src/java/org/apache/solr/handler/RestoreCore.java
@@ -139,6 +139,12 @@ public class RestoreCore implements Callable<Boolean> {
       }
       log.debug("Switching directories");
       core.modifyIndexProps(restoreIndexName);
+      indexDir =
+          core.getDirectoryFactory()
+              .get(
+                  core.getIndexDir(),
+                  DirectoryFactory.DirContext.DEFAULT,
+                  core.getSolrConfig().indexConfig.lockType);
 
       boolean success;
       try {
@@ -173,6 +179,7 @@ public class RestoreCore implements Callable<Boolean> {
             SolrException.ErrorCode.UNKNOWN, "Exception while restoring the backup index", e);
       }
       if (success) {
+        core.getDirectoryFactory().doneWithDirectory(indexDir);
         core.getDirectoryFactory().doneWithDirectory(indexDir);
         // Cleanup all index files not associated with any *named* snapshot.
         core.deleteNonSnapshotIndexFiles(indexDirPath);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17910

Just pushing this up to keep it top of mind, but I'm not sure this is really the solution. There is some issue with IndexFetcher and RestoreCore, where the `restore-#####` index directory can be left behind. This initial attempt seems like a bandaid that might actually break something else.