### PR TITLE
SOLR-17926: Add tracking of time already spent to discount the limit for sub-requests

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -63,6 +63,8 @@ Improvements
 
 * GITHUB#3666: Removing redundant check if field exists in TextToVectorUpdateProcessorFactory (Renato Haeberli via Alessandro Benedetti)
 
+* SOLR-17926: Improve tracking of time already spent to discount the limit for sub-requests when `timeAllowed` is used. (Andrzej Bialecki, hossman)
+
 Optimizations
 ---------------------
 * SOLR-17568: The CLI bin/solr export tool now contacts the appropriate nodes directly for data instead of proxying through one.

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -758,14 +758,15 @@ public class QueryComponent extends SearchComponent {
   protected void regularFinishStage(ResponseBuilder rb) {
     // We may not have been able to retrieve all the docs due to an
     // index change.  Remove any null documents.
-    for (Iterator<SolrDocument> iter = rb.getResponseDocs().iterator(); iter.hasNext(); ) {
+    SolrDocumentList responseDocs = rb.getResponseDocs() != null ? rb.getResponseDocs() : new SolrDocumentList();
+    for (Iterator<SolrDocument> iter = responseDocs.iterator(); iter.hasNext(); ) {
       if (iter.next() == null) {
         iter.remove();
-        rb.getResponseDocs().setNumFound(rb.getResponseDocs().getNumFound() - 1);
+        rb.getResponseDocs().setNumFound(responseDocs.getNumFound() - 1);
       }
     }
 
-    rb.rsp.addResponse(rb.getResponseDocs());
+    rb.rsp.addResponse(responseDocs);
     if (null != rb.getNextCursorMark()) {
       rb.rsp.add(CursorMarkParams.CURSOR_MARK_NEXT, rb.getNextCursorMark().getSerializedTotem());
     }
@@ -1339,6 +1340,9 @@ public class QueryComponent extends SearchComponent {
 
     // for each shard, collect the documents for that shard.
     HashMap<String, Collection<ShardDoc>> shardMap = new HashMap<>();
+    if (rb.resultIds == null) {
+      rb.resultIds = new HashMap<>();
+    }
     for (ShardDoc sdoc : rb.resultIds.values()) {
       Collection<ShardDoc> shardDocs = shardMap.get(sdoc.shard);
       if (shardDocs == null) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -758,7 +758,8 @@ public class QueryComponent extends SearchComponent {
   protected void regularFinishStage(ResponseBuilder rb) {
     // We may not have been able to retrieve all the docs due to an
     // index change.  Remove any null documents.
-    SolrDocumentList responseDocs = rb.getResponseDocs() != null ? rb.getResponseDocs() : new SolrDocumentList();
+    SolrDocumentList responseDocs =
+        rb.getResponseDocs() != null ? rb.getResponseDocs() : new SolrDocumentList();
     for (Iterator<SolrDocument> iter = responseDocs.iterator(); iter.hasNext(); ) {
       if (iter.next() == null) {
         iter.remove();

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -137,6 +137,25 @@ public class ResponseBuilder {
     return this.stage;
   }
 
+  public String getStageName() {
+    switch (this.stage) {
+      case STAGE_START:
+        return "START";
+      case STAGE_PARSE_QUERY:
+        return "PARSE_QUERY";
+      case STAGE_TOP_GROUPS:
+        return "TOP_GROUPS";
+      case STAGE_EXECUTE_QUERY:
+        return "EXECUTE_QUERY";
+      case STAGE_GET_FIELDS:
+        return "GET_FIELDS";
+      case STAGE_DONE:
+        return "DONE";
+      default:
+        return Integer.toString(this.stage);
+    }
+  }
+
   public void setStage(int stage) {
     this.stage = stage;
   }

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -593,7 +593,10 @@ public class SearchHandler extends RequestHandlerBase
                 if (queryLimits.adjustShardRequestLimits(sreq, shard, params, rb)) {
                   // Skip this shard since one or more limits will be tripped
                   if (log.isDebugEnabled()) {
-                    log.info("Skipping request to shard '{}' due to query limits, params {}", shard, params);
+                    log.debug(
+                        "Skipping request to shard '{}' due to query limits, params {}",
+                        shard,
+                        params);
                   }
                   continue;
                 }

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -72,6 +72,7 @@ import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.CursorMark;
+import org.apache.solr.search.QueryLimits;
 import org.apache.solr.search.SortSpec;
 import org.apache.solr.search.facet.FacetModule;
 import org.apache.solr.security.AuthorizationContext;
@@ -563,6 +564,8 @@ public class SearchHandler extends RequestHandlerBase
             // presume we'll get a response from each shard we send to
             sreq.responses = new ArrayList<>(sreq.actualShards.length);
 
+            QueryLimits queryLimits = QueryLimits.getCurrentLimits();
+
             // TODO: map from shard to address[]
             for (String shard : sreq.actualShards) {
               ModifiableSolrParams params = new ModifiableSolrParams(sreq.params);
@@ -585,6 +588,15 @@ public class SearchHandler extends RequestHandlerBase
                 if (!"/select".equals(reqPath)) {
                   params.set(CommonParams.QT, reqPath);
                 } // else if path is /select, then the qt gets passed thru if set
+              }
+              if (queryLimits.isLimitsEnabled()) {
+                if (queryLimits.adjustShardRequestLimits(sreq, shard, params, rb)) {
+                  // Skip this shard since one or more limits will be tripped
+                  if (log.isDebugEnabled()) {
+                    log.debug("Skipping request to shard '{}' due to query limits, params {}", shard, params);
+                  }
+                  continue;
+                }
               }
               shardHandler1.submit(sreq, shard, params);
             }

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -525,7 +525,7 @@ public class SearchHandler extends RequestHandlerBase
           }
         }
       } catch (ExitableDirectoryReader.ExitingReaderException ex) {
-        log.warn("Query: {}; ", req.getParamString(), ex);
+        log.warn("Query terminated: {}; ", req.getParamString(), ex);
         shortCircuitedResults(req, rb);
       }
     } else {
@@ -593,7 +593,7 @@ public class SearchHandler extends RequestHandlerBase
                 if (queryLimits.adjustShardRequestLimits(sreq, shard, params, rb)) {
                   // Skip this shard since one or more limits will be tripped
                   if (log.isDebugEnabled()) {
-                    log.debug("Skipping request to shard '{}' due to query limits, params {}", shard, params);
+                    log.info("Skipping request to shard '{}' due to query limits, params {}", shard, params);
                   }
                   continue;
                 }

--- a/solr/core/src/java/org/apache/solr/search/QueryLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimit.java
@@ -17,6 +17,9 @@
 package org.apache.solr.search;
 
 import org.apache.lucene.index.QueryTimeout;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardRequest;
 
 public interface QueryLimit extends QueryTimeout {
   /**
@@ -28,4 +31,13 @@ public interface QueryLimit extends QueryTimeout {
    *     user.
    */
   Object currentValue();
+
+  /**
+   * Allow limit to adjust shard request parameters if needed.
+   * @return true if the shard request should be skipped because a limit will be tripped after sending, during execution.
+   */
+  default boolean adjustShardRequestLimit(ShardRequest sreq, String shard, ModifiableSolrParams params) {
+    // default is to do nothing
+    return false;
+  }
 }

--- a/solr/core/src/java/org/apache/solr/search/QueryLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimit.java
@@ -18,7 +18,6 @@ package org.apache.solr.search;
 
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.ShardRequest;
 
 public interface QueryLimit extends QueryTimeout {
@@ -34,9 +33,12 @@ public interface QueryLimit extends QueryTimeout {
 
   /**
    * Allow limit to adjust shard request parameters if needed.
-   * @return true if the shard request should be skipped because a limit will be tripped after sending, during execution.
+   *
+   * @return true if the shard request should be skipped because a limit will be tripped after
+   *     sending, during execution.
    */
-  default boolean adjustShardRequestLimit(ShardRequest sreq, String shard, ModifiableSolrParams params) {
+  default boolean adjustShardRequestLimit(
+      ShardRequest sreq, String shard, ModifiableSolrParams params) {
     // default is to do nothing and process the request
     return false;
   }

--- a/solr/core/src/java/org/apache/solr/search/QueryLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimit.java
@@ -37,7 +37,7 @@ public interface QueryLimit extends QueryTimeout {
    * @return true if the shard request should be skipped because a limit will be tripped after sending, during execution.
    */
   default boolean adjustShardRequestLimit(ShardRequest sreq, String shard, ModifiableSolrParams params) {
-    // default is to do nothing
+    // default is to do nothing and process the request
     return false;
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/QueryLimits.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimits.java
@@ -205,7 +205,7 @@ public final class QueryLimits implements QueryTimeout {
    * Allow each limit to adjust the shard request parameters if needed. This is useful for
    * timeAllowed, cpu, or memory limits that need to be propagated to shards with potentially modified values.
    *
-   * @return true if the shard request should be skipped because one or more limits will be tripped after sending, during execution.
+   * @return true if the shard request should be skipped because one or more limits would be tripped after sending, during execution.
    * @throws QueryLimitsExceededException if {@link #allowPartialResults} is false and limits would have
    *     been tripped by the shard request.
    */

--- a/solr/core/src/java/org/apache/solr/search/QueryLimits.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimits.java
@@ -18,6 +18,7 @@ package org.apache.solr.search;
 
 import static org.apache.solr.response.SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_DETAILS_KEY;
 import static org.apache.solr.search.CpuAllowedLimit.hasCpuLimit;
+import static org.apache.solr.search.MemAllowedLimit.hasMemLimit;
 import static org.apache.solr.search.TimeAllowedLimit.hasTimeLimit;
 
 import java.util.ArrayList;
@@ -27,6 +28,9 @@ import java.util.function.Supplier;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardRequest;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
@@ -71,7 +75,7 @@ public final class QueryLimits implements QueryTimeout {
       if (hasCpuLimit(req)) {
         limits.add(new CpuAllowedLimit(req));
       }
-      if (MemAllowedLimit.hasMemLimit(req)) {
+      if (hasMemLimit(req)) {
         limits.add(new MemAllowedLimit(req));
       }
     }
@@ -105,6 +109,18 @@ public final class QueryLimits implements QueryTimeout {
         + limitStatusMessage();
   }
 
+  public String formatShardLimitExceptionMessage(String label, String shard, QueryLimit limit) {
+    return "Limit exceeded before sub-request!"
+        + (label != null ? " (" + label + ")" : "")
+        + ": ["
+        + limit.getClass().getSimpleName()
+        + ": "
+        + limit.currentValue()
+        + "] on shard "
+        + shard
+        + ". This shard request will be skipped.";
+  }
+
   /**
    * If limit is reached then depending on the request param {@link CommonParams#PARTIAL_RESULTS}
    * either mark it as partial result in the response and signal the caller to return, or throw an
@@ -118,21 +134,21 @@ public final class QueryLimits implements QueryTimeout {
   public boolean maybeExitWithPartialResults(Supplier<String> label)
       throws QueryLimitsExceededException {
     if (isLimitsEnabled() && shouldExit()) {
-      if (allowPartialResults) {
-        if (rsp != null) {
-          SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
-          if (requestInfo == null) {
-            throw new SolrException(
-                SolrException.ErrorCode.SERVER_ERROR,
-                "No request active, but attempting to exit with partial results?");
-          }
-          rsp.setPartialResults(requestInfo.getReq());
-          if (rsp.getResponseHeader().get(RESPONSE_HEADER_PARTIAL_RESULTS_DETAILS_KEY) == null) {
-            // don't want to add duplicate keys. Although technically legal, there's a strong risk
-            // that clients won't anticipate it and break.
-            rsp.addPartialResponseDetail(formatExceptionMessage(label.get()));
-          }
+      if (rsp != null) {
+        SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
+        if (requestInfo == null) {
+          throw new SolrException(
+              SolrException.ErrorCode.SERVER_ERROR,
+              "No request active, but attempting to exit with partial results?");
         }
+        rsp.setPartialResults(requestInfo.getReq());
+        if (rsp.getResponseHeader().get(RESPONSE_HEADER_PARTIAL_RESULTS_DETAILS_KEY) == null) {
+          // don't want to add duplicate keys. Although technically legal, there's a strong risk
+          // that clients won't anticipate it and break.
+          rsp.addPartialResponseDetail(formatExceptionMessage(label.get()));
+        }
+      }
+      if (allowPartialResults) {
         return true;
       } else {
         throw new QueryLimitsExceededException(formatExceptionMessage(label.get()));
@@ -183,6 +199,39 @@ public final class QueryLimits implements QueryTimeout {
   /** Return true if there are any limits enabled for the current request. */
   public boolean isLimitsEnabled() {
     return !limits.isEmpty();
+  }
+
+  /**
+   * Allow each limit to adjust the shard request parameters if needed. This is useful for
+   * timeAllowed, cpu, or memory limits that need to be propagated to shards with potentially modified values.
+   *
+   * @return true if the shard request should be skipped because one or more limits will be tripped after sending, during execution.
+   * @throws QueryLimitsExceededException if {@link #allowPartialResults} is false and limits would have
+   *     been tripped by the shard request.
+   */
+  public boolean adjustShardRequestLimits(ShardRequest sreq, String shard, ModifiableSolrParams params, ResponseBuilder rb) throws QueryLimitsExceededException {
+    boolean result = false;
+    for (QueryLimit limit : limits) {
+      boolean shouldSkip = limit.adjustShardRequestLimit(sreq, shard, params);
+      if (shouldSkip) {
+        String label = "stage: " + rb.getStageName();
+        if (rsp != null) {
+          SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
+          if (requestInfo == null) {
+            throw new SolrException(
+                SolrException.ErrorCode.SERVER_ERROR,
+                "No request active, but attempting to exit with partial results?");
+          }
+          rsp.setPartialResults(requestInfo.getReq());
+          rsp.addPartialResponseDetail(formatShardLimitExceptionMessage(label, shard, limit));
+        }
+        if (!allowPartialResults) {
+          throw new QueryLimitsExceededException(formatShardLimitExceptionMessage(label, shard, limit));
+        }
+      }
+      result = result || shouldSkip;
+    }
+    return result;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/QueryLimits.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryLimits.java
@@ -203,13 +203,17 @@ public final class QueryLimits implements QueryTimeout {
 
   /**
    * Allow each limit to adjust the shard request parameters if needed. This is useful for
-   * timeAllowed, cpu, or memory limits that need to be propagated to shards with potentially modified values.
+   * timeAllowed, cpu, or memory limits that need to be propagated to shards with potentially
+   * modified values.
    *
-   * @return true if the shard request should be skipped because one or more limits would be tripped after sending, during execution.
-   * @throws QueryLimitsExceededException if {@link #allowPartialResults} is false and limits would have
-   *     been tripped by the shard request.
+   * @return true if the shard request should be skipped because one or more limits would be tripped
+   *     after sending, during execution.
+   * @throws QueryLimitsExceededException if {@link #allowPartialResults} is false and limits would
+   *     have been tripped by the shard request.
    */
-  public boolean adjustShardRequestLimits(ShardRequest sreq, String shard, ModifiableSolrParams params, ResponseBuilder rb) throws QueryLimitsExceededException {
+  public boolean adjustShardRequestLimits(
+      ShardRequest sreq, String shard, ModifiableSolrParams params, ResponseBuilder rb)
+      throws QueryLimitsExceededException {
     boolean result = false;
     for (QueryLimit limit : limits) {
       boolean shouldSkip = limit.adjustShardRequestLimit(sreq, shard, params);
@@ -226,7 +230,8 @@ public final class QueryLimits implements QueryTimeout {
           rsp.addPartialResponseDetail(formatShardLimitExceptionMessage(label, shard, limit));
         }
         if (!allowPartialResults) {
-          throw new QueryLimitsExceededException(formatShardLimitExceptionMessage(label, shard, limit));
+          throw new QueryLimitsExceededException(
+              formatShardLimitExceptionMessage(label, shard, limit));
         }
       }
       result = result || shouldSkip;

--- a/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
@@ -18,19 +18,36 @@ package org.apache.solr.search;
 
 import static java.lang.System.nanoTime;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.handler.component.ShardRequest;
 import org.apache.solr.request.SolrQueryRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Enforces a wall clock based timeout on a given SolrQueryRequest. This class holds the logic for
  * the {@code timeAllowed} query parameter. Note that timeAllowed will be ignored for
  * <strong><em>local</em></strong> processing of sub-queries in cases where the parent query already
  * has {@code timeAllowed} set. Essentially only one timeAllowed can be specified for any thread
- * executing a query. This is to ensure that subqueries don't escape from the intended limit
+ * executing a query. This is to ensure that subqueries don't escape from the intended limit.
+ * <p>Distributed requests will approximately track the original starting point of the parent request.
+ * Shard requests may be skipped if the limit would run out shortly after they are sent - this in-flight
+ * allowance is determined by {@link #INFLIGHT_PARAM} in milliseconds, with the default value of {@link #DEFAULT_INFLIGHT_MS}.</p>
  */
 public class TimeAllowedLimit implements QueryLimit {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  public static final String USED_PARAM = "_taUsed";
+  public static final String INFLIGHT_PARAM = "timeAllowed.inflight";
+
+  /** Arbitrary small amount of time to account for network flight time in ms */
+  public static final long DEFAULT_INFLIGHT_MS = 2L;
+
+  private final long reqTimeAllowedMs;
+  private final long reqInflightMs;
   private final long timeoutAt;
   private final long timingSince;
 
@@ -43,19 +60,47 @@ public class TimeAllowedLimit implements QueryLimit {
    *     object
    */
   public TimeAllowedLimit(SolrQueryRequest req) {
-    // reduce by time already spent
-    long reqTimeAllowed = req.getParams().getLong(CommonParams.TIME_ALLOWED, -1L);
+    // original timeAllowed in milliseconds
+    reqTimeAllowedMs = req.getParams().getLong(CommonParams.TIME_ALLOWED, -1L);
 
-    if (reqTimeAllowed == -1L) {
+    if (reqTimeAllowedMs == -1L) {
       throw new IllegalArgumentException(
           "Check for limit with hasTimeLimit(req) before creating a TimeAllowedLimit");
     }
-    long timeAlreadySpent = (long) req.getRequestTimer().getTime();
-    long now = nanoTime();
-    long timeAllowed = reqTimeAllowed - timeAlreadySpent;
-    long nanosAllowed = TimeUnit.NANOSECONDS.convert(timeAllowed, TimeUnit.MILLISECONDS);
-    timeoutAt = now + nanosAllowed;
-    timingSince = now - timeAlreadySpent;
+    // time already spent locally before this limit was initialized, in milliseconds
+    long timeAlreadySpentMs = (long) req.getRequestTimer().getTime();
+    long parentUsedMs = req.getParams().getLong(USED_PARAM, -1L);
+    long inflightMs = DEFAULT_INFLIGHT_MS;
+    if (parentUsedMs != -1L) {
+      // this is a sub-request of a request that already had timeAllowed set.
+      // We have to deduct the time already used by the parent request.
+      // Also, arbitrarily add 1 ms to account for the fact that the parentUsedMs
+      // value was captured before the request was sent from the parent
+      inflightMs = req.getParams().getLong(INFLIGHT_PARAM, DEFAULT_INFLIGHT_MS);
+      log.debug("parentUsedMs: {}, inflightMs: {}", parentUsedMs, inflightMs);
+      timeAlreadySpentMs += parentUsedMs + inflightMs;
+    }
+    reqInflightMs = inflightMs;
+    long nowNs = nanoTime();
+    long remainingTimeAllowedMs = reqTimeAllowedMs - timeAlreadySpentMs;
+    log.debug("remainingTimeAllowedMs: {}", remainingTimeAllowedMs);
+    long remainingTimeAllowedNs = TimeUnit.MILLISECONDS.toNanos(remainingTimeAllowedMs);
+    timeoutAt = nowNs + remainingTimeAllowedNs;
+    timingSince = nowNs - TimeUnit.MILLISECONDS.toNanos(timeAlreadySpentMs);
+  }
+
+  @Override
+  public boolean adjustShardRequestLimit(ShardRequest sreq, String shard, ModifiableSolrParams params) {
+    long usedTimeAllowedMs = TimeUnit.NANOSECONDS.toMillis(nanoTime() - timingSince);
+    boolean result = false;
+    if (usedTimeAllowedMs >= reqTimeAllowedMs - reqInflightMs) {
+      // there's no point in sending this request to the shard because the time will run out
+      // before we get a response back
+      result = true;
+    }
+    params.set(USED_PARAM, Long.toString(usedTimeAllowedMs, 16));
+    log.debug("adjustShardRequestLimit: used {} ms (skip? {})", usedTimeAllowedMs, result);
+    return result;
   }
 
   /** Return true if the current request has a parameter with a valid value of the limit. */
@@ -69,6 +114,7 @@ public class TimeAllowedLimit implements QueryLimit {
     return timeoutAt - nanoTime() < 0L;
   }
 
+  /** Return elapsed time in nanoseconds since this limit was started. */
   @Override
   public Object currentValue() {
     return nanoTime() - timingSince;

--- a/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
@@ -74,7 +74,7 @@ public class TimeAllowedLimit implements QueryLimit {
     if (parentUsedMs != -1L) {
       // this is a sub-request of a request that already had timeAllowed set.
       // We have to deduct the time already used by the parent request.
-      // Also, arbitrarily add 1 ms to account for the fact that the parentUsedMs
+      // Also, add some in-flight time to account for the fact that the parentUsedMs
       // value was captured before the request was sent from the parent
       inflightMs = req.getParams().getLong(INFLIGHT_PARAM, DEFAULT_INFLIGHT_MS);
       log.debug("parentUsedMs: {}, inflightMs: {}", parentUsedMs, inflightMs);
@@ -95,7 +95,7 @@ public class TimeAllowedLimit implements QueryLimit {
     boolean result = false;
     if (usedTimeAllowedMs >= reqTimeAllowedMs - reqInflightMs) {
       // there's no point in sending this request to the shard because the time will run out
-      // before we get a response back
+      // before it's processed at the target
       result = true;
     }
     params.set(USED_PARAM, Long.toString(usedTimeAllowedMs, 16));

--- a/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
@@ -70,17 +70,15 @@ public class TimeAllowedLimit implements QueryLimit {
     // time already spent locally before this limit was initialized, in milliseconds
     long timeAlreadySpentMs = (long) req.getRequestTimer().getTime();
     long parentUsedMs = req.getParams().getLong(USED_PARAM, -1L);
-    long inflightMs = DEFAULT_INFLIGHT_MS;
+    reqInflightMs = req.getParams().getLong(INFLIGHT_PARAM, DEFAULT_INFLIGHT_MS);
     if (parentUsedMs != -1L) {
       // this is a sub-request of a request that already had timeAllowed set.
       // We have to deduct the time already used by the parent request.
       // Also, add some in-flight time to account for the fact that the parentUsedMs
       // value was captured before the request was sent from the parent
-      inflightMs = req.getParams().getLong(INFLIGHT_PARAM, DEFAULT_INFLIGHT_MS);
-      log.debug("parentUsedMs: {}, inflightMs: {}", parentUsedMs, inflightMs);
-      timeAlreadySpentMs += parentUsedMs + inflightMs;
+      log.debug("parentUsedMs: {}, inflightMs: {}", parentUsedMs, reqInflightMs);
+      timeAlreadySpentMs += parentUsedMs + reqInflightMs;
     }
-    reqInflightMs = inflightMs;
     long nowNs = nanoTime();
     long remainingTimeAllowedMs = reqTimeAllowedMs - timeAlreadySpentMs;
     log.debug("remainingTimeAllowedMs: {}", remainingTimeAllowedMs);
@@ -98,7 +96,7 @@ public class TimeAllowedLimit implements QueryLimit {
       // before it's processed at the target
       result = true;
     }
-    params.set(USED_PARAM, Long.toString(usedTimeAllowedMs, 16));
+    params.set(USED_PARAM, Long.toString(usedTimeAllowedMs));
     log.debug("adjustShardRequestLimit: used {} ms (skip? {})", usedTimeAllowedMs, result);
     return result;
   }

--- a/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
+++ b/solr/core/src/java/org/apache/solr/search/TimeAllowedLimit.java
@@ -33,9 +33,11 @@ import org.slf4j.LoggerFactory;
  * <strong><em>local</em></strong> processing of sub-queries in cases where the parent query already
  * has {@code timeAllowed} set. Essentially only one timeAllowed can be specified for any thread
  * executing a query. This is to ensure that subqueries don't escape from the intended limit.
- * <p>Distributed requests will approximately track the original starting point of the parent request.
- * Shard requests may be skipped if the limit would run out shortly after they are sent - this in-flight
- * allowance is determined by {@link #INFLIGHT_PARAM} in milliseconds, with the default value of {@link #DEFAULT_INFLIGHT_MS}.</p>
+ *
+ * <p>Distributed requests will approximately track the original starting point of the parent
+ * request. Shard requests may be skipped if the limit would run out shortly after they are sent -
+ * this in-flight allowance is determined by {@link #INFLIGHT_PARAM} in milliseconds, with the
+ * default value of {@link #DEFAULT_INFLIGHT_MS}.
  */
 public class TimeAllowedLimit implements QueryLimit {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -86,7 +88,8 @@ public class TimeAllowedLimit implements QueryLimit {
   }
 
   @Override
-  public boolean adjustShardRequestLimit(ShardRequest sreq, String shard, ModifiableSolrParams params) {
+  public boolean adjustShardRequestLimit(
+      ShardRequest sreq, String shard, ModifiableSolrParams params) {
     long usedTimeAllowedMs = TimeUnit.NANOSECONDS.toMillis(nanoTime() - timingSince);
     // increase by the expected in-flight time
     usedTimeAllowedMs += reqInflightMs;

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/requestfactory/TopGroupsShardRequestFactory.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/requestfactory/TopGroupsShardRequestFactory.java
@@ -132,12 +132,6 @@ public class TopGroupsShardRequestFactory implements ShardRequestFactory {
       sreq.params.set(CommonParams.FL, schema.getUniqueKeyField().getName());
     }
 
-    int origTimeAllowed = sreq.params.getInt(CommonParams.TIME_ALLOWED, -1);
-    if (origTimeAllowed > 0) {
-      sreq.params.set(
-          CommonParams.TIME_ALLOWED, Math.max(1, origTimeAllowed - rb.firstPhaseElapsedTime));
-    }
-
     return new ShardRequest[] {sreq};
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
+++ b/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
@@ -111,7 +111,20 @@ public class TestQueryLimits extends SolrCloudTestCase {
   public void testAdjustShardRequestLimits() throws Exception {
     SolrClient solrClient = cluster.getSolrClient();
     String timeAllowed = "500"; // ms
-    ModifiableSolrParams params = params("q", "id:*", "cache", "false", "group", "true", "group.field", "val_i", "timeAllowed", timeAllowed, "sleep", "100");
+    ModifiableSolrParams params =
+        params(
+            "q",
+            "id:*",
+            "cache",
+            "false",
+            "group",
+            "true",
+            "group.field",
+            "val_i",
+            "timeAllowed",
+            timeAllowed,
+            "sleep",
+            "100");
     QueryResponse rsp = solrClient.query(COLLECTION, params);
     assertNull("should have full results: " + rsp.jsonStr(), rsp.getHeader().get("partialResults"));
 
@@ -122,14 +135,24 @@ public class TestQueryLimits extends SolrCloudTestCase {
     // set a high skew to trigger skipping shard requests
     params.set(TimeAllowedLimit.INFLIGHT_PARAM, "50");
     QueryResponse rsp1 = solrClient.query(COLLECTION, params);
-    assertNotNull("should have partial results: " + rsp1.jsonStr(), rsp1.getHeader().get("partialResults"));
-    assertEquals("partialResults should be true", "true", rsp1.getHeader().get("partialResults").toString());
-    assertTrue("partialResultsDetails should contain 'skipped':" + rsp1.jsonStr(), rsp1.getHeader().get("partialResultsDetails").toString().contains("skipped"));
+    assertNotNull(
+        "should have partial results: " + rsp1.jsonStr(), rsp1.getHeader().get("partialResults"));
+    assertEquals(
+        "partialResults should be true", "true", rsp1.getHeader().get("partialResults").toString());
+    assertTrue(
+        "partialResultsDetails should contain 'skipped':" + rsp1.jsonStr(),
+        rsp1.getHeader().get("partialResultsDetails").toString().contains("skipped"));
 
     params.set(CommonParams.PARTIAL_RESULTS, false);
     QueryResponse rsp2 = solrClient.query(COLLECTION, params);
-    assertNotNull("should have partial results: " + rsp2.jsonStr(), rsp2.getHeader().get("partialResults"));
-    assertEquals("partialResults should be omitted: " + rsp2.jsonStr(), "omitted", rsp2.getHeader().get("partialResults").toString());
-    assertTrue("partialResultsDetails should contain 'skipped': " + rsp2.jsonStr(), rsp2.getHeader().get("partialResultsDetails").toString().contains("skipped"));
+    assertNotNull(
+        "should have partial results: " + rsp2.jsonStr(), rsp2.getHeader().get("partialResults"));
+    assertEquals(
+        "partialResults should be omitted: " + rsp2.jsonStr(),
+        "omitted",
+        rsp2.getHeader().get("partialResults").toString());
+    assertTrue(
+        "partialResultsDetails should contain 'skipped': " + rsp2.jsonStr(),
+        rsp2.getHeader().get("partialResultsDetails").toString().contains("skipped"));
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
+++ b/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
@@ -22,8 +22,11 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.ThreadCpuTimer;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -34,7 +37,7 @@ public class TestQueryLimits extends SolrCloudTestCase {
   @BeforeClass
   public static void setupCluster() throws Exception {
     System.setProperty(ThreadCpuTimer.ENABLE_CPU_TIME, "true");
-    configureCluster(1).addConfig("conf", configset("cloud-minimal")).configure();
+    configureCluster(4).addConfig("conf", configset("exitable-directory")).configure();
     SolrClient solrClient = cluster.getSolrClient();
     CollectionAdminRequest.Create create =
         CollectionAdminRequest.createCollection(COLLECTION, "conf", 3, 2);
@@ -52,6 +55,11 @@ public class TestQueryLimits extends SolrCloudTestCase {
               TestUtil.randomHtmlishString(random(), 100)));
     }
     solrClient.commit(COLLECTION);
+  }
+
+  @After
+  public void teardown() {
+    TestInjection.queryTimeout = null;
   }
 
   // TODO: add more tests and better assertions once SOLR-17151 / SOLR-17158 is done
@@ -97,5 +105,31 @@ public class TestQueryLimits extends SolrCloudTestCase {
       Map<String, Integer> callCounts = limit.getCallCounts();
       assertTrue("call count should be > 0", callCounts.get(matchingExpr) > 0);
     }
+  }
+
+  @Test
+  public void testAdjustShardRequestLimits() throws Exception {
+    SolrClient solrClient = cluster.getSolrClient();
+    String timeAllowed = "500"; // ms
+    ModifiableSolrParams params = params("q", "id:*", "cache", "false", "group", "true", "group.field", "val_i", "timeAllowed", timeAllowed, "sleep", "100");
+    QueryResponse rsp = solrClient.query(COLLECTION, params);
+    assertNull("should have full results: " + rsp.jsonStr(), rsp.getHeader().get("partialResults"));
+
+    // reduce timeAllowed to force partial results
+    params.set("timeAllowed", "100");
+    // pretend this is a request with some time already used
+    params.set(TimeAllowedLimit.USED_PARAM, "4");
+    // set a high skew to trigger skipping shard requests
+    params.set(TimeAllowedLimit.INFLIGHT_PARAM, "50");
+    QueryResponse rsp1 = solrClient.query(COLLECTION, params);
+    assertNotNull("should have partial results: " + rsp1.jsonStr(), rsp1.getHeader().get("partialResults"));
+    assertEquals("partialResults should be true", "true", rsp1.getHeader().get("partialResults").toString());
+    assertTrue("partialResultsDetails should contain 'skipped'", rsp1.getHeader().get("partialResultsDetails").toString().contains("skipped"));
+
+    params.set(CommonParams.PARTIAL_RESULTS, false);
+    QueryResponse rsp2 = solrClient.query(COLLECTION, params);
+    assertNotNull("should have partial results: " + rsp2.jsonStr(), rsp2.getHeader().get("partialResults"));
+    assertEquals("partialResults should be omitted", "omitted", rsp2.getHeader().get("partialResults").toString());
+    assertTrue("partialResultsDetails should contain 'skipped'", rsp2.getHeader().get("partialResultsDetails").toString().contains("skipped"));
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
+++ b/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
@@ -118,18 +118,18 @@ public class TestQueryLimits extends SolrCloudTestCase {
     // reduce timeAllowed to force partial results
     params.set("timeAllowed", "100");
     // pretend this is a request with some time already used
-    params.set(TimeAllowedLimit.USED_PARAM, "4");
+    params.set(TimeAllowedLimit.USED_PARAM, "60");
     // set a high skew to trigger skipping shard requests
     params.set(TimeAllowedLimit.INFLIGHT_PARAM, "50");
     QueryResponse rsp1 = solrClient.query(COLLECTION, params);
     assertNotNull("should have partial results: " + rsp1.jsonStr(), rsp1.getHeader().get("partialResults"));
     assertEquals("partialResults should be true", "true", rsp1.getHeader().get("partialResults").toString());
-    assertTrue("partialResultsDetails should contain 'skipped'", rsp1.getHeader().get("partialResultsDetails").toString().contains("skipped"));
+    assertTrue("partialResultsDetails should contain 'skipped':" + rsp1.jsonStr(), rsp1.getHeader().get("partialResultsDetails").toString().contains("skipped"));
 
     params.set(CommonParams.PARTIAL_RESULTS, false);
     QueryResponse rsp2 = solrClient.query(COLLECTION, params);
     assertNotNull("should have partial results: " + rsp2.jsonStr(), rsp2.getHeader().get("partialResults"));
-    assertEquals("partialResults should be omitted", "omitted", rsp2.getHeader().get("partialResults").toString());
-    assertTrue("partialResultsDetails should contain 'skipped'", rsp2.getHeader().get("partialResultsDetails").toString().contains("skipped"));
+    assertEquals("partialResults should be omitted: " + rsp2.jsonStr(), "omitted", rsp2.getHeader().get("partialResults").toString());
+    assertTrue("partialResultsDetails should contain 'skipped': " + rsp2.jsonStr(), rsp2.getHeader().get("partialResultsDetails").toString().contains("skipped"));
   }
 }

--- a/solr/solr-ref-guide/modules/query-guide/pages/common-query-parameters.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/common-query-parameters.adoc
@@ -382,6 +382,10 @@ As this check is periodically performed, the actual time for which a request can
 If the request consumes more time in other stages, custom components, etc., this parameter is not expected to abort the request.
 Regular search and the JSON Facet component abandon requests in accordance with this parameter.
 
+When `timeAllowed` is specified in a distributed and/or multi-phase search, sub-requests will approximately track the same
+wall clock starting point as the original request. Shard requests may be skipped if the limit would run out shortly after they are
+sent - this in-flight allowance can be set with the `timeAllowed.inflight` parameter in milliseconds (default is 2ms).
+
 == cpuAllowed Parameter
 
 [%autowidth,frame=none]


### PR DESCRIPTION
This implementation is inspired by the idea described by @gus-asf:

* parent request sends an additional parameter to the sub-requests to indicate the time already spent processing the parent req.
* sub-requests deduct this time from `timeAllowed`, and further decrease it by an approximate flight time (configurable)
* additional hook was added to the QueryLimit api to skip sending shard requests if the limit is likely to be reached when they arrive at the target replica. This api should be generic enough to allow us to discount other "used up" limits (cpu, mem) if we decide to do so for consistency.
