### PR TITLE
SOLR-17933: Remove DirectSolrConnection from test

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/TestIndexSearcher.java
+++ b/solr/core/src/test/org/apache/solr/search/TestIndexSearcher.java
@@ -35,7 +35,11 @@ import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.core.SolrCore;
@@ -44,9 +48,7 @@ import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.index.LogDocMergePolicyFactory;
 import org.apache.solr.request.SolrQueryRequest;
-import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.schema.SchemaField;
-import org.apache.solr.servlet.DirectSolrConnection;
 import org.apache.solr.util.plugin.SolrCoreAware;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -276,11 +278,10 @@ public class TestIndexSearcher extends SolrTestCaseJ4 {
   }
 
   private void doQuery(SolrCore core) throws Exception {
-    DirectSolrConnection connection = new DirectSolrConnection(core);
-    ModifiableSolrParams params = new ModifiableSolrParams();
-    params.add("q", "*:*");
-    assertTrue(
-        connection.request("/select", params, null).contains("<int name=\"status\">0</int>"));
+    EmbeddedSolrServer server = new EmbeddedSolrServer(core);
+    SolrQuery query = new SolrQuery("*:*");
+    QueryResponse response = server.query(query);
+    assertEquals(0, response.getStatus());
   }
 
   public void testDontUseColdSearcher() throws Exception {
@@ -421,9 +422,13 @@ public class TestIndexSearcher extends SolrTestCaseJ4 {
   }
 
   private void addDummyDoc(SolrCore core) throws Exception {
-    DirectSolrConnection connection = new DirectSolrConnection(core);
-    SolrRequestHandler handler = core.getRequestHandler("/update");
-    connection.request(handler, null, adoc("id", "1"));
+    EmbeddedSolrServer server = new EmbeddedSolrServer(core);
+
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.addField("id", "1");
+
+    UpdateResponse response = server.add(doc);
+    assertEquals(0, response.getStatus());
   }
 
   public static class MockSearchComponent extends SearchComponent implements SolrCoreAware {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17933

# Description
DirectSolrConnection is deprecated in favour of EmbeddedSolrServer.  This is a first stab at doing that migration for a simple test.


# Solution

Did a migration, but not totally sure I love it...   

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.
