### PR TITLE
removing explicit check on outputField in TextToVectorUpdateProcessorFactory.java, check is already done by late…

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -59,6 +59,8 @@ Improvements
 
 * Minor refactoring of the TextToVectorQParserPlugin (Ilaria Petreti via Alessandro Benedetti)
 
+* GITHUB#3666: Removing redundant check if field exists in TextToVectorUpdateProcessorFactory (Renato Haeberli via Alessandro Benedetti)
+
 Optimizations
 ---------------------
 * SOLR-17568: The CLI bin/solr export tool now contacts the appropriate nodes directly for data instead of proxying through one.

--- a/solr/modules/llm/src/java/org/apache/solr/llm/textvectorisation/update/processor/TextToVectorUpdateProcessorFactory.java
+++ b/solr/modules/llm/src/java/org/apache/solr/llm/textvectorisation/update/processor/TextToVectorUpdateProcessorFactory.java
@@ -76,10 +76,6 @@ public class TextToVectorUpdateProcessorFactory extends UpdateRequestProcessorFa
           SolrException.ErrorCode.SERVER_ERROR, "undefined field: \"" + inputField + "\"");
     }
 
-    if (!latestSchema.isDynamicField(outputField) && !latestSchema.hasExplicitField(outputField)) {
-      throw new SolrException(
-          SolrException.ErrorCode.SERVER_ERROR, "undefined field: \"" + outputField + "\"");
-    }
     final SchemaField outputFieldSchema = latestSchema.getField(outputField);
     assertIsDenseVectorField(outputFieldSchema);
 


### PR DESCRIPTION
As pointed out by @dsmiley, the check on the outputField is redundant, latestSchema.getField already throws a SolrException if a non dynamic field does not exist.

