### PR TITLE
SOLR-17865: Support optional node level metrics recording with OTEL

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -185,7 +185,8 @@ public abstract class RequestHandlerBase
     public static final HandlerMetrics NO_OP =
         new HandlerMetrics(
             new SolrMetricsContext(new SolrMetricManager(null), "NO_OP", "NO_OP"),
-            Attributes.empty());
+            Attributes.empty(),
+            false);
 
     public AttributedLongCounter requests;
     public AttributedLongCounter numServerErrors;

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -282,7 +282,7 @@ public abstract class RequestHandlerBase
     private LongCounter requestCounter(
         SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
       return (isNodeRegistry)
-          ? solrMetricsContext.longCounter("solr_node_requests", "HTTP Solr node requests", null)
+          ? solrMetricsContext.longCounter("solr_node_requests", "HTTP Solr node requests")
           : solrMetricsContext.longCounter("solr_core_requests", "HTTP Solr core requests");
     }
 
@@ -290,7 +290,7 @@ public abstract class RequestHandlerBase
         SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
       return (isNodeRegistry)
           ? solrMetricsContext.longCounter(
-              "solr_node_requests_errors", "HTTP Solr node request errors", null)
+              "solr_node_requests_errors", "HTTP Solr node request errors")
           : solrMetricsContext.longCounter(
               "solr_core_requests_errors", "HTTP Solr core request errors");
     }
@@ -299,7 +299,7 @@ public abstract class RequestHandlerBase
         SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
       return (isNodeRegistry)
           ? solrMetricsContext.longCounter(
-              "solr_node_requests_timeout", "HTTP Solr node request timeouts", null)
+              "solr_node_requests_timeout", "HTTP Solr node request timeouts")
           : solrMetricsContext.longCounter(
               "solr_core_requests_timeout", "HTTP Solr core request timeouts");
     }

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -41,13 +41,13 @@ import org.apache.solr.core.PluginBag;
 import org.apache.solr.core.PluginInfo;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrInfoBean;
-import org.apache.solr.metrics.SolrDelegateRegistryMetricsContext;
 import org.apache.solr.metrics.SolrMetricManager;
