### PR TITLE
SOLR-18061: CrossDC Consumer - add /health endpoint

### DIFF
--- a/changelog/unreleased/solr-18061.yml
+++ b/changelog/unreleased/solr-18061.yml
@@ -1,0 +1,9 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: "CrossDC Consumer: add /health endpoint"
+type: added # added, changed, fixed, deprecated, removed, dependency_update, security, other
+authors:
+  - name: Andrzej Bialecki
+    nick: ab
+links:
+  - name: SOLR-18061
+    url: https://issues.apache.org/jira/browse/SOLR-18061

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/Consumer.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/Consumer.java
@@ -96,6 +96,8 @@ public class Consumer {
       context.setAttribute(
           MetricsServlet.SOLR_METRICS_MANAGER_ATTRIBUTE, metrics.getMetricManager());
       context.addServlet(MetricsServlet.class, "/metrics/*");
+      context.setAttribute(HealthCheckServlet.KAFKA_CROSSDC_CONSUMER, crossDcConsumer);
+      context.addServlet(HealthCheckServlet.class, "/health/*");
 
       for (ServletMapping mapping : context.getServletHandler().getServletMappings()) {
         if (log.isInfoEnabled()) {

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/HealthCheckServlet.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/HealthCheckServlet.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.crossdc.manager.consumer;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HealthCheckServlet extends HttpServlet {
+  private static final long serialVersionUID = -7848291432584409313L;
+
+  public static final String KAFKA_CROSSDC_CONSUMER =
+      HealthCheckServlet.class.getName() + ".kafkaCrossDcConsumer";
+
+  private KafkaCrossDcConsumer consumer;
+
+  @Override
+  public void init() throws ServletException {
+    consumer = (KafkaCrossDcConsumer) getServletContext().getAttribute(KAFKA_CROSSDC_CONSUMER);
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    if (consumer == null) {
+      resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+      return;
+    }
+    boolean kafkaConnected = consumer.isKafkaConnected();
+    boolean solrConnected = consumer.isSolrConnected();
+    boolean running = consumer.isRunning();
+    String content =
+        String.format(
+            "{\n  \"kafka\": %s,\n  \"solr\": %s,\n  \"running\": %s\n}",
+            kafkaConnected, solrConnected, running);
+    resp.setContentType("application/json");
+    resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
+    resp.setCharacterEncoding("UTF-8");
+    resp.getOutputStream().write(content.getBytes("UTF-8"));
+    if (kafkaConnected && solrConnected && running) {
+      resp.setStatus(HttpServletResponse.SC_OK);
+    } else {
+      resp.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+  }
+}

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/HealthCheckServlet.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/HealthCheckServlet.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 public class HealthCheckServlet extends HttpServlet {
   private static final long serialVersionUID = -7848291432584409313L;
@@ -48,8 +49,11 @@ public class HealthCheckServlet extends HttpServlet {
     boolean running = consumer.isRunning();
     String content =
         String.format(
+            Locale.ROOT,
             "{\n  \"kafka\": %s,\n  \"solr\": %s,\n  \"running\": %s\n}",
-            kafkaConnected, solrConnected, running);
+            kafkaConnected,
+            solrConnected,
+            running);
     resp.setContentType("application/json");
     resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
     resp.setCharacterEncoding("UTF-8");

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/HealthCheckServlet.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/HealthCheckServlet.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class HealthCheckServlet extends HttpServlet {
   private static final long serialVersionUID = -7848291432584409313L;
@@ -52,7 +53,7 @@ public class HealthCheckServlet extends HttpServlet {
     resp.setContentType("application/json");
     resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
     resp.setCharacterEncoding("UTF-8");
-    resp.getOutputStream().write(content.getBytes("UTF-8"));
+    resp.getOutputStream().write(content.getBytes(StandardCharsets.UTF_8));
     if (kafkaConnected && solrConnected && running) {
       resp.setStatus(HttpServletResponse.SC_OK);
     } else {

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SolrAndKafkaIntegrationTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SolrAndKafkaIntegrationTest.java
@@ -381,6 +381,21 @@ public class SolrAndKafkaIntegrationTest extends SolrCloudTestCase {
       assertEquals(Boolean.TRUE, map.get("kafka"));
       assertEquals(Boolean.TRUE, map.get("solr"));
       assertEquals(Boolean.TRUE, map.get("running"));
+
+      // kill Solr to trigger unhealthy state
+      solrCluster2.shutdown();
+      solrCluster2 = null;
+      Thread.sleep(5000);
+      rsp = httpJettySolrClient.request(req);
+      content =
+          IOUtils.toString(
+              (InputStream) rsp.get(InputStreamResponseParser.STREAM_KEY), StandardCharsets.UTF_8);
+      assertEquals(Integer.valueOf(503), rsp.get("responseStatus"));
+      map = (Map<String, Object>) ObjectBuilder.fromJSON(content);
+      assertEquals(Boolean.TRUE, map.get("kafka"));
+      assertEquals(Boolean.FALSE, map.get("solr"));
+      assertEquals(Boolean.TRUE, map.get("running"));
+
     } finally {
       httpJettySolrClient.close();
       client.close();

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SolrAndKafkaIntegrationTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SolrAndKafkaIntegrationTest.java
@@ -68,6 +68,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -341,7 +342,7 @@ public class SolrAndKafkaIntegrationTest extends SolrCloudTestCase {
 
   @Test
   @SuppressWarnings({"unchecked"})
-  public void testMetrics() throws Exception {
+  public void testMetricsAndHealthcheck() throws Exception {
     CloudSolrClient client = solrCluster1.getSolrClient();
     SolrInputDocument doc = new SolrInputDocument();
     doc.addField("id", String.valueOf(new Date().getTime()));
@@ -359,6 +360,7 @@ public class SolrAndKafkaIntegrationTest extends SolrCloudTestCase {
     HttpJettySolrClient httpJettySolrClient =
         new HttpJettySolrClient.Builder(baseUrl).useHttp1_1(true).build();
     try {
+      // test the metrics endpoint
       GenericSolrRequest req = new GenericSolrRequest(SolrRequest.METHOD.GET, "/metrics");
       req.setResponseParser(new InputStreamResponseParser(null));
       NamedList<Object> rsp = httpJettySolrClient.request(req);
@@ -366,6 +368,19 @@ public class SolrAndKafkaIntegrationTest extends SolrCloudTestCase {
           IOUtils.toString(
               (InputStream) rsp.get(InputStreamResponseParser.STREAM_KEY), StandardCharsets.UTF_8);
       assertTrue(content, content.contains("crossdc_consumer_output_total"));
+
+      // test the healtcheck endpoint
+      req = new GenericSolrRequest(SolrRequest.METHOD.GET, "/health");
+      req.setResponseParser(new InputStreamResponseParser(null));
+      rsp = httpJettySolrClient.request(req);
+      content =
+          IOUtils.toString(
+              (InputStream) rsp.get(InputStreamResponseParser.STREAM_KEY), StandardCharsets.UTF_8);
+      assertEquals(Integer.valueOf(200), rsp.get("responseStatus"));
+      Map<String, Object> map = (Map<String, Object>) ObjectBuilder.fromJSON(content);
+      assertEquals(Boolean.TRUE, map.get("kafka"));
+      assertEquals(Boolean.TRUE, map.get("solr"));
+      assertEquals(Boolean.TRUE, map.get("running"));
     } finally {
       httpJettySolrClient.close();
       client.close();

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cross-dc-replication.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cross-dc-replication.adoc
@@ -151,8 +151,9 @@ system property.
 
 Currently the following endpoints are exposed (on local port configured using `port` property, default is 8090):
 
-`/metrics` - (GET):: This endpoint returns JSON-formatted metrics describing various aspects of document processing in Consumer.
+`/metrics` - (GET):: This endpoint returns metrics in Prometheus text format, describing various aspects of document processing in Consumer.
 `/threads` - (GET):: Returns a plain-text thread dump of the JVM running the Consumer application.
+`/health` - (GET):: Returns an `HTTP 200 OK` code if the service is in a healthy state, or `HTTP 503 Service Unavailable` if one or more healthcheck probes failed. The JSON response body provides more details.
 
 ==== Configuration Properties for the CrossDC Manager:
 


### PR DESCRIPTION
This endpoint returns either HTTP 200 when consumer is in a "healthy" state and ready for service, or HTTP 500 otherwise. Additionally it returns the state of individual healthchecks.

The healthy status is reported only when:

* Consumer is running
* Kafka brokers are available and connected
* Solr reports healthy status from the /health endpoint.