### PR TITLE
SOLR-17806: Migrate CaffeineCache to OTEL

### DIFF
--- a/solr/core/src/java/org/apache/solr/blockcache/Metrics.java
+++ b/solr/core/src/java/org/apache/solr/blockcache/Metrics.java
@@ -60,14 +60,15 @@ public class Metrics extends SolrCacheBase implements SolrInfoBean {
     var baseAttributes =
         attributes.toBuilder().put(CATEGORY_ATTR, getCategory().toString()).build();
     var blockcacheStats =
-        solrMetricsContext.longMeasurement("solr_block_cache_stats", "Block cache stats");
+        solrMetricsContext.longGaugeMeasurement("solr_block_cache_stats", "Block cache stats");
     var hitRatio =
-        solrMetricsContext.doubleMeasurement("solr_block_cache_hit_ratio", "Block cache hit ratio");
+        solrMetricsContext.doubleGaugeMeasurement(
+            "solr_block_cache_hit_ratio", "Block cache hit ratio");
     var perSecStats =
-        solrMetricsContext.doubleMeasurement(
+        solrMetricsContext.doubleGaugeMeasurement(
             "solr_block_cache_stats_per_second", "Block cache per second stats");
     var bufferCacheStats =
-        solrMetricsContext.doubleMeasurement(
+        solrMetricsContext.doubleGaugeMeasurement(
             "solr_buffer_cache_stats", "Buffer cache per second stats");
 
     this.toClose =

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -33,6 +33,7 @@ import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGI
 
 import com.github.benmanes.caffeine.cache.Interner;
 import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
 import jakarta.inject.Singleton;
@@ -871,8 +872,12 @@ public class CoreContainer {
       for (Map.Entry<String, CacheConfig> e : cachesConfig.entrySet()) {
         SolrCache<?, ?> c = e.getValue().newInstance();
         String cacheName = e.getKey();
-        // NOCOMMIT SOLR-17458: Add Otel
-        c.initializeMetrics(solrMetricsContext, Attributes.empty(), "nodeLevelCache/" + cacheName);
+        c.initializeMetrics(
+            solrMetricsContext,
+            Attributes.builder()
+                .put(AttributeKey.stringKey("cache_name"), "nodeLevelCache/" + cacheName)
+                .build(),
+            "");
         m.put(cacheName, c);
       }
       this.caches = Collections.unmodifiableMap(m);

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -557,6 +557,14 @@ public class SolrCore implements SolrInfoBean, Closeable {
     assert this.name != null;
     assert coreDescriptor.getCloudDescriptor() == null : "Cores are not renamed in SolrCloud";
     this.name = Objects.requireNonNull(v);
+    initCoreAttributes();
+  }
+
+  public Attributes getCoreAttributes() {
+    return coreAttributes;
+  }
+
+  public void initCoreAttributes() {
     this.coreAttributes =
         (coreContainer.isZooKeeperAware())
             ? Attributes.builder()
@@ -568,10 +576,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
                     Utils.parseMetricsReplicaName(coreDescriptor.getCollectionName(), getName()))
                 .build()
             : Attributes.builder().put(CORE_ATTR, getName()).build();
-  }
-
-  public Attributes getCoreAttributes() {
-    return coreAttributes;
   }
 
   /**
@@ -1125,17 +1129,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
       checkVersionFieldExistsInSchema(schema, coreDescriptor);
       setLatestSchema(schema);
 
-      this.coreAttributes =
-          (coreContainer.isZooKeeperAware())
-              ? Attributes.builder()
-                  .put(COLLECTION_ATTR, coreDescriptor.getCollectionName())
-                  .put(CORE_ATTR, coreDescriptor.getName())
-                  .put(SHARD_ATTR, coreDescriptor.getCloudDescriptor().getShardId())
-                  .put(
-                      REPLICA_ATTR,
-                      Utils.parseMetricsReplicaName(coreDescriptor.getCollectionName(), getName()))
-                  .build()
-              : Attributes.builder().put(CORE_ATTR, coreDescriptor.getName()).build();
+      initCoreAttributes();
 
       // initialize core metrics
       initializeMetrics(solrMetricsContext, coreAttributes, "");

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -557,6 +557,17 @@ public class SolrCore implements SolrInfoBean, Closeable {
     assert this.name != null;
     assert coreDescriptor.getCloudDescriptor() == null : "Cores are not renamed in SolrCloud";
     this.name = Objects.requireNonNull(v);
+    this.coreAttributes =
+        (coreContainer.isZooKeeperAware())
+            ? Attributes.builder()
+                .put(COLLECTION_ATTR, coreDescriptor.getCollectionName())
+                .put(CORE_ATTR, getName())
+                .put(SHARD_ATTR, coreDescriptor.getCloudDescriptor().getShardId())
+                .put(
+                    REPLICA_ATTR,
+                    Utils.parseMetricsReplicaName(coreDescriptor.getCollectionName(), getName()))
+                .build()
+            : Attributes.builder().put(CORE_ATTR, getName()).build();
   }
 
   public Attributes getCoreAttributes() {

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -841,7 +841,6 @@ public class ReplicationHandler extends RequestHandlerBase
     }
   }
 
-  // NOCOMMIT SOLR-17458: Update with OTEL
   @Override
   public void initializeMetrics(
       SolrMetricsContext parentContext, Attributes attributes, String scope) {
@@ -853,51 +852,51 @@ public class ReplicationHandler extends RequestHandlerBase
     super.initializeMetrics(parentContext, replicationAttributes, scope);
 
     ObservableLongMeasurement indexSizeMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_index_size", "Size of the index in bytes", OtelUnit.BYTES);
 
     ObservableLongMeasurement indexVersionMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_index_version", "Current index version");
 
     ObservableLongMeasurement indexGenerationMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_index_generation", "Current index generation");
 
     ObservableLongMeasurement isLeaderMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_is_leader", "Whether this node is a leader (1) or not (0)");
 
     ObservableLongMeasurement isFollowerMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_is_follower", "Whether this node is a follower (1) or not (0)");
 
     ObservableLongMeasurement replicationEnabledMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_is_enabled", "Whether replication is enabled (1) or not (0)");
 
     ObservableLongMeasurement isPollingDisabledMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_is_polling_disabled", "Whether polling is disabled (1) or not (0)");
 
     ObservableLongMeasurement isReplicatingMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_is_replicating", "Whether replication is in progress (1) or not (0)");
 
     ObservableLongMeasurement timeElapsedMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_time_elapsed",
             "Time elapsed during replication in seconds",
             OtelUnit.SECONDS);
 
     ObservableLongMeasurement bytesDownloadedMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_downloaded_size",
             "Total bytes downloaded during replication",
             OtelUnit.BYTES);
 
     ObservableLongMeasurement downloadSpeedMetric =
-        solrMetricsContext.longMeasurement(
+        solrMetricsContext.longGaugeMeasurement(
             "solr_replication_download_speed", "Download speed in bytes per second");
 
     metricsCallback =

--- a/solr/core/src/java/org/apache/solr/metrics/SolrCoreMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrCoreMetricManager.java
@@ -20,7 +20,6 @@ import static org.apache.solr.metrics.SolrMetricProducer.HANDLER_ATTR;
 
 import com.codahale.metrics.MetricRegistry;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -128,19 +127,11 @@ public class SolrCoreMetricManager implements Closeable {
     // tracked producers.
     // There is some possible improvement that can be done here to not have to duplicate code in
     // registerMetricProducer
-    var attributes =
-        Attributes.builder()
-            .put(CORE_ATTR, core.getName())
-            .put(COLLECTION_ATTR, collectionName)
-            .put(SHARD_ATTR, shardName)
-            .put(REPLICA_ATTR, replicaName)
-            .build();
-
-    core.initializeMetrics(solrMetricsContext, attributes, core.getName());
+    core.initializeMetrics(solrMetricsContext, core.getCoreAttributes(), core.getName());
 
     registeredProducers.forEach(
         metricProducer -> {
-          var producerAttributes = attributes.toBuilder();
+          var producerAttributes = core.getCoreAttributes().toBuilder();
           if (metricProducer.scope().startsWith("/"))
             producerAttributes.put(HANDLER_ATTR, metricProducer.scope);
           metricProducer.producer.initializeMetrics(
@@ -173,12 +164,7 @@ public class SolrCoreMetricManager implements Closeable {
     // reregisterCoreMetrics
     // There is some possible improvement that can be done here to not have to duplicate code in
     // reregisterCoreMetrics
-    var attributesBuilder =
-        Attributes.builder()
-            .put(CORE_ATTR, core.getName())
-            .put(COLLECTION_ATTR, collectionName)
-            .put(SHARD_ATTR, shardName)
-            .put(REPLICA_ATTR, replicaName);
+    var attributesBuilder = core.getCoreAttributes().toBuilder();
     if (scope.startsWith("/")) attributesBuilder.put(HANDLER_ATTR, scope);
     producer.initializeMetrics(solrMetricsContext, attributesBuilder.build(), scope);
   }

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -368,14 +368,24 @@ public class SolrMetricManager {
         .batchCallback(callback, measurement, additionalMeasurements);
   }
 
-  ObservableLongMeasurement longMeasurement(
+  ObservableLongMeasurement longGaugeMeasurement(
       String registry, String gaugeName, String description, OtelUnit unit) {
     return longGaugeBuilder(registry, gaugeName, description, unit).buildObserver();
   }
 
-  ObservableDoubleMeasurement doubleMeasurement(
+  ObservableDoubleMeasurement doubleGaugeMeasurement(
       String registry, String gaugeName, String description, OtelUnit unit) {
     return doubleGaugeBuilder(registry, gaugeName, description, unit).buildObserver();
+  }
+
+  ObservableLongMeasurement longCounterMeasurement(
+      String registry, String counterName, String description, OtelUnit unit) {
+    return longCounterBuilder(registry, counterName, description, unit).buildObserver();
+  }
+
+  ObservableDoubleMeasurement doubleCounterMeasurement(
+      String registry, String counterName, String description, OtelUnit unit) {
+    return doubleCounterBuilder(registry, counterName, description, unit).buildObserver();
   }
 
   private LongGaugeBuilder longGaugeBuilder(
@@ -398,6 +408,31 @@ public class SolrMetricManager {
             .get(OTEL_SCOPE_NAME)
             .gaugeBuilder(gaugeName)
             .setDescription(description);
+    if (unit != null) builder.setUnit(unit.getSymbol());
+
+    return builder;
+  }
+
+  private LongCounterBuilder longCounterBuilder(
+      String registry, String counterName, String description, OtelUnit unit) {
+    LongCounterBuilder builder =
+        meterProvider(registry)
+            .get(OTEL_SCOPE_NAME)
+            .counterBuilder(counterName)
+            .setDescription(description);
+    if (unit != null) builder.setUnit(unit.getSymbol());
+
+    return builder;
+  }
+
+  private DoubleCounterBuilder doubleCounterBuilder(
+      String registry, String counterName, String description, OtelUnit unit) {
+    DoubleCounterBuilder builder =
+        meterProvider(registry)
+            .get(OTEL_SCOPE_NAME)
+            .counterBuilder(counterName)
+            .setDescription(description)
+            .ofDoubles();
     if (unit != null) builder.setUnit(unit.getSymbol());
 
     return builder;

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricsContext.java
@@ -276,22 +276,41 @@ public class SolrMetricsContext {
         registryName, metricName, description, callback, unit);
   }
 
-  public ObservableLongMeasurement longMeasurement(String metricName, String description) {
-    return longMeasurement(metricName, description, null);
+  public ObservableLongMeasurement longGaugeMeasurement(String metricName, String description) {
+    return longGaugeMeasurement(metricName, description, null);
   }
 
-  public ObservableLongMeasurement longMeasurement(
+  public ObservableLongMeasurement longGaugeMeasurement(
       String metricName, String description, OtelUnit unit) {
-    return metricManager.longMeasurement(registryName, metricName, description, unit);
+    return metricManager.longGaugeMeasurement(registryName, metricName, description, unit);
   }
 
-  public ObservableDoubleMeasurement doubleMeasurement(String metricName, String description) {
-    return doubleMeasurement(metricName, description, null);
+  public ObservableDoubleMeasurement doubleGaugeMeasurement(String metricName, String description) {
+    return doubleGaugeMeasurement(metricName, description, null);
   }
 
-  public ObservableDoubleMeasurement doubleMeasurement(
+  public ObservableDoubleMeasurement doubleGaugeMeasurement(
       String metricName, String description, OtelUnit unit) {
-    return metricManager.doubleMeasurement(registryName, metricName, description, unit);
+    return metricManager.doubleGaugeMeasurement(registryName, metricName, description, unit);
+  }
+
+  public ObservableLongMeasurement longCounterMeasurement(String metricName, String description) {
+    return longCounterMeasurement(metricName, description, null);
+  }
+
+  public ObservableLongMeasurement longCounterMeasurement(
+      String metricName, String description, OtelUnit unit) {
+    return metricManager.longCounterMeasurement(registryName, metricName, description, unit);
+  }
+
+  public ObservableDoubleMeasurement doubleCounterMeasurement(
+      String metricName, String description) {
+    return doubleCounterMeasurement(metricName, description, null);
+  }
+
+  public ObservableDoubleMeasurement doubleCounterMeasurement(
+      String metricName, String description, OtelUnit unit) {
+    return metricManager.doubleCounterMeasurement(registryName, metricName, description, unit);
   }
 
   public BatchCallback batchCallback(

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -501,7 +501,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
 
     ObservableLongMeasurement ramBytesUsedMetric =
         solrMetricsContext.longGaugeMeasurement(
-            "solr_searcher_cache_ram_bytes_used", "RAM bytes used by cache", OtelUnit.BYTES);
+            "solr_searcher_cache_ram_used", "RAM bytes used by cache", OtelUnit.BYTES);
 
     ObservableLongMeasurement warmupTimeMetric =
         solrMetricsContext.longGaugeMeasurement(

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -489,21 +489,23 @@ public class CaffeineCache<K, V> extends SolrCacheBase
 
     ObservableLongMeasurement cacheOperation =
         solrMetricsContext.longCounterMeasurement(
-            "solr_cache_ops", "Number of cache operations (hits, lookups, inserts and evictions)");
+            "solr_searcher_cache_ops",
+            "Number of cache operations (hits, lookups, inserts and evictions)");
 
     ObservableLongMeasurement hitRatioMetric =
-        solrMetricsContext.longGaugeMeasurement("solr_cache_hit_ratio", "Cache hit ratio");
+        solrMetricsContext.longGaugeMeasurement("solr_searcher_cache_hit_ratio", "Cache hit ratio");
 
     ObservableLongMeasurement sizeMetric =
-        solrMetricsContext.longGaugeMeasurement("solr_cache_size", "Current number cache entries");
+        solrMetricsContext.longGaugeMeasurement(
+            "solr_searcher_cache_size", "Current number cache entries");
 
     ObservableLongMeasurement ramBytesUsedMetric =
         solrMetricsContext.longGaugeMeasurement(
-            "solr_cache_ram_bytes_used", "RAM bytes used by cache", OtelUnit.BYTES);
+            "solr_searcher_cache_ram_bytes_used", "RAM bytes used by cache", OtelUnit.BYTES);
 
     ObservableLongMeasurement warmupTimeMetric =
         solrMetricsContext.longGaugeMeasurement(
-            "solr_cache_warmup_time", "Cache warmup time", OtelUnit.MILLISECONDS);
+            "solr_searcher_cache_warmup_time", "Cache warmup time", OtelUnit.MILLISECONDS);
 
     ObservableLongMeasurement cumulativeCacheOperation =
         solrMetricsContext.longGaugeMeasurement(
@@ -520,11 +522,13 @@ public class CaffeineCache<K, V> extends SolrCacheBase
                 long lookupCount = stats.requestCount() + lookups.sum();
 
                 cacheOperation.record(
-                    hitCount, cacheAttributes.toBuilder().put(OPERATION_ATTR, "hit").build());
+                    hitCount, cacheAttributes.toBuilder().put(OPERATION_ATTR, "hits").build());
                 cacheOperation.record(
-                    lookupCount, cacheAttributes.toBuilder().put(OPERATION_ATTR, "lookup").build());
+                    lookupCount,
+                    cacheAttributes.toBuilder().put(OPERATION_ATTR, "lookups").build());
                 cacheOperation.record(
-                    insertCount, cacheAttributes.toBuilder().put(OPERATION_ATTR, "insert").build());
+                    insertCount,
+                    cacheAttributes.toBuilder().put(OPERATION_ATTR, "inserts").build());
                 cacheOperation.record(
                     stats.evictionCount(),
                     cacheAttributes.toBuilder().put(OPERATION_ATTR, "evictions").build());
@@ -541,7 +545,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
                 long cumHits = priorHits + hitCount;
 
                 cumulativeCacheOperation.record(
-                    cumHits, cacheAttributes.toBuilder().put(OPERATION_ATTR, "hit").build());
+                    cumHits, cacheAttributes.toBuilder().put(OPERATION_ATTR, "hits").build());
                 cumulativeCacheOperation.record(
                     cumLookups, cacheAttributes.toBuilder().put(OPERATION_ATTR, "lookups").build());
                 cumulativeCacheOperation.record(
@@ -556,6 +560,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
             sizeMetric,
             ramBytesUsedMetric,
             warmupTimeMetric,
-            cumulativeCacheOperation);
+            cumulativeCacheOperation,
+            hitRatioMetric);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -19,6 +19,7 @@ package org.apache.solr.search;
 import static org.apache.solr.search.CpuAllowedLimit.TIMING_CONTEXT;
 
 import com.codahale.metrics.Gauge;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.io.Closeable;
 import java.io.IOException;
@@ -603,9 +604,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.solrMetricsContext = core.getSolrMetricsContext().getChildContext(this);
     for (SolrCache<?, ?> cache : cacheList) {
       cache.initializeMetrics(
-          // TODO SOLR-17458: Add Otel
           solrMetricsContext,
-          Attributes.empty(),
+          core.getCoreAttributes().toBuilder().put(AttributeKey.stringKey("cache_name"), cache.name()).build(),
           SolrMetricManager.mkName(cache.name(), STATISTICS_KEY));
     }
     // TODO SOLR-17458: Add Otel

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -605,7 +605,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     for (SolrCache<?, ?> cache : cacheList) {
       cache.initializeMetrics(
           solrMetricsContext,
-          core.getCoreAttributes().toBuilder().put(AttributeKey.stringKey("cache_name"), cache.name()).build(),
+          core.getCoreAttributes().toBuilder()
+              .put(AttributeKey.stringKey("cache_name"), cache.name())
+              .build(),
           SolrMetricManager.mkName(cache.name(), STATISTICS_KEY));
     }
     // TODO SOLR-17458: Add Otel

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexWriter.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexWriter.java
@@ -16,15 +16,10 @@
  */
 package org.apache.solr.update;
 
-import static org.apache.solr.metrics.SolrCoreMetricManager.COLLECTION_ATTR;
-import static org.apache.solr.metrics.SolrCoreMetricManager.CORE_ATTR;
-import static org.apache.solr.metrics.SolrCoreMetricManager.REPLICA_ATTR;
-import static org.apache.solr.metrics.SolrCoreMetricManager.SHARD_ATTR;
 import static org.apache.solr.metrics.SolrMetricProducer.CATEGORY_ATTR;
 import static org.apache.solr.metrics.SolrMetricProducer.TYPE_ATTR;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -44,7 +39,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.SuppressForbidden;
-import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.core.DirectoryFactory.DirContext;
 import org.apache.solr.core.SolrCore;
@@ -191,19 +185,10 @@ public class SolrIndexWriter extends IndexWriter {
       } else {
         mergeTotals = false;
       }
-      String coreName = core.getCoreDescriptor().getName();
-      var baseAttributesBuilder =
-          Attributes.builder()
+      var baseAttributes =
+          core.getCoreAttributes().toBuilder()
               .put(CATEGORY_ATTR, SolrInfoBean.Category.INDEX.toString())
-              .put(CORE_ATTR, coreName);
-      if (core.getCoreContainer().isZooKeeperAware()) {
-        String collectionName = core.getCoreDescriptor().getCollectionName();
-        baseAttributesBuilder
-            .put(COLLECTION_ATTR, collectionName)
-            .put(SHARD_ATTR, core.getCoreDescriptor().getCloudDescriptor().getShardId())
-            .put(REPLICA_ATTR, Utils.parseMetricsReplicaName(collectionName, coreName));
-      }
-      var baseAttributes = baseAttributesBuilder.build();
+              .build();
       if (mergeDetails) {
         mergeTotals = true; // override
         majorMergedDocs =

--- a/solr/core/src/test/org/apache/solr/CursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/CursorPagingTest.java
@@ -719,13 +719,17 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
 
     // Get pre-test metrics for filterCache
     var preFilterInserts =
-        SolrMetricTestUtils.getCacheSearcherOps(solrCore, "filterCache", "inserts").getValue();
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(solrCore, SolrMetricTestUtils.FILTER_CACHE)
+            .getValue();
     var preFilterHits =
-        SolrMetricTestUtils.getCacheSearcherOps(solrCore, "filterCache", "hits").getValue();
+        SolrMetricTestUtils.getCacheSearcherOpsHits(solrCore, SolrMetricTestUtils.FILTER_CACHE)
+            .getValue();
 
     // Get pre-test metrics for queryResultCache
     var preQueryInserts =
-        SolrMetricTestUtils.getCacheSearcherOps(solrCore, "queryResultCache", "inserts").getValue();
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+                solrCore, SolrMetricTestUtils.QUERY_RESULT_CACHE)
+            .getValue();
 
     SentinelIntSet ids =
         assertFullWalkNoDups(
@@ -742,11 +746,15 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
 
     // Get post-test metrics
     var postFilterInserts =
-        SolrMetricTestUtils.getCacheSearcherOps(solrCore, "filterCache", "inserts").getValue();
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(solrCore, SolrMetricTestUtils.FILTER_CACHE)
+            .getValue();
     var postFilterHits =
-        SolrMetricTestUtils.getCacheSearcherOps(solrCore, "filterCache", "hits").getValue();
+        SolrMetricTestUtils.getCacheSearcherOpsHits(solrCore, SolrMetricTestUtils.FILTER_CACHE)
+            .getValue();
     var postQueryInserts =
-        SolrMetricTestUtils.getCacheSearcherOps(solrCore, "queryResultCache", "inserts").getValue();
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+                solrCore, SolrMetricTestUtils.QUERY_RESULT_CACHE)
+            .getValue();
 
     assertEquals("query cache inserts changed", preQueryInserts, postQueryInserts, 0.001);
     assertEquals(

--- a/solr/core/src/test/org/apache/solr/CursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/CursorPagingTest.java
@@ -717,15 +717,13 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
 
     SolrCore solrCore = h.getCore();
 
-    // Get pre-test metrics for filterCache
+    // Get initial metrics for filter and query cache
     var preFilterInserts =
         SolrMetricTestUtils.getCacheSearcherOpsInserts(solrCore, SolrMetricTestUtils.FILTER_CACHE)
             .getValue();
     var preFilterHits =
         SolrMetricTestUtils.getCacheSearcherOpsHits(solrCore, SolrMetricTestUtils.FILTER_CACHE)
             .getValue();
-
-    // Get pre-test metrics for queryResultCache
     var preQueryInserts =
         SolrMetricTestUtils.getCacheSearcherOpsInserts(
                 solrCore, SolrMetricTestUtils.QUERY_RESULT_CACHE)
@@ -744,7 +742,6 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
 
     assertEquals(6, ids.size());
 
-    // Get post-test metrics
     var postFilterInserts =
         SolrMetricTestUtils.getCacheSearcherOpsInserts(solrCore, SolrMetricTestUtils.FILTER_CACHE)
             .getValue();
@@ -756,9 +753,9 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
                 solrCore, SolrMetricTestUtils.QUERY_RESULT_CACHE)
             .getValue();
 
-    assertEquals("query cache inserts changed", preQueryInserts, postQueryInserts, 0.001);
+    assertEquals("query cache inserts changed", preQueryInserts, postQueryInserts, 0.0);
     assertEquals(
-        "filter cache did not grow correctly", 2, postFilterInserts - preFilterInserts, 0.001);
+        "filter cache did not grow correctly", 2, postFilterInserts - preFilterInserts, 0.0);
     assertTrue("filter cache did not have any new cache hits", 0 < postFilterHits - preFilterHits);
   }
 

--- a/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrConfigHandler.java
@@ -1016,6 +1016,7 @@ public class TestSolrConfigHandler extends RestTestBase {
     assertTrue(
         "fieldValueCache metrics should be present",
         prometheusMetrics.contains("cache_name=\"fieldValueCache\""));
+    // Here documentCache is disabled at initialization in SolrConfig
     assertFalse(
         "documentCache metrics should be absent",
         prometheusMetrics.contains("cache_name=\"documentCache\""));
@@ -1033,11 +1034,8 @@ public class TestSolrConfigHandler extends RestTestBase {
     // Setting size only will not enable the cache
     restTestHarness.setServerProvider(() -> getBaseUrl());
 
-    // Check prometheus metrics - cache should still be absent
     String prometheusMetrics = restTestHarness.query("/admin/metrics?wt=prometheus");
-    assertFalse(
-        "documentCache metrics should still be absent after setting size only",
-        prometheusMetrics.contains("cache_name=\"documentCache\""));
+    assertFalse(prometheusMetrics.contains("cache_name=\"documentCache\""));
 
     restTestHarness.setServerProvider(oldProvider);
   }
@@ -1049,23 +1047,18 @@ public class TestSolrConfigHandler extends RestTestBase {
     runConfigCommand(restTestHarness, "/config", payload);
     restTestHarness.setServerProvider(() -> getBaseUrl());
 
-    // Check prometheus metrics - cache should now be present
     String prometheusMetrics = restTestHarness.query("/admin/metrics?wt=prometheus");
-    assertTrue(
-        "documentCache metrics should be present after enabling",
-        prometheusMetrics.contains("cache_name=\"documentCache\""));
+    assertTrue(prometheusMetrics.contains("cache_name=\"documentCache\""));
 
     // Disabling Cache
-    restTestHarness.setServerProvider(oldProvider);
     payload = "{ 'set-property' : { 'query.documentCache.enabled': false } }";
+    restTestHarness.setServerProvider(oldProvider);
+
     runConfigCommand(restTestHarness, "/config", payload);
     restTestHarness.setServerProvider(() -> getBaseUrl());
 
-    // Check prometheus metrics - cache should now be absent
     prometheusMetrics = restTestHarness.query("/admin/metrics?wt=prometheus");
-    assertFalse(
-        "documentCache metrics should be absent after disabling",
-        prometheusMetrics.contains("cache_name=\"documentCache\""));
+    assertFalse(prometheusMetrics.contains("cache_name=\"documentCache\""));
 
     restTestHarness.setServerProvider(oldProvider);
   }

--- a/solr/core/src/test/org/apache/solr/core/TimeAllowedTest.java
+++ b/solr/core/src/test/org/apache/solr/core/TimeAllowedTest.java
@@ -112,11 +112,12 @@ public class TimeAllowedTest extends SolrTestCaseJ4 {
     SolrCore core = h.getCore();
 
     CounterSnapshot.CounterDataPointSnapshot fqInsertsPre =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(core, SolrMetricTestUtils.FILTER_CACHE);
     long fqInserts = (long) fqInsertsPre.getValue();
 
     CounterSnapshot.CounterDataPointSnapshot qrInsertsPre =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     long qrInserts = (long) qrInsertsPre.getValue();
 
     // This gets 0 docs back. Use 10000 instead of 1 for timeAllowed, and it gets 100 back and the
@@ -133,14 +134,15 @@ public class TimeAllowedTest extends SolrTestCaseJ4 {
         (Boolean) (header.get(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY)));
 
     CounterSnapshot.CounterDataPointSnapshot qrInsertsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     assertEquals(
         "Should NOT have inserted partial results in the cache!",
         (long) qrInsertsPost.getValue(),
         qrInserts);
 
     CounterSnapshot.CounterDataPointSnapshot fqInsertsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(core, SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("Should NOT have another insert", fqInserts, (long) fqInsertsPost.getValue());
 
     // At the end of all this, we should have no hits in the queryResultCache.
@@ -148,11 +150,11 @@ public class TimeAllowedTest extends SolrTestCaseJ4 {
 
     // Check that we did insert this one.
     CounterSnapshot.CounterDataPointSnapshot fqHitsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(core, SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("Hits should still be 0", (long) fqHitsPost.getValue(), 0L);
 
     CounterSnapshot.CounterDataPointSnapshot fqInsertsPostSecond =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(core, SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("Inserts should be bumped", (long) fqInsertsPostSecond.getValue(), fqInserts + 1);
 
     res = (Map<?, ?>) fromJSONString(response);
@@ -173,18 +175,20 @@ public class TimeAllowedTest extends SolrTestCaseJ4 {
     SolrCore core = h.getCore();
 
     CounterSnapshot.CounterDataPointSnapshot insertsPre =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     long inserts = (long) insertsPre.getValue();
 
     CounterSnapshot.CounterDataPointSnapshot hitsPre =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     long hits = (long) hitsPre.getValue();
 
     String response = JQ(req("q", q, "indent", "true", "timeAllowed", "1", "sleep", sleep));
 
     // The queryResultCache should NOT get an entry here.
     CounterSnapshot.CounterDataPointSnapshot insertsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     assertEquals(
         "Should NOT have inserted partial results!", inserts, (long) insertsPost.getValue());
 
@@ -201,9 +205,10 @@ public class TimeAllowedTest extends SolrTestCaseJ4 {
 
     // Check that we did insert this one.
     CounterSnapshot.CounterDataPointSnapshot hitsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot insertsPost2 =
-        SolrMetricTestUtils.getCacheSearcherOps(core, "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     assertEquals("Hits should still be 0", hits, (long) hitsPost.getValue());
     assertTrue("Inserts should be bumped", inserts < (long) insertsPost2.getValue());
 

--- a/solr/core/src/test/org/apache/solr/search/TestFiltersQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFiltersQueryCaching.java
@@ -49,11 +49,11 @@ public class TestFiltersQueryCaching extends SolrTestCaseJ4 {
   }
 
   private static CounterSnapshot.CounterDataPointSnapshot getFilterCacheInserts(SolrCore core) {
-    return SolrMetricTestUtils.getCacheSearcherOps(core, "filterCache", "inserts");
+    return SolrMetricTestUtils.getCacheSearcherOpsInserts(core, SolrMetricTestUtils.FILTER_CACHE);
   }
 
   private static CounterSnapshot.CounterDataPointSnapshot getFilterCacheHits(SolrCore core) {
-    return SolrMetricTestUtils.getCacheSearcherOps(core, "filterCache", "hits");
+    return SolrMetricTestUtils.getCacheSearcherOpsHits(core, SolrMetricTestUtils.FILTER_CACHE);
   }
 
   private static long lookupFilterCacheInserts(SolrCore core) {

--- a/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
@@ -29,6 +29,7 @@ import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.metrics.MetricsMap;
 import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -89,16 +90,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
   }
 
   private static long coreToInserts(SolrCore core, String cacheName) {
-    return (long)
-        ((MetricsMap)
-                ((SolrMetricManager.GaugeWrapper<?>)
-                        core.getCoreMetricManager()
-                            .getRegistry()
-                            .getMetrics()
-                            .get("CACHE.searcher.".concat(cacheName)))
-                    .getGauge())
-            .getValue()
-            .get("inserts");
+    return (long) SolrMetricTestUtils.getCacheSearcherOps(core, cacheName, "insert").getValue();
   }
 
   private static long coreToSortCount(SolrCore core, String skipOrFull) {
@@ -112,6 +104,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
             .getValue();
   }
 
+  // NOCOMMIT: Fix this once SolrIndexSearcher is migrated for OTEL
   private static long coreToMatchAllDocsInsertCount(SolrCore core) {
     return (long) coreToLiveDocsCacheMetrics(core).get("inserts");
   }

--- a/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
@@ -90,7 +90,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
   }
 
   private static long coreToInserts(SolrCore core, String cacheName) {
-    return (long) SolrMetricTestUtils.getCacheSearcherOps(core, cacheName, "insert").getValue();
+    return (long) SolrMetricTestUtils.getCacheSearcherOpsInserts(core, cacheName).getValue();
   }
 
   private static long coreToSortCount(SolrCore core, String skipOrFull) {
@@ -253,10 +253,11 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
     Map<?, ?> body = (Map<?, ?>) (res.get("response"));
     SolrCore core = h.getCore();
     assertEquals("Bad matchAllDocs insert count", 1, coreToMatchAllDocsInsertCount(core));
-    assertEquals("Bad filterCache insert count", 0, coreToInserts(core, "filterCache"));
+    assertEquals(
+        "Bad filterCache insert count", 0, coreToInserts(core, SolrMetricTestUtils.FILTER_CACHE));
     assertEquals("Bad full sort count", 0, coreToSortCount(core, "full"));
     assertEquals("Should have exactly " + ALL_DOCS, ALL_DOCS, (long) (body.get("numFound")));
-    long queryCacheInsertCount = coreToInserts(core, "queryResultCache");
+    long queryCacheInsertCount = coreToInserts(core, SolrMetricTestUtils.QUERY_RESULT_CACHE);
     if (queryCacheInsertCount == expectCounters[0]) {
       // should be a hit, so all insert/sort-count metrics remain unchanged.
     } else {
@@ -408,7 +409,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
     assertEquals(
         "Bad filterCache insert count",
         expectFilterCacheInsertCount,
-        coreToInserts(core, "filterCache"));
+        coreToInserts(core, SolrMetricTestUtils.FILTER_CACHE));
     assertEquals("Bad full sort count", expectFullSortCount, coreToSortCount(core, "full"));
     assertEquals("Bad skip sort count", expectSkipSortCount, coreToSortCount(core, "skip"));
     assertEquals(

--- a/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
@@ -26,8 +26,7 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.apache.solr.metrics.MetricsMap;
-import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -729,18 +728,10 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
         "//result/doc[4]/str[@name='id'][.='3']",
         "//result/doc[5]/str[@name='id'][.='2']");
 
-    MetricsMap metrics =
-        (MetricsMap)
-            ((SolrMetricManager.GaugeWrapper)
-                    h.getCore()
-                        .getCoreMetricManager()
-                        .getRegistry()
-                        .getMetrics()
-                        .get("CACHE.searcher.queryResultCache"))
-                .getGauge();
-    Map<String, Object> stats = metrics.getValue();
-
-    long inserts = (Long) stats.get("inserts");
+    long inserts =
+        (long)
+            SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts")
+                .getValue();
 
     assertTrue(inserts > 0);
 
@@ -770,9 +761,10 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
         "//result/doc[4]/str[@name='id'][.='2']",
         "//result/doc[5]/str[@name='id'][.='1']");
 
-    stats = metrics.getValue();
-
-    long inserts1 = (Long) stats.get("inserts");
+    long inserts1 =
+        (long)
+            SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts")
+                .getValue();
 
     // Last query was added to the cache
     assertTrue(inserts1 > inserts);
@@ -804,8 +796,10 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
         "//result/doc[4]/str[@name='id'][.='2']",
         "//result/doc[5]/str[@name='id'][.='1']");
 
-    stats = metrics.getValue();
-    long inserts2 = (Long) stats.get("inserts");
+    long inserts2 =
+        (long)
+            SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts")
+                .getValue();
     // Last query was NOT added to the cache
     assertEquals(inserts1, inserts2);
 

--- a/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
@@ -730,7 +730,8 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
 
     long inserts =
         (long)
-            SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts")
+            SolrMetricTestUtils.getCacheSearcherOpsInserts(
+                    h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE)
                 .getValue();
 
     assertTrue(inserts > 0);
@@ -763,7 +764,8 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
 
     long inserts1 =
         (long)
-            SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts")
+            SolrMetricTestUtils.getCacheSearcherOpsInserts(
+                    h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE)
                 .getValue();
 
     // Last query was added to the cache
@@ -798,7 +800,8 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
 
     long inserts2 =
         (long)
-            SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts")
+            SolrMetricTestUtils.getCacheSearcherOpsInserts(
+                    h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE)
                 .getValue();
     // Last query was NOT added to the cache
     assertEquals(inserts1, inserts2);

--- a/solr/core/src/test/org/apache/solr/search/TestSolr4Spatial2.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolr4Spatial2.java
@@ -32,9 +32,8 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.apache.solr.metrics.MetricsMap;
-import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.apache.solr.util.SpatialUtils;
 import org.apache.solr.util.TestUtils;
 import org.junit.Before;
@@ -369,21 +368,15 @@ public class TestSolr4Spatial2 extends SolrTestCaseJ4 {
     if (testCache) {
       // The tricky thing is verifying the cache works correctly...
 
-      MetricsMap cacheMetrics =
-          (MetricsMap)
-              ((SolrMetricManager.GaugeWrapper)
-                      h.getCore()
-                          .getCoreMetricManager()
-                          .getRegistry()
-                          .getMetrics()
-                          .get("CACHE.searcher.perSegSpatialFieldCache_" + fieldName))
-                  .getGauge();
-      assertEquals("1", cacheMetrics.getValue().get("cumulative_inserts").toString());
-      assertEquals("0", cacheMetrics.getValue().get("cumulative_hits").toString());
+      long inserts = getSpatialFieldCacheInserts(fieldName);
+      long hits = getSpatialFieldCacheHits(fieldName);
+      assertEquals(1, inserts);
+      assertEquals(0, hits);
 
       // Repeat the query earlier
       assertJQ(sameReq, "/response/numFound==1", "/response/docs/[0]/id=='1'");
-      assertEquals("1", cacheMetrics.getValue().get("cumulative_hits").toString());
+      hits = getSpatialFieldCacheHits(fieldName);
+      assertEquals(1, hits);
 
       assertEquals("1 segment", 1, getSearcher().getRawReader().leaves().size());
       // Get key of first leaf reader -- this one contains the match for sure.
@@ -404,18 +397,8 @@ public class TestSolr4Spatial2 extends SolrTestCaseJ4 {
       Object leafKey2 = getFirstLeafReaderKey();
       // get the current instance of metrics - the old one may not represent the current cache
       // instance
-      cacheMetrics =
-          (MetricsMap)
-              ((SolrMetricManager.GaugeWrapper)
-                      h.getCore()
-                          .getCoreMetricManager()
-                          .getRegistry()
-                          .getMetrics()
-                          .get("CACHE.searcher.perSegSpatialFieldCache_" + fieldName))
-                  .getGauge();
-      assertEquals(
-          leafKey1.equals(leafKey2) ? "2" : "1",
-          cacheMetrics.getValue().get("cumulative_hits").toString());
+      hits = getSpatialFieldCacheHits(fieldName);
+      assertEquals(leafKey1.equals(leafKey2) ? 2 : 1, hits);
     }
 
     if (testHeatmap) {
@@ -454,6 +437,20 @@ public class TestSolr4Spatial2 extends SolrTestCaseJ4 {
           req("q", fieldName + ":[55.0260828,-115.5085624 TO 55.02646,-115.507337]"),
           "/response/numFound==0");
     }
+  }
+
+  private long getSpatialFieldCacheInserts(String fieldName) {
+    return (long)
+        SolrMetricTestUtils.getCacheSearcherOpsCumulative(
+                h.getCore(), "perSegSpatialFieldCache_" + fieldName, "inserts")
+            .getValue();
+  }
+
+  private long getSpatialFieldCacheHits(String fieldName) {
+    return (long)
+        SolrMetricTestUtils.getCacheSearcherOpsCumulative(
+                h.getCore(), "perSegSpatialFieldCache_" + fieldName, "hits")
+            .getValue();
   }
 
   protected SolrIndexSearcher getSearcher() {

--- a/solr/core/src/test/org/apache/solr/search/TestSolrCachePerf.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolrCachePerf.java
@@ -109,7 +109,6 @@ public class TestSolrCachePerf extends SolrTestCaseJ4 {
       CacheRegenerator cr = new NoOpRegenerator();
       Object o = cache.init(params, null, cr);
       cache.setState(SolrCache.State.LIVE);
-      // TODO SOLR-17458: Fix test later
       cache.initializeMetrics(
           new SolrMetricsContext(metricManager, "foo", "bar"),
           Attributes.of(AttributeKey.stringKey("cache_name"), "foo"),

--- a/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
@@ -579,9 +579,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
     assertU(commit()); // arg... commit no longer "commits" unless there has been a change.
 
     CounterSnapshot.CounterDataPointSnapshot filterInsertsInitial =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsInitial =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
 
     long inserts = (long) filterInsertsInitial.getValue();
     long hits = (long) filterHitsInitial.getValue();
@@ -592,9 +593,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
 
     inserts += 3;
     CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter1 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsAfter1 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter1.getValue());
     assertEquals("wrong number of hits", hits, (long) filterHitsAfter1.getValue());
 
@@ -604,9 +606,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
 
     hits += 3;
     CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter2 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsAfter2 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter2.getValue());
     assertEquals("wrong number of hits", hits, (long) filterHitsAfter2.getValue());
 
@@ -617,9 +620,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
 
     hits += 3;
     CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter3 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsAfter3 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter3.getValue());
     assertEquals("wrong number of hits", hits, (long) filterHitsAfter3.getValue());
 
@@ -635,9 +639,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
     inserts += 1; // +1 for top level fq
     hits += 3;
     CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter4 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsAfter4 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter4.getValue());
     assertEquals("wrong number of hits", hits, (long) filterHitsAfter4.getValue());
 
@@ -652,9 +657,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
 
     hits += 1; // top-level fq should have been found.
     CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter5 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsAfter5 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter5.getValue());
     assertEquals("wrong number of hits", hits, (long) filterHitsAfter5.getValue());
 
@@ -664,9 +670,10 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
     hits += 1; // the inner filter
     inserts += 1; // the outer filter
     CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter6 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     CounterSnapshot.CounterDataPointSnapshot filterHitsAfter6 =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), SolrMetricTestUtils.FILTER_CACHE);
     assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter6.getValue());
     assertEquals("wrong number of hits", hits, (long) filterHitsAfter6.getValue());
 

--- a/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolrQueryParser.java
@@ -23,6 +23,7 @@ import static org.apache.solr.util.QueryMatchers.phraseQuery;
 import static org.apache.solr.util.QueryMatchers.termQuery;
 import static org.hamcrest.core.StringContains.containsString;
 
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,14 +50,13 @@ import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.Utils;
-import org.apache.solr.metrics.MetricsMap;
-import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.parser.QueryParser;
 import org.apache.solr.query.FilterQuery;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.NumberType;
 import org.apache.solr.schema.SchemaField;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -578,54 +578,37 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
     delI("777");
     assertU(commit()); // arg... commit no longer "commits" unless there has been a change.
 
-    final MetricsMap filterCacheStats =
-        (MetricsMap)
-            ((SolrMetricManager.GaugeWrapper)
-                    h.getCore()
-                        .getCoreMetricManager()
-                        .getRegistry()
-                        .getMetrics()
-                        .get("CACHE.searcher.filterCache"))
-                .getGauge();
-    assertNotNull(filterCacheStats);
-    final MetricsMap queryCacheStats =
-        (MetricsMap)
-            ((SolrMetricManager.GaugeWrapper)
-                    h.getCore()
-                        .getCoreMetricManager()
-                        .getRegistry()
-                        .getMetrics()
-                        .get("CACHE.searcher.queryResultCache"))
-                .getGauge();
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsInitial =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsInitial =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
 
-    assertNotNull(queryCacheStats);
-
-    long inserts = (Long) filterCacheStats.getValue().get("inserts");
-    long hits = (Long) filterCacheStats.getValue().get("hits");
+    long inserts = (long) filterInsertsInitial.getValue();
+    long hits = (long) filterHitsInitial.getValue();
 
     assertJQ(
         req("q", "doesnotexist filter(id:1) filter(qqq_s:X) filter(abcdefg)"),
         "/response/numFound==2");
 
     inserts += 3;
-    assertEquals(
-        "wrong number of inserts",
-        inserts,
-        ((Long) filterCacheStats.getValue().get("inserts")).longValue());
-    assertEquals(
-        "wrong number of hits", hits, ((Long) filterCacheStats.getValue().get("hits")).longValue());
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter1 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsAfter1 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+    assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter1.getValue());
+    assertEquals("wrong number of hits", hits, (long) filterHitsAfter1.getValue());
 
     assertJQ(
         req("q", "doesnotexist2 filter(id:1) filter(qqq_s:X) filter(abcdefg)"),
         "/response/numFound==2");
 
     hits += 3;
-    assertEquals(
-        "wrong number of inserts",
-        inserts,
-        ((Long) filterCacheStats.getValue().get("inserts")).longValue());
-    assertEquals(
-        "wrong number of hits", hits, ((Long) filterCacheStats.getValue().get("hits")).longValue());
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter2 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsAfter2 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+    assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter2.getValue());
+    assertEquals("wrong number of hits", hits, (long) filterHitsAfter2.getValue());
 
     // make sure normal "fq" parameters also hit the cache the same way
     assertJQ(
@@ -633,12 +616,12 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
         "/response/numFound==0");
 
     hits += 3;
-    assertEquals(
-        "wrong number of inserts",
-        inserts,
-        ((Long) filterCacheStats.getValue().get("inserts")).longValue());
-    assertEquals(
-        "wrong number of hits", hits, ((Long) filterCacheStats.getValue().get("hits")).longValue());
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter3 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsAfter3 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+    assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter3.getValue());
+    assertEquals("wrong number of hits", hits, (long) filterHitsAfter3.getValue());
 
     // try a query deeply nested in a FQ
     assertJQ(
@@ -651,12 +634,12 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
 
     inserts += 1; // +1 for top level fq
     hits += 3;
-    assertEquals(
-        "wrong number of inserts",
-        inserts,
-        ((Long) filterCacheStats.getValue().get("inserts")).longValue());
-    assertEquals(
-        "wrong number of hits", hits, ((Long) filterCacheStats.getValue().get("hits")).longValue());
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter4 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsAfter4 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+    assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter4.getValue());
+    assertEquals("wrong number of hits", hits, (long) filterHitsAfter4.getValue());
 
     // retry the complex FQ and make sure hashCode/equals works as expected w/ filter queries
     assertJQ(
@@ -668,24 +651,24 @@ public class TestSolrQueryParser extends SolrTestCaseJ4 {
         "/response/numFound==2");
 
     hits += 1; // top-level fq should have been found.
-    assertEquals(
-        "wrong number of inserts",
-        inserts,
-        ((Long) filterCacheStats.getValue().get("inserts")).longValue());
-    assertEquals(
-        "wrong number of hits", hits, ((Long) filterCacheStats.getValue().get("hits")).longValue());
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter5 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsAfter5 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+    assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter5.getValue());
+    assertEquals("wrong number of hits", hits, (long) filterHitsAfter5.getValue());
 
     // try nested filter with multiple top-level args (i.e. a boolean query)
     assertJQ(req("q", "*:* +filter(id:1 filter(qqq_s:X) abcdefg)"), "/response/numFound==2");
 
     hits += 1; // the inner filter
     inserts += 1; // the outer filter
-    assertEquals(
-        "wrong number of inserts",
-        inserts,
-        ((Long) filterCacheStats.getValue().get("inserts")).longValue());
-    assertEquals(
-        "wrong number of hits", hits, ((Long) filterCacheStats.getValue().get("hits")).longValue());
+    CounterSnapshot.CounterDataPointSnapshot filterInsertsAfter6 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "inserts");
+    CounterSnapshot.CounterDataPointSnapshot filterHitsAfter6 =
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "filterCache", "hits");
+    assertEquals("wrong number of inserts", inserts, (long) filterInsertsAfter6.getValue());
+    assertEquals("wrong number of hits", hits, (long) filterHitsAfter6.getValue());
 
     // test the score for a filter, and that default score is 0
     assertJQ(

--- a/solr/core/src/test/org/apache/solr/search/TestThinCache.java
+++ b/solr/core/src/test/org/apache/solr/search/TestThinCache.java
@@ -17,19 +17,19 @@
 package org.apache.solr.search;
 
 import io.opentelemetry.api.common.Attributes;
+import io.prometheus.metrics.model.snapshots.Labels;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.util.EmbeddedSolrServerTestRule;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.apache.solr.util.TestHarness;
-import org.apache.solr.util.stats.MetricUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -95,13 +95,11 @@ public class TestThinCache extends SolrTestCaseJ4 {
     ThinCache<Object, Integer, String> lfuCache = new ThinCache<>();
     lfuCache.setBacking(cacheScope, backing);
     SolrMetricsContext solrMetricsContext = new SolrMetricsContext(metricManager, registry, "foo");
-    // TODO SOLR-17458: Fix test later
     lfuCache.initializeMetrics(solrMetricsContext, Attributes.empty(), scope + "-1");
 
     Object cacheScope2 = new Object();
     ThinCache<Object, Integer, String> newLFUCache = new ThinCache<>();
     newLFUCache.setBacking(cacheScope2, backing);
-    // TODO SOLR-17458: Fix test later
     newLFUCache.initializeMetrics(solrMetricsContext, Attributes.empty(), scope + "-2");
 
     Map<String, String> params = new HashMap<>();
@@ -148,6 +146,8 @@ public class TestThinCache extends SolrTestCaseJ4 {
 
   @Test
   public void testInitCore() throws Exception {
+    String thinCacheName = "nodeLevelCache/myNodeLevelCacheThin";
+    String nodeCacheName = "nodeLevelCache/myNodeLevelCache";
     for (int i = 0; i < 20; i++) {
       assertU(adoc("id", Integer.toString(i)));
     }
@@ -155,28 +155,43 @@ public class TestThinCache extends SolrTestCaseJ4 {
     assertQ(req("q", "*:*", "fq", "id:0"));
     assertQ(req("q", "*:*", "fq", "id:0"));
     assertQ(req("q", "*:*", "fq", "id:1"));
-    Map<String, Object> nodeMetricsSnapshot =
-        MetricUtils.convertMetrics(
-            h.getCoreContainer().getMetricManager().registry("solr.node"),
-            List.of(
-                "CACHE.nodeLevelCache/myNodeLevelCacheThin",
-                "CACHE.nodeLevelCache/myNodeLevelCache"));
-    Map<String, Object> coreMetricsSnapshot =
-        MetricUtils.convertMetrics(
-            h.getCore().getCoreMetricManager().getRegistry(),
-            List.of("CACHE.searcher.filterCache"));
 
-    // check that metrics are accessible, and the core cache writes through to the node-level cache
-    Map<String, Number> assertions = Map.of("lookups", 3L, "hits", 1L, "inserts", 2L, "size", 2);
-    for (Map.Entry<String, Number> e : assertions.entrySet()) {
-      String key = e.getKey();
-      Number val = e.getValue();
-      assertEquals(
-          val, nodeMetricsSnapshot.get("CACHE.nodeLevelCache/myNodeLevelCacheThin.".concat(key)));
-      assertEquals(val, coreMetricsSnapshot.get("CACHE.searcher.filterCache.".concat(key)));
-    }
+    assertEquals(3L, getNodeCacheOp(thinCacheName, "lookups"));
+    assertEquals(1L, getNodeCacheOp(thinCacheName, "hits"));
+    assertEquals(2L, getNodeCacheOp(thinCacheName, "inserts"));
+
+    assertEquals(2, getNodeCacheSize(thinCacheName));
 
     // for the other node-level cache, simply check that metrics are accessible
-    assertEquals(0, nodeMetricsSnapshot.get("CACHE.nodeLevelCache/myNodeLevelCache.size"));
+    assertEquals(0, getNodeCacheSize(nodeCacheName));
+  }
+
+  private long getNodeCacheOp(String cacheName, String operation) {
+    var reader = h.getCoreContainer().getMetricManager().getPrometheusMetricReader("solr.node");
+    return (long)
+        SolrMetricTestUtils.getCounterDatapoint(
+                reader,
+                "solr_searcher_cache_ops",
+                Labels.builder()
+                    .label("category", "CACHE")
+                    .label("ops", operation)
+                    .label("cache_name", cacheName)
+                    .label("otel_scope_name", "org.apache.solr")
+                    .build())
+            .getValue();
+  }
+
+  private long getNodeCacheSize(String cacheName) {
+    var reader = h.getCoreContainer().getMetricManager().getPrometheusMetricReader("solr.node");
+    return (long)
+        SolrMetricTestUtils.getGaugeDatapoint(
+                reader,
+                "solr_searcher_cache_size",
+                Labels.builder()
+                    .label("category", "CACHE")
+                    .label("cache_name", cacheName)
+                    .label("otel_scope_name", "org.apache.solr")
+                    .build())
+            .getValue();
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
@@ -646,17 +646,14 @@ public class BJQParserTest extends SolrTestCaseJ4 {
   }
 
   private long getCacheHits(String cacheName) {
-    return (long)
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), cacheName, "hits").getValue();
+    return (long) SolrMetricTestUtils.getCacheSearcherOpsHits(h.getCore(), cacheName).getValue();
   }
 
   private long getCacheLookups(String cacheName) {
-    return (long)
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), cacheName, "lookups").getValue();
+    return (long) SolrMetricTestUtils.getCacheSearcherOpsLookups(h.getCore(), cacheName).getValue();
   }
 
   private long getCacheInserts(String cacheName) {
-    return (long)
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), cacheName, "inserts").getValue();
+    return (long) SolrMetricTestUtils.getCacheSearcherOpsInserts(h.getCore(), cacheName).getValue();
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/BJQParserTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import javax.xml.xpath.XPathConstants;
 import org.apache.lucene.search.Query;
