### PR TITLE
Small cleanups SolrTestCaseHS

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetErrors.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetErrors.java
@@ -63,7 +63,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   }
 
   public void indexSimple(Client client) throws Exception {
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     client.add(
         sdoc(
             "id",
@@ -130,7 +130,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   }
 
   public void doTestErrors(Client client) throws Exception {
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     SolrException e =
         assertThrows(
@@ -150,7 +150,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   @Test
   public void testDomainErrors() throws Exception {
     Client client = Client.localClient();
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     indexSimple(client);
 
     // using assertQEx so that, status code and error message can be asserted
@@ -215,7 +215,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   @Test
   public void testRangeFacetsErrorCases() throws Exception {
     Client client = Client.localClient();
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     indexSimple(client);
 
     SolrParams params = params("q", "*:*", "rows", "0");
@@ -403,7 +403,7 @@ public class TestJsonFacetErrors extends SolrTestCaseHS {
   @Test
   public void testOtherErrorCases() throws Exception {
     Client client = Client.localClient();
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     indexSimple(client);
 
     // test for sort

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetRefinement.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetRefinement.java
@@ -512,7 +512,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
     final SolrClient c0 = clients.get(0);
     final SolrClient c1 = clients.get(1);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     int id = 0;
 
     // client 0 // shard1: A=1,B=1,C=2 ...
@@ -620,7 +620,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
     final SolrClient c0 = clients.get(0);
     final SolrClient c1 = clients.get(1);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     int id = 0;
 
     // all_ss is only used for sub-faceting...
@@ -951,7 +951,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
     final SolrClient c0 = clients.get(0);
     final SolrClient c1 = clients.get(1);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     int id = 0;
 
     c0.add(sdoc("id", id++, "cat_s", "Ax"));
@@ -1022,7 +1022,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
     final SolrClient c0 = clients.get(0);
     final SolrClient c1 = clients.get(1);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     int id = 0;
 
     // client 0 // shard1
@@ -1237,7 +1237,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
     List<SolrClient> clients = client.getClientProvider().all();
     assertTrue(clients.size() >= 3);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     String cat_s = p.get("cat_s");
     String cat_i = p.get("cat_i"); // just like cat_s, but a number
@@ -1998,7 +1998,7 @@ public class TestJsonFacetRefinement extends SolrTestCaseHS {
     final SolrClient c1 = clients.get(1);
     final SolrClient c2 = clients.get(2);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     int id = 0;
 
     c0.add(sdoc("id", id++, "cat_s", "Z", "price_i", 10));

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -159,7 +159,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
     String make_s = m.expand("${make_s}");
     String model_s = m.expand("${model_s}");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     int nDocs = 99;
     String[] makes = {"honda", "toyota", "ford", null};
@@ -263,7 +263,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   }
 
   public void indexSimple(Client client) throws Exception {
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     client.add(
         sdoc(
             "id",
@@ -326,7 +326,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
 
   public void testMultiValuedBucketReHashing() throws Exception {
     Client client = Client.localClient();
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     // we want a domain with a small number of documents, and more facet (point) values then docs so
     // that we force dvhash to increase the number of slots via resize...
     // (NOTE: normal resizing won't happen w/o at least 1024 slots, but test static overrides this
@@ -1202,7 +1202,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   public void testNestedJoinDomain() throws Exception {
     Client client = Client.localClient();
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     client.add(
         sdoc(
             "id", "1", "1_s", "A", "2_s", "A", "3_s", "C", "y_s", "B", "x_t", "x   z", "z_t",
@@ -1768,7 +1768,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
     String multi_ss = m.expand("${multi_ss}");
     String sparse_num_d = m.expand("${sparse_num_d}");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     /* This code was not needed yet, but may be needed if we want to force empty shard results more often.
     // create a new indexing client that doesn't use one shard to better test for empty or non-existent results
@@ -3785,7 +3785,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   public void doTestPrelimSorting(
       final Client client, final boolean extraAgg, final boolean extraSubFacet) throws Exception {
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     List<SolrClient> clients = client.getClientProvider().all();
 
@@ -4319,7 +4319,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
     List<SolrClient> clients = client.getClientProvider().all();
     assertTrue(clients.size() >= 3);
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     ModifiableSolrParams p = params("cat_s", "cat_s");
     String cat_s = p.get("cat_s");
@@ -4381,7 +4381,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
     String cat_s = m.expand("${cat_s}");
     String where_s = m.expand("${where_s}");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     Random r = new Random(0); // make deterministic
     int numCat = 1;
@@ -4520,7 +4520,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
   public void doBlockJoin(Client client) throws Exception {
     ModifiableSolrParams p = params("rows", "0");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     SolrInputDocument parent;
     parent = sdoc("id", "1", "type_s", "book", "book_s", "A", "v_t", "q");
@@ -4650,7 +4650,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
 
     final SolrParams p = params("rows", "0");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     SolrInputDocument parent;
     parent = sdoc("id", "1", "type_s", "book", "book_s", "A", "v_t", "q");
@@ -4732,7 +4732,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
 
     final SolrParams p = params("rows", "0");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     // build up a list of the docs we want to test with
     List<SolrInputDocument> docsToAdd = new ArrayList<>(10);
@@ -4914,7 +4914,7 @@ public class TestJsonFacets extends SolrTestCaseHS {
 
     final SolrParams p = params("rows", "0");
 
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     List<SolrInputDocument> docsToAdd = new ArrayList<>(6);
     docsToAdd.add(sdoc("id", "1", "severity_mv", "Not Available", "severity_mv", "Low"));

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetsWithNestedObjects.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetsWithNestedObjects.java
@@ -42,7 +42,7 @@ public class TestJsonFacetsWithNestedObjects extends SolrTestCaseHS {
   }
 
   private static void indexDocs(final Client client) throws Exception {
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
 
     SolrInputDocument book1 =
         sdoc(

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonRangeFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonRangeFacets.java
@@ -63,7 +63,7 @@ public class TestJsonRangeFacets extends SolrTestCaseHS {
   }
 
   public void indexSimple(Client client) throws Exception {
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     client.add(
         sdoc(
             "id",
@@ -248,7 +248,7 @@ public class TestJsonRangeFacets extends SolrTestCaseHS {
 
   private void doDateFacets(Client client) throws Exception {
     client.queryDefaults().set("cache", cache);
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     boolean multiValue = random().nextBoolean();
     String dateField = multiValue ? "b_dts" : "b_dt";
     String dateRange = multiValue ? "b_drfs" : "b_drf";
@@ -376,7 +376,7 @@ public class TestJsonRangeFacets extends SolrTestCaseHS {
 
   private void doRangeFacetWithRanges(Client client) throws Exception {
     client.queryDefaults().set("cache", cache);
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     indexSimple(client);
 
     final SolrParams p = params("q", "*:*", "rows", "0");
@@ -461,7 +461,7 @@ public class TestJsonRangeFacets extends SolrTestCaseHS {
 
   private void doRangeFacetWithRangesInNewFormat(Client client) throws Exception {
     client.queryDefaults().set("cache", cache);
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     indexSimple(client);
     SolrParams p = params("q", "*:*", "rows", "0");
 

--- a/solr/core/src/test/org/apache/solr/search/json/TestJsonRequest.java
+++ b/solr/core/src/test/org/apache/solr/search/json/TestJsonRequest.java
@@ -864,7 +864,7 @@ public class TestJsonRequest extends SolrTestCaseHS {
   }
 
   private static void addDocs(Client client) throws Exception {
-    client.deleteByQuery("*:*", null);
+    client.deleteByQuery("*:*");
     client.add(sdoc("id", "1", "cat_s", "A", "where_s", "NY"), null);
     client.add(sdoc("id", "2", "cat_s", "B", "where_s", "NJ"), null);
     client.add(sdoc("id", "3"), null);

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
@@ -306,15 +306,14 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
       }
     }
 
-    public void deleteByQuery(String query, ModifiableSolrParams params)
-        throws IOException, SolrServerException {
+    public void deleteByQuery(String query) throws IOException, SolrServerException {
       if (local()) {
-        assertU(delQ(query)); // todo - handle extra params
+        assertU(delQ(query));
         return;
       }
 
       for (SolrClient client : provider.all()) {
-        client.deleteByQuery(query); // todo - handle extra params
+        client.deleteByQuery(query);
       }
     }
   }

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
@@ -25,14 +25,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
-import java.util.Set;
 import javax.xml.xpath.XPathExpressionException;
 import org.apache.lucene.util.IOUtils;
 import org.apache.solr.client.solrj.SolrClient;
@@ -50,14 +47,11 @@ import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.embedded.JettyConfig;
 import org.apache.solr.embedded.JettySolrRunner;
-import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.security.AllowListUrlChecker;
 import org.apache.solr.servlet.DirectSolrConnection;
 import org.apache.solr.util.TestHarness;
-import org.noggit.JSONUtil;
-import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,15 +60,6 @@ import org.slf4j.LoggerFactory;
 public class SolrTestCaseHS extends SolrTestCaseJ4 {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  @SafeVarargs
-  public static <T> Set<T> set(T... a) {
-    LinkedHashSet<T> s = new LinkedHashSet<>();
-    for (T t : a) {
-      s.add(t);
-    }
-    return s;
-  }
 
   @SuppressWarnings({"unchecked"})
   public static <T> T rand(T... vals) {
@@ -102,45 +87,6 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
       }
     }
     return result;
-  }
-
-  @SuppressWarnings({"unchecked"})
-  public static Object createDocObjects(
-      @SuppressWarnings({"rawtypes"}) Map<Comparable, Doc> fullModel,
-      @SuppressWarnings({"rawtypes"}) Comparator sort,
-      int rows,
-      Collection<String> fieldNames) {
-    List<Doc> docList = new ArrayList<>(fullModel.values());
-    docList.sort(sort);
-    @SuppressWarnings({"rawtypes"})
-    List sortedDocs = new ArrayList(rows);
-    for (Doc doc : docList) {
-      if (sortedDocs.size() >= rows) break;
-      Map<String, Object> odoc = toObject(doc, h.getCore().getLatestSchema(), fieldNames);
-      sortedDocs.add(toObject(doc, h.getCore().getLatestSchema(), fieldNames));
-    }
-    return sortedDocs;
-  }
-
-  public static void compare(
-      SolrQueryRequest req,
-      String path,
-      Object model,
-      @SuppressWarnings({"rawtypes"}) Map<Comparable, Doc> fullModel)
-      throws Exception {
-    String strResponse = h.query(req);
-
-    Object realResponse = ObjectBuilder.fromJSON(strResponse);
-    String err = JSONTestUtil.matchObj(path, realResponse, model);
-    if (err != null) {
-      String msg = "RESPONSE MISMATCH: {}\n\trequest={}\n\tresult={}\n\texpected={}\n\tmodel={}";
-      log.error(msg, err, req, strResponse, JSONUtil.toJSON(model), fullModel);
-
-      // re-execute the request... good for putting a breakpoint here for debugging
-      String rsp = h.query(req);
-
-      fail(err);
-    }
   }
 
   /** Pass "null" for the client to query the local server */
@@ -207,12 +153,6 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
         }
       }
     }
-  }
-
-  public static void clearQueryCache() {
-    SolrQueryRequest req = req();
-    req.getSearcher();
-    req.close();
   }
 
   public static String getQueryResponse(SolrClient client, String wt, SolrParams params)
@@ -539,14 +479,6 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
       Path subHome = dstRoot.resolve(destCollection).resolve("conf");
       Path top = SolrTestCaseJ4.TEST_PATH().resolve("collection1").resolve("conf");
       Files.copy(top.resolve(file), subHome.resolve(file));
-    }
-
-    public void copyConfigFile(Path dstRoot, String destCollection, String file) throws Exception {
-      if (!homeCreated) {
-        createHome();
-      }
-
-      SolrInstance.copyConfFile(dstRoot, destCollection, file);
     }
   }
 


### PR DESCRIPTION

# Description

While migrating the use of NoOpResponseParser I noticed that quite a few methods in SolrTestCaseHS are NOT used.    

In fact, there may be an opportunity to collapse it back into SolrTestCaseJ4 or maybe take the best of both, but that would be more ambitious.


# Solution

Removed unused methods and polished up a few variables.   I didn't do the whole deprecation thing since I don't think we recommend folks use SolrTestCaseHS in any type of external testing, it's pretty much only used by the Json faceting tests, and shouldn't be used.

# Tests

Just rerunning existing tests that extend SolrTestCaseHS.
