### PR TITLE
SOLR-17806: Migrate AuditLoggerPlugin to OTEL

### DIFF
--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -806,7 +806,7 @@ public class SolrMetricManager {
                               .setAggregation(
                                   Aggregation.explicitBucketHistogram(
                                       SOLR_NANOSECOND_HISTOGRAM_BOUNDARIES))
-                              .build());
+                              .build()); // TODO: Make histogram bucket boundaries configurable
               SdkMeterProviderUtil.setExemplarFilter(provider, ExemplarFilter.traceBased());
               return new MeterProviderAndReaders(provider.build(), reader);
             })

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -161,22 +161,22 @@ public class SolrMetricManager {
   private final ConcurrentMap<String, MeterProviderAndReaders> meterProviderAndReaders =
       new ConcurrentHashMap<>();
 
-  private static final List<Double> SOLR_NANOSECOND_HISTOGRAM_BOUNDARIES = Arrays.asList(
-      0.0,
-      5_000.0,
-      10_000.0,
-      25_000.0,
-      50_000.0,
-      100_000.0,
-      250_000.0,
-      500_000.0,
-      1_000_000.0,
-      2_500_000.0,
-      5_000_000.0,
-      25_000_000.0,
-      100_000_000.0,
-      1_000_000_000.0
-  );
+  private static final List<Double> SOLR_NANOSECOND_HISTOGRAM_BOUNDARIES =
+      Arrays.asList(
+          0.0,
+          5_000.0,
+          10_000.0,
+          25_000.0,
+          50_000.0,
+          100_000.0,
+          250_000.0,
+          500_000.0,
+          1_000_000.0,
+          2_500_000.0,
+          5_000_000.0,
+          25_000_000.0,
+          100_000_000.0,
+          1_000_000_000.0);
 
   public SolrMetricManager() {
     metricsConfig = new MetricsConfig.MetricsConfigBuilder().build();
@@ -794,15 +794,19 @@ public class SolrMetricManager {
               var reader = new FilterablePrometheusMetricReader(true, null);
               // NOCOMMIT: We need to add a Periodic Metric Reader here if we want to push with OTLP
               // with an exporter
-              var provider = SdkMeterProvider.builder()
-                  .registerMetricReader(reader)
-                  .registerView(
-                      InstrumentSelector.builder()
-                        .setType(InstrumentType.HISTOGRAM)
-                        .setUnit(OtelUnit.NANOSECONDS.getSymbol()).build(),
-                      View.builder()
-                          .setAggregation(Aggregation.explicitBucketHistogram(SOLR_NANOSECOND_HISTOGRAM_BOUNDARIES))
-                  .build());
+              var provider =
+                  SdkMeterProvider.builder()
+                      .registerMetricReader(reader)
+                      .registerView(
+                          InstrumentSelector.builder()
+                              .setType(InstrumentType.HISTOGRAM)
+                              .setUnit(OtelUnit.NANOSECONDS.getSymbol())
+                              .build(),
+                          View.builder()
+                              .setAggregation(
+                                  Aggregation.explicitBucketHistogram(
+                                      SOLR_NANOSECOND_HISTOGRAM_BOUNDARIES))
+                              .build());
               SdkMeterProviderUtil.setExemplarFilter(provider, ExemplarFilter.traceBased());
               return new MeterProviderAndReaders(provider.build(), reader);
             })

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -162,7 +162,7 @@ public class SolrMetricManager {
       new ConcurrentHashMap<>();
 
   private static final List<Double> SOLR_NANOSECOND_HISTOGRAM_BOUNDARIES =
-      Arrays.asList(
+      List.of(
           0.0,
           5_000.0,
           10_000.0,

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricProducer.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricProducer.java
@@ -27,6 +27,7 @@ public interface SolrMetricProducer extends AutoCloseable {
   public static final AttributeKey<String> CATEGORY_ATTR = AttributeKey.stringKey("category");
   public static final AttributeKey<String> HANDLER_ATTR = AttributeKey.stringKey("handler");
   public static final AttributeKey<String> OPERATION_ATTR = AttributeKey.stringKey("ops");
+  public static final AttributeKey<String> PLUGIN_NAME_ATTR = AttributeKey.stringKey("plugin_name");
 
   /**
    * Unique metric tag identifies components with the same life-cycle, which should be registered /

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -219,7 +219,8 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
         auditsInFlight.incrementAndGet();
         if (event == null) continue;
         if (event.getDate() != null) {
-          long queueTimeNanos = TimeUnit.MILLISECONDS.toNanos(new Date().getTime() - event.getDate().getTime());
+          long queueTimeNanos =
+              TimeUnit.MILLISECONDS.toNanos(new Date().getTime() - event.getDate().getTime());
           queuedTime.record(queueTimeNanos);
         }
         AttributedLongTimer.MetricTimer timer = requestTimes.start(TimeUnit.NANOSECONDS);
@@ -266,24 +267,29 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
     String className = this.getClass().getSimpleName();
     log.debug("Initializing metrics for {}", className);
 
-    Attributes attrsWithCategory = Attributes.builder()
-        .putAll(attributes)
-        .put(CATEGORY_ATTR, Category.SECURITY.toString())
-        .put("plugin_name", this.getClass().getSimpleName())
-        .build();
+    Attributes attrsWithCategory =
+        Attributes.builder()
+            .putAll(attributes)
+            .put(CATEGORY_ATTR, Category.SECURITY.toString())
+            .put("plugin_name", this.getClass().getSimpleName())
+            .build();
 
-    numLogged = new AttributedLongCounter(solrMetricsContext.longCounter(
-        "solr_auditlogger_count",
-            "The number of audit events that were successfully logged."),
-        attrsWithCategory);
-    numErrors = new AttributedLongCounter(solrMetricsContext.longCounter(
-        "solr_auditlogger_errors",
-        "The number of audit events that resulted in errors."),
-        attrsWithCategory);
-    numLost = new AttributedLongCounter(solrMetricsContext.longCounter(
-        "solr_auditlogger_lost",
-        "The number of audit events that were lost."),
-        attrsWithCategory);
+    numLogged =
+        new AttributedLongCounter(
+            solrMetricsContext.longCounter(
+                "solr_auditlogger_count",
+                "The number of audit events that were successfully logged."),
+            attrsWithCategory);
+    numErrors =
+        new AttributedLongCounter(
+            solrMetricsContext.longCounter(
+                "solr_auditlogger_errors", "The number of audit events that resulted in errors."),
+            attrsWithCategory);
+    numLost =
+        new AttributedLongCounter(
+            solrMetricsContext.longCounter(
+                "solr_auditlogger_lost", "The number of audit events that were lost."),
+            attrsWithCategory);
     requestTimes =
         new AttributedLongTimer(
             this.solrMetricsContext.longHistogram(
@@ -297,29 +303,27 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
           "solr_auditlogger_queue",
           "Metrics around the audit logger queue when running in async mode",
           (observableLongMeasurement -> {
-              observableLongMeasurement.record(
-                  blockingQueueSize,
-                  attrsWithCategory.toBuilder().put(TYPE_ATTR, "capacity").build());
-              observableLongMeasurement.record(
-                  blockingQueueSize - queue.remainingCapacity(),
-                  attrsWithCategory.toBuilder().put(TYPE_ATTR, "size").build());
-          })
-      );
-      queuedTime = new AttributedLongTimer(
-          solrMetricsContext.longHistogram(
-              "solr_auditlogger_queued_time",
-              "Distribution of time events spend queued before processing",
-              OtelUnit.NANOSECONDS),
-          attrsWithCategory
-      );
+            observableLongMeasurement.record(
+                blockingQueueSize,
+                attrsWithCategory.toBuilder().put(TYPE_ATTR, "capacity").build());
+            observableLongMeasurement.record(
+                blockingQueueSize - queue.remainingCapacity(),
+                attrsWithCategory.toBuilder().put(TYPE_ATTR, "size").build());
+          }));
+      queuedTime =
+          new AttributedLongTimer(
+              solrMetricsContext.longHistogram(
+                  "solr_auditlogger_queued_time",
+                  "Distribution of time events spend queued before processing",
+                  OtelUnit.NANOSECONDS),
+              attrsWithCategory);
     }
 
     solrMetricsContext.observableLongGauge(
         "solr_auditlogger_async_enabled",
         "Whether the audit logger is running in async mode (1) or not (0)",
         (observableLongMeasurement ->
-            observableLongMeasurement.record(async ? 1 : 0, attrsWithCategory))
-    );
+            observableLongMeasurement.record(async ? 1 : 0, attrsWithCategory)));
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -288,7 +288,7 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
         new AttributedLongTimer(
             this.solrMetricsContext.longHistogram(
                 "solr_auditlogger_request_times",
-                "Distribution of authentication request durations",
+                "Distribution of audit event request durations",
                 OtelUnit.NANOSECONDS),
             attrsWithCategory);
 

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -43,6 +43,7 @@ import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
+import org.apache.solr.metrics.otel.instruments.AttributedLongGauge;
 import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
 import org.apache.solr.security.AuditEvent.EventType;
 import org.apache.solr.util.TimeOut;
@@ -320,11 +321,12 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
               attrsWithCategory);
     }
 
-    solrMetricsContext.observableLongGauge(
-        "solr_auditlogger_async_enabled",
-        "Whether the audit logger is running in async mode (1) or not (0)",
-        (observableLongMeasurement ->
-            observableLongMeasurement.record(async ? 1 : 0, attrsWithCategory)));
+    AttributedLongGauge asyncEnabledGauge = new AttributedLongGauge(
+        solrMetricsContext.longGauge(
+            "solr_auditlogger_async_enabled",
+            "Whether the audit logger is running in async mode (1) or not (0)"),
+        attrsWithCategory);
+    asyncEnabledGauge.set(async ? 1L : 0L);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -271,7 +271,7 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
         Attributes.builder()
             .putAll(attributes)
             .put(CATEGORY_ATTR, Category.SECURITY.toString())
-            .put("plugin_name", this.getClass().getSimpleName())
+            .put(PLUGIN_NAME_ATTR, this.getClass().getSimpleName())
             .build();
 
     numLogged =

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -321,11 +321,12 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
               attrsWithCategory);
     }
 
-    AttributedLongGauge asyncEnabledGauge = new AttributedLongGauge(
-        solrMetricsContext.longGauge(
-            "solr_auditlogger_async_enabled",
-            "Whether the audit logger is running in async mode (1) or not (0)"),
-        attrsWithCategory);
+    AttributedLongGauge asyncEnabledGauge =
+        new AttributedLongGauge(
+            solrMetricsContext.longGauge(
+                "solr_auditlogger_async_enabled",
+                "Whether the audit logger is running in async mode (1) or not (0)"),
+            attrsWithCategory);
     asyncEnabledGauge.set(async ? 1L : 0L);
   }
 

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -288,7 +288,8 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
     numLost =
         new AttributedLongCounter(
             solrMetricsContext.longCounter(
-                "solr_auditlogger_lost", "The number of audit events that were lost."),
+                "solr_auditlogger_lost",
+                "The number of audit events that were lost due to async queue being full."),
             attrsWithCategory);
     requestTimes =
         new AttributedLongTimer(

--- a/solr/core/src/java/org/apache/solr/security/AuthenticationPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuthenticationPlugin.java
@@ -171,8 +171,8 @@ public abstract class AuthenticationPlugin implements SolrInfoBean {
     Attributes attrsWithCategory =
         Attributes.builder()
             .putAll(attributes)
-            .put("category", getCategory().toString())
-            .put("plugin_name", this.getClass().getSimpleName())
+            .put(CATEGORY_ATTR, getCategory().toString())
+            .put(PLUGIN_NAME_ATTR, this.getClass().getSimpleName())
             .build();
     // Metrics
     numErrors =

--- a/solr/core/src/java/org/apache/solr/security/MultiDestinationAuditLogger.java
+++ b/solr/core/src/java/org/apache/solr/security/MultiDestinationAuditLogger.java
@@ -133,8 +133,7 @@ public class MultiDestinationAuditLogger extends AuditLoggerPlugin implements Re
   public void initializeMetrics(
       SolrMetricsContext parentContext, Attributes attributes, String scope) {
     super.initializeMetrics(parentContext, attributes, scope);
-    // TODO SOLR-17458: Add Otel
-    plugins.forEach(p -> p.initializeMetrics(solrMetricsContext, Attributes.empty(), scope));
+    plugins.forEach(p -> p.initializeMetrics(parentContext, Attributes.empty(), scope));
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -608,7 +608,7 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     assertEquals(expectedValue, dataPointSnapshot.getValue(), 0.0);
   }
 
-  private void assertAuditMetricsMinimums(int count, int errors) {
+  private void assertAuditMetricsMinimums(int count, int errors) throws InterruptedException {
     Labels labels = getDefaultAuditLoggerMetricsLabels();
     assertCounterMinimumWithRetry("solr_auditlogger_count", labels, count);
 
@@ -617,20 +617,19 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     }
   }
 
-  private void assertCounterMinimumWithRetry(String metricName, Labels labels, int expectedMinimum) {
+  private void assertCounterMinimumWithRetry(String metricName, Labels labels, int expectedMinimum)
+      throws InterruptedException {
     boolean success = checkCounterMinimum(metricName, labels, expectedMinimum);
 
     if (!success && expectedMinimum > 0) {
       log.info("First {} metric check failed, pausing 2s before re-attempt", metricName);
-      try {
-        Thread.sleep(2000);
-        success = checkCounterMinimum(metricName, labels, expectedMinimum);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      Thread.sleep(2000);
+      success = checkCounterMinimum(metricName, labels, expectedMinimum);
     }
 
-    assertTrue("Counter metric " + metricName + " did not meet minimum " + expectedMinimum + " after retry", success);
+    assertTrue(
+        String.format("Counter metric '%s' did not meet minimum %d after retry", metricName, expectedMinimum),
+        success);
   }
 
   private boolean checkCounterMinimum(String metricName, Labels labels, int expectedMinimum) {

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -116,7 +116,8 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
 
     assertGaugeMetricValue("solr_auditlogger_async_enabled", labels, 0);
 
-    var snapshot = SolrMetricTestUtils.getHistogramDatapoint(
+    var snapshot =
+        SolrMetricTestUtils.getHistogramDatapoint(
             metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
@@ -141,7 +142,8 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     Labels sizeLabels = getDefaultAuditLoggerMetricsLabelsBuilder().label("type", "size").build();
     assertGaugeMetricValue("solr_auditlogger_queue", sizeLabels, 0);
 
-    var snapshot = SolrMetricTestUtils.getHistogramDatapoint(
+    var snapshot =
+        SolrMetricTestUtils.getHistogramDatapoint(
             metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -110,17 +110,13 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
   public void testSynchronous() throws Exception {
     setupCluster(false, null, false);
     runThreeTestAdminCommands();
-
-    Thread.sleep(100);
-
     assertThreeTestAdminEvents();
     assertAuditMetricsMinimums(3, 0);
     Labels labels = getDefaultAuditLoggerMetricsLabelsBuilder().build();
 
     assertGaugeMetricValue("solr_auditlogger_async_enabled", labels, 0);
 
-    HistogramSnapshot.HistogramDataPointSnapshot snapshot =
-        SolrMetricTestUtils.getHistogramDatapoint(
+    var snapshot = SolrMetricTestUtils.getHistogramDatapoint(
             metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
@@ -131,9 +127,6 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     setupCluster(true, null, false);
     runThreeTestAdminCommands();
     assertThreeTestAdminEvents();
-
-    Thread.sleep(100);
-
     assertAuditMetricsMinimums(3, 0);
     Labels labels = getDefaultAuditLoggerMetricsLabelsBuilder().build();
 
@@ -148,8 +141,7 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     Labels sizeLabels = getDefaultAuditLoggerMetricsLabelsBuilder().label("type", "size").build();
     assertGaugeMetricValue("solr_auditlogger_queue", sizeLabels, 0);
 
-    HistogramSnapshot.HistogramDataPointSnapshot snapshot =
-        SolrMetricTestUtils.getHistogramDatapoint(
+    var snapshot = SolrMetricTestUtils.getHistogramDatapoint(
             metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -30,6 +30,11 @@ import static org.apache.solr.security.Sha256AuthenticationProvider.getSaltedHas
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.exporter.prometheus.PrometheusMetricReader;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -49,11 +54,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import io.opentelemetry.exporter.prometheus.PrometheusMetricReader;
-import io.prometheus.metrics.model.snapshots.CounterSnapshot;
-import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
-import io.prometheus.metrics.model.snapshots.Labels;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
@@ -119,8 +119,9 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
 
     assertGaugeMetricValue("solr_auditlogger_async_enabled", labels, 0);
 
-    HistogramSnapshot.HistogramDataPointSnapshot snapshot = SolrMetricTestUtils.getHistogramDatapoint(
-        metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
+    HistogramSnapshot.HistogramDataPointSnapshot snapshot =
+        SolrMetricTestUtils.getHistogramDatapoint(
+            metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
   }
@@ -139,19 +140,17 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     assertGaugeMetricValue("solr_auditlogger_async_enabled", labels, 1);
 
     // Verify queue capacity matches default size
-    Labels capacityLabels = getDefaultAuditLoggerMetricsLabelsBuilder()
-        .label("type", "capacity")
-        .build();
+    Labels capacityLabels =
+        getDefaultAuditLoggerMetricsLabelsBuilder().label("type", "capacity").build();
     assertGaugeMetricValue("solr_auditlogger_queue", capacityLabels, 4096);
 
     // Verify queue is empty after processing events
-    Labels sizeLabels = getDefaultAuditLoggerMetricsLabelsBuilder()
-        .label("type", "size")
-        .build();
+    Labels sizeLabels = getDefaultAuditLoggerMetricsLabelsBuilder().label("type", "size").build();
     assertGaugeMetricValue("solr_auditlogger_queue", sizeLabels, 0);
 
-    HistogramSnapshot.HistogramDataPointSnapshot snapshot = SolrMetricTestUtils.getHistogramDatapoint(
-        metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
+    HistogramSnapshot.HistogramDataPointSnapshot snapshot =
+        SolrMetricTestUtils.getHistogramDatapoint(
+            metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
     assertTrue("Expected a positive sum for request times", snapshot.getSum() >= 0);
@@ -177,8 +176,9 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     assertAuditMetricsMinimums(3, 0);
 
     Labels labels = getDefaultAuditLoggerMetricsLabelsBuilder().build();
-    HistogramSnapshot.HistogramDataPointSnapshot snapshot = SolrMetricTestUtils.getHistogramDatapoint(
-        metricsReader, "solr_auditlogger_queued_time_nanoseconds", labels);
+    HistogramSnapshot.HistogramDataPointSnapshot snapshot =
+        SolrMetricTestUtils.getHistogramDatapoint(
+            metricsReader, "solr_auditlogger_queued_time_nanoseconds", labels);
     assertNotNull(snapshot);
     assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
 
@@ -602,8 +602,9 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
   }
 
   private void assertGaugeMetricValue(String metricName, Labels labels, long expectedValue) {
-    GaugeSnapshot.GaugeDataPointSnapshot dataPointSnapshot = (GaugeSnapshot.GaugeDataPointSnapshot)
-        SolrMetricTestUtils.getDataPointSnapshot(metricsReader, metricName, labels);
+    GaugeSnapshot.GaugeDataPointSnapshot dataPointSnapshot =
+        (GaugeSnapshot.GaugeDataPointSnapshot)
+            SolrMetricTestUtils.getDataPointSnapshot(metricsReader, metricName, labels);
     assertNotNull(dataPointSnapshot);
     assertEquals(expectedValue, dataPointSnapshot.getValue(), 0.0);
   }
@@ -628,7 +629,8 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     }
 
     assertTrue(
-        String.format("Counter metric '%s' did not meet minimum %d after retry", metricName, expectedMinimum),
+        String.format(
+            "Counter metric '%s' did not meet minimum %d after retry", metricName, expectedMinimum),
         success);
   }
 

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerIntegrationTest.java
@@ -28,7 +28,6 @@ import static org.apache.solr.security.AuditEvent.RequestType.SEARCH;
 import static org.apache.solr.security.Sha256AuthenticationProvider.getSaltedHashedValue;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedReader;
@@ -50,6 +49,11 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import io.opentelemetry.exporter.prometheus.PrometheusMetricReader;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
@@ -61,9 +65,11 @@ import org.apache.solr.cloud.SolrCloudAuthTestCase;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
+import org.apache.solr.core.CoreContainer;
 import org.apache.solr.security.AuditEvent.EventType;
 import org.apache.solr.security.AuditEvent.RequestType;
 import org.apache.solr.security.AuditLoggerPlugin.JSONAuditEventFormatter;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -80,6 +86,8 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
   protected static final int NUM_SERVERS = 1;
   // Use a harness per thread to be able to beast this test
   private ThreadLocal<AuditTestHarness> testHarness = new ThreadLocal<>();
+
+  private PrometheusMetricReader metricsReader;
 
   @Override
   @Before
@@ -102,9 +110,19 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
   public void testSynchronous() throws Exception {
     setupCluster(false, null, false);
     runThreeTestAdminCommands();
+
+    Thread.sleep(100);
+
     assertThreeTestAdminEvents();
-    assertAuditMetricsMinimums(
-        testHarness.get().cluster, CallbackAuditLoggerPlugin.class.getSimpleName(), 3, 0);
+    assertAuditMetricsMinimums(3, 0);
+    Labels labels = getDefaultAuditLoggerMetricsLabelsBuilder().build();
+
+    assertGaugeMetricValue("solr_auditlogger_async_enabled", labels, 0);
+
+    HistogramSnapshot.HistogramDataPointSnapshot snapshot = SolrMetricTestUtils.getHistogramDatapoint(
+        metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
+    assertNotNull(snapshot);
+    assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
   }
 
   @Test
@@ -112,8 +130,31 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     setupCluster(true, null, false);
     runThreeTestAdminCommands();
     assertThreeTestAdminEvents();
-    assertAuditMetricsMinimums(
-        testHarness.get().cluster, CallbackAuditLoggerPlugin.class.getSimpleName(), 3, 0);
+
+    Thread.sleep(100);
+
+    assertAuditMetricsMinimums(3, 0);
+    Labels labels = getDefaultAuditLoggerMetricsLabelsBuilder().build();
+
+    assertGaugeMetricValue("solr_auditlogger_async_enabled", labels, 1);
+
+    // Verify queue capacity matches default size
+    Labels capacityLabels = getDefaultAuditLoggerMetricsLabelsBuilder()
+        .label("type", "capacity")
+        .build();
+    assertGaugeMetricValue("solr_auditlogger_queue", capacityLabels, 4096);
+
+    // Verify queue is empty after processing events
+    Labels sizeLabels = getDefaultAuditLoggerMetricsLabelsBuilder()
+        .label("type", "size")
+        .build();
+    assertGaugeMetricValue("solr_auditlogger_queue", sizeLabels, 0);
+
+    HistogramSnapshot.HistogramDataPointSnapshot snapshot = SolrMetricTestUtils.getHistogramDatapoint(
+        metricsReader, "solr_auditlogger_request_times_nanoseconds", labels);
+    assertNotNull(snapshot);
+    assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
+    assertTrue("Expected a positive sum for request times", snapshot.getSum() >= 0);
   }
 
   @Test
@@ -133,20 +174,20 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
     gate.release(3);
 
     assertThreeTestAdminEvents();
-    assertAuditMetricsMinimums(
-        testHarness.get().cluster, CallbackAuditLoggerPlugin.class.getSimpleName(), 3, 0);
-    ArrayList<MetricRegistry> registries = getMetricsRegistries(testHarness.get().cluster);
-    Timer timer =
-        ((Timer)
-            registries
-                .get(0)
-                .getMetrics()
-                .get("SECURITY./auditlogging.CallbackAuditLoggerPlugin.queuedTime"));
-    double meanTimeOnQueue = timer.getSnapshot().getMean();
-    double meanTimeExpected = (start - end) / 3.0D;
+    assertAuditMetricsMinimums(3, 0);
+
+    Labels labels = getDefaultAuditLoggerMetricsLabelsBuilder().build();
+    HistogramSnapshot.HistogramDataPointSnapshot snapshot = SolrMetricTestUtils.getHistogramDatapoint(
+        metricsReader, "solr_auditlogger_queued_time_nanoseconds", labels);
+    assertNotNull(snapshot);
+    assertTrue("Expected at least 3 measurements", snapshot.getCount() >= 3);
+
+    // Calculate mean from sum and count
+    double mean = snapshot.getSum() / snapshot.getCount();
+    double minExpectedTimeNanos = (end - start) / 3.0;
     assertTrue(
-        "Expecting mean time on queue > " + meanTimeExpected + ", got " + meanTimeOnQueue,
-        meanTimeOnQueue > meanTimeExpected);
+        "Expecting mean time on queue > " + minExpectedTimeNanos + " ns, got " + mean + " ns",
+        mean > minExpectedTimeNanos);
   }
 
   @Test
@@ -542,6 +583,60 @@ public class AuditLoggerIntegrationTest extends SolrCloudAuthTestCase {
 
     myCluster.waitForAllNodes(10);
     testHarness.get().setCluster(myCluster);
+
+    CoreContainer coreContainer = myCluster.getJettySolrRunner(0).getCoreContainer();
+    assertNotNull(coreContainer);
+    metricsReader = SolrMetricTestUtils.getPrometheusMetricReader(coreContainer, "solr.node");
+  }
+
+  private Labels.Builder getDefaultAuditLoggerMetricsLabelsBuilder() {
+    return Labels.builder()
+        .label("category", "SECURITY")
+        .label("plugin_name", "CallbackAuditLoggerPlugin")
+        .label("handler", "/auditlogging")
+        .label("otel_scope_name", "org.apache.solr");
+  }
+
+  private Labels getDefaultAuditLoggerMetricsLabels() {
+    return getDefaultAuditLoggerMetricsLabelsBuilder().build();
+  }
+
+  private void assertGaugeMetricValue(String metricName, Labels labels, long expectedValue) {
+    GaugeSnapshot.GaugeDataPointSnapshot dataPointSnapshot = (GaugeSnapshot.GaugeDataPointSnapshot)
+        SolrMetricTestUtils.getDataPointSnapshot(metricsReader, metricName, labels);
+    assertNotNull(dataPointSnapshot);
+    assertEquals(expectedValue, dataPointSnapshot.getValue(), 0.0);
+  }
+
+  private void assertAuditMetricsMinimums(int count, int errors) {
+    Labels labels = getDefaultAuditLoggerMetricsLabels();
+    assertCounterMinimumWithRetry("solr_auditlogger_count", labels, count);
+
+    if (errors > 0) {
+      assertCounterMinimumWithRetry("solr_auditlogger_errors", labels, errors);
+    }
+  }
+
+  private void assertCounterMinimumWithRetry(String metricName, Labels labels, int expectedMinimum) {
+    boolean success = checkCounterMinimum(metricName, labels, expectedMinimum);
+
+    if (!success && expectedMinimum > 0) {
+      log.info("First {} metric check failed, pausing 2s before re-attempt", metricName);
+      try {
+        Thread.sleep(2000);
+        success = checkCounterMinimum(metricName, labels, expectedMinimum);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    assertTrue("Counter metric " + metricName + " did not meet minimum " + expectedMinimum + " after retry", success);
+  }
+
+  private boolean checkCounterMinimum(String metricName, Labels labels, int expectedMinimum) {
+    CounterSnapshot.CounterDataPointSnapshot snapshot =
+        SolrMetricTestUtils.getCounterDatapoint(metricsReader, metricName, labels);
+    return snapshot != null && snapshot.getValue() >= expectedMinimum;
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerPluginTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.security;
 
+import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,7 +25,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import io.opentelemetry.api.common.Attributes;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.metrics.SolrMetricsContext;

--- a/solr/core/src/test/org/apache/solr/security/AuditLoggerPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/security/AuditLoggerPluginTest.java
@@ -24,8 +24,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import io.opentelemetry.api.common.Attributes;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.metrics.SolrMetricsContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -133,6 +135,8 @@ public class AuditLoggerPluginTest extends SolrTestCaseJ4 {
     config = new HashMap<>();
     config.put("async", false);
     plugin.init(config);
+    SolrMetricsContext mockSolrMetricsContext = MockSolrMetricsContextFactory.create();
+    plugin.initializeMetrics(mockSolrMetricsContext, Attributes.empty(), "solr.test");
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/security/MockSolrMetricsContextFactory.java
+++ b/solr/core/src/test/org/apache/solr/security/MockSolrMetricsContextFactory.java
@@ -1,9 +1,9 @@
 package org.apache.solr.security;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
@@ -26,13 +26,16 @@ public final class MockSolrMetricsContextFactory {
     Timer mockTimer = mock(Timer.class);
     Timer.Context mockTimerContext = mock(Timer.Context.class);
     when(mockTimer.time()).thenReturn(mockTimerContext);
-    when(mockChildContext.timer(anyString(), anyString(), anyString(), anyString())).thenReturn(mockTimer);
+    when(mockChildContext.timer(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(mockTimer);
 
     Counter mockCounter = mock(Counter.class);
-    when(mockChildContext.counter(anyString(), anyString(), anyString(), anyString())).thenReturn(mockCounter);
+    when(mockChildContext.counter(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(mockCounter);
 
     LongHistogram mockLongHistogram = mock(LongHistogram.class);
-    when(mockChildContext.longHistogram(anyString(), anyString(), any(OtelUnit.class))).thenReturn(mockLongHistogram);
+    when(mockChildContext.longHistogram(anyString(), anyString(), any(OtelUnit.class)))
+        .thenReturn(mockLongHistogram);
 
     when(mockChildContext.observableLongGauge(anyString(), anyString(), any())).thenReturn(null);
     when(mockChildContext.observableLongCounter(anyString(), anyString(), any())).thenReturn(null);

--- a/solr/core/src/test/org/apache/solr/security/MockSolrMetricsContextFactory.java
+++ b/solr/core/src/test/org/apache/solr/security/MockSolrMetricsContextFactory.java
@@ -1,0 +1,42 @@
+package org.apache.solr.security;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import org.apache.solr.metrics.SolrMetricsContext;
+import org.apache.solr.metrics.otel.OtelUnit;
+
+public final class MockSolrMetricsContextFactory {
+
+  public static SolrMetricsContext create() {
+    SolrMetricsContext mockParentContext = mock(SolrMetricsContext.class);
+    SolrMetricsContext mockChildContext = mock(SolrMetricsContext.class);
+
+    when(mockParentContext.getChildContext(any())).thenReturn(mockChildContext);
+
+    LongCounter mockOtelLongCounter = mock(LongCounter.class);
+    when(mockChildContext.longCounter(anyString(), any())).thenReturn(mockOtelLongCounter);
+
+    Timer mockTimer = mock(Timer.class);
+    Timer.Context mockTimerContext = mock(Timer.Context.class);
+    when(mockTimer.time()).thenReturn(mockTimerContext);
+    when(mockChildContext.timer(anyString(), anyString(), anyString(), anyString())).thenReturn(mockTimer);
+
+    Counter mockCounter = mock(Counter.class);
+    when(mockChildContext.counter(anyString(), anyString(), anyString(), anyString())).thenReturn(mockCounter);
+
+    LongHistogram mockLongHistogram = mock(LongHistogram.class);
+    when(mockChildContext.longHistogram(anyString(), anyString(), any(OtelUnit.class))).thenReturn(mockLongHistogram);
+
+    when(mockChildContext.observableLongGauge(anyString(), anyString(), any())).thenReturn(null);
+    when(mockChildContext.observableLongCounter(anyString(), anyString(), any())).thenReturn(null);
+
+    return mockParentContext;
+  }
+}

--- a/solr/core/src/test/org/apache/solr/security/MockSolrMetricsContextFactory.java
+++ b/solr/core/src/test/org/apache/solr/security/MockSolrMetricsContextFactory.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.LongHistogram;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.metrics.otel.OtelUnit;
@@ -39,6 +40,9 @@ public final class MockSolrMetricsContextFactory {
 
     when(mockChildContext.observableLongGauge(anyString(), anyString(), any())).thenReturn(null);
     when(mockChildContext.observableLongCounter(anyString(), anyString(), any())).thenReturn(null);
+
+    LongGauge mockLongGauge = mock(LongGauge.class);
+    when(mockChildContext.longGauge(anyString(), anyString())).thenReturn(mockLongGauge);
 
     return mockParentContext;
   }

--- a/solr/core/src/test/org/apache/solr/security/MultiDestinationAuditLoggerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/MultiDestinationAuditLoggerTest.java
@@ -22,8 +22,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import io.opentelemetry.api.common.Attributes;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.metrics.SolrMetricsContext;
 import org.junit.Test;
 
 public class MultiDestinationAuditLoggerTest extends SolrTestCaseJ4 {
@@ -51,6 +53,9 @@ public class MultiDestinationAuditLoggerTest extends SolrTestCaseJ4 {
     SolrResourceLoader loader = new SolrResourceLoader(Path.of(""));
     al.inform(loader);
     al.init(config);
+
+    SolrMetricsContext mockSolrMetricsContext = MockSolrMetricsContextFactory.create();
+    al.initializeMetrics(mockSolrMetricsContext, Attributes.empty(), "solr.test");
 
     al.doAudit(new AuditEvent(AuditEvent.EventType.ANONYMOUS).setUsername("me"));
     assertEquals(

--- a/solr/core/src/test/org/apache/solr/security/MultiDestinationAuditLoggerTest.java
+++ b/solr/core/src/test/org/apache/solr/security/MultiDestinationAuditLoggerTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.solr.security;
 
+import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import io.opentelemetry.api.common.Attributes;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.metrics.SolrMetricsContext;

--- a/solr/core/src/test/org/apache/solr/security/SolrLogAuditLoggerPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/security/SolrLogAuditLoggerPluginTest.java
@@ -20,8 +20,8 @@ package org.apache.solr.security;
 import static org.apache.solr.security.AuditLoggerPluginTest.EVENT_ANONYMOUS;
 import static org.apache.solr.security.AuditLoggerPluginTest.EVENT_AUTHENTICATED;
 
-import java.util.HashMap;
 import io.opentelemetry.api.common.Attributes;
+import java.util.HashMap;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.metrics.SolrMetricsContext;

--- a/solr/core/src/test/org/apache/solr/security/SolrLogAuditLoggerPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/security/SolrLogAuditLoggerPluginTest.java
@@ -21,8 +21,10 @@ import static org.apache.solr.security.AuditLoggerPluginTest.EVENT_ANONYMOUS;
 import static org.apache.solr.security.AuditLoggerPluginTest.EVENT_AUTHENTICATED;
 
 import java.util.HashMap;
+import io.opentelemetry.api.common.Attributes;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.metrics.SolrMetricsContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +40,8 @@ public class SolrLogAuditLoggerPluginTest extends SolrTestCaseJ4 {
     plugin = new SolrLogAuditLoggerPlugin();
     config = new HashMap<>();
     config.put("async", false);
+    SolrMetricsContext mockSolrMetricsContext = MockSolrMetricsContextFactory.create();
+    plugin.initializeMetrics(mockSolrMetricsContext, Attributes.empty(), "solr.test");
   }
 
   @Test(expected = SolrException.class)

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/audit-logging.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/audit-logging.adoc
@@ -230,20 +230,17 @@ See the javadocs for the base class at {solr-javadocs}/core/org/apache/solr/secu
 
 == Metrics
 
-Audit logging plugins record metrics about count and timing of log requests, as well as queue size for async loggers.
-The metrics keys are all recorded on the `SECURITY` category, and each metric name are prefixed with a scope of `/auditlogging` and the class name of the logger, e.g., `SolrLogAuditLoggerPlugin`.
+The metrics keys are all recorded on the `SECURITY` category, and each metric includes attributes for the handler (e.g., `/auditlogging`) and the class name of the logger (e.g., `SolrLogAuditLoggerPlugin`).
 The individual metrics are:
 
-* `count`: (_meter_) Records number and rate of audit logs written.
-* `errors`: (_meter_) Records number and rate of errors.
-* `lost`: (_meter_) Records number and rate of events lost if the queue is full and `blockAsync=false`.
-* `requestTimes`: (_timer_) Records latency and percentiles for audit logging performance.
-* `totalTime`: (_counter_) Records total time spent logging.
-* `queueCapacity`: (_gauge_) Records the maximum size of the async logging queue.
-* `queueSize`: (_gauge_) Records the number of events currently waiting in the queue.
-* `queuedTime`: (_timer_) Records the amount of time events waited in queue.
-Adding this with the `requestTimes` metric will show the total time from event to logging complete.
-* `async`: (_gauge_) Tells whether this logger is in async mode.
+* `solr_auditlogger_count_total`: (_counter_) Records number of audit logs written.
+* `solr_auditlogger_errors_total`: (_counter_) Records number of errors.
+* `solr_auditlogger_lost_total`: (_counter_) Records number of events lost if the queue is full and `blockAsync=false`.
+* `solr_auditlogger_request_times_nanoseconds`: (_histogram_) Records latency and percentiles for audit logging performance.
+* `solr_auditlogger_queue`: (_gauge_) Records the maximum size (`type=capacity`) and current size (`type=size`) of the async logging queue.
+* `solr_auditlogger_queued_time_nanoseconds`: (_histogram_) Records the amount of time events waited in queue.
+Adding this with the `solr_auditlogger_request_times_nanoseconds` metric will show the total time from event to logging complete.
+* `solr_auditlogger_async_enabled`: (_gauge_) Tells whether this logger is in async mode (1) or not (0).
 
-TIP: If you experience a very high request rate and have a slow audit logger plugin, you may see the `queueSize` and `queuedTime` metrics increase, and possibly start dropping events (shown by an increase in `lost` count).
+TIP: If you experience a very high request rate and have a slow audit logger plugin, you may see the `solr_auditlogger_queue` size metric increase, and possibly start dropping events (shown by an increase in `solr_auditlogger_lost_total` count).
 In this case you may want to increase the `numThreads` setting.

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
@@ -336,46 +336,6 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
     return metrics;
   }
 
-  /**
-   * Common test method to be able to check audit metrics
-   *
-   * @param className the class name to be used for composing prefix, e.g.
-   *     "SECURITY./auditlogging/SolrLogAuditLoggerPlugin"
-   */
-  protected void assertAuditMetricsMinimums(
-      MiniSolrCloudCluster cluster, String className, int count, int errors)
-      throws InterruptedException {
-    String prefix = "SECURITY./auditlogging." + className + ".";
-    Map<String, Long> expectedCounts = new HashMap<>();
-    expectedCounts.put("count", (long) count);
-
-    Map<String, Long> counts = countSecurityMetrics(cluster, prefix, AUDIT_METRICS_KEYS);
-    boolean success = isMetricsEqualOrLarger(AUDIT_METRICS_TO_COMPARE, expectedCounts, counts);
-    if (!success) {
-      log.info("First metrics count assert failed, pausing 2s before re-attempt");
-      Thread.sleep(2000);
-      counts = countSecurityMetrics(cluster, prefix, AUDIT_METRICS_KEYS);
-      success = isMetricsEqualOrLarger(AUDIT_METRICS_TO_COMPARE, expectedCounts, counts);
-    }
-
-    assertTrue(
-        "Expected metric minimums for prefix "
-            + prefix
-            + ": "
-            + expectedCounts
-            + ", but got: "
-            + counts,
-        success);
-  }
-
-  private boolean isMetricsEqualOrLarger(
-      List<String> metricsToCompare,
-      Map<String, Long> expectedCounts,
-      Map<String, Long> actualCounts) {
-    return metricsToCompare.stream()
-        .allMatch(k -> actualCounts.get(k).intValue() >= expectedCounts.get(k).intValue());
-  }
-
   // Have to sum the metrics from all three shards/nodes
   private long sumCount(String prefix, String key, List<Map<String, Metric>> metrics) {
     assertTrue(
@@ -386,9 +346,9 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
       return (long)
           ((long) 1000
               * metrics.stream()
-                  .mapToDouble(l -> ((Timer) l.get(prefix + key)).getMeanRate())
-                  .average()
-                  .orElse(0.0d));
+              .mapToDouble(l -> ((Timer) l.get(prefix + key)).getMeanRate())
+              .average()
+              .orElse(0.0d));
     else return metrics.stream().mapToLong(l -> ((Counter) l.get(prefix + key)).getCount()).sum();
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
@@ -346,9 +346,9 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
       return (long)
           ((long) 1000
               * metrics.stream()
-              .mapToDouble(l -> ((Timer) l.get(prefix + key)).getMeanRate())
-              .average()
-              .orElse(0.0d));
+                  .mapToDouble(l -> ((Timer) l.get(prefix + key)).getMeanRate())
+                  .average()
+                  .orElse(0.0d));
     else return metrics.stream().mapToLong(l -> ((Counter) l.get(prefix + key)).getCount()).sum();
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806

# Description

Migrates DropWizard metrics for AuditLoggerPlugin to OpenTelemetry.

See: https://solr.apache.org/guide/solr/latest/deployment-guide/audit-logging.html

# Solution

- Migrates AuditLoggerPlugin metrics to Open Telemetry format
- Supports both async and non-async mode
- Updates Solr docs with new metric names

# Output

The following output was tested manually with the following steps:

1. Start Solr 
    e.g. ` ./solr/packaging/build/dev/bin/solr start -f`
2. Upload a `security.json` config to Zookeeper to enable the AuditLoggerPlugin 
    e.g. `./solr/packaging/build/dev/bin/solr zk cp ./security.json zk:/security.json`
3. Create a core
    e.g. `./solr/packaging/build/dev/bin/solr create -c test_core`

Example Async config:
```json
// security.json
{
  "auditlogging": {
    "class": "solr.SolrLogAuditLoggerPlugin"
  }
}
```

Example non-async config:
```json
// security.json
{
  "auditlogging": {
    "class": "solr.SolrLogAuditLoggerPlugin",
   "async": false
  }
}
```

## Dropwizard Metrics

### Sync mode (async=false)

```json
"SECURITY./auditlogging.SolrLogAuditLoggerPlugin.async":false,
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.count":{
        "count":6,
        "meanRate":0.3923022549607172,
        "1minRate":0.08827522768645096,
        "5minRate":0.019506424007533902,
        "15minRate":0.006611350453169309
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.errors":{
        "count":0,
        "meanRate":0.0,
        "1minRate":0.0,
        "5minRate":0.0,
        "15minRate":0.0
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.lost":{
        "count":0,
        "meanRate":0.0,
        "1minRate":0.0,
        "5minRate":0.0,
        "15minRate":0.0
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.requestTimes":{
        "count":6,
        "meanRate":0.39230042098166823,
        "1minRate":0.08827522768645096,
        "5minRate":0.019506424007533902,
        "15minRate":0.006611350453169309,
        "min_ms":0.031542,
        "max_ms":2.2115,
        "mean_ms":0.40006581990839635,
        "median_ms":0.0425,
        "stddev_ms":0.806469113833175,
        "p75_ms":0.050458,
        "p95_ms":2.2115,
        "p99_ms":2.2115,
        "p999_ms":2.2115
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.totalTime":2416499,
```

### Async mode
```json
"SECURITY./auditlogging.SolrLogAuditLoggerPlugin.async":true,
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.count":{
        "count":7,
        "meanRate":0.21123983604708124,
        "1minRate":0.10740483851948114,
        "5minRate":0.02292676949451791,
        "15minRate":0.007731861467774362
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.errors":{
        "count":0,
        "meanRate":0.0,
        "1minRate":0.0,
        "5minRate":0.0,
        "15minRate":0.0
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.lost":{
        "count":0,
        "meanRate":0.0,
        "1minRate":0.0,
        "5minRate":0.0,
        "15minRate":0.0
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.queueCapacity":4096,
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.queueSize":0,
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.queuedTime":{
        "count":7,
        "meanRate":0.21124007854388954,
        "1minRate":0.10740483851948114,
        "5minRate":0.02292676949451791,
        "15minRate":0.007731861467774362,
        "min_ms":0.0,
        "max_ms":3.0,
        "mean_ms":0.4855092884037528,
        "median_ms":0.0,
        "stddev_ms":0.958895062084824,
        "p75_ms":1.0,
        "p95_ms":3.0,
        "p99_ms":3.0,
        "p999_ms":3.0
      },
      "SECURITY./auditlogging.SolrLogAuditLoggerPlugin.requestTimes":{
        "count":7,
        "meanRate":0.21123863204315033,
        "1minRate":0.10740483851948114,
        "5minRate":0.02292676949451791,
        "15minRate":0.007731861467774362,
        "min_ms":0.033083,
        "max_ms":5.814917,
        "mean_ms":0.6863585464871763,
        "median_ms":0.042,
        "stddev_ms":1.8178587517257718,
        "p75_ms":0.059334,
        "p95_ms":5.814917,
        "p99_ms":5.814917,
        "p999_ms":5.814917
      },
```

## Open Telemetry Metrics

### Sync mode (async=false)

```bash
# HELP solr_auditlogger_async_enabled Whether the audit logger is running in async mode (1) or not (0)
# TYPE solr_auditlogger_async_enabled gauge
solr_auditlogger_async_enabled{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 0.0
# HELP solr_auditlogger_count_total The number of audit events that were successfully logged.
# TYPE solr_auditlogger_count_total counter
solr_auditlogger_count_total{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6.0
# HELP solr_auditlogger_request_times_nanoseconds Distribution of audit event request durations
# TYPE solr_auditlogger_request_times_nanoseconds histogram
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="0.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="25000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="50000.0"} 4
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="100000.0"} 5
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="250000.0"} 5
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="500000.0"} 5
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1000000.0"} 5
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2500000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2.5E7"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1.0E8"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1.0E9"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="+Inf"} 6
solr_auditlogger_request_times_nanoseconds_count{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6
solr_auditlogger_request_times_nanoseconds_sum{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 2275875.0
```

<details>
<summary>Sync mode metrics without Nanosecond histogram buckets</summary>

```bash
# HELP solr_auditlogger_async_enabled Whether the audit logger is running in async mode (1) or not (0)
# TYPE solr_auditlogger_async_enabled gauge
solr_auditlogger_async_enabled{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 0.0
# HELP solr_auditlogger_count_total The number of audit events that were successfully logged.
# TYPE solr_auditlogger_count_total counter
solr_auditlogger_count_total{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6.0
# HELP solr_auditlogger_request_times_nanoseconds Distribution of audit event request durations
# TYPE solr_auditlogger_request_times_nanoseconds histogram
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="0.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="25.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="50.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="75.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="100.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="250.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="500.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="750.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2500.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="7500.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="+Inf"} 6
solr_auditlogger_request_times_nanoseconds_count{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6
solr_auditlogger_request_times_nanoseconds_sum{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 2402416.0
```
</details>

### Async mode

```bash
# HELP solr_auditlogger_async_enabled Whether the audit logger is running in async mode (1) or not (0)
# TYPE solr_auditlogger_async_enabled gauge
solr_auditlogger_async_enabled{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 1.0
# HELP solr_auditlogger_count_total The number of audit events that were successfully logged.
# TYPE solr_auditlogger_count_total counter
solr_auditlogger_count_total{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 7.0
# HELP solr_auditlogger_queue Metrics around the audit logger queue when running in async mode
# TYPE solr_auditlogger_queue gauge
solr_auditlogger_queue{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",type="capacity"} 4096.0
solr_auditlogger_queue{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",type="size"} 0.0
# HELP solr_auditlogger_queued_time_nanoseconds Distribution of time events spend queued before processing
# TYPE solr_auditlogger_queued_time_nanoseconds histogram
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="0.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="25000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="50000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="100000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="250000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="500000.0"} 6
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1000000.0"} 7
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2500000.0"} 7
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000000.0"} 7
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2.5E7"} 7
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1.0E8"} 7
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1.0E9"} 7
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="+Inf"} 7
solr_auditlogger_queued_time_nanoseconds_count{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 7
solr_auditlogger_queued_time_nanoseconds_sum{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 1000000.0
# HELP solr_auditlogger_request_times_nanoseconds Distribution of audit event request durations
# TYPE solr_auditlogger_request_times_nanoseconds histogram
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="0.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="25000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="50000.0"} 3
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="100000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="250000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="500000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1000000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2500000.0"} 6
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000000.0"} 7
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2.5E7"} 7
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1.0E8"} 7
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1.0E9"} 7
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="+Inf"} 7
solr_auditlogger_request_times_nanoseconds_count{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 7
solr_auditlogger_request_times_nanoseconds_sum{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 2906583.0
```

<details>
<summary>Async mode metrics without Nanosecond histogram buckets</summary>

```bash
# HELP solr_auditlogger_async_enabled Whether the audit logger is running in async mode (1) or not (0)
# TYPE solr_auditlogger_async_enabled gauge
solr_auditlogger_async_enabled{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 1.0
# HELP solr_auditlogger_count_total The number of audit events that were successfully logged.
# TYPE solr_auditlogger_count_total counter
solr_auditlogger_count_total{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6.0
# HELP solr_auditlogger_queue Metrics around the audit logger queue when running in async mode
# TYPE solr_auditlogger_queue gauge
solr_auditlogger_queue{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",type="capacity"} 4096.0
solr_auditlogger_queue{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",type="size"} 0.0
# HELP solr_auditlogger_queued_time_nanoseconds Distribution of time events spend queued before processing
# TYPE solr_auditlogger_queued_time_nanoseconds histogram
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="0.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="25.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="50.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="75.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="100.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="250.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="500.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="750.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1000.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2500.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="7500.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10000.0"} 4
solr_auditlogger_queued_time_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="+Inf"} 6
solr_auditlogger_queued_time_nanoseconds_count{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6
solr_auditlogger_queued_time_nanoseconds_sum{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 2000000.0
# HELP solr_auditlogger_request_times_nanoseconds Distribution of audit event request durations
# TYPE solr_auditlogger_request_times_nanoseconds histogram
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="0.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="25.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="50.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="75.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="100.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="250.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="500.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="750.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="1000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="2500.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="5000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="7500.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="10000.0"} 0
solr_auditlogger_request_times_nanoseconds_bucket{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin",le="+Inf"} 6
solr_auditlogger_request_times_nanoseconds_count{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 6
solr_auditlogger_request_times_nanoseconds_sum{category="SECURITY",handler="/auditlogging",otel_scope_name="org.apache.solr",plugin_name="SolrLogAuditLoggerPlugin"} 3441999.0
```
</details>

# Tests

Updates existing unit and integration tests and manually tested the change.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [ ] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
