### PR TITLE
[SOLR-17806] Revamped and simplified merge metrics

### DIFF
--- a/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
@@ -161,7 +161,9 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .label(MERGE_TYPE_ATTR.toString(), "minor")
                   .build());
-      assertTrue("minorMergeTimer instances should be at least 2, got: " + minorMergeTimer.getCount(), minorMergeTimer.getCount() == 2);
+      assertTrue(
+          "minorMergeTimer instances should be at least 2, got: " + minorMergeTimer.getCount(),
+          minorMergeTimer.getCount() == 2);
       var majorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
@@ -170,7 +172,9 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
-      assertTrue("majorMergeTimer instances should be at least 2, got: " + majorMergeTimer.getCount(), majorMergeTimer.getCount() == 2);
+      assertTrue(
+          "majorMergeTimer instances should be at least 2, got: " + majorMergeTimer.getCount(),
+          majorMergeTimer.getCount() == 2);
 
       var majorMergeDocs =
           SolrMetricTestUtils.getCounterDatapoint(
@@ -182,7 +186,9 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(MERGE_STATE_ATTR.toString(), "finished")
                   .build());
       // majorMergeDocs is the total number of docs merged during major merge operations
-      assertTrue("majorMergeDocs should be 1000, got: " + majorMergeDocs.getValue(), majorMergeDocs.getValue() == 1000);
+      assertTrue(
+          "majorMergeDocs should be 1000, got: " + majorMergeDocs.getValue(),
+          majorMergeDocs.getValue() == 1000);
 
       var flushCounter =
           SolrMetricTestUtils.getCounterDatapoint(
@@ -191,7 +197,9 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .build());
-      assertTrue("should be at greater than 10 flushes: " + flushCounter.getValue(), flushCounter.getValue() >= 10);
+      assertTrue(
+          "should be at greater than 10 flushes: " + flushCounter.getValue(),
+          flushCounter.getValue() >= 10);
     }
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexMetricsTest.java
@@ -153,8 +153,6 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
       //     4. 300 + 100 + 100 ==> new 500 doc segment, above the 450 threshold ==> major merge
 
       // check basic index meters
-
-      // solr_indexwriter_mergetime_ms
       var minorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
@@ -163,7 +161,7 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .label(MERGE_TYPE_ATTR.toString(), "minor")
                   .build());
-      assertTrue("minorMergeTimer: " + minorMergeTimer.getCount(), minorMergeTimer.getCount() == 2);
+      assertTrue("minorMergeTimer instances should be at least 2, got: " + minorMergeTimer.getCount(), minorMergeTimer.getCount() == 2);
       var majorMergeTimer =
           SolrMetricTestUtils.getHistogramDatapoint(
               core,
@@ -172,9 +170,8 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .label(MERGE_TYPE_ATTR.toString(), "major")
                   .build());
-      assertTrue("majorMergeTimer: " + majorMergeTimer.getCount(), majorMergeTimer.getCount() == 2);
+      assertTrue("majorMergeTimer instances should be at least 2, got: " + majorMergeTimer.getCount(), majorMergeTimer.getCount() == 2);
 
-      // check detailed meters
       var majorMergeDocs =
           SolrMetricTestUtils.getCounterDatapoint(
               core,
@@ -185,7 +182,7 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
                   .label(MERGE_STATE_ATTR.toString(), "finished")
                   .build());
       // majorMergeDocs is the total number of docs merged during major merge operations
-      assertTrue("majorMergeDocs: " + majorMergeDocs.getValue(), majorMergeDocs.getValue() == 1000);
+      assertTrue("majorMergeDocs should be 1000, got: " + majorMergeDocs.getValue(), majorMergeDocs.getValue() == 1000);
 
       var flushCounter =
           SolrMetricTestUtils.getCounterDatapoint(
@@ -194,7 +191,7 @@ public class SolrIndexMetricsTest extends SolrTestCaseJ4 {
               SolrMetricTestUtils.newStandaloneLabelsBuilder(core)
                   .label(CATEGORY_ATTR.toString(), SolrInfoBean.Category.INDEX.toString())
                   .build());
-      assertTrue("flush: " + flushCounter.getValue(), flushCounter.getValue() >= 10);
+      assertTrue("should be at greater than 10 flushes: " + flushCounter.getValue(), flushCounter.getValue() >= 10);
     }
   }
 }

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/metrics-reporting.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/metrics-reporting.adoc
@@ -87,7 +87,7 @@ When making requests with the <<Metrics API>>, you can specify `&group=core` to 
 
 * all common RequestHandlers report: request timers / counters, timeouts, errors.
 Handlers that support process distributed shard requests also report `shardRequests` sub-counters for each type of distributed request.
-* <<Index Merge Metrics,index-level events>>: meters for minor / major merges, number of merged docs, number of deleted docs, gauges for currently running merges and their size.
+* <<Index Merge Metrics,index-level events>>: meters for minor / major merges, number of merged docs, number of deleted docs, number of flushes
 * shard replication and transaction log replay on replicas,
 * open / available / pending connections for shard handler and update handler.
 
