### PR TITLE
SOLR-17880: Migrate SolrClientNodeStateProvider and NodeValueFetcher to OTEL

### DIFF
--- a/solr/core/src/java/org/apache/solr/cluster/placement/Metric.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/Metric.java
@@ -36,4 +36,31 @@ public interface Metric<T> {
    * @return converted value
    */
   T convert(Object value);
+
+  /**
+   * Return the label key for Prometheus metrics filtering, if any.
+   *
+   * @return label key or null if no label filtering is needed
+   */
+  default String getLabelKey() {
+    return null;
+  }
+
+  /**
+   * Return the label value for Prometheus metrics filtering, if any.
+   *
+   * @return label value or null if no label filtering is needed
+   */
+  default String getLabelValue() {
+    return null;
+  }
+
+  /**
+   * Return true if this metric has label filtering.
+   *
+   * @return true if both label key and value are non-null
+   */
+  default boolean hasLabels() {
+    return getLabelKey() != null && getLabelValue() != null;
+  }
 }

--- a/solr/core/src/java/org/apache/solr/cluster/placement/NodeMetric.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/NodeMetric.java
@@ -17,30 +17,40 @@
 
 package org.apache.solr.cluster.placement;
 
+import org.apache.solr.client.solrj.impl.NodeValueFetcher;
+import org.apache.solr.cluster.placement.impl.MetricImpl;
+import org.apache.solr.cluster.placement.impl.NodeMetricImpl;
+
 /**
- * Node metric identifier, corresponding to a node-level metric registry and the internal metric
- * name.
+ * Node metric identifier, corresponding to a node-level metric name with optional labels for metric
  */
 public interface NodeMetric<T> extends Metric<T> {
+  /** Total disk space in GB. */
+  NodeMetricImpl<Double> TOTAL_DISK_GB =
+      new NodeMetricImpl<>(
+          "totalDisk",
+          "solr_disk_space_bytes",
+          "type",
+          "total_space",
+          MetricImpl.BYTES_TO_GB_CONVERTER);
 
-  /**
-   * Metric registry. If this metric identifier uses a fully-qualified metric key instead, then this
-   * method will return {@link Registry#UNSPECIFIED}.
-   */
-  Registry getRegistry();
+  /** Free (usable) disk space in GB. */
+  NodeMetricImpl<Double> FREE_DISK_GB =
+      new NodeMetricImpl<>(
+          "freeDisk",
+          "solr_disk_space_bytes",
+          "type",
+          "usable_space",
+          MetricImpl.BYTES_TO_GB_CONVERTER);
 
-  /** Registry options for node metrics. */
-  enum Registry {
-    /** corresponds to solr.node */
-    SOLR_NODE,
-    /** corresponds to solr.jvm */
-    SOLR_JVM,
-    /** corresponds to solr.jetty */
-    SOLR_JETTY,
-    /**
-     * In case when the registry name is not relevant (eg. a fully-qualified metric key was provided
-     * as the metric name).
-     */
-    UNSPECIFIED
-  }
+  /** Number of all cores. */
+  NodeMetricImpl<Integer> NUM_CORES = new NodeMetricImpl<>(NodeValueFetcher.CORES);
+
+  /** System load average. */
+  NodeMetricImpl<Double> SYSLOAD_AVG =
+      new NodeMetricImpl<>("sysLoadAvg", "jvm_system_cpu_utilization_ratio");
+
+  //  /** Number of available processors. */
+  NodeMetricImpl<Integer> AVAILABLE_PROCESSORS =
+      new NodeMetricImpl<>("availableProcessors", "jvm_cpu_count");
 }

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/NodeMetricImpl.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/NodeMetricImpl.java
@@ -17,70 +17,31 @@
 
 package org.apache.solr.cluster.placement.impl;
 
-import java.util.Objects;
 import java.util.function.Function;
-import org.apache.solr.client.solrj.impl.NodeValueFetcher;
 import org.apache.solr.cluster.placement.NodeMetric;
 
