### PR TITLE
SOLR-18083: Fix replication and other general operations in readOnly mode

### DIFF
--- a/changelog/unreleased/solr-18083-fix-read-only-behavior.yml
+++ b/changelog/unreleased/solr-18083-fix-read-only-behavior.yml
@@ -1,0 +1,9 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Fix normal operation errors for readOnly collections
+type: other # added, changed, fixed, deprecated, removed, dependency_update, security, other
+authors:
+  - name: Houston Putman
+    nick: HoustonPutman
+links:
+  - name: SOLR-18083
+    url: https://issues.apache.org/jira/browse/SOLR-18083

--- a/changelog/unreleased/solr-18083-fix-read-only-behavior.yml
+++ b/changelog/unreleased/solr-18083-fix-read-only-behavior.yml
@@ -1,6 +1,6 @@
 # See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-title: Fix normal operation errors for readOnly collections
-type: other # added, changed, fixed, deprecated, removed, dependency_update, security, other
+title: Fix operational issues with readOnly collections, such as restarting SolrNodes and replicating from the leader.
+type: fixed # added, changed, fixed, deprecated, removed, dependency_update, security, other
 authors:
   - name: Houston Putman
     nick: HoustonPutman

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -231,9 +231,8 @@ public class RecoveryStrategy implements Runnable, Closeable {
 
     log.info("Attempting to replicate from core [{}] on node [{}].", leaderCore, leaderBaseUrl);
 
-    // send commit if replica could be a leader.
-    // if the collection is in readOnly mode, all replicas are already commited, so do not send a commit (which will fail because the collection cannot be written to)
-    if (replicaType.leaderEligible && !zkController.getClusterState().getCollection(coreDescriptor.getCollectionName()).isReadOnly()) {
+    // send commit if replica could be a leader
+    if (replicaType.leaderEligible) {
       commitOnLeader(leaderBaseUrl, leaderCore);
     }
 
@@ -304,6 +303,8 @@ public class RecoveryStrategy implements Runnable, Closeable {
       // ureq.getParams().set(UpdateParams.OPEN_SEARCHER, onlyLeaderIndexes);
       // Why do we need to open searcher if "onlyLeaderIndexes"?
       ureq.getParams().set(UpdateParams.OPEN_SEARCHER, false);
+      // If the leader is readOnly, do not fail since the core is already committed.
+      ureq.getParams().set(UpdateParams.FAIL_ON_READ_ONLY, false);
       ureq.setAction(AbstractUpdateRequest.ACTION.COMMIT, false, true).process(client);
     }
   }

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -231,8 +231,9 @@ public class RecoveryStrategy implements Runnable, Closeable {
 
     log.info("Attempting to replicate from core [{}] on node [{}].", leaderCore, leaderBaseUrl);
 
-    // send commit if replica could be a leader
-    if (replicaType.leaderEligible) {
+    // send commit if replica could be a leader.
+    // if the collection is in readOnly mode, all replicas are already commited, so do not send a commit (which will fail because the collection cannot be written to)
+    if (replicaType.leaderEligible && !zkController.getClusterState().getCollection(coreDescriptor.getCollectionName()).isReadOnly()) {
       commitOnLeader(leaderBaseUrl, leaderCore);
     }
 

--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -659,15 +659,17 @@ public class RecoveryStrategy implements Runnable, Closeable {
           break;
         }
 
-        // we wait a bit so that any updates on the leader
-        // that started before they saw recovering state
-        // are sure to have finished (see SOLR-7141 for
-        // discussion around current value)
-        // TODO since SOLR-11216, we probably won't need this
-        try {
-          Thread.sleep(waitForUpdatesWithStaleStatePauseMilliSeconds);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
+        if (!core.readOnly) {
+          // we wait a bit so that any updates on the leader
+          // that started before they saw recovering state
+          // are sure to have finished (see SOLR-7141 for
+          // discussion around current value)
+          // TODO since SOLR-11216, we probably won't need this
+          try {
+            Thread.sleep(waitForUpdatesWithStaleStatePauseMilliSeconds);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
         }
 
         // first thing we just try to sync

--- a/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContext.java
@@ -195,7 +195,7 @@ final class ShardLeaderElectionContext extends ShardLeaderElectionContextBase {
         // first cancel any current recovery
         core.getUpdateHandler().getSolrCoreState().cancelRecovery();
 
-        if (weAreReplacement) {
+        if (weAreReplacement && !core.readOnly) {
           // wait a moment for any floating updates to finish
           try {
             Thread.sleep(2500);

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2476,7 +2476,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
                   true,
                   directoryFactory);
         } else {
-          RefCounted<IndexWriter> writer = getSolrCoreState().getIndexWriter(this);
+          RefCounted<IndexWriter> writer = getSolrCoreState().getIndexWriter(this, true);
           DirectoryReader newReader = null;
           try {
             newReader = indexReaderFactory.newReader(writer.get(), this);

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -530,7 +530,7 @@ public class IndexFetcher {
           // we just clear ours and commit
           log.info("New index in Leader. Deleting mine...");
           RefCounted<IndexWriter> iw =
-              solrCore.getUpdateHandler().getSolrCoreState().getIndexWriter(solrCore);
+              solrCore.getUpdateHandler().getSolrCoreState().getIndexWriter(solrCore, true);
           try {
             iw.get().deleteAll();
           } finally {
@@ -624,7 +624,7 @@ public class IndexFetcher {
           // are successfully deleted
           solrCore.getUpdateHandler().newIndexWriter(true);
           RefCounted<IndexWriter> writer =
-              solrCore.getUpdateHandler().getSolrCoreState().getIndexWriter(null);
+              solrCore.getUpdateHandler().getSolrCoreState().getIndexWriter(null, true);
           try {
             IndexWriter indexWriter = writer.get();
             int c = 0;

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -537,7 +537,7 @@ public class IndexFetcher {
             iw.decref();
           }
           assert TestInjection.injectDelayBeforeFollowerCommitRefresh();
-          if (skipCommitOnLeaderVersionZero) {
+          if (skipCommitOnLeaderVersionZero || solrCore.readOnly) {
             openNewSearcherAndUpdateCommitPoint();
           } else {
             SolrQueryRequest req = new LocalSolrQueryRequest(solrCore, new ModifiableSolrParams());

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1378,7 +1378,7 @@ public class ReplicationHandler extends RequestHandlerBase
 
           // ensure the writer is initialized so that we have a list of commit points
           RefCounted<IndexWriter> iw =
-              core.getUpdateHandler().getSolrCoreState().getIndexWriter(core);
+              core.getUpdateHandler().getSolrCoreState().getIndexWriter(core, true);
           iw.decref();
 
         } catch (IOException e) {

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerUtils.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerUtils.java
@@ -99,6 +99,7 @@ public class RequestHandlerUtils {
     cmd.maxOptimizeSegments =
         params.getInt(UpdateParams.MAX_OPTIMIZE_SEGMENTS, cmd.maxOptimizeSegments);
     cmd.prepareCommit = params.getBool(UpdateParams.PREPARE_COMMIT, cmd.prepareCommit);
+    cmd.failOnReadOnly = params.getBool(UpdateParams.FAIL_ON_READ_ONLY, cmd.failOnReadOnly);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/update/CommitUpdateCommand.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitUpdateCommand.java
@@ -98,9 +98,10 @@ public class CommitUpdateCommand extends UpdateCommand {
             .append(",softCommit=")
             .append(softCommit)
             .append(",prepareCommit=")
-            .append(prepareCommit)
-            .append(",failOnReadOnly=")
-            .append(failOnReadOnly);
+            .append(prepareCommit);
+    if (!failOnReadOnly) {
+      sb.append(",failOnReadOnly=").append(failOnReadOnly);
+    }
     if (commitData != null) {
       sb.append(",commitData=").append(commitData);
     }

--- a/solr/core/src/java/org/apache/solr/update/CommitUpdateCommand.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitUpdateCommand.java
@@ -39,6 +39,7 @@ public class CommitUpdateCommand extends UpdateCommand {
   public boolean expungeDeletes = false;
   public boolean softCommit = false;
   public boolean prepareCommit = false;
+  public boolean failOnReadOnly = true; // fail the commit if the core or collection is readOnly
 
   /**
    * User provided commit data. Can be let to null if there is none. It is possible to commit this
@@ -97,7 +98,9 @@ public class CommitUpdateCommand extends UpdateCommand {
             .append(",softCommit=")
             .append(softCommit)
             .append(",prepareCommit=")
-            .append(prepareCommit);
+            .append(prepareCommit)
+            .append(",failOnReadOnly=")
+            .append(failOnReadOnly);
     if (commitData != null) {
       sb.append(",commitData=").append(commitData);
     }

--- a/solr/core/src/java/org/apache/solr/update/DefaultSolrCoreState.java
+++ b/solr/core/src/java/org/apache/solr/update/DefaultSolrCoreState.java
@@ -106,8 +106,9 @@ public final class DefaultSolrCoreState extends SolrCoreState
   }
 
   @Override
-  public RefCounted<IndexWriter> getIndexWriter(SolrCore core) throws IOException {
-    if (core != null && (!core.indexEnabled || core.readOnly)) {
+  public RefCounted<IndexWriter> getIndexWriter(SolrCore core, boolean readOnlyCompatible)
+      throws IOException {
+    if (core != null && (!core.indexEnabled || (!readOnlyCompatible && core.readOnly))) {
       throw new SolrException(
           SolrException.ErrorCode.SERVICE_UNAVAILABLE, "Indexing is temporarily disabled");
     }

--- a/solr/core/src/java/org/apache/solr/update/SolrCoreState.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrCoreState.java
@@ -178,7 +178,19 @@ public abstract class SolrCoreState {
    *
    * @throws IOException If there is a low-level I/O error.
    */
-  public abstract RefCounted<IndexWriter> getIndexWriter(SolrCore core) throws IOException;
+  public RefCounted<IndexWriter> getIndexWriter(SolrCore core) throws IOException {
+    return getIndexWriter(core, false);
+  }
+
+  /**
+   * Get the current IndexWriter. If a new IndexWriter must be created, use the settings from the
+   * given {@link SolrCore}. Be very careful using the {@code readOnlyCompatible} flag, by default
+   * it should be false if the returned indexWriter will be used for writing.
+   *
+   * @throws IOException If there is a low-level I/O error.
+   */
+  public abstract RefCounted<IndexWriter> getIndexWriter(SolrCore core, boolean readOnlyCompatible)
+      throws IOException;
 
   /**
    * Rollback the current IndexWriter. When creating the new IndexWriter use the settings from the

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -127,7 +127,7 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
   protected final SolrQueryResponse rsp;
   private final AtomicUpdateDocumentMerger docMerger;
 
-  private final UpdateLog ulog;
+  protected final UpdateLog ulog;
   private final VersionInfo vinfo;
   private final boolean versionsStored;
   private boolean returnVersions;

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -166,6 +166,8 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
       } else {
         // Committing on a readOnly core/collection is a no-op, since the core was committed when
         // becoming read-only and hasn't had any updates since.
+        assert ulog == null || !ulog.hasUncommittedChanges()
+            : "Uncommitted changes found when trying to commit on a read-only collection";
         return;
       }
     }

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -164,7 +164,8 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
       if (cmd.failOnReadOnly) {
         throw new SolrException(ErrorCode.FORBIDDEN, "Collection " + collection + " is read-only.");
       } else {
-        // Committing on a readOnly core/collection is a no-op, since the core was committed when becoming read-only and hasn't had any updates since.
+        // Committing on a readOnly core/collection is a no-op, since the core was committed when
+        // becoming read-only and hasn't had any updates since.
         return;
       }
     }

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -161,7 +161,12 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     assert TestInjection.injectFailUpdateRequests();
 
     if (isReadOnly()) {
-      throw new SolrException(ErrorCode.FORBIDDEN, "Collection " + collection + " is read-only.");
+      if (cmd.failOnReadOnly) {
+        throw new SolrException(ErrorCode.FORBIDDEN, "Collection " + collection + " is read-only.");
+      } else {
+        // Committing on a readOnly core/collection is a no-op, since the core was committed when becoming read-only and hasn't had any updates since.
+        return;
+      }
     }
 
     List<SolrCmdDistributor.Node> nodes = null;

--- a/solr/solrj/src/java/org/apache/solr/common/params/UpdateParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/UpdateParams.java
@@ -46,6 +46,9 @@ public interface UpdateParams {
   /** expert: calls IndexWriter.prepareCommit */
   public static String PREPARE_COMMIT = "prepareCommit";
 
+  /** Fail a commit when the core or collection is in read-only mode */
+  public static String FAIL_ON_READ_ONLY = "failOnReadOnly";
+
   /** Rollback update commands */
   public static String ROLLBACK = "rollback";
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18083

Issues with readOnly:
- Currently parts of recovery issue a commit to the leader, which can't happen if the leader is in readOnly mode. Since readOnly replicas will have already committed, we can introduce an option for commit to be a NO-OP if the core is in read-only mode.
- If we are in read-only mode, we do not need to wait for documents to come in during various operations
- IndexWriter cannot be opened in readOnly mode. The issue here is that certain operations open an IndexWriter for non-write reasons. Such as metrics, or opening a SolrSearcher with an IndexWriter to tell it what to read.

One other issue during indexFetching a readOnly core is that if we want to delete all documents during a fetch, then we want to be able to open an indexWriter to clear the index. While this goes against the spirit of a readOnly core, we are replicating from the leader and want to be in-sync. So we should allow writing in this case.

So instead of just disallowing opening IndexWriters at all, we should allow opening an indexWriter with a flag that says it will be used in accordance with the spirit of read-only rules.