### PR TITLE
Fix repeated phrase in config-sets.adoc

### DIFF
--- a/solr/solr-ref-guide/modules/configuration-guide/pages/config-sets.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/config-sets.adoc
@@ -62,7 +62,7 @@ However, users can impose stricter or looser limits on their systems by providin
 
 == Configsets in User-Managed Clusters or Single-Node Installations
 
-If you are using Solr in a If you are using Solr in a user-managed cluster or a single-node installation, configsets are managed on the filesystem. installation, configsets are managed on the filesystem.
+If you are using Solr in a user-managed cluster or a single-node installation, configsets are managed on the filesystem. installation, configsets are managed on the filesystem.
 
 Each Solr core can have it's very own configset located beneath it in a `<instance_dir>/conf/` dir.
 Here, it is not named or shared and the word _configset_ isn't found.


### PR DESCRIPTION
# Description

This PR makes a minor update to the documentation for configsets in user-managed Solr clusters or single-node installations. It corrects a duplicated sentence for clarity.