@@ -31,13 +30,12 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
-import org.apache.solr.metrics.MetricsMap;
-import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.util.BaseTestHarness;
 import org.apache.solr.util.RandomNoReverseMergePolicyFactory;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -49,6 +47,8 @@ public class BJQParserTest extends SolrTestCaseJ4 {
   private static final String[] klm = new String[] {"k", "l", "m"};
   private static final List<String> xyz = Arrays.asList("x", "y", "z");
   private static final String[] abcdef = new String[] {"a", "b", "c", "d", "e", "f"};
+  private static final String PER_SEG_FILTER_CACHE_NAME = "perSegFilter";
+  private static final String FILTER_CACHE_NAME = "filterCache";
 
   @ClassRule
   public static final TestRule noReverseMerge = RandomNoReverseMergePolicyFactory.createRule();
@@ -397,28 +397,15 @@ public class BJQParserTest extends SolrTestCaseJ4 {
   @Test
   public void testCacheHit() {
 
-    MetricsMap parentFilterCache =
-        (MetricsMap)
-            ((SolrMetricManager.GaugeWrapper<?>)
-                    h.getCore()
-                        .getCoreMetricManager()
-                        .getRegistry()
-                        .getMetrics()
-                        .get("CACHE.searcher.perSegFilter"))
-                .getGauge();
-    MetricsMap filterCache =
-        (MetricsMap)
-            ((SolrMetricManager.GaugeWrapper<?>)
-                    h.getCore()
-                        .getCoreMetricManager()
-                        .getRegistry()
-                        .getMetrics()
-                        .get("CACHE.searcher.filterCache"))
-                .getGauge();
+    // Get initial values
+    long parentLookupsBefore = getCacheLookups(PER_SEG_FILTER_CACHE_NAME);
+    ;
+    long parentHitsBefore = getCacheHits(PER_SEG_FILTER_CACHE_NAME);
+    long parentInsertsBefore = getCacheInserts(PER_SEG_FILTER_CACHE_NAME);
+    ;
 
-    Map<String, Object> parentsBefore = parentFilterCache.getValue();
-
-    Map<String, Object> filtersBefore = filterCache.getValue();
+    long filterHitsBefore = getCacheHits(FILTER_CACHE_NAME);
+    long filterInsertsBefore = getCacheInserts(FILTER_CACHE_NAME);
 
     // it should be weird enough to be uniq
     String parentFilter = "parent_s:([a TO c] [d TO f])";
@@ -433,8 +420,7 @@ public class BJQParserTest extends SolrTestCaseJ4 {
         req("q", "*:*", "fq", "{!parent which=\"" + parentFilter + "\"}"),
         "//*[@numFound='6']");
 
-    assertEquals(
-        "didn't hit fqCache yet ", 0L, delta("hits", filterCache.getValue(), filtersBefore));
+    assertEquals("didn't hit fqCache yet ", 0L, getCacheHits(FILTER_CACHE_NAME) - filterHitsBefore);
 
     assertQ(
         "filter by join",
@@ -444,28 +430,24 @@ public class BJQParserTest extends SolrTestCaseJ4 {
     assertEquals(
         "in cache mode every request lookups",
         3,
-        delta("lookups", parentFilterCache.getValue(), parentsBefore));
+        getCacheLookups(PER_SEG_FILTER_CACHE_NAME) - parentLookupsBefore);
     assertEquals(
         "last two lookups causes hits",
         2,
-        delta("hits", parentFilterCache.getValue(), parentsBefore));
+        getCacheHits(PER_SEG_FILTER_CACHE_NAME) - parentHitsBefore);
     assertEquals(
         "the first lookup gets insert",
         1,
-        delta("inserts", parentFilterCache.getValue(), parentsBefore));
+        getCacheInserts(PER_SEG_FILTER_CACHE_NAME) - parentInsertsBefore);
 
     assertEquals(
         "true join query was not in fqCache",
         0L,
-        delta("hits", filterCache.getValue(), filtersBefore));
+        getCacheHits(FILTER_CACHE_NAME) - filterHitsBefore);
     assertEquals(
         "true join query is cached in fqCache",
         1L,
-        delta("inserts", filterCache.getValue(), filtersBefore));
-  }
-
-  private long delta(String key, Map<String, Object> a, Map<String, Object> b) {
-    return (Long) a.get(key) - (Long) b.get(key);
+        getCacheInserts(FILTER_CACHE_NAME) - filterInsertsBefore);
   }
 
   @Test
