### PR TITLE
SOLR-17923: Add fullOuterJoin stream function

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
@@ -817,52 +817,6 @@ having(rollup(over=a_s,
 
 In this example, the `having` expression iterates the aggregated tuples from the `rollup` expression and emits all tuples where the field `sum(a_i)` is greater than 100 and less than 110.
 
-== leftOuterJoin
-
-The `leftOuterJoin` function wraps two streams, Left and Right, and emits tuples from Left.
-If there is a tuple in Right equal (as defined by `on`) then the values in that tuple will be included in the emitted tuple.
-An equal tuple in Right *need not* exist for the Left tuple to be emitted.
-This supports one-to-one, one-to-many, many-to-one, and many-to-many left outer join scenarios.
-The tuples are emitted in the order in which they appear in the Left stream.
-Both streams must be sorted by the fields being used to determine equality (using the `on` parameter).
-If both tuples contain a field of the same name then the value from the Right stream will be used in the emitted tuple.
-
-You can wrap the incoming streams with a `select` function to be specific about which field values are included in the emitted tuple.
-
-=== leftOuterJoin Parameters
-
-* `StreamExpression for StreamLeft`
-* `StreamExpression for StreamRight`
-* `on`: Fields to be used for checking equality of tuples between Left and Right.
-Can be of the format `on="fieldName"`, `on="fieldNameInLeft=fieldNameInRight"`, or `on="fieldName, otherFieldName=rightOtherFieldName"`.
-
-=== leftOuterJoin Syntax
-
-[source,text]
-----
-leftOuterJoin(
-  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
-  search(pets, q="type:cat", qt="/export", fl="personId,petName", sort="personId asc"),
-  on="personId"
-)
-
-leftOuterJoin(
-  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
-  search(pets, q="type:cat", qt="/export", fl="ownerId,petName", sort="ownerId asc"),
-  on="personId=ownerId"
-)
-
-leftOuterJoin(
-  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
-  select(
-    search(pets, q="type:cat", qt="/export", fl="ownerId,name", sort="ownerId asc"),
-    ownerId,
-    name as petName
-  ),
-  on="personId=ownerId"
-)
-----
-
 == hashJoin
 
 The `hashJoin` function wraps two streams, Left and Right, and for every tuple in Left which exists in Right will emit a tuple containing the fields of both tuples.
@@ -983,6 +937,52 @@ intersect(
   search(collection1, q="a_s:(setA || setAB)", qt="/export", fl="id,a_s,a_i", sort="a_i asc, a_s asc"),
   search(collection1, q="a_s:(setB || setAB)", qt="/export", fl="id,a_s,a_i", sort="a_i asc, a_s asc"),
   on="a_i,a_s"
+)
+----
+
+== leftOuterJoin
+
+The `leftOuterJoin` function wraps two streams, Left and Right, and emits tuples from Left.
+If there is a tuple in Right equal (as defined by `on`) then the values in that tuple will be included in the emitted tuple.
+An equal tuple in Right *need not* exist for the Left tuple to be emitted.
+This supports one-to-one, one-to-many, many-to-one, and many-to-many left outer join scenarios.
+The tuples are emitted in the order in which they appear in the Left stream.
+Both streams must be sorted by the fields being used to determine equality (using the `on` parameter).
+If both tuples contain a field of the same name then the value from the Right stream will be used in the emitted tuple.
+
+You can wrap the incoming streams with a `select` function to be specific about which field values are included in the emitted tuple.
+
+=== leftOuterJoin Parameters
+
+* `StreamExpression for StreamLeft`
+* `StreamExpression for StreamRight`
+* `on`: Fields to be used for checking equality of tuples between Left and Right.
+Can be of the format `on="fieldName"`, `on="fieldNameInLeft=fieldNameInRight"`, or `on="fieldName, otherFieldName=rightOtherFieldName"`.
+
+=== leftOuterJoin Syntax
+
+[source,text]
+----
+leftOuterJoin(
+  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
+  search(pets, q="type:cat", qt="/export", fl="personId,petName", sort="personId asc"),
+  on="personId"
+)
+
+leftOuterJoin(
+  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
+  search(pets, q="type:cat", qt="/export", fl="ownerId,petName", sort="ownerId asc"),
+  on="personId=ownerId"
+)
+
+leftOuterJoin(
+  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
+  select(
+    search(pets, q="type:cat", qt="/export", fl="ownerId,name", sort="ownerId asc"),
+    ownerId,
+    name as petName
+  ),
+  on="personId=ownerId"
 )
 ----
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/stream-decorator-reference.adoc
@@ -786,6 +786,52 @@ fetch(addresses,
 
 The example above fetches addresses for users by matching the username in the tuple with the userId field in the addresses collection.
 
+== fullOuterJoin
+
+The `fullOuterJoin` function wraps two streams, Left and Right, and emits tuples from both.
+If there is a tuple in Right equal (as defined by `on`) then the values in that tuple will be included in the emitted tuple.
+An equal tuple in one stream *need not* exist for a tuple in the other to be emitted.
+This supports one-to-one, one-to-many, many-to-one, and many-to-many left outer join scenarios.
+The tuples are emitted in the order in which they appear in the streams.
+Both streams must be sorted by the fields being used to determine equality (using the `on` parameter).
+If both tuples contain a field of the same name then the value from the Right stream will be used in the emitted tuple.
+
+You can wrap the incoming streams with a `select` function to be specific about which field values are included in the emitted tuple.
+
+=== fullOuterJoin Parameters
+
+* `StreamExpression for StreamLeft`
+* `StreamExpression for StreamRight`
+* `on`: Fields to be used for checking equality of tuples between Left and Right.
+Can be of the format `on="fieldName"`, `on="fieldNameInLeft=fieldNameInRight"`, or `on="fieldName, otherFieldName=rightOtherFieldName"`.
+
+=== fullOuterJoin Syntax
+
+[source,text]
+----
+fullOuterJoin(
+  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
+  search(pets, q="type:cat", qt="/export", fl="personId,petName", sort="personId asc"),
+  on="personId"
+)
+
+fullOuterJoin(
+  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
+  search(pets, q="type:cat", qt="/export", fl="ownerId,petName", sort="ownerId asc"),
+  on="personId=ownerId"
+)
+
+fullOuterJoin(
+  search(people, q="*:*", qt="/export", fl="personId,name", sort="personId asc"),
+  select(
+    search(pets, q="type:cat", qt="/export", fl="ownerId,name", sort="ownerId asc"),
+    ownerId,
+    name as petName
+  ),
+  on="personId=ownerId"
+)
+----
+
 == having
 
 The `having` expression wraps a stream and applies a boolean operation to each tuple.

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/Lang.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/Lang.java
@@ -272,6 +272,7 @@ import org.apache.solr.client.solrj.io.stream.Facet2DStream;
 import org.apache.solr.client.solrj.io.stream.FacetStream;
 import org.apache.solr.client.solrj.io.stream.FeaturesSelectionStream;
 import org.apache.solr.client.solrj.io.stream.FetchStream;
+import org.apache.solr.client.solrj.io.stream.FullOuterJoinStream;
 import org.apache.solr.client.solrj.io.stream.GetStream;
 import org.apache.solr.client.solrj.io.stream.HashJoinStream;
 import org.apache.solr.client.solrj.io.stream.HashRollupStream;
@@ -355,6 +356,7 @@ public class Lang {
         .withFunctionName("stats", StatsStream.class)
         .withFunctionName("innerJoin", InnerJoinStream.class)
         .withFunctionName("leftOuterJoin", LeftOuterJoinStream.class)
+        .withFunctionName("fullOuterJoin", FullOuterJoinStream.class)
         .withFunctionName("hashJoin", HashJoinStream.class)
         .withFunctionName("outerHashJoin", OuterHashJoinStream.class)
         .withFunctionName("intersect", IntersectStream.class)

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/FullOuterJoinStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/FullOuterJoinStream.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.solrj.io.stream;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.comp.StreamComparator;
+import org.apache.solr.client.solrj.io.eq.StreamEqualitor;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
+
+/**
+ * Joins leftStream with rightStream based on an Equalitor. Both streams must be sorted by the
+ * fields being joined on. Resulting stream is sorted by the equalitor.
+ *
+ * @since 9.10.0
+ */
+public class FullOuterJoinStream extends BiJoinStream {
+
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> joinedTuples = new LinkedList<>();
+
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> leftTupleGroup = new LinkedList<>();
+
+  @SuppressWarnings("JdkObsolete")
+  private final LinkedList<Tuple> rightTupleGroup = new LinkedList<>();
+
+  public FullOuterJoinStream(TupleStream leftStream, TupleStream rightStream, StreamEqualitor eq)
+      throws IOException {
+    super(leftStream, rightStream, eq);
+  }
+
+  public FullOuterJoinStream(StreamExpression expression, StreamFactory factory)
+      throws IOException {
+    super(expression, factory);
+  }
+
+  @Override
+  public Tuple read() throws IOException {
+    // if we've already figured out the next joined tuple then just return it
+    if (joinedTuples.size() > 0) {
+      return joinedTuples.removeFirst();
+    }
+
+    // keep going until we find something to return or both streams are empty
+    while (true) {
+
+      // load next set of equal tuples from leftStream into leftTupleGroup
+      if (0 == leftTupleGroup.size()) {
+        loadEqualTupleGroup(leftStream, leftTupleGroup, leftStreamComparator);
+      }
+
+      // same for right
+      if (0 == rightTupleGroup.size()) {
+        loadEqualTupleGroup(rightStream, rightTupleGroup, rightStreamComparator);
+      }
+
+      Boolean leftFinished = (0 == leftTupleGroup.size() || leftTupleGroup.get(0).EOF);
+      Boolean rightFinished = (0 == rightTupleGroup.size() || rightTupleGroup.get(0).EOF);
+
+      // If both streams are at EOF, we're done
+      if (leftFinished && rightFinished) {
+        return Tuple.EOF();
+      }
+
+      // If the left stream is at the EOF, we just return the next element from the right stream
+      if (leftFinished) {
+        return rightTupleGroup.removeFirst();
+      }
+
+      // If the right stream is at the EOF, we just return the next element from the left stream
+      if (rightFinished) {
+        return leftTupleGroup.removeFirst();
+      }
+
+      // At this point we know both left and right groups have at least 1 member
+      if (eq.test(leftTupleGroup.get(0), rightTupleGroup.get(0))) {
+        // The groups are equal. Join em together and build the joinedTuples
+        for (Tuple left : leftTupleGroup) {
+          for (Tuple right : rightTupleGroup) {
+            Tuple clone = left.clone();
+            clone.merge(right);
+            joinedTuples.add(clone);
+          }
+        }
+
+        // Cause each to advance next time we need to look
+        leftTupleGroup.clear();
+        rightTupleGroup.clear();
+
+        return joinedTuples.removeFirst();
+      } else {
+        int c = iterationComparator.compare(leftTupleGroup.get(0), rightTupleGroup.get(0));
+        if (c < 0) {
+          // If there's no match, we still advance the left stream while returning every element.
+          // Because it's an outer join we still return the left tuple if no match on right.
+          return leftTupleGroup.removeFirst();
+        } else {
+          // return right item as it didn't match left and this is a full outer join
+          return rightTupleGroup.removeFirst();
+        }
+      }
+    }
+  }
+
+  @Override
+  public StreamComparator getStreamSort() {
+    return iterationComparator;
+  }
+}

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/TestLang.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/TestLang.java
@@ -61,6 +61,7 @@ public class TestLang extends SolrTestCase {
     "stats",
     "innerJoin",
     "leftOuterJoin",
+    "fullOuterJoin",
     "hashJoin",
     "outerHashJoin",
     "intersect",

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -2512,6 +2512,164 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       tuples = getTuples(stream);
       assertEquals(10, tuples.size());
       assertOrder(tuples, 1, 1, 15, 15, 2, 3, 4, 5, 6, 7);
+
+      // Basic mixed order, with id in right (compare fullOuterJoin ordering)
+      expression =
+          StreamExpressionParser.parse(
+              "leftOuterJoin("
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i desc, join2_s asc, id desc\"),"
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i desc, join2_s asc, id desc\"),"
+                  + "on=\"join1_i, join2_s\")");
+      stream = new LeftOuterJoinStream(expression, factory);
+      stream.setStreamContext(streamContext);
+      tuples = getTuples(stream);
+      assertEquals(10, tuples.size());
+      assertOrder(tuples, 14, 6, 10, 11, 12, 9, 8, 9, 8, 2);
+
+    } finally {
+      solrClientCache.close();
+    }
+  }
+
+  @Test
+  public void testFullOuterJoinStream() throws Exception {
+
+    new UpdateRequest()
+        .add(id, "1", "side_s", "left", "join1_i", "0", "join2_s", "a", "ident_s", "left_1") // 8, 9
+        .add(
+            id, "15", "side_s", "left", "join1_i", "0", "join2_s", "a", "ident_s", "left_1") // 8, 9
+        .add(id, "2", "side_s", "left", "join1_i", "0", "join2_s", "b", "ident_s", "left_2")
+        .add(id, "3", "side_s", "left", "join1_i", "1", "join2_s", "a", "ident_s", "left_3") // 10
+        .add(id, "4", "side_s", "left", "join1_i", "1", "join2_s", "b", "ident_s", "left_4") // 11
+        .add(id, "5", "side_s", "left", "join1_i", "1", "join2_s", "c", "ident_s", "left_5") // 12
+        .add(id, "6", "side_s", "left", "join1_i", "2", "join2_s", "d", "ident_s", "left_6")
+        .add(id, "7", "side_s", "left", "join1_i", "3", "join2_s", "e", "ident_s", "left_7") // 14
+        .add(
+            id, "8", "side_s", "right", "join1_i", "0", "join2_s", "a", "ident_s", "right_1",
+            "join3_i", "0") // 1,15
+        .add(
+            id, "9", "side_s", "right", "join1_i", "0", "join2_s", "a", "ident_s", "right_2",
+            "join3_i", "0") // 1,15
+        .add(
+            id, "10", "side_s", "right", "join1_i", "1", "join2_s", "a", "ident_s", "right_3",
+            "join3_i", "1") // 3
+        .add(
+            id, "11", "side_s", "right", "join1_i", "1", "join2_s", "b", "ident_s", "right_4",
+            "join3_i", "1") // 4
+        .add(
+            id, "12", "side_s", "right", "join1_i", "1", "join2_s", "c", "ident_s", "right_5",
+            "join3_i", "1") // 5
+        .add(
+            id, "13", "side_s", "right", "join1_i", "2", "join2_s", "dad", "ident_s", "right_6",
+            "join3_i", "2")
+        .add(
+            id, "14", "side_s", "right", "join1_i", "3", "join2_s", "e", "ident_s", "right_7",
+            "join3_i", "3") // 7
+        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    StreamExpression expression;
+    TupleStream stream;
+    List<Tuple> tuples;
+    StreamContext streamContext = new StreamContext();
+    SolrClientCache solrClientCache = new SolrClientCache();
+    streamContext.setSolrClientCache(solrClientCache);
+
+    StreamFactory factory =
+        new StreamFactory()
+            .withCollectionZkHost(COLLECTIONORALIAS, cluster.getZkServer().getZkAddress())
+            .withFunctionName("search", CloudSolrStream.class)
+            .withFunctionName("fullOuterJoin", FullOuterJoinStream.class);
+
+    // Basic test
+    try {
+      expression =
+          StreamExpressionParser.parse(
+              "fullOuterJoin("
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i asc, join2_s asc, id asc\"),"
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i asc, join2_s asc, id asc\"),"
+                  + "on=\"join1_i=join1_i, join2_s=join2_s\")");
+      stream = new FullOuterJoinStream(expression, factory);
+      stream.setStreamContext(streamContext);
+      tuples = getTuples(stream);
+      assertEquals(11, tuples.size());
+      assertOrder(tuples, 8, 9, 8, 9, 2, 10, 11, 12, 6, 13, 14);
+
+      // Basic desc
+      expression =
+          StreamExpressionParser.parse(
+              "fullOuterJoin("
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i desc, join2_s asc\"),"
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i desc, join2_s asc\"),"
+                  + "on=\"join1_i, join2_s\")");
+      stream = new FullOuterJoinStream(expression, factory);
+      stream.setStreamContext(streamContext);
+      tuples = getTuples(stream);
+      assertEquals(11, tuples.size());
+      assertOrder(tuples, 14, 6, 13, 10, 11, 12, 9, 8, 9, 8, 2);
+
+      // Results in both searches, no join matches
+      expression =
+          StreamExpressionParser.parse(
+              "fullOuterJoin("
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\"),"
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\", aliases=\"ident_s=right_ident_s\"),"
+                  + "on=\"ident_s=right_ident_s\")");
+      stream = new FullOuterJoinStream(expression, factory);
+      stream.setStreamContext(streamContext);
+      tuples = getTuples(stream);
+      assertEquals(15, tuples.size());
+      assertOrder(tuples, 1, 15, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+
+      // Differing field names
+      expression =
+          StreamExpressionParser.parse(
+              "fullOuterJoin("
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i asc, join2_s asc, id asc\"),"
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:right\", fl=\"id,join3_i,join2_s,ident_s\", sort=\"join3_i asc, join2_s asc, id asc\", aliases=\"join3_i=aliasesField\"),"
+                  + "on=\"join1_i=aliasesField, join2_s=join2_s\")");
+      stream = new FullOuterJoinStream(expression, factory);
+      stream.setStreamContext(streamContext);
+      tuples = getTuples(stream);
+      assertEquals(11, tuples.size());
+      assertOrder(tuples, 8, 9, 8, 9, 2, 10, 11, 12, 6, 13, 14);
+
+      // Basic mixed order, with id in right (compare leftOuterJoin order above)
+      expression =
+          StreamExpressionParser.parse(
+              "fullOuterJoin("
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i desc, join2_s asc, id desc\"),"
+                  + "search("
+                  + COLLECTIONORALIAS
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i desc, join2_s asc, id desc\"),"
+                  + "on=\"join1_i, join2_s\")");
+      stream = new FullOuterJoinStream(expression, factory);
+      stream.setStreamContext(streamContext);
+      tuples = getTuples(stream);
+      assertEquals(11, tuples.size());
+      assertOrder(tuples, 14, 6, 13, 10, 11, 12, 9, 8, 9, 8, 2);
+
     } finally {
       solrClientCache.close();
     }

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -2366,8 +2366,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
                   + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\"),"
                   + "search("
                   + COLLECTIONORALIAS
-                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\", aliases=\"id=right.id, join1_i=right.join1_i, join2_s=right.join2_s, ident_s=right.ident_s\"),"
-                  + "on=\"ident_s=right.ident_s\")");
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\", aliases=\"id=right_id, join1_i=right_join1_i, join2_s=right_join2_s, ident_s=right_ident_s\"),"
+                  + "on=\"ident_s=right_ident_s\")");
       stream = new InnerJoinStream(expression, factory);
       stream.setStreamContext(streamContext);
       tuples = getTuples(stream);
@@ -2488,8 +2488,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
                   + ", q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\"),"
                   + "search("
                   + COLLECTIONORALIAS
-                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\", aliases=\"id=right.id, join1_i=right.join1_i, join2_s=right.join2_s, ident_s=right.ident_s\"),"
-                  + "on=\"ident_s=right.ident_s\")");
+                  + ", q=\"side_s:right\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"ident_s asc\", aliases=\"id=right_id, join1_i=right_join1_i, join2_s=right_join2_s, ident_s=right_ident_s\"),"
+                  + "on=\"ident_s=right_ident_s\")");
       stream = new LeftOuterJoinStream(expression, factory);
       stream.setStreamContext(streamContext);
       tuples = getTuples(stream);
@@ -2925,14 +2925,14 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       clause =
           "innerJoin("
               + "select("
-              + "id, join1_i as left.join1, join2_s as left.join2, ident_s as left.ident,"
+              + "id, join1_i as left_join1, join2_s as left_join2, ident_s as left_ident,"
               + "search(collection1, q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i asc, join2_s asc, id asc\")"
               + "),"
               + "select("
-              + "join3_i as right.join1, join2_s as right.join2, ident_s as right.ident,"
+              + "join3_i as right_join1, join2_s as right_join2, ident_s as right_ident,"
               + "search(collection1, q=\"side_s:right\", fl=\"join3_i,join2_s,ident_s\", sort=\"join3_i asc, join2_s asc\"),"
               + "),"
-              + "on=\"left.join1=right.join1, left.join2=right.join2\""
+              + "on=\"left_join1=right_join1, left_join2=right_join2\""
               + ")";
       stream = factory.constructStream(clause);
       stream.setStreamContext(streamContext);
@@ -2940,34 +2940,34 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       assertFields(
           tuples,
           "id",
-          "left.join1",
-          "left.join2",
-          "left.ident",
-          "right.join1",
-          "right.join2",
-          "right.ident");
+          "left_join1",
+          "left_join2",
+          "left_ident",
+          "right_join1",
+          "right_join2",
+          "right_ident");
 
       // Wrapped select test
       clause =
           "select("
