### PR TITLE
SOLR-18127 Solr native text to vector model interface

### DIFF
--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/textvectorisation/model/Langchain4jModelAdapter.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/textvectorisation/model/Langchain4jModelAdapter.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.languagemodels.textvectorisation.model;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.languagemodels.textvectorisation.store.TextToVectorModelException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adapter that wraps a LangChain4j {@link EmbeddingModel} to implement the Solr-native {@link
+ * TextToVectorModel} interface.
+ *
+ * <p>This provides backward compatibility for existing LangChain4j model configurations (OpenAI,
+ * Cohere, HuggingFace, MistralAI).
+ */
+public class Langchain4jModelAdapter implements TextToVectorModel {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final String TIMEOUT_PARAM = "timeout";
+  private static final String MAX_SEGMENTS_PER_BATCH_PARAM = "maxSegmentsPerBatch";
+  private static final String MAX_RETRIES_PARAM = "maxRetries";
+
+  private final EmbeddingModel delegate;
+
+  public Langchain4jModelAdapter(EmbeddingModel delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * Create a Langchain4jModelAdapter by instantiating the specified EmbeddingModel class using
+   * reflection and the builder pattern.
+   */
+  public static Langchain4jModelAdapter create(
+      SolrResourceLoader solrResourceLoader, String className, Map<String, Object> params)
+      throws TextToVectorModelException {
+    try {
+      Class<?> modelClass = solrResourceLoader.findClass(className, EmbeddingModel.class);
+      var builder = modelClass.getMethod("builder").invoke(null);
+
+      if (params != null) {
+        /*
+         * This block of code has the responsibility of instantiate a {@link
+         * dev.langchain4j.model.embedding.EmbeddingModel} using the params provided.classes have
+         * params of The specific implementation of {@link
+         * dev.langchain4j.model.embedding.EmbeddingModel} is not known beforehand. So we benefit of
+         * the design choice in langchain4j that each subclass implementing {@link
+         * dev.langchain4j.model.embedding.EmbeddingModel} uses setters with the same name of the
+         * param.
+         */
+        for (String paramName : params.keySet()) {
+          /*
+           * When a param is not primitive, we need to instantiate the object explicitly and then call the
+           * setter method.
+           * N.B. when adding support to new models, pay attention to all the parameters they
+           * support, some of them may require to be handled in here as separate switch cases
+           */
+          switch (paramName) {
+            case TIMEOUT_PARAM -> {
+              Duration timeOut = Duration.ofSeconds((Long) params.get(paramName));
+              builder.getClass().getMethod(paramName, Duration.class).invoke(builder, timeOut);
+            }
+            case MAX_SEGMENTS_PER_BATCH_PARAM, MAX_RETRIES_PARAM -> builder
+                .getClass()
+                .getMethod(paramName, Integer.class)
+                .invoke(builder, ((Long) params.get(paramName)).intValue());
+
+              /*
+               * For primitive params if there's only one setter available, we call it.
+               * If there's choice we default to the string one
+               */
+            default -> {
+              ArrayList<Method> paramNameMatches = new ArrayList<>();
+              for (var method : builder.getClass().getMethods()) {
+                if (paramName.equals(method.getName()) && method.getParameterCount() == 1) {
+                  paramNameMatches.add(method);
+                }
+              }
+              if (paramNameMatches.size() == 1) {
+                Method method = paramNameMatches.getFirst();
+                Class<?> paramType = method.getParameterTypes()[0];
+                Object convertedValue =
+                    ModelConfigUtils.convertValue(params.get(paramName), paramType);
+                method.invoke(builder, convertedValue);
+              } else {
+                try {
+                  builder
+                      .getClass()
+                      .getMethod(paramName, String.class)
+                      .invoke(builder, params.get(paramName).toString());
+                } catch (NoSuchMethodException e) {
+                  log.error("Parameter {} not supported by model {}", paramName, className);
+                  throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e.getMessage(), e);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      EmbeddingModel embeddingModel =
+          (EmbeddingModel) builder.getClass().getMethod("build").invoke(builder);
+      return new Langchain4jModelAdapter(embeddingModel);
+    } catch (final Exception e) {
+      throw new TextToVectorModelException("LangChain4j model loading failed for " + className, e);
+    }
+  }
+
+  @Override
+  public float[] vectorise(String text) {
+    Embedding vector = delegate.embed(text).content();
+    return vector.vector();
+  }
+}

--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/textvectorisation/model/ModelConfigUtils.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/textvectorisation/model/ModelConfigUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.languagemodels.textvectorisation.model;
+
+public class ModelConfigUtils {
+
+  /** Convert JSON-parsed values to the expected parameter type */
+  public static Object convertValue(Object value, Class<?> targetType) {
+    if (value == null) return null;
+
+    if (targetType.isAssignableFrom(value.getClass())) {
+      return value;
+    }
+
+    // Handle common type conversions from JSON parsing
+    if (targetType == int.class || targetType == Integer.class) {
+      if (value instanceof Long) return ((Long) value).intValue();
+      if (value instanceof String) return Integer.parseInt((String) value);
+    }
+    if (targetType == long.class || targetType == Long.class) {
+      if (value instanceof Integer) return ((Integer) value).longValue();
+      if (value instanceof String) return Long.parseLong((String) value);
+    }
+    if (targetType == double.class || targetType == Double.class) {
+      if (value instanceof Number) return ((Number) value).doubleValue();
+      if (value instanceof String) return Double.parseDouble((String) value);
+    }
+    if (targetType == float.class || targetType == Float.class) {
+      if (value instanceof Number) return ((Number) value).floatValue();
+      if (value instanceof String) return Float.parseFloat((String) value);
+    }
+    if (targetType == boolean.class || targetType == Boolean.class) {
+      if (value instanceof String) return Boolean.parseBoolean((String) value);
+    }
+    if (targetType == String.class) {
+      return value.toString();
+    }
+
+    return value;
+  }
+}

--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/textvectorisation/model/TextToVectorModel.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/textvectorisation/model/TextToVectorModel.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.languagemodels.textvectorisation.model;
+
+import java.util.Map;
+
+/**
+ * Interface for text-to-vector embedding models.
+ *
+ * <p>Implement this interface to create custom embedding model integrations (e.g., Triton Inference
+ * Server, TensorFlow Serving, or any custom HTTP endpoint).
+ *
+ * <p>Implementations must have either:
+ *
+ * <ul>
+ *   <li>A public no-arg constructor, or
+ *   <li>A static {@code builder()} method returning a builder with a {@code build()} method
+ * </ul>
+ *
+ * <p>Example usage in model configuration:
+ *
+ * <pre>
+ * {
+ *   "class": "com.example.MyCustomEmbeddingModel",
+ *   "name": "my-model",
+ *   "params": {
+ *     "endpoint": "http://my-server:8000/embed",
+ *     "api_key": "my-api-key",
+ *     "dimension": 384
+ *   }
+ * }
+ * </pre>
+ */
+public interface TextToVectorModel {
+  /**
+   * Convert text to a vector embedding.
+   *
+   * @param text the input text to vectorise
+   * @return the embedding vector as a float array
+   */
+  float[] vectorise(String text);
+
+  /**
+   * Initialize the model with configuration parameters. Called after construction with the params
+   * from the model configuration.
+   *
+   * @param params the configuration parameters from the model JSON
+   */
+  default void init(Map<String, Object> params) {}
+}

--- a/solr/modules/language-models/src/test-files/modelExamples/dummy-custom-model.json
+++ b/solr/modules/language-models/src/test-files/modelExamples/dummy-custom-model.json
@@ -1,0 +1,7 @@
+{
+  "class": "org.apache.solr.languagemodels.textvectorisation.model.DummyTextToVectorModel",
+  "name": "dummy-1",
+  "params": {
+    "embedding": [1.0, 2.0, 3.0, 4.0]
+  }
+}

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModel.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModel.java
@@ -16,15 +16,28 @@
  */
 package org.apache.solr.languagemodels.textvectorisation.model;
 
-public class DummyTextToVectorModel implements TextToVectorModel {
-  private final float[] vector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-  public DummyTextToVectorModel(float[] vector) {
-    this.vector = vector;
+public class DummyTextToVectorModel implements TextToVectorModel {
+  private float[] vector;
+
+  public DummyTextToVectorModel() {
   }
 
   @Override
   public float[] vectorise(String text) {
     return vector;
+  }
+
+  @Override
+  public void init(Map<String, Object> params) {
+    List<?> embeddings = (List<?>) params.get("embedding");
+    float[] floatArray = new float[embeddings.size()];
+    for (int i = 0; i < embeddings.size(); i++) {
+      floatArray[i] = ((Number) embeddings.get(i)).floatValue();
+    }
+    this.vector = floatArray;
   }
 }

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModel.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModel.java
@@ -1,6 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.languagemodels.textvectorisation.model;
 
-public class DummyTextToVectorModel implements TextToVectorModel{
+public class DummyTextToVectorModel implements TextToVectorModel {
   private final float[] vector;
 
   public DummyTextToVectorModel(float[] vector) {

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModel.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModel.java
@@ -1,0 +1,14 @@
+package org.apache.solr.languagemodels.textvectorisation.model;
+
+public class DummyTextToVectorModel implements TextToVectorModel{
+  private final float[] vector;
+
+  public DummyTextToVectorModel(float[] vector) {
+    this.vector = vector;
+  }
+
+  @Override
+  public float[] vectorise(String text) {
+    return vector;
+  }
+}

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModelTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModelTest.java
@@ -1,8 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.solr.languagemodels.textvectorisation.model;
 
+import java.util.Arrays;
 import org.apache.solr.SolrTestCase;
 import org.junit.Test;
-import java.util.Arrays;
 
 public class DummyTextToVectorModelTest extends SolrTestCase {
   @Test

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModelTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModelTest.java
@@ -1,0 +1,14 @@
+package org.apache.solr.languagemodels.textvectorisation.model;
+
+import org.apache.solr.SolrTestCase;
+import org.junit.Test;
+import java.util.Arrays;
+
+public class DummyTextToVectorModelTest extends SolrTestCase {
+  @Test
+  public void testVectorise() {
+    DummyTextToVectorModel model = new DummyTextToVectorModel(new float[] {1, 2, 3});
+    float[] vector = model.vectorise("test");
+    assertEquals("[1.0, 2.0, 3.0]", Arrays.toString(vector));
+  }
+}

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModelTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/model/DummyTextToVectorModelTest.java
@@ -17,13 +17,15 @@
 package org.apache.solr.languagemodels.textvectorisation.model;
 
 import java.util.Arrays;
+import java.util.Map;
 import org.apache.solr.SolrTestCase;
 import org.junit.Test;
 
 public class DummyTextToVectorModelTest extends SolrTestCase {
   @Test
   public void testVectorise() {
-    DummyTextToVectorModel model = new DummyTextToVectorModel(new float[] {1, 2, 3});
+    DummyTextToVectorModel model = new DummyTextToVectorModel();
+    model.init(Map.of("embedding", new float[] {1, 2, 3}));
     float[] vector = model.vectorise("test");
     assertEquals("[1.0, 2.0, 3.0]", Arrays.toString(vector));
   }

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/update/processor/TextToVectorUpdateProcessorFactoryTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/update/processor/TextToVectorUpdateProcessorFactoryTest.java
@@ -188,7 +188,7 @@ public class TextToVectorUpdateProcessorFactoryTest extends TestLanguageModelBas
     NamedList<String> args = new NamedList<>();
 
     ManagedTextToVectorModelStore.getManagedModelStore(collection1)
-        .addModel(new SolrTextToVectorModel(modelName, null, null));
+        .addModel(new SolrTextToVectorModel(modelName, null, null, null));
     args.add("inputField", inputFieldName);
     args.add("outputField", outputFieldName);
     args.add("model", modelName);

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/update/processor/TextToVectorUpdateProcessorTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/textvectorisation/update/processor/TextToVectorUpdateProcessorTest.java
@@ -51,7 +51,16 @@ public class TextToVectorUpdateProcessorTest extends TestLanguageModelBase {
 
   @Test
   public void processAdd_inputField_shouldVectoriseInputField() throws Exception {
-    loadModel("dummy-model.json"); // preparation
+    assertVectorisationWithModel("dummy-model.json");
+  }
+
+  @Test
+  public void processAdd_customModel_shouldVectoriseInputField() throws Exception {
+    assertVectorisationWithModel("dummy-custom-model.json");
+  }
+
+  private void assertVectorisationWithModel(String modelJsonFile) throws Exception {
+    loadModel(modelJsonFile);
 
     addWithChain(sdoc("id", "99", "_text_", "Vegeta is the saiyan prince."), "textToVector");
     addWithChain(
@@ -68,8 +77,6 @@ public class TextToVectorUpdateProcessorTest extends TestLanguageModelBase {
         "/response/docs/[0]/vector==[1.0, 2.0, 3.0, 4.0]",
         "/response/docs/[1]/id=='98'",
         "/response/docs/[1]/vector==[1.0, 2.0, 3.0, 4.0]");
-
-    restTestHarness.delete(ManagedTextToVectorModelStore.REST_END_POINT + "/dummy-1"); // clean up
   }
 
   private SolrQuery getSolrQuery() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18127

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA.
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

This PR adds a Solr‑native `TextToVectorModel` interface so that users can plug in their own embedding models without needing to implement LangChain4j classes. Right now, `SolrTextToVectorModel` is tied directly to LangChain4j’s `EmbeddingModel`, which makes it awkward for anyone who has a custom embedding service — they have to implement the whole LC4j API even if they don’t use it anywhere else.

The goal here is to give Solr a simple internal abstraction for “text → vector” while keeping all existing LangChain4j providers working the same as before.

# Solution

The change is broken up into a few pieces:

1. **New `TextToVectorModel` interface**  
   A small interface that provides the basic methods Solr needs.

2. **`LangChain4jModelAdapter`**  
   An adapter that wraps an LC4j `EmbeddingModel` and exposes it through the new interface. This keeps everything backwards‑compatible so existing configs keep working without changes.

3. **Updates to the model initialization workflow**  
   SolrTextToVectorModel's getInstance() now recognizes either:
   - a native `TextToVectorModel` implementation, or  
   - a LangChain4j model wrapped using the adapter.

### AI Assist Disclosure

The `ModelConfigUtils.convertValue` helper method was written with some assistance from the AI tool **Windsurf**. It’s a small utility that converts parsed JSON model config values into the types expected by constructors.

# Tests

- Added a test to `TextToVectorUpdateProcessorTest` that loads a custom `DummyTextToVectorModel`.  
- This verifies the new interface works end‑to‑end and that the updated initialization logic can discover and load custom models correctly.  
- Existing LC4j-based tests continue to work through the adapter.

# Checklist

- [x] I have reviewed the Contributing Guide and tried to follow the conventions as closely as possible.  
- [x] I have created a Jira issue and referenced it in the PR title.  
- [x] I have given Solr maintainers access to my PR branch.  
- [x] I have developed this change against `main`.  
- [x] I have run `./gradlew check`.  
- [x] I have added tests for the new functionality.  
- [ ] I have added documentation to the Reference Guide.  
- [ ] I have added a changelog entry.