@@ -661,5 +643,20 @@ public class BJQParserTest extends SolrTestCaseJ4 {
   public void cleanAfterTestFiltersCache() {
     assertU("should be noop", delI("12275"));
     assertU("most of the time", commit());
+  }
+
+  private long getCacheHits(String cacheName) {
+    return (long)
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), cacheName, "hits").getValue();
+  }
+
+  private long getCacheLookups(String cacheName) {
+    return (long)
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), cacheName, "lookups").getValue();
+  }
+
+  private long getCacheInserts(String cacheName) {
+    return (long)
+        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), cacheName, "inserts").getValue();
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/join/TestNestedDocsSort.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestNestedDocsSort.java
@@ -136,21 +136,17 @@ public class TestNestedDocsSort extends SolrTestCaseJ4 {
       @SuppressWarnings({"rawtypes"})
       final SolrCache cache = req.getSearcher().getCache("perSegFilter");
       assertNotNull(cache);
-
       var core = req.getSearcher().getCore();
-
       double before =
           SolrMetricTestUtils.getCacheSearcherOpsLookups(
                   core, SolrMetricTestUtils.PER_SEG_FILTER_CACHE)
               .getValue();
 
       parse("childfield(name_s1,$q) asc");
-
       double after =
           SolrMetricTestUtils.getCacheSearcherOpsLookups(
                   core, SolrMetricTestUtils.PER_SEG_FILTER_CACHE)
               .getValue();
-
       assertEquals(
           "parsing bjq lookups parent filter,"
               + "parsing sort spec lookups parent and child filters, "

--- a/solr/core/src/test/org/apache/solr/search/join/TestNestedDocsSort.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestNestedDocsSort.java
@@ -140,12 +140,16 @@ public class TestNestedDocsSort extends SolrTestCaseJ4 {
       var core = req.getSearcher().getCore();
 
       double before =
-          SolrMetricTestUtils.getCacheSearcherOps(core, "perSegFilter", "lookups").getValue();
+          SolrMetricTestUtils.getCacheSearcherOpsLookups(
+                  core, SolrMetricTestUtils.PER_SEG_FILTER_CACHE)
+              .getValue();
 
       parse("childfield(name_s1,$q) asc");
 
       double after =
-          SolrMetricTestUtils.getCacheSearcherOps(core, "perSegFilter", "lookups").getValue();
+          SolrMetricTestUtils.getCacheSearcherOpsLookups(
+                  core, SolrMetricTestUtils.PER_SEG_FILTER_CACHE)
+              .getValue();
 
       assertEquals(
           "parsing bjq lookups parent filter,"

--- a/solr/core/src/test/org/apache/solr/search/join/TestNestedDocsSort.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestNestedDocsSort.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.search.join;
 
-import java.util.Map;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.solr.SolrTestCaseJ4;
@@ -26,6 +25,7 @@ import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SortSpec;
 import org.apache.solr.search.SortSpecParsing;
 import org.apache.solr.util.RandomNoReverseMergePolicyFactory;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -136,23 +136,23 @@ public class TestNestedDocsSort extends SolrTestCaseJ4 {
       @SuppressWarnings({"rawtypes"})
       final SolrCache cache = req.getSearcher().getCache("perSegFilter");
       assertNotNull(cache);
-      final Map<String, Object> state = cache.getSolrMetricsContext().getMetricsSnapshot();
-      String lookupsKey = null;
-      for (String key : state.keySet()) {
-        if (key.endsWith(".lookups")) {
-          lookupsKey = key;
-          break;
-        }
-      }
-      Number before = (Number) state.get(lookupsKey);
+
+      var core = req.getSearcher().getCore();
+
+      double before =
+          SolrMetricTestUtils.getCacheSearcherOps(core, "perSegFilter", "lookups").getValue();
+
       parse("childfield(name_s1,$q) asc");
-      Number after = (Number) cache.getSolrMetricsContext().getMetricsSnapshot().get(lookupsKey);
+
+      double after =
+          SolrMetricTestUtils.getCacheSearcherOps(core, "perSegFilter", "lookups").getValue();
+
       assertEquals(
           "parsing bjq lookups parent filter,"
               + "parsing sort spec lookups parent and child filters, "
               + "hopefully for the purpose",
           3,
-          after.intValue() - before.intValue());
+          (int) (after - before));
     } finally {
       req.close();
     }

--- a/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPScore.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPScore.java
@@ -228,11 +228,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     {
       // Get initial cache metrics
       CounterSnapshot.CounterDataPointSnapshot lookupsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+          SolrMetricTestUtils.getCacheSearcherOpsLookups(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot hitsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+          SolrMetricTestUtils.getCacheSearcherOpsHits(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot insertsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+          SolrMetricTestUtils.getCacheSearcherOpsInserts(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
       h.query(
           req(
@@ -249,11 +252,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     {
       // Get metrics before second query
       CounterSnapshot.CounterDataPointSnapshot lookupsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+          SolrMetricTestUtils.getCacheSearcherOpsLookups(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot hitsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+          SolrMetricTestUtils.getCacheSearcherOpsHits(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot insertsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+          SolrMetricTestUtils.getCacheSearcherOpsInserts(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
       h.query(
           req(
@@ -270,11 +276,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     {
       // Get metrics before dynamic query
       CounterSnapshot.CounterDataPointSnapshot lookupsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+          SolrMetricTestUtils.getCacheSearcherOpsLookups(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot hitsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+          SolrMetricTestUtils.getCacheSearcherOpsHits(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot insertsPre =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+          SolrMetricTestUtils.getCacheSearcherOpsInserts(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
       Random r = random();
       boolean changed = false;
@@ -313,11 +322,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
 
       // Get metrics before repeat query
       CounterSnapshot.CounterDataPointSnapshot lookupsPreRepeat =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+          SolrMetricTestUtils.getCacheSearcherOpsLookups(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot hitsPreRepeat =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+          SolrMetricTestUtils.getCacheSearcherOpsHits(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
       CounterSnapshot.CounterDataPointSnapshot insertsPreRepeat =
-          SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+          SolrMetricTestUtils.getCacheSearcherOpsInserts(
+              h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
       final String repeat =
           h.query(
@@ -359,7 +371,8 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     // however, it might be better to extract this method into a separate suite
     // for a while let's nuke a cache content, in case of repetitions
     @SuppressWarnings("rawtypes")
-    SolrCache cache = (SolrCache) h.getCore().getInfoRegistry().get("queryResultCache");
+    SolrCache cache =
+        (SolrCache) h.getCore().getInfoRegistry().get(SolrMetricTestUtils.QUERY_RESULT_CACHE);
     cache.clear();
   }
 
@@ -375,11 +388,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
       CounterSnapshot.CounterDataPointSnapshot hitsPre,
       CounterSnapshot.CounterDataPointSnapshot insertsPre) {
     CounterSnapshot.CounterDataPointSnapshot lookupsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+        SolrMetricTestUtils.getCacheSearcherOpsLookups(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot hitsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot insertsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
     assertEquals("it lookups", 1, delta(lookupsPost, lookupsPre));
     assertEquals("it doesn't hit", 0, delta(hitsPost, hitsPre));
@@ -391,11 +407,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
       CounterSnapshot.CounterDataPointSnapshot hitsPre,
       CounterSnapshot.CounterDataPointSnapshot insertsPre) {
     CounterSnapshot.CounterDataPointSnapshot lookupsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+        SolrMetricTestUtils.getCacheSearcherOpsLookups(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot hitsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot insertsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
     assertEquals("it lookups", 1, delta(lookupsPost, lookupsPre));
     assertEquals("it hits", 1, delta(hitsPost, hitsPre));
@@ -407,11 +426,14 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
       CounterSnapshot.CounterDataPointSnapshot hitsPre,
       CounterSnapshot.CounterDataPointSnapshot insertsPre) {
     CounterSnapshot.CounterDataPointSnapshot lookupsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "lookups");
+        SolrMetricTestUtils.getCacheSearcherOpsLookups(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot hitsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "hits");
+        SolrMetricTestUtils.getCacheSearcherOpsHits(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
     CounterSnapshot.CounterDataPointSnapshot insertsPost =
-        SolrMetricTestUtils.getCacheSearcherOps(h.getCore(), "queryResultCache", "inserts");
+        SolrMetricTestUtils.getCacheSearcherOpsInserts(
+            h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
 
     assertEquals("it lookups", 1, delta(lookupsPost, lookupsPre));
     final long mayHit = delta(hitsPost, hitsPre);

--- a/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPScore.java
+++ b/solr/core/src/test/org/apache/solr/search/join/TestScoreJoinQPScore.java
@@ -226,7 +226,6 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     indexDataForScoring();
 
     {
-      // Get initial cache metrics
       CounterSnapshot.CounterDataPointSnapshot lookupsPre =
           SolrMetricTestUtils.getCacheSearcherOpsLookups(
               h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
@@ -250,7 +249,6 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     }
 
     {
-      // Get metrics before second query
       CounterSnapshot.CounterDataPointSnapshot lookupsPre =
           SolrMetricTestUtils.getCacheSearcherOpsLookups(
               h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
@@ -274,7 +272,6 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
     }
 
     {
-      // Get metrics before dynamic query
       CounterSnapshot.CounterDataPointSnapshot lookupsPre =
           SolrMetricTestUtils.getCacheSearcherOpsLookups(
               h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);
@@ -320,7 +317,6 @@ public class TestScoreJoinQPScore extends SolrTestCaseJ4 {
 
       assertInsert(lookupsPre, hitsPre, insertsPre);
 
-      // Get metrics before repeat query
       CounterSnapshot.CounterDataPointSnapshot lookupsPreRepeat =
           SolrMetricTestUtils.getCacheSearcherOpsLookups(
               h.getCore(), SolrMetricTestUtils.QUERY_RESULT_CACHE);

--- a/solr/test-framework/src/java/org/apache/solr/util/SolrMetricTestUtils.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/SolrMetricTestUtils.java
@@ -246,6 +246,11 @@ public final class SolrMetricTestUtils {
     return getDataPoint(reader, metricName, labels, CounterSnapshot.CounterDataPointSnapshot.class);
   }
 
+  public static GaugeSnapshot.GaugeDataPointSnapshot getGaugeDatapoint(
+      PrometheusMetricReader reader, String metricName, Labels labels) {
+    return getDataPoint(reader, metricName, labels, GaugeSnapshot.GaugeDataPointSnapshot.class);
+  }
+
   public static HistogramSnapshot.HistogramDataPointSnapshot getHistogramDatapoint(
       PrometheusMetricReader reader, String metricName, Labels labels) {
     return getDataPoint(
@@ -301,6 +306,30 @@ public final class SolrMetricTestUtils {
         SolrMetricTestUtils.newCloudLabelsBuilder(core)
             .label("handler", "/update")
             .label("category", "UPDATE")
+            .build());
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getCacheSearcherOps(
+      SolrCore core, String cacheName, String operation) {
+    return SolrMetricTestUtils.getCounterDatapoint(
+        core,
+        "solr_searcher_cache_ops",
+        SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+            .label("category", "CACHE")
+            .label("ops", operation)
+            .label("cache_name", cacheName)
+            .build());
+  }
+
+  public static GaugeSnapshot.GaugeDataPointSnapshot getCacheSearcherOpsCumulative(
+      SolrCore core, String cacheName, String operation) {
+    return SolrMetricTestUtils.getGaugeDatapoint(
+        core,
+        "solr_cache_cumulative_ops",
+        SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+            .label("category", "CACHE")
+            .label("ops", operation)
+            .label("cache_name", cacheName)
             .build());
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/util/SolrMetricTestUtils.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/SolrMetricTestUtils.java
@@ -45,6 +45,12 @@ public final class SolrMetricTestUtils {
   private static final int MAX_ITERATIONS = 100;
   private static final SolrInfoBean.Category CATEGORIES[] = SolrInfoBean.Category.values();
 
+  // Cache name constants
+  public static final String QUERY_RESULT_CACHE = "queryResultCache";
+  public static final String FILTER_CACHE = "filterCache";
+  public static final String DOCUMENT_CACHE = "documentCache";
+  public static final String PER_SEG_FILTER_CACHE = "perSegFilter";
+
   public static String getRandomScope(Random random) {
     return getRandomScope(random, random.nextBoolean());
   }
@@ -309,6 +315,18 @@ public final class SolrMetricTestUtils {
             .build());
   }
 
+  public static GaugeSnapshot.GaugeDataPointSnapshot getCacheSearcherOpsCumulative(
+      SolrCore core, String cacheName, String operation) {
+    return SolrMetricTestUtils.getGaugeDatapoint(
+        core,
+        "solr_cache_cumulative_ops",
+        SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
+            .label("category", "CACHE")
+            .label("ops", operation)
+            .label("cache_name", cacheName)
+            .build());
+  }
+
   public static CounterSnapshot.CounterDataPointSnapshot getCacheSearcherOps(
       SolrCore core, String cacheName, String operation) {
     return SolrMetricTestUtils.getCounterDatapoint(
@@ -321,16 +339,19 @@ public final class SolrMetricTestUtils {
             .build());
   }
 
-  public static GaugeSnapshot.GaugeDataPointSnapshot getCacheSearcherOpsCumulative(
-      SolrCore core, String cacheName, String operation) {
-    return SolrMetricTestUtils.getGaugeDatapoint(
-        core,
-        "solr_cache_cumulative_ops",
-        SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
-            .label("category", "CACHE")
-            .label("ops", operation)
-            .label("cache_name", cacheName)
-            .build());
+  public static CounterSnapshot.CounterDataPointSnapshot getCacheSearcherOpsHits(
+      SolrCore core, String cacheName) {
+    return SolrMetricTestUtils.getCacheSearcherOps(core, cacheName, "hits");
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getCacheSearcherOpsLookups(
+      SolrCore core, String cacheName) {
+    return SolrMetricTestUtils.getCacheSearcherOps(core, cacheName, "lookups");
+  }
+
+  public static CounterSnapshot.CounterDataPointSnapshot getCacheSearcherOpsInserts(
+      SolrCore core, String cacheName) {
+    return SolrMetricTestUtils.getCacheSearcherOps(core, cacheName, "inserts");
   }
 
   public static class TestSolrMetricProducer implements SolrMetricProducer {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806

Migrate CaffeineCache metrics to OTEL. This also cleaned up some things like `core attributes` and some some of the observable instruments for batchCallbacks so we have gauge and counters.

```
# HELP solr_cache_cumulative_ops Number of cumulative cache operations (hits, lookups, inserts and evictions)
# TYPE solr_cache_cumulative_ops gauge
solr_cache_cumulative_ops{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_cache_cumulative_ops{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
# HELP solr_searcher_cache_hit_ratio Cache hit ratio
# TYPE solr_searcher_cache_hit_ratio gauge
solr_searcher_cache_hit_ratio{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_hit_ratio{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_hit_ratio{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_hit_ratio{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_hit_ratio{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
# HELP solr_searcher_cache_ops_total Number of cache operations (hits, lookups, inserts and evictions)
# TYPE solr_searcher_cache_ops_total counter
solr_searcher_cache_ops_total{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="evictions",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="hits",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="inserts",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_ops_total{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",ops="lookups",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
# HELP solr_searcher_cache_ram_used_bytes RAM bytes used by cache
# TYPE solr_searcher_cache_ram_used_bytes gauge
solr_searcher_cache_ram_used_bytes{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 440.0
solr_searcher_cache_ram_used_bytes{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 448.0
solr_searcher_cache_ram_used_bytes{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 440.0
solr_searcher_cache_ram_used_bytes{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 592.0
solr_searcher_cache_ram_used_bytes{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 440.0
# HELP solr_searcher_cache_size Current number cache entries
# TYPE solr_searcher_cache_size gauge
solr_searcher_cache_size{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_size{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_size{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_size{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_size{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
# HELP solr_searcher_cache_warmup_time_milliseconds Cache warmup time
# TYPE solr_searcher_cache_warmup_time_milliseconds gauge
solr_searcher_cache_warmup_time_milliseconds{cache_name="documentCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_warmup_time_milliseconds{cache_name="fieldValueCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_warmup_time_milliseconds{cache_name="filterCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_warmup_time_milliseconds{cache_name="perSegFilter",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
solr_searcher_cache_warmup_time_milliseconds{cache_name="queryResultCache",category="CACHE",collection="demo",core="demo_shard1_replica_n1",otel_scope_name="org.apache.solr",replica="replica_n1",shard="shard1"} 0.0
```