### PR TITLE
SOLR-18063: Fix NPE when resubmitting requests to dead-letter queue.

### DIFF
--- a/changelog/unreleased/solr-18063.yml
+++ b/changelog/unreleased/solr-18063.yml
@@ -1,0 +1,9 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: SOLR-18063 -  NPE when resubmitting to DLQ
+type: fixed
+authors:
+  - name: Andrzej Bialecki
+  - nick: ab
+links:
+  - name: SOLR-18063
+    url: https://issues.apache.org/jira/browse/SOLR-18063

--- a/changelog/unreleased/solr-18063.yml
+++ b/changelog/unreleased/solr-18063.yml
@@ -3,7 +3,7 @@ title: SOLR-18063 -  NPE when resubmitting to DLQ
 type: fixed
 authors:
   - name: Andrzej Bialecki
-  - nick: ab
+    nick: ab
 links:
   - name: SOLR-18063
     url: https://issues.apache.org/jira/browse/SOLR-18063

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
@@ -31,6 +31,8 @@ import org.apache.solr.client.solrj.response.SolrResponseBase;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
+import org.apache.solr.common.cloud.ClusterState;
+import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
@@ -108,7 +110,7 @@ public class SolrMessageProcessor extends MessageProcessor
     try {
       prepareIfUpdateRequest(request);
       logRequest(request);
-      result = processMirroredSolrRequest(request, mirroredSolrRequest.getType());
+      result = processMirroredSolrRequest(mirroredSolrRequest);
     } catch (Exception e) {
       result = handleException(mirroredSolrRequest, e);
     }
@@ -124,7 +126,7 @@ public class SolrMessageProcessor extends MessageProcessor
     logIf4xxException(solrException);
     if (!isRetryable(e)) {
       log.error("Non retryable exception processing Solr update", e);
-      return new Result<>(ResultStatus.FAILED_NO_RETRY, e);
+      return new Result<>(ResultStatus.FAILED_NO_RETRY, e, mirroredSolrRequest);
     } else {
       logFailure(mirroredSolrRequest, e, solrException);
       mirroredSolrRequest.setAttempt(mirroredSolrRequest.getAttempt() + 1);
@@ -188,13 +190,32 @@ public class SolrMessageProcessor extends MessageProcessor
 
   /** Process the SolrRequest. If not, this method throws an exception. */
   private Result<MirroredSolrRequest<?>> processMirroredSolrRequest(
-      SolrRequest<?> request, MirroredSolrRequest.Type type) throws Exception {
+      MirroredSolrRequest<?> mirroredSolrRequest) throws Exception {
+    final SolrRequest<?> request = mirroredSolrRequest.getSolrRequest();
+    final MirroredSolrRequest.Type type = mirroredSolrRequest.getType();
     if (log.isDebugEnabled()) {
       log.debug(
           "Sending request to Solr at ZK address={} with params {}",
           ZkStateReader.from(clientSupplier.get()).getZkClient().getZkServerAddress(),
           request.getParams());
     }
+    // short-circuit requests to nonexistent or not updatable collections
+    if (type == MirroredSolrRequest.Type.UPDATE && request.getCollection() != null) {
+      ClusterState clusterState = clientSupplier.get().getClusterState();
+      DocCollection docCollection = clusterState.getCollectionOrNull(request.getCollection());
+      if (docCollection == null
+          || docCollection.isReadOnly()
+          || docCollection.getActiveSlices().isEmpty()) {
+        if (log.isInfoEnabled()) {
+          log.warn(
+              "Skipping update request to nonexistent / not updatable collection {}",
+              request.getCollection());
+        }
+        metrics.counter(MetricRegistry.name(type.name(), "invalid-collection")).inc();
+        return new Result<>(ResultStatus.FAILED_NO_RETRY, mirroredSolrRequest);
+      }
+    }
+
     Result<MirroredSolrRequest<?>> result;
     SolrResponseBase response;
     Timer.Context ctx = metrics.timer(MetricRegistry.name(type.name(), "outputTime")).time();
@@ -222,7 +243,7 @@ public class SolrMessageProcessor extends MessageProcessor
           request.getParams(),
           status);
     }
-    result = new Result<>(ResultStatus.HANDLED);
+    result = new Result<>(ResultStatus.HANDLED, mirroredSolrRequest);
     return result;
   }
 

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/consumer/KafkaCrossDcConsumerTest.java
@@ -297,7 +297,7 @@ public class KafkaCrossDcConsumerTest {
   public void testHandleValidMirroredSolrRequest() {
     KafkaConsumer<String, MirroredSolrRequest<?>> mockConsumer = mock(KafkaConsumer.class);
     KafkaCrossDcConsumer spyConsumer = createCrossDcConsumerSpy(mockConsumer);
-    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED))
+    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED, null))
         .when(messageProcessorMock)
         .handleItem(any());
     SolrInputDocument doc = new SolrInputDocument();