-              + "id, left.ident, right.ident,"
+              + "id, left_ident, right_ident,"
               + "innerJoin("
               + "select("
-              + "id, join1_i as left.join1, join2_s as left.join2, ident_s as left.ident,"
+              + "id, join1_i as left_join1, join2_s as left_join2, ident_s as left_ident,"
               + "search(collection1, q=\"side_s:left\", fl=\"id,join1_i,join2_s,ident_s\", sort=\"join1_i asc, join2_s asc, id asc\")"
               + "),"
               + "select("
-              + "join3_i as right.join1, join2_s as right.join2, ident_s as right.ident,"
+              + "join3_i as right_join1, join2_s as right_join2, ident_s as right_ident,"
               + "search(collection1, q=\"side_s:right\", fl=\"join3_i,join2_s,ident_s\", sort=\"join3_i asc, join2_s asc\"),"
               + "),"
-              + "on=\"left.join1=right.join1, left.join2=right.join2\""
+              + "on=\"left_join1=right_join1, left_join2=right_join2\""
               + ")"
               + ")";
       stream = factory.constructStream(clause);
       stream.setStreamContext(streamContext);
       tuples = getTuples(stream);
-      assertFields(tuples, "id", "left.ident", "right.ident");
-      assertNotFields(tuples, "left.join1", "left.join2", "right.join1", "right.join2");
+      assertFields(tuples, "id", "left_ident", "right_ident");
+      assertNotFields(tuples, "left_join1", "left_join2", "right_join1", "right_join2");
     } finally {
       solrClientCache.close();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17923

# Description

The existing `join` functions discard tuples from the Right stream that don't appear in the Left. Adding a `fullOuterJoin` function will enable the construction of e.g. Reciprocal Rank Fusion (RRF) stream expressions that require non-matching tuples from the Right stream to be included.

# Solution

This PR adds a `fullOuterJoin` function based on `leftOuterJoin`.

# Tests

The tests are based on those for `leftOuterJoin` - I've also included a new pair of tests that illustrate the difference in behaviour between that and `fullOuterJoin`, with one new `id` appearing in the output.

The `right.field` syntax used in existing tests confused me as it looked like special syntax. I've replaced the dots with underscores as I think this makes it clearer.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
