### PR TITLE
SOLR-18034: Add index-time nested vector expansion tests

### DIFF
--- a/solr/core/src/test-files/solr/collection1/conf/schema-nest.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-nest.xml
@@ -35,6 +35,8 @@
 
   <dynamicField name="*_s" type="string" indexed="true" stored="true"/>
   <dynamicField name="*_ss" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="vector_single" type="knn_vector" indexed="true" stored="true"/>
+  <field name="vector_multivalued" type="knn_vector" indexed="true" stored="true" multiValued="true"/>
 
   <!-- required to test updates nested inplaceUpdates -->
   <field name="inplace_updatable_int"   type="int"   indexed="false" stored="false"/>
@@ -42,6 +44,7 @@
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
 
   <fieldType name="_nest_path_" class="solr.NestPathField" />
+  <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="4" similarityFunction="cosine" />
 
   <!-- Point Fields -->
   <fieldType name="int" class="solr.IntPointField"/>


### PR DESCRIPTION
## Description
  This PR adds focused index-time test coverage for SOLR-18034 to validate how nested vector documents are constructed from multi-valued dense vectors.

  The goal here is to make the existing behavior explicit and regression-safe before any broader lifecycle work.

  ## Context from issue discussion
  Issue: SOLR-18034

  From the discussion, the scope is server-side indexing assistance for parent/child modeling of nested vectors (aligned with nested-vector direction from SOLR-17736, while avoiding overlap with broader multi-valued vector/query-time scope in SOLR-18074

  This PR is intentionally scoped as PR-1: index-time behavior validation.

  ## Changes
  - Added test coverage to assert that a parent document with a multi-valued dense vector field is expanded into nested children (one vector per child) during update
  processing.
  - Added assertions for generated child metadata and structure:
    - child `id` format
    - `_nest_parent_`
    - `_nest_path_`
    - parent field cleanup when expansion occurs
  - Added complementary coverage to assert that a single-valued dense vector field remains on the parent and does not trigger nested-vector expansion.

  ## Behavior / Safety
  - No new runtime feature wiring or query behavior was introduced in this PR.
  - Compatibility boundary:
    - Multi-valued dense vectors: existing expansion behavior is now explicitly verified by tests.
    - Single-valued dense vectors: existing fallback behavior remains unchanged (stays on parent, no generated nested vector children).
  - Risk boundary is low: this is test/schema coverage only, intended to reduce regression risk for existing logic.

  ## Validation
  Executed and passing:

  - `./gradlew :solr:core:test --tests org.apache.solr.update.TestNestedUpdateProcessor`
  - `./gradlew tidy`
  - `./gradlew check -x test`

  Result: all commands completed successfully for this branch.

  ## Follow-ups
  Planned next step (PR-2), based on maintainer feedback:
  - lifecycle safety work (delete/update consistency for generated vector children),
  - integration coverage for parent-child lifecycle behavior,
  - small doc updates if behavior/user guidance needs clarification.
