### PR TITLE
NO JIRA: provide ResponseBuilder.(get,set)Stage accessors, deprecate direct access

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
@@ -200,10 +200,10 @@ public class DebugComponent extends SearchComponent {
       NamedList<Object> stageList =
           (NamedList<Object>)
               ((NamedList<Object>) rb.getDebugInfo().get("track"))
-                  .get(getDistributedStageName(rb.stage));
+                  .get(getDistributedStageName(rb.getStage()));
       if (stageList == null) {
         stageList = new SimpleOrderedMap<>();
-        rb.addDebug(stageList, "track", getDistributedStageName(rb.stage));
+        rb.addDebug(stageList, "track", getDistributedStageName(rb.getStage()));
       }
       for (ShardResponse response : sreq.responses) {
         stageList.add(response.getShard(), getTrackResponse(response));
@@ -216,7 +216,7 @@ public class DebugComponent extends SearchComponent {
   @Override
   @SuppressWarnings({"unchecked"})
   public void finishStage(ResponseBuilder rb) {
-    if (rb.isDebug() && rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.isDebug() && rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
       NamedList<Object> info = rb.getDebugInfo();
       NamedList<Object> explain = new SimpleOrderedMap<>();
 

--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -454,7 +454,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
 
   @Override
   public int distributedProcess(ResponseBuilder rb) throws IOException {
-    if (rb.doExpand && rb.stage < finishingStage) {
+    if (rb.doExpand && rb.getStage() < finishingStage) {
       return finishingStage;
     }
     return ResponseBuilder.STAGE_DONE;
@@ -507,7 +507,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       return;
     }
 
-    if (rb.stage != finishingStage) {
+    if (rb.getStage() != finishingStage) {
       return;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/FacetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/FacetComponent.java
@@ -361,7 +361,7 @@ public class FacetComponent extends SearchComponent {
       return ResponseBuilder.STAGE_DONE;
     }
 
-    if (rb.stage != ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) {
       return ResponseBuilder.STAGE_DONE;
     }
     // Overlap facet refinement requests (those shards that we need a count
@@ -846,7 +846,7 @@ public class FacetComponent extends SearchComponent {
   }
 
   private void removeQueryFacetsUnderLimits(ResponseBuilder rb) {
-    if (rb.stage != ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() != ResponseBuilder.STAGE_EXECUTE_QUERY) {
       return;
     }
     FacetInfo fi = rb._facetInfo;
@@ -876,7 +876,7 @@ public class FacetComponent extends SearchComponent {
   }
 
   private void removeRangeFacetsUnderLimits(ResponseBuilder rb) {
-    if (rb.stage != ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() != ResponseBuilder.STAGE_EXECUTE_QUERY) {
       return;
     }
 
@@ -895,7 +895,7 @@ public class FacetComponent extends SearchComponent {
   }
 
   private void removeFieldFacetsUnderLimits(ResponseBuilder rb) {
-    if (rb.stage != ResponseBuilder.STAGE_DONE) {
+    if (rb.getStage() != ResponseBuilder.STAGE_DONE) {
       return;
     }
 
@@ -1089,7 +1089,7 @@ public class FacetComponent extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (!rb.doFacets || rb.stage != ResponseBuilder.STAGE_GET_FIELDS) return;
+    if (!rb.doFacets || rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) return;
     // wait until STAGE_GET_FIELDS
     // so that "result" is already stored in the response (for aesthetics)
 

--- a/solr/core/src/java/org/apache/solr/handler/component/HighlightComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HighlightComponent.java
@@ -212,7 +212,7 @@ public class HighlightComponent extends SearchComponent
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (rb.doHighlights && rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.doHighlights && rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
 
       final Object[] objArr = newHighlightsArray(rb.resultIds.size());
       final String highlightingResponseField = highlightingResponseField();

--- a/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/MoreLikeThisComponent.java
@@ -229,7 +229,7 @@ public class MoreLikeThisComponent extends SearchComponent {
     // Handling Responses in finishStage, because solrResponse will put
     // moreLikeThis xml
     // segment ahead of result/response.
-    if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS
+    if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS
         && rb.req.getParams().getBool(COMPONENT_NAME, false)) {
       Map<Object, SolrDocumentList> tempResults = new LinkedHashMap<>();
 

--- a/solr/core/src/java/org/apache/solr/handler/component/PhrasesIdentificationComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/PhrasesIdentificationComponent.java
@@ -154,10 +154,10 @@ public class PhrasesIdentificationComponent extends SearchComponent {
       return ResponseBuilder.STAGE_DONE;
     }
 
-    if (rb.stage < ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() < ResponseBuilder.STAGE_EXECUTE_QUERY) {
       return ResponseBuilder.STAGE_EXECUTE_QUERY;
 
-    } else if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    } else if (rb.getStage() == ResponseBuilder.STAGE_EXECUTE_QUERY) {
       // if we're being used in conjunction with QueryComponent, it should have already created
       // (in this staged) the only ShardRequest we need...
       for (ShardRequest sreq : rb.outgoing) {
@@ -174,7 +174,7 @@ public class PhrasesIdentificationComponent extends SearchComponent {
       rb.addRequest(this, sreq);
       return ResponseBuilder.STAGE_GET_FIELDS;
 
-    } else if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    } else if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
       // NOTE: we don't do any actual work in this stage, but we need to ensure that even if we are
       // being used in isolation w/o QueryComponent that SearchHandler "tracks" a STAGE_GET_FIELDS.
       // so that finishStage(STAGE_GET_FIELDS) is called on us and we can add our merged results
@@ -194,7 +194,7 @@ public class PhrasesIdentificationComponent extends SearchComponent {
 
     final PhrasesContextData contextData =
         (PhrasesContextData) rb.req.getContext().get(this.getClass());
-    if (null == contextData || rb.stage != ResponseBuilder.STAGE_GET_FIELDS) {
+    if (null == contextData || rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) {
       // if prepare didn't give us anything to work with, or this isn't our stage, then do nothing
       return;
     }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -605,24 +605,24 @@ public class QueryComponent extends SearchComponent {
     int nextStage = ResponseBuilder.STAGE_DONE;
     ShardRequestFactory shardRequestFactory = null;
 
-    if (rb.stage < ResponseBuilder.STAGE_PARSE_QUERY) {
+    if (rb.getStage() < ResponseBuilder.STAGE_PARSE_QUERY) {
       nextStage = ResponseBuilder.STAGE_PARSE_QUERY;
-    } else if (rb.stage == ResponseBuilder.STAGE_PARSE_QUERY) {
+    } else if (rb.getStage() == ResponseBuilder.STAGE_PARSE_QUERY) {
       createDistributedStats(rb);
       nextStage = ResponseBuilder.STAGE_TOP_GROUPS;
-    } else if (rb.stage < ResponseBuilder.STAGE_TOP_GROUPS) {
+    } else if (rb.getStage() < ResponseBuilder.STAGE_TOP_GROUPS) {
       nextStage = ResponseBuilder.STAGE_TOP_GROUPS;
-    } else if (rb.stage == ResponseBuilder.STAGE_TOP_GROUPS) {
+    } else if (rb.getStage() == ResponseBuilder.STAGE_TOP_GROUPS) {
       shardRequestFactory = new SearchGroupsRequestFactory();
       nextStage = ResponseBuilder.STAGE_EXECUTE_QUERY;
-    } else if (rb.stage < ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    } else if (rb.getStage() < ResponseBuilder.STAGE_EXECUTE_QUERY) {
       nextStage = ResponseBuilder.STAGE_EXECUTE_QUERY;
-    } else if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    } else if (rb.getStage() == ResponseBuilder.STAGE_EXECUTE_QUERY) {
       shardRequestFactory = new TopGroupsShardRequestFactory();
       nextStage = ResponseBuilder.STAGE_GET_FIELDS;
-    } else if (rb.stage < ResponseBuilder.STAGE_GET_FIELDS) {
+    } else if (rb.getStage() < ResponseBuilder.STAGE_GET_FIELDS) {
       nextStage = ResponseBuilder.STAGE_GET_FIELDS;
-    } else if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    } else if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
       shardRequestFactory = new StoredFieldsShardRequestFactory();
       nextStage = ResponseBuilder.STAGE_DONE;
     }
@@ -636,24 +636,24 @@ public class QueryComponent extends SearchComponent {
   }
 
   protected int regularDistributedProcess(ResponseBuilder rb) {
-    if (rb.stage < ResponseBuilder.STAGE_PARSE_QUERY) {
+    if (rb.getStage() < ResponseBuilder.STAGE_PARSE_QUERY) {
       return ResponseBuilder.STAGE_PARSE_QUERY;
     }
-    if (rb.stage == ResponseBuilder.STAGE_PARSE_QUERY) {
+    if (rb.getStage() == ResponseBuilder.STAGE_PARSE_QUERY) {
       createDistributedStats(rb);
       return ResponseBuilder.STAGE_EXECUTE_QUERY;
     }
-    if (rb.stage < ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() < ResponseBuilder.STAGE_EXECUTE_QUERY) {
       return ResponseBuilder.STAGE_EXECUTE_QUERY;
     }
-    if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() == ResponseBuilder.STAGE_EXECUTE_QUERY) {
       createMainQuery(rb);
       return ResponseBuilder.STAGE_GET_FIELDS;
     }
-    if (rb.stage < ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() < ResponseBuilder.STAGE_GET_FIELDS) {
       return ResponseBuilder.STAGE_GET_FIELDS;
     }
-    if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS && !rb.onePassDistributedQuery) {
+    if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS && !rb.onePassDistributedQuery) {
       createRetrieveDocs(rb);
       return ResponseBuilder.STAGE_DONE;
     }
@@ -700,7 +700,7 @@ public class QueryComponent extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (rb.stage != ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) {
       return;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -1030,8 +1030,8 @@ public class RealTimeGetComponent extends SearchComponent {
 
   @Override
   public int distributedProcess(ResponseBuilder rb) throws IOException {
-    if (rb.stage < ResponseBuilder.STAGE_GET_FIELDS) return ResponseBuilder.STAGE_GET_FIELDS;
-    if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() < ResponseBuilder.STAGE_GET_FIELDS) return ResponseBuilder.STAGE_GET_FIELDS;
+    if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
       return createSubRequests(rb);
     }
     return ResponseBuilder.STAGE_DONE;
@@ -1143,7 +1143,7 @@ public class RealTimeGetComponent extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (rb.stage != ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) {
       return;
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -130,7 +130,8 @@ public class ResponseBuilder {
   public static final int STAGE_GET_FIELDS = 3000;
   public static final int STAGE_DONE = Integer.MAX_VALUE;
 
-  private int stage; // What stage is this current request at?
+  // public access is deprecated, please use getStage and setStage instead.
+  @Deprecated public int stage; // What stage is this current request at?
 
   public int getStage() {
     return this.stage;

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -130,8 +130,7 @@ public class ResponseBuilder {
   public static final int STAGE_GET_FIELDS = 3000;
   public static final int STAGE_DONE = Integer.MAX_VALUE;
 
-  // public access is deprecated, please use getStage and setStage instead.
-  @Deprecated public int stage; // What stage is this current request at?
+  private int stage; // What stage is this current request at?
 
   public int getStage() {
     return this.stage;

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -130,7 +130,16 @@ public class ResponseBuilder {
   public static final int STAGE_GET_FIELDS = 3000;
   public static final int STAGE_DONE = Integer.MAX_VALUE;
 
-  public int stage; // What stage is this current request at?
+  // public access is deprecated, please use getStage and setStage instead.
+  @Deprecated public int stage; // What stage is this current request at?
+
+  public int getStage() {
+    return this.stage;
+  }
+
+  public void setStage(int stage) {
+    this.stage = stage;
+  }
 
   // The address of the Shard
   boolean isDistrib; // is this a distributed search?

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -538,7 +538,7 @@ public class SearchHandler extends RequestHandlerBase
       int nextStage = 0;
       long totalShardCpuTime = 0L;
       do {
-        rb.stage = nextStage;
+        rb.setStage(nextStage);
         nextStage = ResponseBuilder.STAGE_DONE;
 
         // call all components

--- a/solr/core/src/java/org/apache/solr/handler/component/SpellCheckComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SpellCheckComponent.java
@@ -397,7 +397,7 @@ public class SpellCheckComponent extends SearchComponent implements SolrCoreAwar
   @Override
   public void finishStage(ResponseBuilder rb) {
     SolrParams params = rb.req.getParams();
-    if (!params.getBool(COMPONENT_NAME, false) || rb.stage != ResponseBuilder.STAGE_GET_FIELDS)
+    if (!params.getBool(COMPONENT_NAME, false) || rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS)
       return;
 
     boolean extendedResults = params.getBool(SPELLCHECK_EXTENDED_RESULTS, false);

--- a/solr/core/src/java/org/apache/solr/handler/component/StatsComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/StatsComponent.java
@@ -110,7 +110,7 @@ public class StatsComponent extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (!rb.doStats || rb.stage != ResponseBuilder.STAGE_GET_FIELDS) return;
+    if (!rb.doStats || rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) return;
     // wait until STAGE_GET_FIELDS
     // so that "result" is already stored in the response (for aesthetics)
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SuggestComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SuggestComponent.java
@@ -216,8 +216,9 @@ public class SuggestComponent extends SearchComponent
   public int distributedProcess(ResponseBuilder rb) {
     SolrParams params = rb.req.getParams();
     log.info("SuggestComponent distributedProcess with : {}", params);
-    if (rb.stage < ResponseBuilder.STAGE_EXECUTE_QUERY) return ResponseBuilder.STAGE_EXECUTE_QUERY;
-    if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() < ResponseBuilder.STAGE_EXECUTE_QUERY)
+      return ResponseBuilder.STAGE_EXECUTE_QUERY;
+    if (rb.getStage() == ResponseBuilder.STAGE_EXECUTE_QUERY) {
       ShardRequest sreq = new ShardRequest();
       sreq.purpose = ShardRequest.PURPOSE_GET_TOP_IDS;
       sreq.params = new ModifiableSolrParams(rb.req.getParams());
@@ -296,7 +297,7 @@ public class SuggestComponent extends SearchComponent
   public void finishStage(ResponseBuilder rb) {
     SolrParams params = rb.req.getParams();
     log.info("SuggestComponent finishStage with : {}", params);
-    if (!params.getBool(COMPONENT_NAME, false) || rb.stage != ResponseBuilder.STAGE_GET_FIELDS)
+    if (!params.getBool(COMPONENT_NAME, false) || rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS)
       return;
     int count = params.getInt(SUGGEST_COUNT, 1);
 

--- a/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TermVectorComponent.java
@@ -416,7 +416,7 @@ public class TermVectorComponent extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
 
       NamedList<Object> termVectorsNL = new NamedList<>();
 

--- a/solr/core/src/java/org/apache/solr/handler/component/TermsComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TermsComponent.java
@@ -358,7 +358,7 @@ public class TermsComponent extends SearchComponent {
       return ResponseBuilder.STAGE_DONE;
     }
 
-    if (rb.stage == ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() == ResponseBuilder.STAGE_EXECUTE_QUERY) {
       TermsHelper th = rb._termsHelper;
       if (th == null) {
         th = rb._termsHelper = new TermsHelper();
@@ -368,7 +368,7 @@ public class TermsComponent extends SearchComponent {
       rb.addRequest(this, sreq);
     }
 
-    if (rb.stage < ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (rb.getStage() < ResponseBuilder.STAGE_EXECUTE_QUERY) {
       return ResponseBuilder.STAGE_EXECUTE_QUERY;
     } else {
       return ResponseBuilder.STAGE_DONE;
@@ -403,7 +403,7 @@ public class TermsComponent extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (!rb.doTerms || rb.stage != ResponseBuilder.STAGE_EXECUTE_QUERY) {
+    if (!rb.doTerms || rb.getStage() != ResponseBuilder.STAGE_EXECUTE_QUERY) {
       return;
     }
 

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
@@ -173,7 +173,7 @@ public class FacetModule extends SearchComponent {
     FacetComponentState facetState = getFacetComponentState(rb);
     if (facetState == null) return ResponseBuilder.STAGE_DONE;
 
-    if (rb.stage != ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) {
       return ResponseBuilder.STAGE_DONE;
     }
 
@@ -328,7 +328,7 @@ public class FacetModule extends SearchComponent {
 
   @Override
   public void finishStage(ResponseBuilder rb) {
-    if (rb.stage != ResponseBuilder.STAGE_GET_FIELDS) return;
+    if (rb.getStage() != ResponseBuilder.STAGE_GET_FIELDS) return;
 
     FacetComponentState facetState = getFacetComponentState(rb);
     if (facetState == null) return;

--- a/solr/modules/clustering/src/java/org/apache/solr/handler/clustering/ClusteringComponent.java
+++ b/solr/modules/clustering/src/java/org/apache/solr/handler/clustering/ClusteringComponent.java
@@ -327,7 +327,7 @@ public class ClusteringComponent extends SearchComponent implements SolrCoreAwar
       return;
     }
 
-    if (rb.stage == ResponseBuilder.STAGE_GET_FIELDS) {
+    if (rb.getStage() == ResponseBuilder.STAGE_GET_FIELDS) {
       List<InputDocument> inputs = new ArrayList<>();
       rb.finished.stream()
           .filter(shardRequest -> (shardRequest.purpose & ShardRequest.PURPOSE_GET_FIELDS) != 0)


### PR DESCRIPTION
this could:
 * facilitate deriving `ResponseBuilder` classes e.g. see #3648
 * make it (perhaps) clearer that and how (typically) search components get i.e. read the stage but that only the search handler sets i.e. updates the stage
 * deprecate-and-retain `ResponseBuilder.stage` i.e. it becomes private only in (say) Solr 11 or a higher 10.x future version