-import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.metrics.otel.instruments.AttributedLongTimer;
+import org.apache.solr.metrics.otel.instruments.DualRegistryAttributedLongCounter;
+import org.apache.solr.metrics.otel.instruments.DualRegistryAttributedLongTimer;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.response.SolrQueryResponse;
@@ -167,21 +167,13 @@ public abstract class RequestHandlerBase
   @Override
   public void initializeMetrics(
       SolrMetricsContext parentContext, Attributes attributes, String scope) {
-    if (aggregateNodeLevelMetricsEnabled) {
-      this.solrMetricsContext =
-          new SolrDelegateRegistryMetricsContext(
-              parentContext.getMetricManager(),
-              parentContext.getRegistryName(),
-              SolrMetricProducer.getUniqueMetricTag(this, parentContext.getTag()),
-              SolrMetricManager.getRegistryName(SolrInfoBean.Group.node));
-    } else {
-      this.solrMetricsContext = parentContext.getChildContext(this);
-    }
+    this.solrMetricsContext = parentContext.getChildContext(this);
 
     metrics =
         new HandlerMetrics(
             solrMetricsContext,
-            attributes.toBuilder().put(CATEGORY_ATTR, getCategory().toString()).build());
+            attributes.toBuilder().put(CATEGORY_ATTR, getCategory().toString()).build(),
+            aggregateNodeLevelMetricsEnabled);
 
     // NOCOMMIT: I don't see value in this metric
     solrMetricsContext.gauge(
@@ -201,53 +193,124 @@ public abstract class RequestHandlerBase
     public AttributedLongCounter numTimeouts;
     public AttributedLongTimer requestTimes;
 
-    public HandlerMetrics(SolrMetricsContext solrMetricsContext, Attributes attributes) {
-      LongCounter requestMetric;
-      LongCounter errorRequestMetric;
-      LongCounter timeoutRequestMetric;
-      LongHistogram requestTimeMetric;
+    public HandlerMetrics(
+        SolrMetricsContext solrMetricsContext,
+        Attributes coreAttributes,
+        boolean aggregateNodeLevelMetricsEnabled) {
 
-      if (solrMetricsContext.getRegistryName().equals("solr.node")) {
-        requestMetric =
-            solrMetricsContext.longCounter("solr_node_requests", "Http Solr node requests");
-        errorRequestMetric =
-            solrMetricsContext.longCounter(
-                "solr_node_requests_errors", "HTTP Solr node request errors");
-        timeoutRequestMetric =
-            solrMetricsContext.longCounter(
-                "solr_node_requests_timeout", "HTTP Solr node request timeouts");
-        requestTimeMetric =
-            solrMetricsContext.longHistogram(
-                "solr_node_requests_times", "HTTP Solr node request times", OtelUnit.MILLISECONDS);
+      if (aggregateNodeLevelMetricsEnabled) {
+        createDualRegistryMetrics(solrMetricsContext, coreAttributes);
       } else {
-        requestMetric =
-            solrMetricsContext.longCounter("solr_core_requests", "HTTP Solr core requests");
-        errorRequestMetric =
-            solrMetricsContext.longCounter(
-                "solr_core_requests_errors", "HTTP Solr core request errors");
-        timeoutRequestMetric =
-            solrMetricsContext.longCounter(
-                "solr_core_requests_timeout", "HTTP Solr core request timeouts");
-        requestTimeMetric =
-            solrMetricsContext.longHistogram(
-                "solr_core_requests_times", "HTTP Solr core request times", OtelUnit.MILLISECONDS);
+        createSingleRegistryMetrics(solrMetricsContext, coreAttributes);
       }
+    }
 
-      requests = new AttributedLongCounter(requestMetric, attributes);
+    private void createDualRegistryMetrics(
+        SolrMetricsContext solrCoreMetricsContext, Attributes coreAttributes) {
+      SolrMetricsContext solrNodeMetricsContext =
+          new SolrMetricsContext(
+              solrCoreMetricsContext.getMetricManager(),
+              SolrMetricManager.getRegistryName(SolrInfoBean.Group.node),
+              null);
 
+      Attributes nodeAttributes =
+          Attributes.builder()
+              .put(CATEGORY_ATTR, coreAttributes.get(CATEGORY_ATTR))
+              .put(HANDLER_ATTR, coreAttributes.get(HANDLER_ATTR))
+              .build();
+
+      requests =
+          new DualRegistryAttributedLongCounter(
+              requestCounter(solrCoreMetricsContext, false), coreAttributes,
+              requestCounter(solrNodeMetricsContext, true), nodeAttributes);
       numServerErrors =
-          new AttributedLongCounter(
-              errorRequestMetric,
-              attributes.toBuilder().put(AttributeKey.stringKey("source"), "server").build());
+          new DualRegistryAttributedLongCounter(
+              requestErrorCounter(solrCoreMetricsContext, false),
+              coreAttributes.toBuilder().put(AttributeKey.stringKey("source"), "server").build(),
+              requestErrorCounter(solrNodeMetricsContext, true),
+              nodeAttributes.toBuilder().put(AttributeKey.stringKey("source"), "server").build());
 
       numClientErrors =
+          new DualRegistryAttributedLongCounter(
+              requestErrorCounter(solrCoreMetricsContext, false),
+              coreAttributes.toBuilder().put(AttributeKey.stringKey("source"), "client").build(),
+              requestErrorCounter(solrNodeMetricsContext, true),
+              nodeAttributes.toBuilder().put(AttributeKey.stringKey("source"), "client").build());
+      numTimeouts =
+          new DualRegistryAttributedLongCounter(
+              requestTimeoutCounter(solrCoreMetricsContext, false), coreAttributes,
+              requestTimeoutCounter(solrNodeMetricsContext, true), nodeAttributes);
+      requestTimes =
+          new DualRegistryAttributedLongTimer(
+              requestTimeHistogram(solrCoreMetricsContext, false), coreAttributes,
+              requestTimeHistogram(solrNodeMetricsContext, true), nodeAttributes);
+    }
+
+    private void createSingleRegistryMetrics(
+        SolrMetricsContext solrMetricsContext, Attributes coreAttributes) {
+      boolean isNodeRegistry =
+          solrMetricsContext
+              .getRegistryName()
+              .equals(SolrMetricManager.getRegistryName(SolrInfoBean.Group.node));
+
+      Attributes attributes =
+          isNodeRegistry
+              ? Attributes.builder()
+                  .put(CATEGORY_ATTR, coreAttributes.get(CATEGORY_ATTR))
+                  .put(HANDLER_ATTR, coreAttributes.get(HANDLER_ATTR))
+                  .build()
+              : coreAttributes;
+
+      requests =
+          new AttributedLongCounter(requestCounter(solrMetricsContext, isNodeRegistry), attributes);
+      numServerErrors =
           new AttributedLongCounter(
-              errorRequestMetric,
+              requestErrorCounter(solrMetricsContext, isNodeRegistry),
+              attributes.toBuilder().put(AttributeKey.stringKey("source"), "server").build());
+      numClientErrors =
+          new AttributedLongCounter(
+              requestErrorCounter(solrMetricsContext, isNodeRegistry),
               attributes.toBuilder().put(AttributeKey.stringKey("source"), "client").build());
+      numTimeouts =
+          new AttributedLongCounter(
+              requestTimeoutCounter(solrMetricsContext, isNodeRegistry), attributes);
+      requestTimes =
+          new AttributedLongTimer(
+              requestTimeHistogram(solrMetricsContext, isNodeRegistry), attributes);
+    }
 
-      numTimeouts = new AttributedLongCounter(timeoutRequestMetric, attributes);
+    private LongCounter requestCounter(
+        SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
+      return (isNodeRegistry)
+          ? solrMetricsContext.longCounter("solr_node_requests", "HTTP Solr node requests", null)
+          : solrMetricsContext.longCounter("solr_core_requests", "HTTP Solr core requests");
+    }
 
-      requestTimes = new AttributedLongTimer(requestTimeMetric, attributes);
+    private LongCounter requestErrorCounter(
+        SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
+      return (isNodeRegistry)
+          ? solrMetricsContext.longCounter(
+              "solr_node_requests_errors", "HTTP Solr node request errors", null)
+          : solrMetricsContext.longCounter(
+              "solr_core_requests_errors", "HTTP Solr core request errors");
+    }
+
+    private LongCounter requestTimeoutCounter(
+        SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
+      return (isNodeRegistry)
+          ? solrMetricsContext.longCounter(
+              "solr_node_requests_timeout", "HTTP Solr node request timeouts", null)
+          : solrMetricsContext.longCounter(
+              "solr_core_requests_timeout", "HTTP Solr core request timeouts");
+    }
+
+    private LongHistogram requestTimeHistogram(
+        SolrMetricsContext solrMetricsContext, boolean isNodeRegistry) {
+      return (isNodeRegistry)
+          ? solrMetricsContext.longHistogram(
+              "solr_node_requests_times", "HTTP Solr node request times", OtelUnit.MILLISECONDS)
+          : solrMetricsContext.longHistogram(
+              "solr_core_requests_times", "HTTP Solr core request times", OtelUnit.MILLISECONDS);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -98,8 +98,6 @@ public class SearchHandler extends RequestHandlerBase
   static final String INIT_FIRST_COMPONENTS = "first-components";
   static final String INIT_LAST_COMPONENTS = "last-components";
 
-  protected static final String SHARD_HANDLER_SUFFIX = "[shard]";
-
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   /**
@@ -171,7 +169,8 @@ public class SearchHandler extends RequestHandlerBase
                 .putAll(attributes)
                 .put(CATEGORY_ATTR, getCategory().toString())
                 .put(INTERNAL_ATTR, true)
-                .build());
+                .build(),
+            false);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/metrics/otel/instruments/AttributedDoubleCounter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/instruments/AttributedDoubleCounter.java
@@ -30,7 +30,7 @@ public class AttributedDoubleCounter {
   }
 
   public void inc() {
-    add(1.0);
+    counter.add(1.0, attributes);
   }
 
   public void add(Double value) {

--- a/solr/core/src/java/org/apache/solr/metrics/otel/instruments/AttributedLongCounter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/instruments/AttributedLongCounter.java
@@ -30,7 +30,7 @@ public class AttributedLongCounter {
   }
 
   public void inc() {
-    add(1L);
+    baseCounter.add(1L, attributes);
   }
 
   public void add(Long value) {

--- a/solr/core/src/java/org/apache/solr/metrics/otel/instruments/AttributedLongUpDownCounter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/instruments/AttributedLongUpDownCounter.java
@@ -30,11 +30,11 @@ public class AttributedLongUpDownCounter {
   }
 
   public void inc() {
-    add(1L);
+    upDownCounter.add(1L, attributes);
   }
 
   public void dec() {
-    add(-1L);
+    upDownCounter.add(-1L, attributes);
   }
 
   public void add(Long value) {

--- a/solr/core/src/java/org/apache/solr/metrics/otel/instruments/DualRegistryAttributedLongCounter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/instruments/DualRegistryAttributedLongCounter.java
@@ -17,27 +17,34 @@
 package org.apache.solr.metrics.otel.instruments;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.LongCounter;
 
-public class AttributedDoubleUpDownCounter {
+/**
+ * An AttributedLongCounter that writes to both core and node registries with corresponding
+ * attributes.
+ */
+public class DualRegistryAttributedLongCounter extends AttributedLongCounter {
 
-  private final DoubleUpDownCounter upDownCounter;
-  private final Attributes attributes;
+  private final AttributedLongCounter nodeCounter;
 
-  public AttributedDoubleUpDownCounter(DoubleUpDownCounter upDownCounter, Attributes attributes) {
-    this.upDownCounter = upDownCounter;
-    this.attributes = attributes;
+  public DualRegistryAttributedLongCounter(
+      LongCounter coreCounter,
+      Attributes coreAttributes,
+      LongCounter nodeCounter,
+      Attributes nodeAttributes) {
+    super(coreCounter, coreAttributes);
+    this.nodeCounter = new AttributedLongCounter(nodeCounter, nodeAttributes);
   }
 
+  @Override
   public void inc() {
-    upDownCounter.add(1.0, attributes);
+    super.inc();
+    nodeCounter.inc();
   }
 
-  public void dec() {
-    upDownCounter.add(-1.0, attributes);
-  }
-
-  public void add(Double value) {
-    upDownCounter.add(value, attributes);
+  @Override
+  public void add(Long value) {
+    super.add(value);
+    nodeCounter.add(value);
   }
 }

--- a/solr/core/src/java/org/apache/solr/metrics/otel/instruments/DualRegistryAttributedLongTimer.java
+++ b/solr/core/src/java/org/apache/solr/metrics/otel/instruments/DualRegistryAttributedLongTimer.java
@@ -17,27 +17,28 @@
 package org.apache.solr.metrics.otel.instruments;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
 
-public class AttributedDoubleUpDownCounter {
+/**
+ * An AttributedLongTimer that records to both core and node registries with corresponding
+ * attributes.
+ */
+public class DualRegistryAttributedLongTimer extends AttributedLongTimer {
 
-  private final DoubleUpDownCounter upDownCounter;
-  private final Attributes attributes;
+  private final AttributedLongTimer nodeTimer;
 
-  public AttributedDoubleUpDownCounter(DoubleUpDownCounter upDownCounter, Attributes attributes) {
-    this.upDownCounter = upDownCounter;
-    this.attributes = attributes;
+  public DualRegistryAttributedLongTimer(
+      LongHistogram coreHistogram,
+      Attributes coreAttributes,
+      LongHistogram nodeHistogram,
+      Attributes nodeAttributes) {
+    super(coreHistogram, coreAttributes);
+    this.nodeTimer = new AttributedLongTimer(nodeHistogram, nodeAttributes);
   }
 
-  public void inc() {
-    upDownCounter.add(1.0, attributes);
-  }
-
-  public void dec() {
-    upDownCounter.add(-1.0, attributes);
-  }
-
-  public void add(Double value) {
-    upDownCounter.add(value, attributes);
+  @Override
+  public void record(Long value) {
+    super.record(value);
+    nodeTimer.record(value);
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/RequestHandlerBaseTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/RequestHandlerBaseTest.java
@@ -196,6 +196,8 @@ public class RequestHandlerBaseTest extends SolrTestCaseJ4 {
     when(metricsContext.longHistogram(any(), any())).thenReturn(mockLongHistogram);
 
     return new RequestHandlerBase.HandlerMetrics(
-        metricsContext, Attributes.of(AttributeKey.stringKey("/handler"), "/someBaseMetricPath"));
+        metricsContext,
+        Attributes.of(AttributeKey.stringKey("/handler"), "/someBaseMetricPath"),
+        false);
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/RequestHandlerMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/RequestHandlerMetricsTest.java
@@ -52,7 +52,6 @@ public class RequestHandlerMetricsTest extends SolrCloudTestCase {
     System.clearProperty("metricsEnabled");
   }
 
-  // Test for dual registry metrics (core + node level aggregation)
   @Test
   public void testAggregateNodeLevelMetrics() throws SolrServerException, IOException {
     String collection1 = "testRequestHandlerMetrics1";
@@ -122,10 +121,8 @@ public class RequestHandlerMetricsTest extends SolrCloudTestCase {
 
     assertNotNull("Node select requests should be recorded", nodeSelectRequests);
     assertNotNull("Node update requests should be recorded", nodeUpdateRequests);
-    assertEquals(
-        "Node should have 2 select requests total", 2.0, nodeSelectRequests.getValue(), 0.0);
-    assertEquals(
-        "Node should have 2 update requests total", 2.0, nodeUpdateRequests.getValue(), 0.0);
+    assertEquals(2.0, nodeSelectRequests.getValue(), 0.0);
+    assertEquals(2.0, nodeUpdateRequests.getValue(), 0.0);
 
     core1.close();
     core2.close();

--- a/solr/core/src/test/org/apache/solr/handler/RequestHandlerMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/RequestHandlerMetricsTest.java
@@ -26,7 +26,7 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.metrics.SolrMetricTestUtils;
+import org.apache.solr.util.SolrMetricTestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/solr/core/src/test/org/apache/solr/handler/RequestHandlerMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/RequestHandlerMetricsTest.java
@@ -16,19 +16,17 @@
  */
 package org.apache.solr.handler;
 
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.metrics.SolrMetricTestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -54,11 +52,8 @@ public class RequestHandlerMetricsTest extends SolrCloudTestCase {
     System.clearProperty("metricsEnabled");
   }
 
-  // NOCOMMIT: Need to fix aggregateNodeLevelMetricsEnabled for OTEL. Delegate registries currently
-  // do not play nice with OTEL instrumentation
+  // Test for dual registry metrics (core + node level aggregation)
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-17458")
-  @SuppressWarnings({"unchecked"})
   public void testAggregateNodeLevelMetrics() throws SolrServerException, IOException {
     String collection1 = "testRequestHandlerMetrics1";
     String collection2 = "testRequestHandlerMetrics2";
@@ -83,97 +78,56 @@ public class RequestHandlerMetricsTest extends SolrCloudTestCase {
     cloudClient.query(collection1, solrQuery);
     cloudClient.query(collection2, solrQuery);
 
-    NamedList<Object> response =
-        cloudClient.request(
-            new GenericSolrRequest(
-                SolrRequest.METHOD.GET, "/admin/metrics", SolrRequest.SolrRequestType.ADMIN));
+    var coreContainer = cluster.getJettySolrRunners().get(0).getCoreContainer();
+    SolrCore core1 = coreContainer.getCore(coreContainer.getAllCoreNames().get(0));
+    SolrCore core2 = coreContainer.getCore(coreContainer.getAllCoreNames().get(1));
 
-    NamedList<Object> metrics = (NamedList<Object>) response.get("metrics");
+    CounterSnapshot.CounterDataPointSnapshot actualCore1Selects =
+        SolrMetricTestUtils.newCloudSelectRequestsDatapoint(core1);
+    CounterSnapshot.CounterDataPointSnapshot actualCore1Updates =
+        SolrMetricTestUtils.newCloudUpdateRequestsDatapoint(core1);
+    CounterSnapshot.CounterDataPointSnapshot actualCore2Selects =
+        SolrMetricTestUtils.newCloudSelectRequestsDatapoint(core2);
+    CounterSnapshot.CounterDataPointSnapshot actualCore2Updates =
+        SolrMetricTestUtils.newCloudUpdateRequestsDatapoint(core2);
 
-    final double[] minQueryTime = {Double.MAX_VALUE};
-    final double[] maxQueryTime = {-1.0};
-    final double[] minUpdateTime = {Double.MAX_VALUE};
-    final double[] maxUpdateTime = {-1.0};
-    Set<NamedList<Object>> coreMetrics = new HashSet<>();
-    metrics.forEach(
-        (key, coreMetric) -> {
-          if (key.startsWith("solr.core.testRequestHandlerMetrics")) {
-            coreMetrics.add((NamedList<Object>) coreMetric);
-          }
-        });
-    assertEquals(2, coreMetrics.size());
-    coreMetrics.forEach(
-        metric -> {
-          assertEquals(
-              1L,
-              ((Map<String, Number>) metric.get("QUERY./select.requestTimes"))
-                  .get("count")
-                  .longValue());
-          minQueryTime[0] =
-              Math.min(
-                  minQueryTime[0],
-                  ((Map<String, Number>) metric.get("QUERY./select.requestTimes"))
-                      .get("min_ms")
-                      .doubleValue());
-          maxQueryTime[0] =
-              Math.max(
-                  maxQueryTime[0],
-                  ((Map<String, Number>) metric.get("QUERY./select.requestTimes"))
-                      .get("max_ms")
-                      .doubleValue());
-          assertEquals(
-              1L,
-              ((Map<String, Number>) metric.get("UPDATE./update.requestTimes"))
-                  .get("count")
-                  .longValue());
-          minUpdateTime[0] =
-              Math.min(
-                  minUpdateTime[0],
-                  ((Map<String, Number>) metric.get("UPDATE./update.requestTimes"))
-                      .get("min_ms")
-                      .doubleValue());
-          maxUpdateTime[0] =
-              Math.max(
-                  maxUpdateTime[0],
-                  ((Map<String, Number>) metric.get("UPDATE./update.requestTimes"))
-                      .get("max_ms")
-                      .doubleValue());
-        });
+    assertEquals(1.0, actualCore1Selects.getValue(), 0.0);
+    assertEquals(1.0, actualCore1Updates.getValue(), 0.0);
+    assertEquals(1.0, actualCore2Updates.getValue(), 0.0);
+    assertEquals(1.0, actualCore2Selects.getValue(), 0.0);
 
-    NamedList<Object> nodeMetrics = (NamedList<Object>) metrics.get("solr.node");
+    // Get node metrics and the select/update requests should be the sum of both cores requests
+    var nodeReader = SolrMetricTestUtils.getPrometheusMetricReader(coreContainer, "solr.node");
+
+    CounterSnapshot.CounterDataPointSnapshot nodeSelectRequests =
+        (CounterSnapshot.CounterDataPointSnapshot)
+            SolrMetricTestUtils.getDataPointSnapshot(
+                nodeReader,
+                "solr_node_requests",
+                Labels.builder()
+                    .label("category", "QUERY")
+                    .label("handler", "/select")
+                    .label("otel_scope_name", "org.apache.solr")
+                    .build());
+    CounterSnapshot.CounterDataPointSnapshot nodeUpdateRequests =
+        (CounterSnapshot.CounterDataPointSnapshot)
+            SolrMetricTestUtils.getDataPointSnapshot(
+                nodeReader,
+                "solr_node_requests",
+                Labels.builder()
+                    .label("category", "UPDATE")
+                    .label("handler", "/update")
+                    .label("otel_scope_name", "org.apache.solr")
+                    .build());
+
+    assertNotNull("Node select requests should be recorded", nodeSelectRequests);
+    assertNotNull("Node update requests should be recorded", nodeUpdateRequests);
     assertEquals(
-        2L,
-        ((Map<String, Number>) nodeMetrics.get("QUERY./select.requestTimes"))
-            .get("count")
-            .longValue());
+        "Node should have 2 select requests total", 2.0, nodeSelectRequests.getValue(), 0.0);
     assertEquals(
-        minQueryTime[0],
-        ((Map<String, Number>) nodeMetrics.get("QUERY./select.requestTimes"))
-            .get("min_ms")
-            .doubleValue(),
-        0.0);
-    assertEquals(
-        maxQueryTime[0],
-        ((Map<String, Number>) nodeMetrics.get("QUERY./select.requestTimes"))
-            .get("max_ms")
-            .doubleValue(),
-        0.0);
-    assertEquals(
-        2L,
-        ((Map<String, Number>) nodeMetrics.get("UPDATE./update.requestTimes"))
-            .get("count")
-            .longValue());
-    assertEquals(
-        minUpdateTime[0],
-        ((Map<String, Number>) nodeMetrics.get("UPDATE./update.requestTimes"))
-            .get("min_ms")
-            .doubleValue(),
-        0.0);
-    assertEquals(
-        maxUpdateTime[0],
-        ((Map<String, Number>) nodeMetrics.get("UPDATE./update.requestTimes"))
-            .get("max_ms")
-            .doubleValue(),
-        0.0);
+        "Node should have 2 update requests total", 2.0, nodeUpdateRequests.getValue(), 0.0);
+
+    core1.close();
+    core2.close();
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17865

In RequestHandlerBase, user can enable aggregateNodeLevelMetricsEnabled to rollup core level metrics at a node level. We need to migrate this logic from Dropwizard to still have this as a supported option