-/**
- * Node metric identifier, corresponding to a node-level metric registry and the internal metric
- * name.
- */
+/** Node metric identifier, corresponding to a node-level metric name with labels */
 public class NodeMetricImpl<T> extends MetricImpl<T> implements NodeMetric<T> {
 
-  /** Total disk space in GB. */
-  public static final NodeMetricImpl<Double> TOTAL_DISK_GB =
-      new NodeMetricImpl<>(
-          "totalDisk", Registry.SOLR_NODE, "CONTAINER.fs.totalSpace", BYTES_TO_GB_CONVERTER);
+  public NodeMetricImpl(String name, String internalName) {
+    this(name, internalName, null);
+  }
 
-  /** Free (usable) disk space in GB. */
-  public static final NodeMetricImpl<Double> FREE_DISK_GB =
-      new NodeMetricImpl<>(
-          "freeDisk", Registry.SOLR_NODE, "CONTAINER.fs.usableSpace", BYTES_TO_GB_CONVERTER);
-
-  /** Number of all cores. */
-  public static final NodeMetricImpl<Integer> NUM_CORES =
-      new NodeMetricImpl<>(NodeValueFetcher.CORES);
-
-  public static final NodeMetricImpl<Double> HEAP_USAGE =
-      new NodeMetricImpl<>(NodeValueFetcher.Tags.HEAPUSAGE.tagName);
-
-  /** System load average. */
-  public static final NodeMetricImpl<Double> SYSLOAD_AVG =
-      new NodeMetricImpl<>(
-          NodeValueFetcher.Tags.SYSLOADAVG.tagName,
-          Registry.SOLR_JVM,
-          NodeValueFetcher.Tags.SYSLOADAVG.prefix);
-
-  /** Number of available processors. */
-  public static final NodeMetricImpl<Integer> AVAILABLE_PROCESSORS =
-      new NodeMetricImpl<>("availableProcessors", Registry.SOLR_JVM, "os.availableProcessors");
-
-  private final Registry registry;
-
-  public NodeMetricImpl(String name, Registry registry, String internalName) {
-    this(name, registry, internalName, null);
+  public NodeMetricImpl(String name, String internalName, Function<Object, T> converter) {
+    super(name, internalName, converter);
   }
 
   public NodeMetricImpl(
-      String name, Registry registry, String internalName, Function<Object, T> converter) {
-    super(name, internalName, converter);
-    Objects.requireNonNull(registry);
-    this.registry = registry;
+      String name,
+      String internalName,
+      String labelKey,
+      String labelValue,
+      Function<Object, T> converter) {
+    super(name, internalName, converter, labelKey, labelValue);
   }
 
   public NodeMetricImpl(String key) {
-    this(key, null);
-  }
-
-  public NodeMetricImpl(String key, Function<Object, T> converter) {
-    super(key, key, converter);
-    this.registry = Registry.UNSPECIFIED;
-  }
-
-  @Override
-  public Registry getRegistry() {
-    return registry;
+    super(key, key);
   }
 
   @Override
@@ -88,37 +49,19 @@ public class NodeMetricImpl<T> extends MetricImpl<T> implements NodeMetric<T> {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof NodeMetricImpl<?> that)) {
+    if (!(o instanceof NodeMetricImpl<?>)) {
       return false;
     }
-    if (!super.equals(o)) {
-      return false;
-    }
-    return registry == that.registry;
+    return super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), registry);
+    return super.hashCode();
   }
 
   @Override
   public String toString() {
-    if (registry != null) {
-      return "NodeMetricImpl{"
-          + "name='"
-          + name
-          + '\''
-          + ", internalName='"
-          + internalName
-          + '\''
-          + ", converter="
-          + converter
-          + ", registry="
-          + registry
-          + '}';
-    } else {
-      return "NodeMetricImpl{key=" + internalName + "}";
-    }
+    return "NodeMetricImpl{key=" + getInternalName() + "," + labelKey + "=" + labelValue + "}";
   }
 }

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/ReplicaMetricImpl.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/ReplicaMetricImpl.java
@@ -24,18 +24,9 @@ import org.apache.solr.cluster.placement.ReplicaMetric;
  * reported in <code>solr.core.[collection].[replica]</code> registry)
  */
 public class ReplicaMetricImpl<T> extends MetricImpl<T> implements ReplicaMetric<T> {
-
   /** Replica index size in GB. */
   public static final ReplicaMetricImpl<Double> INDEX_SIZE_GB =
-      new ReplicaMetricImpl<>("sizeGB", "INDEX.sizeInBytes", BYTES_TO_GB_CONVERTER);
-
-  /** 1-min query rate of the /select handler. */
-  public static final ReplicaMetricImpl<Double> QUERY_RATE_1MIN =
-      new ReplicaMetricImpl<>("queryRate", "QUERY./select.requestTimes:1minRate");
-
-  /** 1-min update rate of the /update handler. */
-  public static final ReplicaMetricImpl<Double> UPDATE_RATE_1MIN =
-      new ReplicaMetricImpl<>("updateRate", "UPDATE./update.requestTimes:1minRate");
+      new ReplicaMetricImpl<>("sizeGB", "solr_core_index_size_bytes", BYTES_TO_GB_CONVERTER);
 
   public ReplicaMetricImpl(String name, String internalName) {
     super(name, internalName);

--- a/solr/core/src/java/org/apache/solr/cluster/placement/plugins/MinimizeCoresPlacementFactory.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/MinimizeCoresPlacementFactory.java
@@ -25,11 +25,11 @@ import org.apache.solr.cluster.Replica;
 import org.apache.solr.cluster.SolrCollection;
 import org.apache.solr.cluster.placement.AttributeFetcher;
 import org.apache.solr.cluster.placement.AttributeValues;
+import org.apache.solr.cluster.placement.NodeMetric;
 import org.apache.solr.cluster.placement.PlacementContext;
 import org.apache.solr.cluster.placement.PlacementException;
 import org.apache.solr.cluster.placement.PlacementPlugin;
 import org.apache.solr.cluster.placement.PlacementPluginFactory;
-import org.apache.solr.cluster.placement.impl.NodeMetricImpl;
 
 /**
  * Factory for creating {@link MinimizeCoresPlacementPlugin}, a Placement plugin implementing
@@ -60,19 +60,18 @@ public class MinimizeCoresPlacementFactory
         throws PlacementException {
       // Fetch attributes for a superset of all nodes requested amongst the placementRequests
       AttributeFetcher attributeFetcher = placementContext.getAttributeFetcher();
-      attributeFetcher.requestNodeMetric(NodeMetricImpl.NUM_CORES);
+      attributeFetcher.requestNodeMetric(NodeMetric.NUM_CORES);
       attributeFetcher.fetchFrom(nodes);
       AttributeValues attrValues = attributeFetcher.fetchAttributes();
       HashMap<Node, WeightedNode> nodeMap = new HashMap<>();
       for (Node node : nodes) {
-        if (skipNodesWithErrors
-            && attrValues.getNodeMetric(node, NodeMetricImpl.NUM_CORES).isEmpty()) {
+        if (skipNodesWithErrors && attrValues.getNodeMetric(node, NodeMetric.NUM_CORES).isEmpty()) {
           throw new PlacementException("Can't get number of cores in " + node);
         }
         nodeMap.put(
             node,
             new NodeWithCoreCount(
-                node, attrValues.getNodeMetric(node, NodeMetricImpl.NUM_CORES).orElse(0)));
+                node, attrValues.getNodeMetric(node, NodeMetric.NUM_CORES).orElse(0)));
       }
 
       return nodeMap;

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -930,27 +930,6 @@ public class CoreContainer {
     // initialize gauges for reporting the number of cores and disk total/free
     solrCores.initializeMetrics(solrMetricsContext, containerAttrs, "");
 
-    // NOCOMMIT: Can't remove these without impacting node state reporting
-    // until NodeValueFetcher and SolrClientNodeStateProvider are patched
-    solrMetricsContext.gauge(
-        solrCores::getNumLoadedPermanentCores,
-        true,
-        "loaded",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "cores");
-    solrMetricsContext.gauge(
-        solrCores::getNumLoadedTransientCores,
-        true,
-        "lazy",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "cores");
-    solrMetricsContext.gauge(
-        solrCores::getNumUnloadedCores,
-        true,
-        "unloaded",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "cores");
-
     Path dataHome =
         cfg.getSolrDataHome() != null ? cfg.getSolrDataHome() : cfg.getCoreRootDirectory();
 
@@ -975,95 +954,6 @@ public class CoreContainer {
         },
         OtelUnit.BYTES);
 
-    // NOCOMMIT: Can't remove these without impacting node state reporting
-    // until NodeValueFetcher and SolrClientNodeStateProvider are patched
-    solrMetricsContext.gauge(
-        () -> {
-          try {
-            return Files.getFileStore(dataHome).getTotalSpace();
-          } catch (IOException e) {
-            throw new SolrException(
-                ErrorCode.SERVER_ERROR,
-                "Error retrieving total space for data home directory" + dataHome,
-                e);
-          }
-        },
-        true,
-        "totalSpace",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "fs");
-
-    solrMetricsContext.gauge(
-        () -> {
-          try {
-            return Files.getFileStore(dataHome).getUsableSpace();
-          } catch (IOException e) {
-            throw new SolrException(
-                ErrorCode.SERVER_ERROR,
-                "Error retrieving usable space for data home directory" + dataHome,
-                e);
-          }
-        },
-        true,
-        "usableSpace",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "fs");
-    solrMetricsContext.gauge(
-        dataHome::toString, true, "path", SolrInfoBean.Category.CONTAINER.toString(), "fs");
-    solrMetricsContext.gauge(
-        () -> {
-          try {
-            return Files.getFileStore(cfg.getCoreRootDirectory()).getTotalSpace();
-          } catch (IOException e) {
-            throw new SolrException(
-                SolrException.ErrorCode.SERVER_ERROR,
-                "Error retrieving total space for core root directory: "
-                    + cfg.getCoreRootDirectory(),
-                e);
-          }
-        },
-        true,
-        "totalSpace",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "fs",
-        "coreRoot");
-    solrMetricsContext.gauge(
-        () -> {
-          try {
-            return Files.getFileStore(cfg.getCoreRootDirectory()).getUsableSpace();
-          } catch (IOException e) {
-            throw new SolrException(
-                SolrException.ErrorCode.SERVER_ERROR,
-                "Error retrieving usable space for core root directory: "
-                    + cfg.getCoreRootDirectory(),
-                e);
-          }
-        },
-        true,
-        "usableSpace",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "fs",
-        "coreRoot");
-    solrMetricsContext.gauge(
-        () -> cfg.getCoreRootDirectory().toString(),
-        true,
-        "path",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "fs",
-        "coreRoot");
-    // add version information
-    solrMetricsContext.gauge(
-        () -> this.getClass().getPackage().getSpecificationVersion(),
-        true,
-        "specification",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "version");
-    solrMetricsContext.gauge(
-        () -> this.getClass().getPackage().getImplementationVersion(),
-        true,
-        "implementation",
-        SolrInfoBean.Category.CONTAINER.toString(),
-        "version");
     SolrFieldCacheBean fieldCacheBean = new SolrFieldCacheBean();
     fieldCacheBean.initializeMetrics(
         solrMetricsContext,

--- a/solr/core/src/java/org/apache/solr/metrics/otel/FilterablePrometheusMetricReader.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/FilterablePrometheusMetricReader.java
@@ -42,7 +42,7 @@ public class FilterablePrometheusMetricReader extends PrometheusMetricReader {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final Set<String> PROM_SUFFIXES =
-      Set.of("_total", "_sum", "_count", "_bucket", "_gcount", "_gsum", "_created", "_info");
+      Set.of("_total", "_sum", "_bucket", "_created", "_info");
 
   public FilterablePrometheusMetricReader(
       boolean otelScopeEnabled, Predicate<String> allowedResourceAttributesFilter) {

--- a/solr/core/src/test/org/apache/solr/cluster/placement/impl/PlacementPluginIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/impl/PlacementPluginIntegrationTest.java
@@ -82,8 +82,9 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
 
   @BeforeClass
   public static void setupCluster() throws Exception {
-    // placement plugins need metrics
+    // placement plugins need metrics and JVM metrics
     System.setProperty("metricsEnabled", "true");
+    System.setProperty("solr.metrics.jvm.enabled", "true");
     configureCluster(3).addConfig("conf", configset("cloud-minimal")).configure();
     cc = cluster.getJettySolrRunner(0).getCoreContainer();
     cloudManager = cc.getZkController().getSolrCloudManager();
@@ -388,7 +389,6 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
   // NOCOMMIT: This test fails because of CollectionMetricsBuilder. Need to dive deeper into what
   // this is and if we need to shim otel into this metrics map.
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-17458")
   public void testNodeTypeIntegration() throws Exception {
     // this functionality relies on System.getProperty which we cannot set on individual
     // nodes in a mini cluster.
@@ -440,9 +440,7 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
     System.clearProperty(AffinityPlacementConfig.NODE_TYPE_SYSPROP);
   }
 
-  // NOCOMMIT: This test needs to be fixed after migrating the collection metrics builder
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-17458")
   public void testAttributeFetcherImpl() throws Exception {
     CollectionAdminResponse rsp =
         CollectionAdminRequest.createCollection(COLLECTION, "conf", 2, 2)
@@ -452,51 +450,35 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
     Cluster cluster = new SimpleClusterAbstractionsImpl.ClusterImpl(cloudManager);
     SolrCollection collection = cluster.getCollection(COLLECTION);
     AttributeFetcher attributeFetcher = new AttributeFetcherImpl(cloudManager);
-    NodeMetric<String> someMetricKey = new NodeMetricImpl<>("solr.jvm:system.properties:user.name");
     String sysprop = "user.name";
     attributeFetcher
         .fetchFrom(cluster.getLiveNodes())
-        .requestNodeMetric(NodeMetricImpl.HEAP_USAGE)
-        .requestNodeMetric(NodeMetricImpl.SYSLOAD_AVG)
-        .requestNodeMetric(NodeMetricImpl.NUM_CORES)
-        .requestNodeMetric(NodeMetricImpl.FREE_DISK_GB)
-        .requestNodeMetric(NodeMetricImpl.TOTAL_DISK_GB)
-        .requestNodeMetric(NodeMetricImpl.AVAILABLE_PROCESSORS)
-        .requestNodeMetric(someMetricKey)
+        .requestNodeMetric(NodeMetric.SYSLOAD_AVG)
+        .requestNodeMetric(NodeMetric.NUM_CORES)
+        .requestNodeMetric(NodeMetric.FREE_DISK_GB)
+        .requestNodeMetric(NodeMetric.TOTAL_DISK_GB)
+        .requestNodeMetric(NodeMetric.AVAILABLE_PROCESSORS)
         .requestNodeSystemProperty(sysprop)
-        .requestCollectionMetrics(
-            collection,
-            Set.of(
-                ReplicaMetricImpl.INDEX_SIZE_GB,
-                ReplicaMetricImpl.QUERY_RATE_1MIN,
-                ReplicaMetricImpl.UPDATE_RATE_1MIN));
+        .requestCollectionMetrics(collection, Set.of(ReplicaMetricImpl.INDEX_SIZE_GB));
     AttributeValues attributeValues = attributeFetcher.fetchAttributes();
     String userName = System.getProperty("user.name");
     // node metrics
     for (Node node : cluster.getLiveNodes()) {
-      Optional<Double> doubleOpt = attributeValues.getNodeMetric(node, NodeMetricImpl.HEAP_USAGE);
-      assertTrue("heap usage", doubleOpt.isPresent());
-      assertTrue(
-          "heap usage should be 0 < heapUsage < 100 but was " + doubleOpt,
-          doubleOpt.get() > 0 && doubleOpt.get() < 100);
-      doubleOpt = attributeValues.getNodeMetric(node, NodeMetricImpl.TOTAL_DISK_GB);
+      Optional<Double> doubleOpt = attributeValues.getNodeMetric(node, NodeMetric.TOTAL_DISK_GB);
       assertTrue("total disk", doubleOpt.isPresent());
       assertTrue("total disk should be > 0 but was " + doubleOpt, doubleOpt.get() > 0);
-      doubleOpt = attributeValues.getNodeMetric(node, NodeMetricImpl.FREE_DISK_GB);
+      doubleOpt = attributeValues.getNodeMetric(node, NodeMetric.FREE_DISK_GB);
       assertTrue("free disk", doubleOpt.isPresent());
       assertTrue("free disk should be > 0 but was " + doubleOpt, doubleOpt.get() > 0);
-      Optional<Integer> intOpt = attributeValues.getNodeMetric(node, NodeMetricImpl.NUM_CORES);
+      Optional<Integer> intOpt = attributeValues.getNodeMetric(node, NodeMetric.NUM_CORES);
       assertTrue("cores", intOpt.isPresent());
       assertTrue("cores should be > 0", intOpt.get() > 0);
       assertTrue(
           "systemLoadAverage 2",
-          attributeValues.getNodeMetric(node, NodeMetricImpl.SYSLOAD_AVG).isPresent());
+          attributeValues.getNodeMetric(node, NodeMetric.SYSLOAD_AVG).isPresent());
       assertTrue(
           "availableProcessors",
-          attributeValues.getNodeMetric(node, NodeMetricImpl.AVAILABLE_PROCESSORS).isPresent());
-      Optional<String> userNameOpt = attributeValues.getNodeMetric(node, someMetricKey);
-      assertTrue("user.name", userNameOpt.isPresent());
-      assertEquals("userName", userName, userNameOpt.get());
+          attributeValues.getNodeMetric(node, NodeMetric.AVAILABLE_PROCESSORS).isPresent());
       Optional<String> syspropOpt = attributeValues.getSystemProperty(node, sysprop);
       assertTrue("sysprop", syspropOpt.isPresent());
       assertEquals("user.name sysprop", userName, syspropOpt.get());
@@ -528,13 +510,6 @@ public class PlacementPluginIntegrationTest extends SolrCloudTestCase {
                         assertTrue(
                             "indexSize should be < 0.01 but was " + indexSizeOpt.get(),
                             indexSizeOpt.get() < 0.01);
-
-                        assertNotNull(
-                            "queryRate",
-                            replicaMetrics.getReplicaMetric(ReplicaMetricImpl.QUERY_RATE_1MIN));
-                        assertNotNull(
-                            "updateRate",
-                            replicaMetrics.getReplicaMetric(ReplicaMetricImpl.UPDATE_RATE_1MIN));
                       });
             });
   }

--- a/solr/core/src/test/org/apache/solr/cluster/placement/plugins/StubShardAffinityPlacementFactory.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/plugins/StubShardAffinityPlacementFactory.java
@@ -35,7 +35,6 @@ import org.apache.solr.cluster.placement.PlacementPlanFactory;
 import org.apache.solr.cluster.placement.PlacementPlugin;
 import org.apache.solr.cluster.placement.PlacementRequest;
 import org.apache.solr.cluster.placement.impl.AttributeValuesImpl;
-import org.apache.solr.cluster.placement.impl.NodeMetricImpl;
 
 public class StubShardAffinityPlacementFactory extends AffinityPlacementFactory {
 
@@ -57,12 +56,12 @@ public class StubShardAffinityPlacementFactory extends AffinityPlacementFactory 
         final Map<String, CollectionMetrics> collectionMetrics = new HashMap<>();
 
         for (Node node : placementContext.getCluster().getLiveNodes()) {
-          metrics.computeIfAbsent(NodeMetricImpl.NUM_CORES, n -> new HashMap<>()).put(node, 1);
+          metrics.computeIfAbsent(NodeMetric.NUM_CORES, n -> new HashMap<>()).put(node, 1);
           metrics
-              .computeIfAbsent(NodeMetricImpl.FREE_DISK_GB, n -> new HashMap<>())
+              .computeIfAbsent(NodeMetric.FREE_DISK_GB, n -> new HashMap<>())
               .put(node, (double) 10);
           metrics
-              .computeIfAbsent(NodeMetricImpl.TOTAL_DISK_GB, n -> new HashMap<>())
+              .computeIfAbsent(NodeMetric.TOTAL_DISK_GB, n -> new HashMap<>())
               .put(node, (double) 100);
         }
         final PlacementContext wrappingContext;

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/NodeValueFetcher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/NodeValueFetcher.java
@@ -17,29 +17,26 @@
 
 package org.apache.solr.client.solrj.impl;
 
-import java.util.ArrayList;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.response.SimpleSolrResponse;
 import org.apache.solr.common.SolrException;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.StrUtils;
-import org.apache.solr.common.util.Utils;
 
 /**
  * This class is responsible for fetching metrics and other attributes from a given node in Solr
  * cluster. This is a helper class that is used by {@link SolrClientNodeStateProvider}
  */
-// NOCOMMIT: Need to removed hardcoded references to Dropwizard metrics for OTEL conversion, and
-// probably change enum structure to be more compatible with OTEL naming
 public class NodeValueFetcher {
   // well known tags
   public static final String NODE = "node";
@@ -47,127 +44,163 @@ public class NodeValueFetcher {
   public static final String HOST = "host";
   public static final String CORES = "cores";
   public static final String SYSPROP = "sysprop.";
-  public static final Set<String> tags =
-      Set.of(NODE, PORT, HOST, CORES, Tags.FREEDISK.tagName, Tags.HEAPUSAGE.tagName);
+  public static final Set<String> tags = Set.of(NODE, PORT, HOST, CORES);
   public static final Pattern hostAndPortPattern = Pattern.compile("(?:https?://)?([^:]+):(\\d+)");
   public static final String METRICS_PREFIX = "metrics:";
 
   /** Various well known tags that can be fetched from a node */
-  public enum Tags {
-    FREEDISK(
-        "freedisk", "solr.node", "CONTAINER.fs.usableSpace", "solr.node/CONTAINER.fs.usableSpace"),
-    TOTALDISK(
-        "totaldisk", "solr.node", "CONTAINER.fs.totalSpace", "solr.node/CONTAINER.fs.totalSpace"),
-    CORES("cores", "solr.node", "CONTAINER.cores", null) {
+  public enum Metrics {
+    FREEDISK("freedisk", "solr_cores_filesystem_disk_space", "type", "usable_space"),
+    TOTALDISK("totaldisk", "solr_cores_filesystem_disk_space", "type", "total_space"),
+    CORES("cores", "solr_cores_loaded") {
       @Override
-      public Object extractResult(Object root) {
-        NamedList<?> node = (NamedList<?>) Utils.getObjectByPath(root, false, "solr.node");
-        int count = 0;
-        for (String leafCoreMetricName : new String[] {"lazy", "loaded", "unloaded"}) {
-          Number n = (Number) node.get("CONTAINER.cores." + leafCoreMetricName);
-          if (n != null) count += n.intValue();
+      public Object extractResult(NamedList<Object> root) {
+        Object metrics = root.get("stream");
+        if (metrics == null || metricName == null) return null;
+
+        try (InputStream in = (InputStream) metrics) {
+          String[] lines = parsePrometheusOutput(in);
+          int count = 0;
+
+          for (String line : lines) {
+            if (shouldSkipPrometheusLine(line) || !line.startsWith(metricName)) continue;
+            count += (int) extractPrometheusValue(line);
+          }
+          return count;
+        } catch (Exception e) {
+          throw new SolrException(
+              SolrException.ErrorCode.SERVER_ERROR, "Unable to read prometheus metrics output", e);
         }
-        return count;
       }
     },
-    SYSLOADAVG("sysLoadAvg", "solr.jvm", "os.systemLoadAverage", "solr.jvm/os.systemLoadAverage"),
-    HEAPUSAGE("heapUsage", "solr.jvm", "memory.heap.usage", "solr.jvm/memory.heap.usage");
-    // the metrics group
-    public final String group;
-    // the metrics prefix
-    public final String prefix;
+    SYSLOADAVG("sysLoadAvg", "jvm_system_cpu_utilization_ratio");
+
     public final String tagName;
-    // the json path in the response
-    public final String path;
+    public final String metricName;
+    public final String labelKey;
+    public final String labelValue;
 
-    Tags(String name, String group, String prefix, String path) {
-      this.group = group;
-      this.prefix = prefix;
+    Metrics(String name, String metricName) {
+      this(name, metricName, null, null);
+    }
+
+    Metrics(String name, String metricName, String labelKey, String labelValue) {
       this.tagName = name;
-      this.path = path;
+      this.metricName = metricName;
+      this.labelKey = labelKey;
+      this.labelValue = labelValue;
     }
 
-    public Object extractResult(Object root) {
-      Object v = Utils.getObjectByPath(root, true, path);
-      return v == null ? null : convertVal(v);
+    public Object extractResult(NamedList<Object> root) {
+      return extractFromPrometheusResponse(root, metricName, labelKey, labelValue);
     }
 
-    public Object convertVal(Object val) {
-      if (val instanceof String) {
-        return Double.valueOf((String) val);
-      } else if (val instanceof Number num) {
-        return num.doubleValue();
+    /**
+     * Extract metric value from Prometheus response, optionally filtering by label. This
+     * consolidated method handles both labeled and unlabeled metrics.
+     */
+    private static Long extractFromPrometheusResponse(
+        NamedList<Object> root, String metricName, String labelKey, String labelValue) {
+      Object metrics = root.get("stream");
 
+      if (metrics == null || metricName == null) {
+        return null;
+      }
+
+      try (InputStream in = (InputStream) metrics) {
+        String[] lines = parsePrometheusOutput(in);
+
+        for (String line : lines) {
+          if (shouldSkipPrometheusLine(line) || !line.startsWith(metricName)) continue;
+
+          // If metric with specific labels were requested, then return the metric with that label
+          // and skip others
+          if (labelKey != null && labelValue != null) {
+            String expectedLabel = labelKey + "=\"" + labelValue + "\"";
+            if (!line.contains(expectedLabel)) {
+              continue;
+            }
+          }
+
+          return extractPrometheusValue(line);
+        }
+      } catch (Exception e) {
+        throw new SolrException(
+            SolrException.ErrorCode.SERVER_ERROR, "Unable to read prometheus metrics output", e);
+      }
+
+      return null;
+    }
+
+    public static long extractPrometheusValue(String line) {
+      line = line.trim();
+      String actualValue;
+      if (line.contains("}")) {
+        actualValue = line.substring(line.lastIndexOf("} ") + 1);
       } else {
-        throw new IllegalArgumentException("Unknown type : " + val);
+        actualValue = line.split(" ")[1];
       }
+      return (long) Double.parseDouble(actualValue);
+    }
+
+    public static String[] parsePrometheusOutput(InputStream inputStream) throws Exception {
+      String output = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+      return output.split("\n");
     }
   }
 
-  /** Retrieve values that match JVM system properties and metrics. */
-  private void getRemotePropertiesAndMetrics(
-      Set<String> requestedTagNames, SolrClientNodeStateProvider.RemoteCallCtx ctx) {
-
-    Map<String, Set<Object>> metricsKeyVsTag = new HashMap<>();
-    for (String tag : requestedTagNames) {
-      if (tag.startsWith(SYSPROP)) {
-        metricsKeyVsTag
-            .computeIfAbsent(
-                "solr.jvm:system.properties:" + tag.substring(SYSPROP.length()),
-                k -> new HashSet<>())
-            .add(tag);
-      } else if (tag.startsWith(METRICS_PREFIX)) {
-        metricsKeyVsTag
-            .computeIfAbsent(tag.substring(METRICS_PREFIX.length()), k -> new HashSet<>())
-            .add(tag);
-      }
-    }
-    if (!metricsKeyVsTag.isEmpty()) {
-      SolrClientNodeStateProvider.fetchReplicaMetrics(ctx.getNode(), ctx, metricsKeyVsTag);
-    }
-  }
-
-  /** Retrieve values of well known tags, as defined in {@link Tags}. */
-  private void getRemoteTags(
+  /** Retrieve values of well known tags, as defined in {@link Metrics}. */
+  private void getRemoteMetricsFromTags(
       Set<String> requestedTagNames, SolrClientNodeStateProvider.RemoteCallCtx ctx) {
 
     // First resolve names into actual Tags instances
-    EnumSet<Tags> requestedTags = EnumSet.noneOf(Tags.class);
-    for (Tags t : Tags.values()) {
+    EnumSet<Metrics> requestedMetricNames = EnumSet.noneOf(Metrics.class);
+    for (Metrics t : Metrics.values()) {
       if (requestedTagNames.contains(t.tagName)) {
-        requestedTags.add(t);
+        requestedMetricNames.add(t);
       }
     }
-    if (requestedTags.isEmpty()) {
+
+    if (requestedMetricNames.isEmpty()) {
       return;
     }
 
-    Set<String> groups = new HashSet<>();
-    List<String> prefixes = new ArrayList<>();
-    for (Tags t : requestedTags) {
-      groups.add(t.group);
-      prefixes.add(t.prefix);
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.add("wt", "prometheus");
+
+    // Collect unique metric names
+    Set<String> uniqueMetricNames = new HashSet<>();
+    for (Metrics t : requestedMetricNames) {
+      uniqueMetricNames.add(t.metricName);
     }
 
-    ModifiableSolrParams params = new ModifiableSolrParams();
-    params.add("group", StrUtils.join(groups, ','));
-    params.add("prefix", StrUtils.join(prefixes, ','));
+    // Use metric name filtering to get only the metrics we need
+    params.add("name", StrUtils.join(uniqueMetricNames, ','));
 
     try {
+      var req = new GenericSolrRequest(METHOD.GET, "/admin/metrics", SolrRequestType.ADMIN, params);
+      req.setResponseParser(new InputStreamResponseParser("prometheus"));
+
+      String baseUrl =
+          ctx.zkClientClusterStateProvider.getZkStateReader().getBaseUrlForNodeName(ctx.getNode());
       SimpleSolrResponse rsp =
-          ctx.invokeWithRetry(ctx.getNode(), CommonParams.METRICS_PATH, params);
-      NamedList<?> metrics = (NamedList<?>) rsp.getResponse().get("metrics");
-      if (metrics != null) {
-        for (Tags t : requestedTags) {
-          ctx.tags.put(t.tagName, t.extractResult(metrics));
+          ctx.cloudSolrClient.getHttpClient().requestWithBaseUrl(baseUrl, req::process);
+
+      for (Metrics t : requestedMetricNames) {
+        Object value = t.extractResult(rsp.getResponse());
+        if (value != null) {
+          ctx.tags.put(t.tagName, value);
         }
       }
     } catch (Exception e) {
-      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error getting remote info", e);
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
     }
   }
 
   public void getTags(Set<String> requestedTags, SolrClientNodeStateProvider.RemoteCallCtx ctx) {
+    Set<String> requestsProperties = new HashSet<>();
+    Set<String> requestedMetrics = new HashSet<>();
+    Set<String> requestedMetricTags = new HashSet<>();
 
     try {
       if (requestedTags.contains(NODE)) ctx.tags.put(NODE, ctx.getNode());
@@ -185,10 +218,153 @@ public class NodeValueFetcher {
         return;
       }
 
-      getRemotePropertiesAndMetrics(requestedTags, ctx);
-      getRemoteTags(requestedTags, ctx);
+      // Categorize requested system properties or metrics
+      requestedTags.forEach(
+          tag -> {
+            if (tag.startsWith(SYSPROP)) {
+              requestsProperties.add(tag);
+            } else if (tag.startsWith(METRICS_PREFIX)) {
+              requestedMetrics.add(tag);
+            } else {
+              requestedMetricTags.add(tag);
+            }
+          });
+
+      getRemoteSystemProps(requestsProperties, ctx);
+      getRemoteMetrics(requestedMetrics, ctx);
+      getRemoteMetricsFromTags(requestedMetricTags, ctx);
+
     } catch (Exception e) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
+    }
+  }
+
+  private void getRemoteSystemProps(
+      Set<String> requestedTagNames, SolrClientNodeStateProvider.RemoteCallCtx ctx) {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    try {
+      SimpleSolrResponse rsp = ctx.invokeWithRetry(ctx.getNode(), "/admin/info/properties", params);
+      NamedList<?> systemPropsRsp = (NamedList<?>) rsp.getResponse().get("system.properties");
+      for (String requestedProperty : requestedTagNames) {
+        Object property = systemPropsRsp.get(requestedProperty.substring(SYSPROP.length()));
+        if (property != null) ctx.tags.put(requestedProperty, property.toString());
+      }
+    } catch (Exception e) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error getting remote info", e);
+    }
+  }
+
+  /**
+   * Retrieve values that match metrics. Metrics names are structured like below:
+   *
+   * <p>"metrics:solr_cores_filesystem_disk_space_bytes:type=usable_space" or
+   * "metrics:jvm_cpu_count" Metrics are fetched from /admin/metrics and parsed using shared utility
+   * methods.
+   */
+  private void getRemoteMetrics(
+      Set<String> requestedTagNames, SolrClientNodeStateProvider.RemoteCallCtx ctx) {
+    Set<MetricRequest> metricRequests = new HashSet<>();
+    Set<String> requestedMetricNames = new HashSet<>();
+    Set<String> labelsFilter = new HashSet<>();
+
+    // Parse metric tags into structured MetricRequest objects
+    for (String tag : requestedTagNames) {
+      try {
+        MetricRequest request = MetricRequest.fromTag(tag);
+        metricRequests.add(request);
+        requestedMetricNames.add(request.metricName());
+
+        if (request.hasLabelFilter()) {
+          labelsFilter.add(request.kvLabel());
+        }
+
+        // Pre-populate the map tag key to match its corresponding prometheus metrics
+        ctx.tags.put(tag, null);
+      } catch (IllegalArgumentException e) {
+        // Skip invalid metric tags
+        continue;
+      }
+    }
+
+    if (requestedMetricNames.isEmpty()) {
+      return;
+    }
+
+    // Fetch all prometheus metrics from requested prometheus metric names
+    String[] lines =
+        SolrClientNodeStateProvider.fetchBatchedMetric(ctx.getNode(), ctx, requestedMetricNames);
+
+    // Process prometheus response using structured MetricRequest objects
+    for (String line : lines) {
+      if (shouldSkipPrometheusLine(line)) continue;
+
+      String lineMetricName = extractMetricNameFromLine(line);
+      Long value = Metrics.extractPrometheusValue(line);
+
+      // Find matching MetricRequest(s) for this line
+      for (MetricRequest request : metricRequests) {
+        if (!request.metricName().equals(lineMetricName)) {
+          continue; // Metric name doesn't match
+        }
+
+        // Skip metric if it does not contain requested label
+        if (request.hasLabelFilter() && !line.contains(request.kvLabel())) {
+          continue;
+        }
+
+        // Found a match - store the value using the original tag
+        ctx.tags.put(request.originalTag(), value);
+        break; // Move to next line since we found our match
+      }
+    }
+  }
+
+  public static String extractMetricNameFromLine(String line) {
+    if (line.contains("{")) {
+      return line.substring(0, line.indexOf("{"));
+    } else {
+      return line.split(" ")[0];
+    }
+  }
+
+  public static String extractLabelValueFromLine(String line, String labelKey) {
+    String labelPattern = labelKey + "=\"";
+    if (!line.contains(labelPattern)) return null;
+
+    int startIdx = line.indexOf(labelPattern) + labelPattern.length();
+    int endIdx = line.indexOf("\"", startIdx);
+    return endIdx > startIdx ? line.substring(startIdx, endIdx) : null;
+  }
+
+  /** Helper method to check if a Prometheus line should be skipped (comments or empty lines). */
+  public static boolean shouldSkipPrometheusLine(String line) {
+    return line.startsWith("#") || line.trim().isEmpty();
+  }
+
+  /**
+   * Represents a structured metric request instead of using string parsing. This eliminates the
+   * need for complex string manipulation and parsing.
+   */
+  record MetricRequest(String metricName, String kvLabel, String originalTag) {
+
+    /**
+     * Create a MetricRequest from a metric tag string like "metrics:jvm_cpu_count" or
+     * "metrics:solr_cores_filesystem_disk_space_bytes:type=usable_space"
+     */
+    public static MetricRequest fromTag(String tag) {
+      String[] parts = tag.split(":");
+      if (parts.length < 2) {
+        throw new IllegalArgumentException("Invalid metric tag format: " + tag);
+      }
+
+      String metricName = parts[1];
+      String labelFilter = parts.length > 2 ? parts[2] : null;
+
+      return new MetricRequest(metricName, labelFilter, tag);
+    }
+
+    public boolean hasLabelFilter() {
+      return kvLabel != null;
     }
   }
 }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientNodeStateProvider.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientNodeStateProvider.java
@@ -18,9 +18,9 @@
 package org.apache.solr.client.solrj.impl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.cloud.NodeStateProvider;
@@ -40,7 +38,6 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.Replica;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.Pair;
@@ -138,74 +135,95 @@ public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter
       String node, Collection<String> keys) {
     Map<String, Map<String, List<Replica>>> result =
         nodeVsCollectionVsShardVsReplicaInfo.computeIfAbsent(node, o -> new HashMap<>());
-    if (!keys.isEmpty()) {
-      Map<String, Pair<String, Replica>> metricsKeyVsTagReplica = new HashMap<>();
-      forEachReplica(
-          result,
-          r -> {
-            for (String key : keys) {
-              if (r.getProperties().containsKey(key)) continue; // it's already collected
-              String perReplicaMetricsKey =
-                  "solr.core."
-                      + r.getCollection()
-                      + "."
-                      + r.getShard()
-                      + "."
-                      + Utils.parseMetricsReplicaName(r.getCollection(), r.getCoreName())
-                      + ":";
-              String perReplicaValue = key;
-              perReplicaMetricsKey += perReplicaValue;
-              metricsKeyVsTagReplica.put(perReplicaMetricsKey, new Pair<>(key, r));
-            }
-          });
 
-      if (!metricsKeyVsTagReplica.isEmpty()) {
-        Map<String, Object> tagValues = fetchReplicaMetrics(node, metricsKeyVsTagReplica);
-        tagValues.forEach(
-            (k, o) -> {
-              Pair<String, Replica> p = metricsKeyVsTagReplica.get(k);
-              if (p.second() != null) p.second().getProperties().put(p.first(), o);
-            });
+    if (keys.isEmpty()) {
+      return result;
+    }
+
+    // Build mapping from core name to (replica, metric) {coreName: <Replica, Prometheus Metric
+    // Name>}
+    Map<String, List<Pair<Replica, String>>> coreToReplicaProps = new HashMap<>();
+    Set<String> requestedMetricNames = new HashSet<>();
+
+    forEachReplica(
+        result,
+        replica -> {
+          for (String key : keys) {
+            if (replica.getProperties().containsKey(key)) continue;
+
+            // Build core name as the key to the replica and the metric it needs
+            String coreName =
+                replica.getCollection()
+                    + "_"
+                    + replica.getShard()
+                    + "_"
+                    + Utils.parseMetricsReplicaName(replica.getCollection(), replica.getCoreName());
+
+            coreToReplicaProps
+                .computeIfAbsent(coreName, k -> new ArrayList<>())
+                .add(new Pair<>(replica, key));
+            requestedMetricNames.add(key);
+          }
+        });
+
+    if (coreToReplicaProps.isEmpty()) {
+      return result;
+    }
+
+    RemoteCallCtx ctx = new RemoteCallCtx(node, solrClient);
+    String[] lines = fetchBatchedMetric(node, ctx, requestedMetricNames);
+
+    // Parse through prometheus metrics and map the metric with its corresponding replica properties
+    for (String line : lines) {
+      if (NodeValueFetcher.shouldSkipPrometheusLine(line)) continue;
+
+      String prometheusMetricName = NodeValueFetcher.extractMetricNameFromLine(line);
+
+      // Extract core name from prometheus line and the core label
+      String coreParam = NodeValueFetcher.extractLabelValueFromLine(line, "core");
+      if (coreParam == null) continue;
+
+      // Find the matching core and set the metric value to its corresponding replica properties
+      List<Pair<Replica, String>> replicaProps = coreToReplicaProps.get(coreParam);
+      if (replicaProps != null) {
+        Long value = NodeValueFetcher.Metrics.extractPrometheusValue(line);
+        replicaProps.stream()
+            .filter(pair -> pair.second().equals(prometheusMetricName))
+            .forEach(pair -> pair.first().getProperties().put(pair.second(), value));
       }
     }
+
     return result;
   }
 
-  protected Map<String, Object> fetchReplicaMetrics(
-      String node, Map<String, Pair<String, Replica>> metricsKeyVsTagReplica) {
-    Map<String, Set<Object>> collect =
-        metricsKeyVsTagReplica.entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey(), e -> Set.of(e.getKey())));
-    RemoteCallCtx ctx = new RemoteCallCtx(null, solrClient);
-    fetchReplicaMetrics(node, ctx, collect);
-    return ctx.tags;
-  }
+  static String[] fetchBatchedMetric(String solrNode, RemoteCallCtx ctx, Set<String> metricNames) {
+    if (!ctx.isNodeAlive(solrNode))
+      throw new SolrException(
+          SolrException.ErrorCode.SERVER_ERROR,
+          "Solr node is not healthy. Cannot request metrics: " + solrNode);
 
-  // NOCOMMIT: We need to change the /admin/metrics call here to work with
-  // Prometheus/OTEL telemetry
-  static void fetchReplicaMetrics(
-      String solrNode, RemoteCallCtx ctx, Map<String, Set<Object>> metricsKeyVsTag) {
-    if (!ctx.isNodeAlive(solrNode)) return;
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.add("key", metricsKeyVsTag.keySet().toArray(new String[0]));
-    try {
-      SimpleSolrResponse rsp = ctx.invokeWithRetry(solrNode, CommonParams.METRICS_PATH, params);
-      metricsKeyVsTag.forEach(
-          (key, tags) -> {
-            Object v =
-                Utils.getObjectByPath(rsp.getResponse(), true, Arrays.asList("metrics", key));
-            for (Object tag : tags) {
-              if (tag instanceof Function) {
-                @SuppressWarnings({"unchecked"})
-                Pair<String, Object> p = (Pair<String, Object>) ((Function) tag).apply(v);
-                ctx.tags.put(p.first(), p.second());
-              } else {
-                if (v != null) ctx.tags.put(tag.toString(), v);
-              }
-            }
-          });
+    params.add("wt", "prometheus");
+    params.add("name", String.join(",", metricNames));
+
+    var req =
+        new GenericSolrRequest(
+            SolrRequest.METHOD.GET, "/admin/metrics", SolrRequest.SolrRequestType.ADMIN, params);
+    req.setResponseParser(new InputStreamResponseParser("prometheus"));
+
+    String baseUrl =
+        ctx.zkClientClusterStateProvider.getZkStateReader().getBaseUrlForNodeName(solrNode);
+    try (InputStream in =
+        (InputStream)
+            ctx.cloudSolrClient
+                .getHttpClient()
+                .requestWithBaseUrl(baseUrl, req::process)
+                .getResponse()
+                .get("stream")) {
+      return NodeValueFetcher.Metrics.parsePrometheusOutput(in);
     } catch (Exception e) {
-      log.warn("could not get tags from node {}", solrNode, e);
+      throw new SolrException(
+          SolrException.ErrorCode.SERVER_ERROR, "Unable to read prometheus metrics output", e);
     }
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/cluster/placement/Builders.java
+++ b/solr/test-framework/src/java/org/apache/solr/cluster/placement/Builders.java
@@ -33,7 +33,6 @@ import org.apache.solr.cluster.placement.impl.AttributeFetcherImpl;
 import org.apache.solr.cluster.placement.impl.AttributeValuesImpl;
 import org.apache.solr.cluster.placement.impl.BalancePlanFactoryImpl;
 import org.apache.solr.cluster.placement.impl.CollectionMetricsBuilder;
-import org.apache.solr.cluster.placement.impl.NodeMetricImpl;
 import org.apache.solr.cluster.placement.impl.PlacementPlanFactoryImpl;
 import org.apache.solr.cluster.placement.impl.ReplicaMetricImpl;
 import org.apache.solr.common.util.Pair;
@@ -152,17 +151,17 @@ public class Builders {
 
         if (nodeBuilder.getCoreCount() != null) {
           metrics
-              .computeIfAbsent(NodeMetricImpl.NUM_CORES, n -> new HashMap<>())
+              .computeIfAbsent(NodeMetric.NUM_CORES, n -> new HashMap<>())
               .put(node, nodeBuilder.getCoreCount());
         }
         if (nodeBuilder.getFreeDiskGB() != null) {
           metrics
-              .computeIfAbsent(NodeMetricImpl.FREE_DISK_GB, n -> new HashMap<>())
+              .computeIfAbsent(NodeMetric.FREE_DISK_GB, n -> new HashMap<>())
               .put(node, nodeBuilder.getFreeDiskGB());
         }
         if (nodeBuilder.getTotalDiskGB() != null) {
           metrics
-              .computeIfAbsent(NodeMetricImpl.TOTAL_DISK_GB, n -> new HashMap<>())
+              .computeIfAbsent(NodeMetric.TOTAL_DISK_GB, n -> new HashMap<>())
               .put(node, nodeBuilder.getTotalDiskGB());
         }
         if (nodeBuilder.getSysprops() != null) {
@@ -185,9 +184,9 @@ public class Builders {
 
       if (!collectionBuilders.isEmpty()) {
         Map<Node, Object> nodeToCoreCount =
-            metrics.computeIfAbsent(NodeMetricImpl.NUM_CORES, n -> new HashMap<>());
+            metrics.computeIfAbsent(NodeMetric.NUM_CORES, n -> new HashMap<>());
         Map<Node, Object> nodeToFreeDisk =
-            metrics.computeIfAbsent(NodeMetricImpl.FREE_DISK_GB, n -> new HashMap<>());
+            metrics.computeIfAbsent(NodeMetric.FREE_DISK_GB, n -> new HashMap<>());
         collectionBuilders.forEach(
             builder -> {
               CollectionMetrics thisCollMetrics = builder.collectionMetricsBuilder.build();

--- a/solr/test-framework/src/test/org/apache/solr/cluster/placement/BuildersTest.java
+++ b/solr/test-framework/src/test/org/apache/solr/cluster/placement/BuildersTest.java
@@ -29,7 +29,6 @@ import org.apache.solr.cluster.Cluster;
 import org.apache.solr.cluster.Node;
 import org.apache.solr.cluster.Shard;
 import org.apache.solr.cluster.SolrCollection;
-import org.apache.solr.cluster.placement.impl.NodeMetricImpl;
 import org.apache.solr.cluster.placement.impl.ReplicaMetricImpl;
 import org.junit.Test;
 
@@ -85,17 +84,17 @@ public class BuildersTest extends SolrTestCaseJ4 {
     AttributeFetcher attributeFetcher = clusterBuilder.buildAttributeFetcher();
     attributeFetcher
         .fetchFrom(cluster.getLiveNodes())
-        .requestNodeMetric(NodeMetricImpl.NUM_CORES)
-        .requestNodeMetric(NodeMetricImpl.FREE_DISK_GB)
-        .requestNodeMetric(NodeMetricImpl.TOTAL_DISK_GB)
+        .requestNodeMetric(NodeMetric.NUM_CORES)
+        .requestNodeMetric(NodeMetric.FREE_DISK_GB)
+        .requestNodeMetric(NodeMetric.TOTAL_DISK_GB)
         .requestCollectionMetrics(collection, Set.of(ReplicaMetricImpl.INDEX_SIZE_GB));
     AttributeValues attributeValues = attributeFetcher.fetchAttributes();
     for (Node node : cluster.getLiveNodes()) {
-      Optional<Integer> coreCount = attributeValues.getNodeMetric(node, NodeMetricImpl.NUM_CORES);
+      Optional<Integer> coreCount = attributeValues.getNodeMetric(node, NodeMetric.NUM_CORES);
       assertTrue("coreCount present", coreCount.isPresent());
-      Optional<Double> diskOpt = attributeValues.getNodeMetric(node, NodeMetricImpl.FREE_DISK_GB);
+      Optional<Double> diskOpt = attributeValues.getNodeMetric(node, NodeMetric.FREE_DISK_GB);
       assertTrue("freeDisk", diskOpt.isPresent());
-      diskOpt = attributeValues.getNodeMetric(node, NodeMetricImpl.TOTAL_DISK_GB);
+      diskOpt = attributeValues.getNodeMetric(node, NodeMetric.TOTAL_DISK_GB);
       assertTrue("totalDisk", diskOpt.isPresent());
     }
     Optional<CollectionMetrics> collectionMetricsOpt =


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17880

SolrClientNodeStateProvider and NodeValueFetcher had hardcoded sets of metrics that it requested from /admin/metrics. It retrieved metrics and system properties from the same endpoint. Since OTEL no longer has system properties on the, this needs to make 2 calls and combine the results from /admin/metrics for metrics and /admin/info/properties for system properties. Some metrics are no longer available like 1 or 5 minute request rates. Also tried to clean up code.