### PR TITLE
SOLR-17864: Migrate our variable to less problematic language

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/SolrZkServer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/SolrZkServer.java
@@ -40,7 +40,8 @@ import org.slf4j.LoggerFactory;
 public class SolrZkServer {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public static final String ZK_WHITELIST_PROPERTY = "zookeeper.4lw.commands.whitelist";
+  // We do not have control over how Zookeeper names it's properties.
+  public static final String ZK_ALLOWLIST_PROPERTY = "zookeeper.4lw.commands.whitelist";
 
   boolean zkRun = false;
   String zkHost;
@@ -138,8 +139,8 @@ public class SolrZkServer {
       return;
     }
 
-    if (System.getProperty(ZK_WHITELIST_PROPERTY) == null) {
-      System.setProperty(ZK_WHITELIST_PROPERTY, "ruok, mntr, conf");
+    if (EnvUtils.getProperty(ZK_ALLOWLIST_PROPERTY) == null) {
+      System.setProperty(ZK_ALLOWLIST_PROPERTY, "ruok, mntr, conf");
     }
     AtomicReference<Exception> zkException = new AtomicReference<>();
     zkThread =

--- a/solr/core/src/test/org/apache/solr/handler/admin/ZookeeperStatusHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ZookeeperStatusHandlerTest.java
@@ -118,7 +118,7 @@ public class ZookeeperStatusHandlerTest extends SolrCloudTestCase {
     when(zkStatusHandler.getZkRawResponse("zoo2:2181", "ruok")).thenReturn(Arrays.asList(""));
 
     when(zkStatusHandler.getZkRawResponse("zoo3:2181", "ruok")).thenReturn(Arrays.asList("imok"));
-    // Actual response from ZK if not whitelisted
+    // Actual response from ZK if not allow listed
     when(zkStatusHandler.getZkRawResponse("zoo3:2181", "mntr"))
         .thenReturn(Arrays.asList("mntr is not executed because it is not in the whitelist."));
     when(zkStatusHandler.getZkRawResponse("zoo3:2181", "conf"))

--- a/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.solr.cloud;
 
-import static org.apache.solr.cloud.SolrZkServer.ZK_WHITELIST_PROPERTY;
+import static org.apache.solr.cloud.SolrZkServer.ZK_ALLOWLIST_PROPERTY;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
@@ -43,6 +43,7 @@ import javax.management.JMException;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkNodeProps;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.ObjectReleaseTracker;
 import org.apache.solr.common.util.Utils;
@@ -540,7 +541,7 @@ public class ZkTestServer {
 
   public void run(boolean solrFormat) throws InterruptedException, IOException {
     log.info("STARTING ZK TEST SERVER");
-    ensureStatCommandWhitelisted();
+    ensureStatCommandAllowlisted();
 
     AtomicReference<Throwable> zooError = new AtomicReference<>();
     try {
@@ -863,26 +864,26 @@ public class ZkTestServer {
   }
 
   /** Ensure the {@link ClientBase} helper methods we want to use will work. */
-  private static void ensureStatCommandWhitelisted() {
+  private static void ensureStatCommandAllowlisted() {
     // Use this instead of hardcoding "stat" so we get compile error if ZK removes the command
     final String stat = FourLetterCommands.getCommandString(FourLetterCommands.statCmd);
     if (!FourLetterCommands.isEnabled(stat)) {
-      final String original = System.getProperty(ZK_WHITELIST_PROPERTY);
+      final String original = EnvUtils.getProperty(ZK_ALLOWLIST_PROPERTY);
       try {
         log.error(
             "ZkTestServer requires the 'stat' command, temporarily manipulating your whitelist");
-        System.setProperty(ZK_WHITELIST_PROPERTY, "*");
+        System.setProperty(ZK_ALLOWLIST_PROPERTY, "*");
         FourLetterCommands.resetWhiteList();
-        // This call to isEnabled should force ZK to "re-read" the system property in it's static
-        // vrs
+        // This call to isEnabled should force ZK to "re-read" the system property in its static
+        // variables
         assertTrue(
             "Temporary manipulation of ZK Whitelist didn't work?",
             FourLetterCommands.isEnabled(stat));
       } finally {
         if (null == original) {
-          System.clearProperty(ZK_WHITELIST_PROPERTY);
+          System.clearProperty(ZK_ALLOWLIST_PROPERTY);
         } else {
-          System.setProperty(ZK_WHITELIST_PROPERTY, original);
+          System.setProperty(ZK_ALLOWLIST_PROPERTY, original);
         }
       }
       assertTrue(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17864

Unfortunantly the underlying system property is defined by the Zookeeper project, so we can't change that.

I thought originally I could just use our EnvUtils and map the old name to the new name, but I don't think that will work.  So I just renamed the variable in Solr land..

Question: Does this indirection make the code harder to read and maybe not worth it?
