### PR TITLE
SOLR-18039: Add byte-path parity tests for repeated parents.preFilter

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/join/BlockJoinNestedVectorsQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/BlockJoinNestedVectorsQParserTest.java
@@ -295,6 +295,23 @@ public class BlockJoinNestedVectorsQParserTest extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void parentRetrievalByte_knnChildrenWithMultipleParentFilters_shouldReturnKnnParents() {
+    assertQ(
+        req(
+            "q", "{!parent which=$allParents score=max v=$children.q}",
+            "fl", "id,score",
+            "children.q",
+                "{!knn f=vector_byte topK=3 parents.preFilter=$parentFilter1 parents.preFilter=$parentFilter2 childrenOf=$allParents}"
+                    + BYTE_QUERY_VECTOR,
+            "allParents", "parent_s:[* TO *]",
+            "parentFilter1", "parent_s:(a c)",
+            "parentFilter2", "parent_s:(c e)"),
+        "//*[@numFound='2']",
+        "//result/doc[1]/str[@name='id'][.='8']",
+        "//result/doc[2]/str[@name='id'][.='2']");
+  }
+
+  @Test
   public void
       parentRetrievalByte_knnChildrenWithParentFilterAndChildrenFilter_shouldReturnKnnParents() {
     assertQ(
@@ -306,6 +323,24 @@ public class BlockJoinNestedVectorsQParserTest extends SolrTestCaseJ4 {
                     + BYTE_QUERY_VECTOR,
             "allParents", "parent_s:[* TO *]",
             "someParents", "parent_s:(a c)"),
+        "//*[@numFound='2']",
+        "//result/doc[1]/str[@name='id'][.='8']",
+        "//result/doc[2]/str[@name='id'][.='2']");
+  }
+
+  @Test
+  public void
+      parentRetrievalByte_knnChildrenWithMultipleParentFiltersAndChildrenFilter_shouldReturnKnnParents() {
+    assertQ(
+        req(
+            "q", "{!parent which=$allParents score=max v=$children.q}",
+            "fl", "id,score",
+            "children.q",
+                "{!knn f=vector_byte topK=3 preFilter=child_s:m parents.preFilter=$parentFilter1 parents.preFilter=$parentFilter2 childrenOf=$allParents}"
+                    + BYTE_QUERY_VECTOR,
+            "allParents", "parent_s:[* TO *]",
+            "parentFilter1", "parent_s:(a c)",
+            "parentFilter2", "parent_s:(c e)"),
         "//*[@numFound='2']",
         "//result/doc[1]/str[@name='id'][.='8']",
         "//result/doc[2]/str[@name='id'][.='2']");


### PR DESCRIPTION
## Description
  This PR adds parity coverage for `SOLR-18039` by validating repeated `parents.preFilter` behavior on the byte-vector nested KNN paths. The core parser fix was merged in #4139, this follow-up keeps scope narrow to test coverage only.

  ## Context from issue discussion
  In SOLR-18039, we fixed repeated `parents.preFilter` handling and added focused float-path coverage. The remaining gap was parity validation for equivalent byte-vector nested parent-retrieval flows, so this PR closes that gap without extending scope into parser refactoring yet.

  ## Changes
  - Added parity tests for repeated `parents.preFilter` in byte-vector nested parent retrieval.
  - Added parity tests for repeated `parents.preFilter` in byte-vector nested parent retrieval with child `preFilter`.
  - Assertions verify intersection semantics for multiple parent filters, matching the expected behavior already covered on the float path.

  ## Behavior / Safety
  - Compatibility: no API or runtime behavior changes.
  - Fallback path: existing query execution and filter wiring remain unchanged; this PR only adds coverage.
  - Risk boundary: test-only change, focused on regression protection for the byte-vector path.
  - Unchanged: parser logic, scoring behavior, request parameter contract, and single-filter behavior from [#4139](https://github.com/apache/solr/pull/4139).

  ## Validation
  Ran with Java `21` active (`jenv`/`JAVA_HOME` set to `21`):

  - `./gradlew -p solr/core test --tests org.apache.solr.search.join.BlockJoinNestedVectorsQParserTest --tests
  org.apache.solr.search.join.BlockJoinNestedVectorsParentQParserTest`
    Outcome: `BUILD SUCCESSFUL` (`:solr:core:test`, `17` tests).
  - `./gradlew tidy`
    Outcome: `BUILD SUCCESSFUL`.
  - `./gradlew check -x test`
    Outcome: `BUILD SUCCESSFUL`.

  ## Follow-ups
  A separate small cleanup PR can still be done to consolidate shared filter-subquery parsing between `preFilter` and `parents.preFilter` paths, keeping behavior unchanged.