### PR TITLE
SOLR-18068:  POC of keeping existing assertQ logic with solrTestRule

### DIFF
--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestPhraseSuggestions.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestPhraseSuggestions.java
@@ -18,14 +18,14 @@ package org.apache.solr.spelling.suggest;
 
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.SolrTestCaseJ4Test;
-import org.apache.solr.SolrXpathTestCase;
+import org.apache.solr.SolrXPathTestCase;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.common.params.SpellingParams;
 import org.apache.solr.util.EmbeddedSolrServerTestRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
-public class TestPhraseSuggestions extends SolrXpathTestCase {
+public class TestPhraseSuggestions extends SolrXPathTestCase {
   static final String URI = "/suggest_wfst";
 
   @ClassRule

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestPhraseSuggestions.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestPhraseSuggestions.java
@@ -46,7 +46,6 @@ public class TestPhraseSuggestions extends SolrXpathTestCase {
         .create();
   }
 
-
   public SolrClient getSolrClient() {
     return solrTestRule.getSolrClient();
   }

--- a/solr/core/src/test/org/apache/solr/spelling/suggest/TestPhraseSuggestions.java
+++ b/solr/core/src/test/org/apache/solr/spelling/suggest/TestPhraseSuggestions.java
@@ -44,6 +44,10 @@ public class TestPhraseSuggestions extends SolrXPathTestCase {
         .withConfigFile("conf/solrconfig-phrasesuggest.xml")
         .withSchemaFile("conf/schema-phrasesuggest.xml")
         .create();
+
+    assertQ(
+        solrTestRule.getSolrClient(),
+        req("qt", URI, "q", "", SpellingParams.SPELLCHECK_BUILD, "true"));
   }
 
   public SolrClient getSolrClient() {
@@ -51,8 +55,6 @@ public class TestPhraseSuggestions extends SolrXPathTestCase {
   }
 
   public void test() {
-    assertQ(req("qt", URI, "q", "", SpellingParams.SPELLCHECK_BUILD, "true"));
-
     assertQ(
         req("qt", URI, "q", "the f", SpellingParams.SPELLCHECK_COUNT, "4"),
         "//lst[@name='spellcheck']/lst[@name='suggestions']/lst[@name='the f']/int[@name='numFound'][.='3']",

--- a/solr/test-framework/src/java/org/apache/solr/SolrClientTestHelpers.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrClientTestHelpers.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr;
+
+import java.io.StringWriter;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.response.InputStreamResponseParser;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.XMLResponseParser;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.util.BaseTestHarness;
+
+/**
+ * Helper methods for using assertQ/req style testing with SolrClient-based tests. This bridges the
+ * gap between TestHarness-style tests and EmbeddedSolrServerTestRule tests.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * import static org.apache.solr.SolrClientTestHelpers.assertQClient;
+ * import static org.apache.solr.SolrClientTestHelpers.params;
+ *
+ * SolrClient client = solrTestRule.getSolrClient();
+ * assertQClient(client, params("q", "*:*"),
+ *               "/response/lst[@name='responseHeader']/int[@name='status'][.='0']");
+ * </pre>
+ */
+public class SolrClientTestHelpers {
+
+  /**
+   * Creates a SolrParams object from key-value pairs, similar to req() in SolrTestCaseJ4. Use this
+   * with assertQClient(SolrClient, SolrParams, xpaths...).
+   *
+   * @param params alternating key-value pairs for query parameters
+   * @return SolrParams object
+   */
+  public static SolrParams params(String... params) {
+    ModifiableSolrParams solrParams = new ModifiableSolrParams();
+    for (int i = 0; i < params.length; i += 2) {
+      if (i + 1 < params.length) {
+        solrParams.add(params[i], params[i + 1]);
+      }
+    }
+    return solrParams;
+  }
+
+  public static GenericSolrRequest req3(String... q) {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+
+    if (q.length == 1) {
+      params.set("q", q);
+    }
+
+    params.set("wt", "xml");
+
+    params.set("indent", params.get("indent", "off"));
+
+    var req =
+        new GenericSolrRequest(
+            SolrRequest.METHOD.GET, "/select", params // .add("indent", "true")
+            );
+    // Using the "smart" solr parsers won't work, because they decode into Solr objects.
+    // When trying to re-write into JSON, the JSONWriter doesn't have the right info to print it
+    // correctly.
+    // All we want to do is pass the JSON response to the user, so do that.
+    req.setResponseParser(new XMLResponseParser());
+
+    return req;
+  }
+
+  public static QueryRequest req2(String... q) {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+
+    if (q.length == 1) {
+      params.set("q", q);
+    }
+    if (q.length % 2 != 0) {
+      throw new RuntimeException(
+          "The length of the string array (query arguments) needs to be even");
+    }
+    for (int i = 0; i < q.length; i += 2) {
+      params.set(q[i], q[i + 1]);
+    }
+
+    params.set("wt", "xml");
+    params.set("indent", params.get("indent", "off"));
+
+    QueryRequest req = new QueryRequest(params);
+    String path = params.get("qt");
+    if (path != null) {
+      req.setPath(path);
+    }
+    req.setResponseParser(new InputStreamResponseParser("xml"));
+    return req;
+  }
+
+  public static ModifiableSolrParams params2(String... params) {
+    if (params.length % 2 != 0) throw new RuntimeException("Params length should be even");
+    ModifiableSolrParams msp = new ModifiableSolrParams();
+    for (int i = 0; i < params.length; i += 2) {
+      msp.add(params[i], params[i + 1]);
+    }
+    return msp;
+  }
+
+  /**
+   * Executes a query using SolrClient with a custom message and validates against XPath
+   * expressions.
+   *
+   * @param message custom error message prefix
+   * @param client the SolrClient to execute the query against
+   * @param params the query parameters
+   * @param tests XPath expressions to validate against the response
+   */
+  public static void assertQ2(
+      String message, SolrClient client, SolrParams params, String... tests) {
+    try {
+      // Ensure we request XML format for XPath validation
+      ModifiableSolrParams xmlParams = new ModifiableSolrParams(params);
+      if (xmlParams.get("wt") == null) {
+        xmlParams.set("wt", "xml");
+      }
+      xmlParams.set("indent", xmlParams.get("indent", "off"));
+
+      // Execute the query
+      QueryRequest req = new QueryRequest(xmlParams);
+      QueryResponse rsp = req.process(client);
+
+      // Convert response to XML for XPath validation
+      String xml = toXML(rsp.getResponse());
+
+      // Validate using BaseTestHarness XPath validation
+      String results = BaseTestHarness.validateXPath(xml, tests);
+
+      if (results != null) {
+        String msg =
+            (message == null ? "" : message + " ")
+                + "REQUEST FAILED: xpath="
+                + results
+                + "\n\txml response was: "
+                + xml
+                + "\n\trequest was: "
+                + params;
+        throw new RuntimeException(msg);
+      }
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Error executing query with SolrClient: " + params, e);
+    }
+  }
+
+  /**
+   * Converts a NamedList response to XML string for XPath validation. This recreates the XML format
+   * that Solr produces.
+   *
+   * @param response the NamedList response to convert
+   * @return XML string representation
+   */
+  private static String toXML(NamedList<Object> response) {
+    try {
+      StringWriter writer = new StringWriter();
+
+      // Write XML manually since we don't have a full XMLWriter context
+      writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+      writeNamedListAsXML(writer, response, "response", 0);
+
+      return writer.toString();
+    } catch (Exception e) {
+      throw new RuntimeException("Error converting response to XML", e);
+    }
+  }
+
+  /** Recursively writes a NamedList as XML. */
+  private static void writeNamedListAsXML(
+      StringWriter writer, NamedList<?> nl, String rootName, int indent) {
+    String indentStr = "  ".repeat(indent);
+
+    if (rootName != null) {
+      writer.write(indentStr + "<" + rootName + ">\n");
+    }
+
+    for (int i = 0; i < nl.size(); i++) {
+      String name = nl.getName(i);
+      Object value = nl.getVal(i);
+      writeValueAsXML(writer, name, value, indent + 1);
+    }
+
+    if (rootName != null) {
+      writer.write(indentStr + "</" + rootName + ">\n");
+    }
+  }
+
+  /** Writes a value as XML. */
+  private static void writeValueAsXML(StringWriter writer, String name, Object value, int indent) {
+    String indentStr = "  ".repeat(indent);
+
+    if (value == null) {
+      writer.write(indentStr + "<null name=\"" + xmlEscape(name) + "\"/>\n");
+    } else if (value instanceof NamedList) {
+      writer.write(indentStr + "<lst name=\"" + xmlEscape(name) + "\">\n");
+      NamedList<?> nl = (NamedList<?>) value;
+      for (int i = 0; i < nl.size(); i++) {
+        writeValueAsXML(writer, nl.getName(i), nl.getVal(i), indent + 1);
+      }
+      writer.write(indentStr + "</lst>\n");
+    } else if (value instanceof Iterable) {
+      writer.write(indentStr + "<arr name=\"" + xmlEscape(name) + "\">\n");
+      for (Object item : (Iterable<?>) value) {
+        writeValueAsXML(writer, null, item, indent + 1);
+      }
+      writer.write(indentStr + "</arr>\n");
+    } else {
+      String type = getXMLType(value);
+      if (name != null) {
+        writer.write(
+            indentStr
+                + "<"
+                + type
+                + " name=\""
+                + xmlEscape(name)
+                + "\">"
+                + xmlEscape(String.valueOf(value))
+                + "</"
+                + type
+                + ">\n");
+      } else {
+        writer.write(
+            indentStr + "<" + type + ">" + xmlEscape(String.valueOf(value)) + "</" + type + ">\n");
+      }
+    }
+  }
+
+  /** Determines XML type tag for a value. */
+  private static String getXMLType(Object value) {
+    if (value instanceof Integer || value instanceof Long) {
+      return "int";
+    } else if (value instanceof Float || value instanceof Double) {
+      return "float";
+    } else if (value instanceof Boolean) {
+      return "bool";
+    } else if (value instanceof java.util.Date) {
+      return "date";
+    } else {
+      return "str";
+    }
+  }
+
+  /** Escapes XML special characters. */
+  private static String xmlEscape(String str) {
+    if (str == null) return "";
+    return str.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;");
+  }
+}

--- a/solr/test-framework/src/java/org/apache/solr/SolrXPathTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrXPathTestCase.java
@@ -39,15 +39,16 @@ public class SolrXPathTestCase extends SolrTestCase {
    * Executes a query using SolrClient and validates the XML response against XPath expressions.
    * This provides a similar interface to assertQ() in SolrTestCaseJ4 but works with SolrClient.
    *
+   * @param client the SolrClient to use for the request
    * @param req the query parameters
    * @param tests XPath expressions to validate against the response
    * @see SolrTestCaseJ4#assertQ(String, SolrQueryRequest, String...)
    */
-  public void assertQ(QueryRequest req, String... tests) {
+  public static void assertQ(SolrClient client, QueryRequest req, String... tests) {
     try {
 
       // Process request and extract raw response
-      QueryResponse rsp = req.process(getSolrClient());
+      QueryResponse rsp = req.process(client);
       NamedList<Object> rawResponse = rsp.getResponse();
       InputStream stream = (InputStream) rawResponse.get("stream");
       String response = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
@@ -71,6 +72,17 @@ public class SolrXPathTestCase extends SolrTestCase {
       log.error("REQUEST FAILED: {}", req.getParams(), e3);
       throw new RuntimeException("Exception during query", e3);
     }
+  }
+
+  /**
+   * Instance method that delegates to the static assertQ using the instance's SolrClient. This
+   * provides a convenient way to call assertQ from instance test methods.
+   *
+   * @param req the query parameters
+   * @param tests XPath expressions to validate against the response
+   */
+  public void assertQ(QueryRequest req, String... tests) {
+    assertQ(getSolrClient(), req, tests);
   }
 
   /**

--- a/solr/test-framework/src/java/org/apache/solr/SolrXPathTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrXPathTestCase.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr;
 
 import java.io.InputStream;
@@ -15,7 +31,7 @@ import org.apache.solr.util.BaseTestHarness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SolrXpathTestCase extends SolrTestCase {
+public class SolrXPathTestCase extends SolrTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/test-framework/src/java/org/apache/solr/SolrXpathTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrXpathTestCase.java
@@ -1,0 +1,96 @@
+package org.apache.solr;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.response.InputStreamResponseParser;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.util.BaseTestHarness;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+
+public class SolrXpathTestCase extends SolrTestCase {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * Executes a query using SolrClient and validates the XML response against XPath expressions.
+   * This provides a similar interface to assertQ() in SolrTestCaseJ4 but works with SolrClient.
+   *
+   * @param req the query parameters
+   * @param tests XPath expressions to validate against the response
+   *
+   * @see SolrTestCaseJ4#assertQ(String, SolrQueryRequest, String...)
+   */
+  public void assertQ(QueryRequest req, String... tests) {
+    try {
+
+      // Process request and extract raw response
+      QueryResponse rsp = req.process(getSolrClient());
+      NamedList<Object> rawResponse = rsp.getResponse();
+      InputStream stream = (InputStream) rawResponse.get("stream");
+      String response = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+
+      String results = BaseTestHarness.validateXPath(response, tests);
+
+      if (results != null) {
+        String msg =
+            "REQUEST FAILED: xpath="
+                + results
+                + "\n\txml response was: "
+                + response
+                + "\n\trequest was:"
+                + req.getQueryParams();
+
+        fail(msg);
+      }
+    } catch (XPathExpressionException e1) {
+      throw new RuntimeException("XPath is invalid", e1);
+    } catch (Throwable e3) {
+      log.error("REQUEST FAILED: {}", req.getParams(), e3);
+      throw new RuntimeException("Exception during query", e3);
+    }
+  }
+
+  /**
+   * Generates a QueryRequest
+   *
+   * @see SolrTestCaseJ4#req(String...)
+   */
+  public static QueryRequest req(String... q) {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+
+    if (q.length == 1) {
+      params.set("q", q);
+    }
+    if (q.length % 2 != 0) {
+      throw new RuntimeException(
+          "The length of the string array (query arguments) needs to be even");
+    }
+    for (int i = 0; i < q.length; i += 2) {
+      params.set(q[i], q[i + 1]);
+    }
+
+    params.set("wt", "xml");
+    params.set("indent", params.get("indent", "off"));
+
+    QueryRequest req = new QueryRequest(params);
+    String path = params.get("qt");
+    if (path != null) {
+      req.setPath(path);
+    }
+    req.setResponseParser(new InputStreamResponseParser("xml"));
+    return req;
+  }
+
+  public SolrClient getSolrClient(){
+    throw new RuntimeException("This method needs to be overridden");
+  }
+
+}

--- a/solr/test-framework/src/java/org/apache/solr/SolrXpathTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrXpathTestCase.java
@@ -1,5 +1,9 @@
 package org.apache.solr;
 
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import javax.xml.xpath.XPathExpressionException;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.InputStreamResponseParser;
@@ -10,10 +14,6 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.util.BaseTestHarness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javax.xml.xpath.XPathExpressionException;
-import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
-import java.nio.charset.StandardCharsets;
 
 public class SolrXpathTestCase extends SolrTestCase {
 
@@ -25,7 +25,6 @@ public class SolrXpathTestCase extends SolrTestCase {
    *
    * @param req the query parameters
    * @param tests XPath expressions to validate against the response
-   *
    * @see SolrTestCaseJ4#assertQ(String, SolrQueryRequest, String...)
    */
   public void assertQ(QueryRequest req, String... tests) {
@@ -89,8 +88,7 @@ public class SolrXpathTestCase extends SolrTestCase {
     return req;
   }
 
-  public SolrClient getSolrClient(){
+  public SolrClient getSolrClient() {
     throw new RuntimeException("This method needs to be overridden");
   }
-
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18068



# Description

Experimenting with how to move us from extending SolrTestCaseJ4 and using `initCore` to using a SolrTestRule

# Solution

I didn't want to change any of the assert logic like:

```
 assertQ(
        req("qt", URI, "q", "the f", SpellingParams.SPELLCHECK_COUNT, "4"),
        "//lst[@name='spellcheck']/lst[@name='suggestions']/lst[@name='the f']/int[@name='numFound'][.='3']",
        "//lst[@name='spellcheck']/lst[@name='suggestions']/lst[@name='the f']/arr[@name='suggestion']/str[1][.='the final phrase']",
        "//lst[@name='spellcheck']/lst[@name='suggestions']/lst[@name='the f']/arr[@name='suggestion']/str[2][.='the fifth phrase']",
        "//lst[@name='spellcheck']/lst[@name='suggestions']/lst[@name='the f']/arr[@name='suggestion']/str[3][.='the first phrase']");
```
It is all xpath based, and to change that to the json equivalents would be a lot of error prone work.  

I introduced a class `SolrXPathTestCase` between `TestPhraseSuggestions` and `SolrTestCase`, cutting out the old extension on `SolrTestCaseJ4`.   I then added the `req` and `assertQ` methods to that class, but with the various new types.

# Tests

Modified existing test and made sure it still passes.  

