### PR TITLE
SOLR-17936: add focus indicator to navigation sidebar entries in new UI

### DIFF
--- a/solr/ui/src/commonMain/kotlin/org/apache/solr/ui/views/navigation/NavigationSideBar.kt
+++ b/solr/ui/src/commonMain/kotlin/org/apache/solr/ui/views/navigation/NavigationSideBar.kt
@@ -18,6 +18,7 @@
 package org.apache.solr.ui.views.navigation
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -44,8 +45,13 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -124,6 +130,9 @@ private fun MenuElement(
     onClick: () -> Unit = {},
 ) {
     val alpha = if (enabled) 1f else 0.38f
+    var borderAlpha by remember {
+        mutableFloatStateOf(0f)
+    }
     Tab(
         modifier = modifier.background(
             if (selected) {
@@ -131,7 +140,11 @@ private fun MenuElement(
             } else {
                 Color.Unspecified
             },
-        ),
+        ).border(
+            width = 2.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha)
+        ).onFocusChanged {
+            borderAlpha = if (it.isFocused) 1f else 0f
+        },
         selected = selected,
         enabled = enabled,
         selectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = alpha),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17936

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

In the new ui, add a focus indicator around the sidebar entry that has focus.

Before (light mode) -- the cluster element has keyboard focus but there is no way to know that:
<img width="237" height="669" alt="a light nav bar. environment is selected but all other entries look the same" src="https://github.com/user-attachments/assets/c96b0f8c-fafe-4996-98e3-cc98424efb58" />

Before (dark mode):

<img width="233" height="645" alt="a dark nav bar. environment is selected but all other entries look the same" src="https://github.com/user-attachments/assets/5d9d2815-92e2-4fcd-9265-7585de5f2c90" />

After (light mode):
<img width="362" height="909" alt="a light nav bar. environment is selected. cluster has a light gray box around it" src="https://github.com/user-attachments/assets/554519fd-43da-4ffd-b09a-cc69253583f9" />

After (dark mode):
<img width="369" height="1006" alt="a dark nav bar. environment is selected. cluster has a light gray box around it" src="https://github.com/user-attachments/assets/f71f739a-8815-4d68-8ef3-68005d2a4abc" />

# Solution


Use Compose's `onFocusChanged` functionality to determine when an element has focus, and add a border around it if so.  Thanks to [this guidance](https://github.com/cvs-health/android-compose-accessibility-techniques/blob/main/doc/interactions/CustomFocusIndicators.md) for the approach.


# Tests

I wasn't sure how to write an effective automated test for this; I couldn't find a way to make assertions about modifiers or color alpha values in compose -- it seemed like screenshot testing is encouraged more for this type of thing?  I'd be happy to add a test if there are some ideas about the approach (or if I could write this functionality in a more testable way)!

I tested this manually by:
1. Running `./gradlew :solr:ui:run`, connecting to my local solr, and tabbing through the various sidebar entries
2. Building solr locally, opening the new UI in the browser, connecting to my local solr, and tabbing through the various sidebar entries
3. Turning dark mode on in my OS and repeating the above steps.
 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