@@ -336,7 +336,7 @@ public class KafkaCrossDcConsumerTest {
   public void testHandleValidAdminRequest() throws Exception {
     KafkaConsumer<String, MirroredSolrRequest<?>> mockConsumer = mock(KafkaConsumer.class);
     KafkaCrossDcConsumer spyConsumer = createCrossDcConsumerSpy(mockConsumer);
-    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED))
+    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED, null))
         .when(messageProcessorMock)
         .handleItem(any());
     CollectionAdminRequest.Create create =
@@ -417,7 +417,7 @@ public class KafkaCrossDcConsumerTest {
             CrossDcConf.COLLAPSE_UPDATES, collapseUpdates.name(),
             CrossDcConf.MAX_COLLAPSE_RECORDS, String.valueOf(maxCollapseRecords));
     KafkaCrossDcConsumer spyConsumer = createCrossDcConsumerSpy(mockConsumer);
-    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED))
+    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED, null))
         .when(messageProcessorMock)
         .handleItem(any());
     List<ConsumerRecord<String, MirroredSolrRequest<?>>> records = new ArrayList<>();
@@ -452,7 +452,7 @@ public class KafkaCrossDcConsumerTest {
   public void testHandleInvalidMirroredSolrRequest() {
     KafkaConsumer<String, MirroredSolrRequest<?>> mockConsumer = mock(KafkaConsumer.class);
     SolrMessageProcessor mockSolrMessageProcessor = mock(SolrMessageProcessor.class);
-    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED))
+    doReturn(new IQueueHandler.Result<>(IQueueHandler.ResultStatus.HANDLED, null))
         .when(mockSolrMessageProcessor)
         .handleItem(any());
     KafkaCrossDcConsumer spyConsumer =

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessorTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessorTest.java
@@ -18,7 +18,7 @@ package org.apache.solr.crossdc.manager.messageprocessor;
 
 import static org.apache.solr.SolrTestCaseJ4.assumeWorkingMockito;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -76,6 +76,7 @@ public class SolrMessageProcessorTest {
         solrMessageProcessor.handleItem(mirroredSolrRequest);
 
     assertEquals(IQueueHandler.ResultStatus.FAILED_RESUBMIT, result.status());
+    assertNotNull(result.getItem());
   }
 
   /** Should handle MirroredSolrRequest and return a failed result with resubmit */
@@ -92,6 +93,7 @@ public class SolrMessageProcessorTest {
         solrMessageProcessor.handleItem(mirroredSolrRequest);
 
     assertEquals(IQueueHandler.ResultStatus.FAILED_RESUBMIT, result.status());
+    assertNotNull(result.getItem());
     assertEquals(mirroredSolrRequest, result.getItem());
   }
 
@@ -111,7 +113,7 @@ public class SolrMessageProcessorTest {
         solrMessageProcessor.handleItem(mirroredSolrRequest);
 
     assertEquals(IQueueHandler.ResultStatus.HANDLED, result.status());
-    assertNull(result.getItem());
+    assertNotNull(result.getItem());
   }
 
   /** Should connect to Solr if not connected and process the request */

--- a/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/common/IQueueHandler.java
+++ b/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/common/IQueueHandler.java
@@ -39,16 +39,8 @@ public interface IQueueHandler<T> {
     private final Throwable _throwable;
     private final T _item;
 
-    public Result(final ResultStatus status) {
-      _status = status;
-      _throwable = null;
-      _item = null;
-    }
-
-    public Result(final ResultStatus status, final Throwable throwable) {
-      _status = status;
-      _throwable = throwable;
-      _item = null;
+    public Result(final ResultStatus status, final T newItem) {
+      this(status, null, newItem);
     }
 
     public Result(final ResultStatus status, final Throwable throwable, final T newItem) {


### PR DESCRIPTION
There were some code paths where the original `MirroredSolrRequest` wasn't preserved in `IQueueHandler.Result`. This resulted in NPEs when re-submitting to a dead-letter queue, but IMHO the fact that you could produce `Result` with a null item was trappy enough so I refactored the constructors to avoid it.

This PR also drops requests for non-existent or read-only collections to avoid unnecessary errors from Solr.