### PR TITLE
SOLR-17889: Fix noisy TestMainQueryCaching and TestFiltersQueryCaching (and cleanups)

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -3080,8 +3080,7 @@ public class ZkController implements Closeable {
         }
         registeredSearcher.decref();
       } else {
-        @SuppressWarnings("unchecked")
-        Future<Void>[] waitSearcher = (Future<Void>[]) Array.newInstance(Future.class, 1);
+        Future<?>[] waitSearcher = (Future<?>[]) Array.newInstance(Future.class, 1);
         if (log.isInfoEnabled()) {
           log.info(
               "No registered searcher found for core: {}, waiting until a searcher is registered before publishing as active",

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2068,8 +2068,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
   private int onDeckSearchers; // number of searchers preparing
   // Lock ordering: one can acquire the openSearcherLock and then the searcherLock, but not
   // vice-versa.
-  private Object searcherLock = new Object(); // the sync object for the searcher
-  private ReentrantLock openSearcherLock =
+  private final Object searcherLock = new Object(); // the sync object for the searcher
+  private final ReentrantLock openSearcherLock =
       new ReentrantLock(true); // used to serialize opens/reopens for absolute ordering
   private final int maxWarmingSearchers; // max number of on-deck searchers allowed
   private final int slowQueryThresholdMillis; // threshold above which a query is considered slow
@@ -2269,7 +2269,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   }
 
   public RefCounted<SolrIndexSearcher> getSearcher(
-      boolean forceNew, boolean returnSearcher, final Future<Void>[] waitSearcher) {
+      boolean forceNew, boolean returnSearcher, final Future<?>[] waitSearcher) {
     return getSearcher(forceNew, returnSearcher, waitSearcher, false);
   }
 
@@ -2506,7 +2506,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   public RefCounted<SolrIndexSearcher> getSearcher(
       boolean forceNew,
       boolean returnSearcher,
-      final Future<Void>[] waitSearcher,
+      final Future<?>[] waitSearcher,
       boolean updateHandlerReopens) {
     // it may take some time to open an index.... we may need to make
     // sure that two threads aren't trying to open one at the same time
@@ -2574,7 +2574,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
     }
 
     // a signal to decrement onDeckSearchers if something goes wrong.
-    final boolean[] decrementOnDeckCount = new boolean[] {true};
     RefCounted<SolrIndexSearcher> currSearcherHolder = null; // searcher we are autowarming from
     RefCounted<SolrIndexSearcher> searchHolder = null;
     boolean success = false;
@@ -2599,7 +2598,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
           // want to register this one before warming is complete instead of waiting.
           if (solrConfig.useColdSearcher) {
             registerSearcher(newSearchHolder);
-            decrementOnDeckCount[0] = false;
             alreadyRegistered = true;
           }
         } else {
@@ -2612,7 +2610,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
       final SolrIndexSearcher currSearcher =
           currSearcherHolder == null ? null : currSearcherHolder.get();
 
-      Future<Void> future = null;
+      Future<?> future = null;
 
       // if the underlying searcher has not changed, no warming is needed
       if (newSearcher != currSearcher) {

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1019,8 +1019,7 @@ public class IndexFetcher {
       if (core == null) {
         return; // core closed, presumably
       }
-      @SuppressWarnings("unchecked")
-      Future<Void>[] waitSearcher = (Future<Void>[]) Array.newInstance(Future.class, 1);
+      Future<?>[] waitSearcher = (Future<?>[]) Array.newInstance(Future.class, 1);
       RefCounted<SolrIndexSearcher> searcher = core.getSearcher(true, true, waitSearcher, true);
       try {
         if (waitSearcher[0] != null) {

--- a/solr/core/src/java/org/apache/solr/handler/RestoreCore.java
+++ b/solr/core/src/java/org/apache/solr/handler/RestoreCore.java
@@ -196,8 +196,7 @@ public class RestoreCore implements Callable<Boolean> {
   }
 
   private void openNewSearcher() throws Exception {
-    @SuppressWarnings("unchecked")
-    Future<Void>[] waitSearcher = (Future<Void>[]) Array.newInstance(Future.class, 1);
+    Future<?>[] waitSearcher = (Future<?>[]) Array.newInstance(Future.class, 1);
     core.getSearcher(true, false, waitSearcher, true);
     if (waitSearcher[0] != null) {
       waitSearcher[0].get();

--- a/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
+++ b/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
@@ -729,9 +729,8 @@ public class DirectUpdateHandler2 extends UpdateHandler
       if (cmd.expungeDeletes) expungeDeleteCommands.mark();
     }
 
-    @SuppressWarnings("unchecked")
-    Future<Void>[] waitSearcher =
-        cmd.waitSearcher ? (Future<Void>[]) Array.newInstance(Future.class, 1) : null;
+    Future<?>[] waitSearcher =
+        cmd.waitSearcher ? (Future<?>[]) Array.newInstance(Future.class, 1) : null;
 
     boolean error = true;
     try {

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexSplitter.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexSplitter.java
@@ -512,8 +512,7 @@ public class SolrIndexSplitter {
   }
 
   private void openNewSearcher(SolrCore core) throws Exception {
-    @SuppressWarnings("unchecked")
-    Future<Void>[] waitSearcher = (Future<Void>[]) Array.newInstance(Future.class, 1);
+    Future<?>[] waitSearcher = (Future<?>[]) Array.newInstance(Future.class, 1);
     core.getSearcher(true, false, waitSearcher, true);
     if (waitSearcher[0] != null) {
       waitSearcher[0].get();

--- a/solr/core/src/test/org/apache/solr/search/TestIndexSearcher.java
+++ b/solr/core/src/test/org/apache/solr/search/TestIndexSearcher.java
@@ -259,8 +259,7 @@ public class TestIndexSearcher extends SolrTestCaseJ4 {
       addDummyDoc(newCore);
 
       // Open a new searcher, this should call the newSearcherListeners
-      @SuppressWarnings("unchecked")
-      Future<Void>[] future = (Future<Void>[]) Array.newInstance(Future.class, 1);
+      Future<?>[] future = (Future<?>[]) Array.newInstance(Future.class, 1);
       newCore.getSearcher(true, false, future);
       future[0].get();
 

--- a/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
@@ -18,6 +18,7 @@ package org.apache.solr.search;
 
 import static org.apache.solr.common.util.Utils.fromJSONString;
 
+import java.lang.reflect.Array;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
@@ -86,6 +87,12 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
     // testing caching, it's far simpler to just reload the core every time to prevent
     // subsequent requests from affecting each other
     h.reload();
+
+    // Make sure the new searcher (after reload) is fully initialized. This is to avoid races
+    // between queries submitted by the test and metrics warmup of the new searcher.
+    Future<?>[] waitSearcher = (Future<?>[]) Array.newInstance(Future.class, 1);
+    h.getCore().getSearcher(true, false, waitSearcher, true);
+    waitSearcher[0].get();
   }
 
   private static long coreToInserts(SolrCore core, String cacheName) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17889

I figured out `TestMainQueryCaching` and `TestFiltersQueryCaching` are exposed to a race condition when reloading the core. A side effect is some metrics are reset when using the new searcher. When forcing to wait for the new searcher, I don't reproduce the flappers anymore.

Since I had to deeply review the code that opens a new searcher to understand the root cause, this change includes some code cleanups in this area (with no behavior changes) mostly to remove some annoying `@SuppressWarnings("unchecked")` annotations. No functional changes here.