### PR TITLE
SOLR-17023: Use modern property name, not deprecated name

### DIFF
--- a/solr/packaging/test/test_opennlp.bats
+++ b/solr/packaging/test/test_opennlp.bats
@@ -60,7 +60,7 @@ teardown() {
     # Can't figure out magic policy stuff to allow loading ONNX, so disable security manager.
   export SOLR_SECURITY_MANAGER_ENABLED=false
 
-  solr start -m 4g -Dsolr.modules=analysis-extras -Denable.packages=true
+  solr start -m 4g -Dsolr.modules=analysis-extras -Dsolr.packages.enabled=true
   solr assert --started http://localhost:${SOLR_PORT}/solr --timeout 5000
 
   run solr create -c COLL_NAME

--- a/solr/solr-ref-guide/modules/getting-started/pages/tutorial-opennlp.adoc
+++ b/solr/solr-ref-guide/modules/getting-started/pages/tutorial-opennlp.adoc
@@ -39,7 +39,7 @@ To enable NLP processing in Solr, start Solr with the `analysis-extras` module a
 [,console]
 ----
 $ export SOLR_SECURITY_MANAGER_ENABLED=false
-$ bin/solr start -m 4g -Dsolr.modules=analysis-extras -Denable.packages=true
+$ bin/solr start -m 4g -Dsolr.modules=analysis-extras -Dsolr.packages.enabled=true
 ----
 
 [NOTE]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17023

I thought I had never migrated the `enable.packages` property, but turned out the docs and test predated the `solr.packages.enabled` setting, so updating.  No CHANGELOG.