@@ -312,7 +312,7 @@ complex objects:
 ----
 
 === Caching Threads Metrics ===
-The threads metrics in the JVM group can be expensive to compute, as it requires traversing all threads. 
+The threads metrics in the JVM group can be expensive to compute, as it requires traversing all threads.
 This can be avoided for every call to the metrics API (group=jvm) by setting a high caching expiration interval
 (in seconds). For example, to cache the thread metrics for 5 seconds:
 
@@ -657,7 +657,7 @@ Metrics can be aggregated across cores using Shard and Cluster reporters.
 
 These metrics are collected in respective registries for each core (e.g., `solr.core.collection1....`), under the `INDEX` category.
 
-Metrics collection is controlled by boolean parameters in the `<metrics>` section of `solrconfig.xml`:
+Metrics collection for index merges can be configured in the `<metrics>` section of `solrconfig.xml`:
 
 Basic metrics:
 
@@ -668,7 +668,6 @@ Basic metrics:
   <indexConfig>
     <metrics>
       <long name="majorMergeDocs">524288</long>
-      <bool name="merge">true</bool>
     </metrics>
     ...
   </indexConfig>
@@ -676,43 +675,28 @@ Basic metrics:
 </config>
 ----
 
-Detailed metrics:
+For merge metrics, metrics are tracked with the distinction of "minor" and "major" merges. This is indicated by the
+`merge_type` label for the metric. The threshold for when a merge becomes large enough to be major is configurable, but
+defaults to 512k documents.
 
-[source,xml]
-----
-<config>
-  ...
-  <indexConfig>
-    <metrics>
-      <long name="majorMergeDocs">524288</long>
-      <bool name="mergeDetails">true</bool>
-    </metrics>
-    ...
-  </indexConfig>
-...
-</config>
-----
+The following merge metrics are collected:
 
-The following metrics are collected:
+* 'solr_indexwriter_merge_time_milliseconds' - timer for total duration of merge operations
 
-* `INDEX.merge.major` - timer for merge operations that include at least "majorMergeDocs" (default value for this parameter is 512k documents).
-* `INDEX.merge.minor` - timer for merge operations that include less than "majorMergeDocs".
-* `INDEX.merge.errors` - counter for merge errors.
-* `INDEX.flush` - meter for index flush operations.
+The following metrics, in addition to the above labels for "minor"/"major" `merge_type` also have a label for `merge_state`.
+This label can have a value of either "started" or "finished" indicating when the value was reported ("started" when a merge
+is being prepared and "finished" when a merge is concluded).
+These metrics are monotonically increasing, and so the values for specific merge operations can be calculated by taking
+the diff of the values between times or between `started` / `finished` types.
 
-Additionally, the following gauges are reported, which help to monitor the momentary state of index merge operations:
+* 'solr_indexwriter_docs_merged' - counter for total number of documents included in the merge (this excludes deleted docs)
+* 'solr_solr_indexwriter_docs_deleted' - counter for total number of documents deleted by the merge
+* 'solr_indexwriter_segments' - counter for total number of segments merged
 
-* `INDEX.merge.major.running` - number of running major merge operations (depending on the implementation of `MergeScheduler` that is used there can be several concurrently running merge operations).
-* `INDEX.merge.minor.running` - as above, for minor merge operations.
-* `INDEX.merge.major.running.docs` - total number of documents in the segments being currently merged in major merge operations.
-* `INDEX.merge.minor.running.docs` - as above, for minor merge operations.
-* `INDEX.merge.major.running.segments` - number of segments being currently merged in major merge operations.
-* `INDEX.merge.minor.running.segments` - as above, for minor merge operations.
+And finally, we have some metrics that are static for the core (collected irrespective of merge type/state)
 
-If the boolean flag `mergeDetails` is true then the following additional metrics are collected:
-
-* `INDEX.merge.major.docs` - meter for the number of documents merged in major merge operations
-* `INDEX.merge.major.deletedDocs` - meter for the number of deleted documents expunged in major merge operations
+* 'solr_indexwriter_merge_errors' - counter for total number of merges that failed
+* 'solr_indexwriter_flushes' - counter for total number of flushes to disk
 
 == Metrics API
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17806


# Description

Replace existing segment merge metrics with consistent counters

# Solution

* Enabled segment merge metrics by default (configurable threshold for major merges behavior is unchanged)
* Removed the index merge running gauge metrics

Added the following index merge metrics:

* solr_indexwriter_merge_time
* solr_indexwriter_merge_errors
* solr_indexwriter_flushes
* solr_indexwriter_merges
* solr_indexwriter_docs_merged
* solr_indexwriter_docs_deleted
* solr_indexwriter_segments

Also added labels for `merge_type` (minor / major) and `merge_state` (started / finished). In this way the counters are consistent and monotonically increasing. To get the current state of a merge, the current started metric can be subtracted from the current finished metric.

# Tests

* Updated existing merge metrics tests

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
