### PR TITLE
SOLR-17943: ClusterStateProvider to support HttpJdkSolrClient

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -115,7 +115,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
   private ClusterStateProvider createHttp2ClusterStateProvider(
       List<String> solrUrls, Http2SolrClient httpClient) {
     try {
-      return new Http2ClusterStateProvider(solrUrls, httpClient);
+      return new Http2ClusterStateProvider<>(solrUrls, httpClient);
     } catch (Exception e) {
       closeMyClientIfNeeded();
       throw new RuntimeException(

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2ClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2ClusterStateProvider.java
@@ -19,17 +19,16 @@ package org.apache.solr.client.solrj.impl;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.solr.client.solrj.SolrClient;
 
-public class Http2ClusterStateProvider<C extends HttpSolrClientBase> extends BaseHttpClusterStateProvider {
+public class Http2ClusterStateProvider<C extends HttpSolrClientBase>
+    extends BaseHttpClusterStateProvider {
   final C httpClient;
 
-  public Http2ClusterStateProvider(List<String> solrUrls, C httpClient)
-      throws Exception {
-    if(httpClient == null) {
+  public Http2ClusterStateProvider(List<String> solrUrls, C httpClient) throws Exception {
+    if (httpClient == null) {
       throw new IllegalArgumentException("You must provide an Http client.");
     }
-    this.httpClient =  httpClient;
+    this.httpClient = httpClient;
     initConfiguredNodes(solrUrls);
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2ClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2ClusterStateProvider.java
@@ -21,31 +21,31 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.solr.client.solrj.SolrClient;
 
-public class Http2ClusterStateProvider extends BaseHttpClusterStateProvider {
-  final Http2SolrClient httpClient;
-  final boolean closeClient;
+public class Http2ClusterStateProvider<C extends HttpSolrClientBase> extends BaseHttpClusterStateProvider {
+  final C httpClient;
 
-  public Http2ClusterStateProvider(List<String> solrUrls, Http2SolrClient httpClient)
+  public Http2ClusterStateProvider(List<String> solrUrls, C httpClient)
       throws Exception {
-    this.httpClient = httpClient == null ? new Http2SolrClient.Builder().build() : httpClient;
-    this.closeClient = httpClient == null;
+    if(httpClient == null) {
+      throw new IllegalArgumentException("You must provide an Http client.");
+    }
+    this.httpClient =  httpClient;
     initConfiguredNodes(solrUrls);
   }
 
   @Override
   public void close() throws IOException {
-    if (this.closeClient && this.httpClient != null) {
-      httpClient.close();
-    }
+    httpClient.close();
     super.close();
   }
 
   @Override
-  protected SolrClient getSolrClient(String baseUrl) {
-    return new Http2SolrClient.Builder(baseUrl).withHttpClient(httpClient).build();
+  @SuppressWarnings("unchecked")
+  protected C getSolrClient(String baseUrl) {
+    return (C) httpClient.builder().withBaseSolrUrl(baseUrl).build();
   }
 
-  public Http2SolrClient getHttpClient() {
+  public C getHttpClient() {
     return httpClient;
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -647,7 +647,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
   public HttpSolrClientBuilderBase<?, ?> builder() {
     return new Http2SolrClient.Builder().withHttpClient(this);
   }
-  
+
   private NamedList<Object> processErrorsAndResponse(
       SolrRequest<?> solrRequest, Response response, InputStream is, String urlExceptionMessage)
       throws SolrServerException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -1102,30 +1102,12 @@ public class Http2SolrClient extends HttpSolrClientBase {
       return new Http2SolrClient(baseSolrUrl, this);
     }
 
-    /**
-     * Provide a seed Http2SolrClient for the builder values, values can still be overridden by
-     * using builder methods
-     */
     public Builder withHttpClient(Http2SolrClient http2SolrClient) {
+      super.withHttpClient(http2SolrClient);
       this.httpClient = http2SolrClient.httpClient;
 
-      if (this.basicAuthAuthorizationStr == null) {
-        this.basicAuthAuthorizationStr = http2SolrClient.basicAuthAuthorizationStr;
-      }
       if (this.idleTimeoutMillis == null) {
         this.idleTimeoutMillis = http2SolrClient.idleTimeoutMillis;
-      }
-      if (this.requestTimeoutMillis == null) {
-        this.requestTimeoutMillis = http2SolrClient.requestTimeoutMillis;
-      }
-      if (this.requestWriter == null) {
-        this.requestWriter = http2SolrClient.requestWriter;
-      }
-      if (this.responseParser == null) {
-        this.responseParser = http2SolrClient.parser;
-      }
-      if (this.urlParamNames == null) {
-        this.urlParamNames = http2SolrClient.urlParamNames;
       }
       if (this.listenerFactories == null) {
         this.listenerFactories = http2SolrClient.listenerFactory;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -643,6 +643,11 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
   }
 
+  @Override
+  public HttpSolrClientBuilderBase<?, ?> builder() {
+    return new Http2SolrClient.Builder().withHttpClient(this);
+  }
+  
   private NamedList<Object> processErrorsAndResponse(
       SolrRequest<?> solrRequest, Response response, InputStream is, String urlExceptionMessage)
       throws SolrServerException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -597,6 +597,5 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
       this.cookieHandler = cookieHandler;
       return this;
     }
-
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -537,6 +537,11 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
         .collect(Collectors.joining(", "));
   }
 
+  @Override
+  public HttpSolrClientBuilderBase<?, ?> builder() {
+    return new HttpJdkSolrClient.Builder().withHttpClient(this);
+  }
+
   public static class Builder
       extends HttpSolrClientBuilderBase<HttpJdkSolrClient.Builder, HttpJdkSolrClient> {
 
@@ -589,5 +594,6 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
       this.cookieHandler = cookieHandler;
       return this;
     }
+
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -558,6 +558,15 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
       return new HttpJdkSolrClient(baseSolrUrl, this);
     }
 
+    @Override
+    public Builder withHttpClient(HttpJdkSolrClient httpSolrClient) {
+      super.withHttpClient(httpSolrClient);
+      if (this.executor == null) {
+        this.executor = httpSolrClient.executor;
+      }
+      return this;
+    }
+
     /**
      * Use the provided SSLContext. See {@link
      * java.net.http.HttpClient.Builder#sslContext(SSLContext)}.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpJdkSolrClient.java
@@ -205,7 +205,7 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     return requestWithBaseUrl(null, solrRequest, collection);
   }
 
-  private PreparedRequest prepareRequest(
+  protected PreparedRequest prepareRequest(
       SolrRequest<?> solrRequest, String collection, String overrideBaseUrl)
       throws SolrServerException, IOException {
     checkClosed();
@@ -342,7 +342,7 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
     return new PreparedRequest(reqb, contentWritingFuture);
   }
 
-  private static class PreparedRequest {
+  protected static class PreparedRequest {
     Future<?> contentWritingFuture;
     HttpRequest.Builder reqb;
 
@@ -568,6 +568,9 @@ public class HttpJdkSolrClient extends HttpSolrClientBase {
       super.withHttpClient(httpSolrClient);
       if (this.executor == null) {
         this.executor = httpSolrClient.executor;
+      }
+      if (this.sslContext == null) {
+        this.sslContext = httpSolrClient.httpClient.sslContext();
       }
       return this;
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
@@ -388,4 +388,11 @@ public abstract class HttpSolrClientBase extends SolrClient {
   public Set<String> getUrlParamNames() {
     return urlParamNames;
   }
+
+  /**
+   * Obtain a Builder that can be used to create new clients based on the setting of this client.
+   *
+   * @return a Builder
+   */
+  public abstract HttpSolrClientBuilderBase<?,?> builder() ;
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBase.java
@@ -394,5 +394,5 @@ public abstract class HttpSolrClientBase extends SolrClient {
    *
    * @return a Builder
    */
-  public abstract HttpSolrClientBuilderBase<?,?> builder() ;
+  public abstract HttpSolrClientBuilderBase<?, ?> builder();
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
@@ -47,6 +47,30 @@ public abstract class HttpSolrClientBuilderBase<
 
   public abstract C build();
 
+  /**
+   * Provide a seed HttpSolrClient for the builder values, values can still be overridden by
+   * using builder methods
+   */
+  @SuppressWarnings("unchecked")
+  public B withHttpClient(C httpSolrClient) {
+    if (this.basicAuthAuthorizationStr == null) {
+      this.basicAuthAuthorizationStr = httpSolrClient.basicAuthAuthorizationStr;
+    }
+    if (this.requestTimeoutMillis == null) {
+      this.requestTimeoutMillis = httpSolrClient.requestTimeoutMillis;
+    }
+    if (this.requestWriter == null) {
+      this.requestWriter = httpSolrClient.requestWriter;
+    }
+    if (this.responseParser == null) {
+      this.responseParser = httpSolrClient.parser;
+    }
+    if (this.urlParamNames == null) {
+      this.urlParamNames = httpSolrClient.urlParamNames;
+    }
+    return (B) (this);
+  }
+
   /** Provides a {@link RequestWriter} for created clients to use when handing requests. */
   @SuppressWarnings("unchecked")
   public B withRequestWriter(RequestWriter requestWriter) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
@@ -71,6 +71,13 @@ public abstract class HttpSolrClientBuilderBase<
     return (B) (this);
   }
 
+  /** Provides the Base Solr Url. */
+  @SuppressWarnings("unchecked")
+  public B withBaseSolrUrl(String baseSolrUrl) {
+    this.baseSolrUrl = baseSolrUrl;
+    return (B) this;
+  }
+
   /** Provides a {@link RequestWriter} for created clients to use when handing requests. */
   @SuppressWarnings("unchecked")
   public B withRequestWriter(RequestWriter requestWriter) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
@@ -48,8 +48,8 @@ public abstract class HttpSolrClientBuilderBase<
   public abstract C build();
 
   /**
-   * Provide a seed HttpSolrClient for the builder values, values can still be overridden by
-   * using builder methods
+   * Provide a seed HttpSolrClient for the builder values, values can still be overridden by using
+   * builder methods
    */
   @SuppressWarnings("unchecked")
   public B withHttpClient(C httpSolrClient) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
@@ -78,7 +78,7 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
 
   private static Http2ClusterStateProvider<?> http2ClusterStateProvider(String userAgent) {
     try {
-      var csp =  new Http2ClusterStateProvider<Http2SolrClient>(
+      var csp =  new Http2ClusterStateProvider<>(
           List.of(
               cluster.getJettySolrRunner(0).getBaseUrl().toString(),
               cluster.getJettySolrRunner(1).getBaseUrl().toString()),

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
@@ -45,8 +46,32 @@ import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ClusterStateProviderTest extends SolrCloudTestCase {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  static class UserAgentChangingJdkClient extends HttpJdkSolrClient {
+
+    final String userAgent;
+
+    protected UserAgentChangingJdkClient(Builder builder, String userAgent) {
+      super(null, builder);
+      this.userAgent = userAgent;
+    }
+
+    @Override
+    protected PreparedRequest prepareRequest(
+        SolrRequest<?> solrRequest, String collection, String overrideBaseUrl)
+        throws SolrServerException, IOException {
+      var pr = super.prepareRequest(solrRequest, collection, overrideBaseUrl);
+      pr.reqb.header("User-Agent", userAgent);
+      return pr;
+    }
+  }
+
 
   @BeforeClass
   public static void setupCluster() throws Exception {
@@ -78,17 +103,30 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
 
   private static Http2ClusterStateProvider<?> http2ClusterStateProvider(String userAgent) {
     try {
+      var useJdkProvider = random().nextBoolean();
+      HttpSolrClientBase client;
+
+      if (userAgent != null) {
+        if (useJdkProvider) {
+          client = new UserAgentChangingJdkClient(new HttpJdkSolrClient.Builder().withSSLContext(MockTrustManager.ALL_TRUSTING_SSL_CONTEXT), userAgent);
+        } else {
+          var http2SolrClient = new Http2SolrClient.Builder().build();
+          http2SolrClient.getHttpClient()
+              .setUserAgentField(
+                  new HttpField(
+                      HttpHeader.USER_AGENT, userAgent));
+          client = http2SolrClient;
+        }
+      } else {
+         client = useJdkProvider ? new HttpJdkSolrClient.Builder().withSSLContext(MockTrustManager.ALL_TRUSTING_SSL_CONTEXT).build() : new Http2SolrClient.Builder().build();
+      }
+
+      log.info("Using Http client implementaton: {}", client.getClass().getName());
+
       var csp =  new Http2ClusterStateProvider<>(
           List.of(
               cluster.getJettySolrRunner(0).getBaseUrl().toString(),
-              cluster.getJettySolrRunner(1).getBaseUrl().toString()),
-          new Http2SolrClient.Builder().build());
-      if(userAgent != null) {
-        csp.getHttpClient().getHttpClient()
-            .setUserAgentField(
-                new HttpField(
-                    HttpHeader.USER_AGENT, userAgent));
-      }
+              cluster.getJettySolrRunner(1).getBaseUrl().toString()), client);
       return csp;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
@@ -72,7 +72,6 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
     }
   }
 
-
   @BeforeClass
   public static void setupCluster() throws Exception {
     configureCluster(2)
@@ -108,25 +107,35 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
 
       if (userAgent != null) {
         if (useJdkProvider) {
-          client = new UserAgentChangingJdkClient(new HttpJdkSolrClient.Builder().withSSLContext(MockTrustManager.ALL_TRUSTING_SSL_CONTEXT), userAgent);
+          client =
+              new UserAgentChangingJdkClient(
+                  new HttpJdkSolrClient.Builder()
+                      .withSSLContext(MockTrustManager.ALL_TRUSTING_SSL_CONTEXT),
+                  userAgent);
         } else {
           var http2SolrClient = new Http2SolrClient.Builder().build();
-          http2SolrClient.getHttpClient()
-              .setUserAgentField(
-                  new HttpField(
-                      HttpHeader.USER_AGENT, userAgent));
+          http2SolrClient
+              .getHttpClient()
+              .setUserAgentField(new HttpField(HttpHeader.USER_AGENT, userAgent));
           client = http2SolrClient;
         }
       } else {
-         client = useJdkProvider ? new HttpJdkSolrClient.Builder().withSSLContext(MockTrustManager.ALL_TRUSTING_SSL_CONTEXT).build() : new Http2SolrClient.Builder().build();
+        client =
+            useJdkProvider
+                ? new HttpJdkSolrClient.Builder()
+                    .withSSLContext(MockTrustManager.ALL_TRUSTING_SSL_CONTEXT)
+                    .build()
+                : new Http2SolrClient.Builder().build();
       }
 
       log.info("Using Http client implementaton: {}", client.getClass().getName());
 
-      var csp =  new Http2ClusterStateProvider<>(
-          List.of(
-              cluster.getJettySolrRunner(0).getBaseUrl().toString(),
-              cluster.getJettySolrRunner(1).getBaseUrl().toString()), client);
+      var csp =
+          new Http2ClusterStateProvider<>(
+              List.of(
+                  cluster.getJettySolrRunner(0).getBaseUrl().toString(),
+                  cluster.getJettySolrRunner(1).getBaseUrl().toString()),
+              client);
       return csp;
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -259,7 +268,9 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
 
     try (var cspZk = zkClientClusterStateProvider();
         // SolrJ < version 9.9.0 for non streamed response
-        var cspHttp = http2ClusterStateProvider("Solr[" + MethodHandles.lookup().lookupClass().getName() + "] " + "9.8.0")) {
+        var cspHttp =
+            http2ClusterStateProvider(
+                "Solr[" + MethodHandles.lookup().lookupClass().getName() + "] " + "9.8.0")) {
 
       assertThat(cspHttp.getCollection("col1"), equalTo(cspZk.getCollection("col1")));
 
@@ -280,7 +291,9 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
 
     try (var cspZk = zkClientClusterStateProvider();
         // Even older SolrJ versionsg for non streamed response
-        var cspHttp = http2ClusterStateProvider("Solr[" + MethodHandles.lookup().lookupClass().getName() + "] " + "2.0")) {
+        var cspHttp =
+            http2ClusterStateProvider(
+                "Solr[" + MethodHandles.lookup().lookupClass().getName() + "] " + "2.0")) {
 
       assertThat(cspHttp.getCollection("col1"), equalTo(cspZk.getCollection("col1")));
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/ClusterStateProviderTest.java
@@ -127,8 +127,8 @@ public class ClusterStateProviderTest extends SolrCloudTestCase {
                     .build()
                 : new Http2SolrClient.Builder().build();
       }
-
-      log.info("Using Http client implementaton: {}", client.getClass().getName());
+      var clientClassName = client.getClass().getName();
+      log.info("Using Http client implementaton: {}", clientClassName);
 
       var csp =
           new Http2ClusterStateProvider<>(


### PR DESCRIPTION
This makes the necessary changes to `Http2ClusterStateProvider` to allow it to work with any subclass of `HttpSolrClientBase`, namely `HttpJdkSolrClient`.  This required one behavior change:  callers must pass an instance of `HttpSolrClientBase` to the constructor.  Passing `null` will result in an `IllegalArgumentException`.  (Internally, only the unit test was relying on prior behavior)

In addition method `withHttpClient`  was added to `HttpJdkSolrClient.Builder`, allowing H2CSP to clone client instances with different base urls.  Also a `builder()` method was added to the `HttpSolrClientBase` api so that H2CSP can obtain a builder of the correct type.

The unit test randomly chooses to test either client implementation.

In lieu of this approach, I considered creating a new class for the JDK client, leaving H2CSP unchanged.  It seems better to make these value-add clients generic rather than creating yet more class variants.

This PR is targeted for main/10.x only.