### PR TITLE
SOLR-18057: Prefer Path.resolve over Path.of for derived paths

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestCustomCoreProperties.java
+++ b/solr/core/src/test/org/apache/solr/TestCustomCoreProperties.java
@@ -49,11 +49,11 @@ public class TestCustomCoreProperties extends SolrTestCaseJ4 {
 
     Files.createDirectories(confDir);
 
-    String srcDir = TEST_HOME() + "/collection1/conf";
-    Files.copy(Path.of(srcDir, "schema-tiny.xml"), confDir.resolve("schema.xml"));
-    Files.copy(Path.of(srcDir, "solrconfig-coreproperties.xml"), confDir.resolve("solrconfig.xml"));
+    Path srcDir = TEST_HOME().resolve("collection1").resolve("conf");
+    Files.copy(srcDir.resolve("schema-tiny.xml"), confDir.resolve("schema.xml"));
+    Files.copy(srcDir.resolve("solrconfig-coreproperties.xml"), confDir.resolve("solrconfig.xml"));
     Files.copy(
-        Path.of(srcDir, "solrconfig.snippet.randomindexconfig.xml"),
+        srcDir.resolve("solrconfig.snippet.randomindexconfig.xml"),
         confDir.resolve("solrconfig.snippet.randomindexconfig.xml"));
 
     Properties p = new Properties();

--- a/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
@@ -104,12 +104,12 @@ public class TestCoreDiscovery extends SolrTestCaseJ4 {
   }
 
   private void addConfFiles(Path confDir) throws Exception {
-    String top = SolrTestCaseJ4.TEST_HOME() + "/collection1/conf";
+    Path top = SolrTestCaseJ4.TEST_HOME().resolve("collection1").resolve("conf");
     Files.createDirectories(confDir);
-    Files.copy(Path.of(top, "schema-tiny.xml"), confDir.resolve("schema-tiny.xml"));
-    Files.copy(Path.of(top, "solrconfig-minimal.xml"), confDir.resolve("solrconfig-minimal.xml"));
+    Files.copy(top.resolve("schema-tiny.xml"), confDir.resolve("schema-tiny.xml"));
+    Files.copy(top.resolve("solrconfig-minimal.xml"), confDir.resolve("solrconfig-minimal.xml"));
     Files.copy(
-        Path.of(top, "solrconfig.snippet.randomindexconfig.xml"),
+        top.resolve("solrconfig.snippet.randomindexconfig.xml"),
         confDir.resolve("solrconfig.snippet.randomindexconfig.xml"));
   }
 

--- a/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
+++ b/solr/core/src/test/org/apache/solr/core/TestLazyCores.java
@@ -416,13 +416,13 @@ public class TestLazyCores extends SolrTestCaseJ4 {
     }
 
     // Collect the files that we'll write to the config directories.
-    String top = SolrTestCaseJ4.TEST_HOME() + "/collection1/conf";
-    String min_schema = Files.readString(Path.of(top, "schema-tiny.xml"), StandardCharsets.UTF_8);
+    Path top = SolrTestCaseJ4.TEST_HOME().resolve("collection1").resolve("conf");
+    String min_schema = Files.readString(top.resolve("schema-tiny.xml"), StandardCharsets.UTF_8);
     String min_config =
-        Files.readString(Path.of(top, "solrconfig-minimal.xml"), StandardCharsets.UTF_8);
+        Files.readString(top.resolve("solrconfig-minimal.xml"), StandardCharsets.UTF_8);
     String rand_snip =
         Files.readString(
-            Path.of(top, "solrconfig.snippet.randomindexconfig.xml"), StandardCharsets.UTF_8);
+            top.resolve("solrconfig.snippet.randomindexconfig.xml"), StandardCharsets.UTF_8);
 
     // Now purposely mess up the config files, introducing stupid syntax errors.
     String bad_config = min_config.replace("<requestHandler", "<reqsthalr");
@@ -449,9 +449,8 @@ public class TestLazyCores extends SolrTestCaseJ4 {
   private void copyGoodConf(String coreName, String srcName, String dstName) throws IOException {
     Path coreRoot = solrHomeDirectory.resolve(coreName);
     Path subHome = coreRoot.resolve("conf");
-    String top = SolrTestCaseJ4.TEST_HOME() + "/collection1/conf";
-    Files.copy(
-        Path.of(top, srcName), subHome.resolve(dstName), StandardCopyOption.REPLACE_EXISTING);
+    Path top = SolrTestCaseJ4.TEST_HOME().resolve("collection1").resolve("conf");
+    Files.copy(top.resolve(srcName), subHome.resolve(dstName), StandardCopyOption.REPLACE_EXISTING);
   }
 
   // If ok==true, we shouldn't be seeing any failure cases.

--- a/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
+++ b/solr/core/src/test/org/apache/solr/handler/ReplicationTestHelper.java
@@ -299,8 +299,8 @@ public final class ReplicationTestHelper {
       SolrTestCaseJ4.writeCoreProperties(
           homeDir.resolve("collection1"), props, "TestReplicationHandler");
 
-      dataDir = Path.of(homeDir + "/collection1", "data");
-      confDir = Path.of(homeDir + "/collection1", "conf");
+      dataDir = homeDir.resolve("collection1").resolve("data");
+      confDir = homeDir.resolve("collection1").resolve("conf");
 
       Files.createDirectories(homeDir);
       Files.createDirectories(dataDir);

--- a/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminCreateDiscoverTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminCreateDiscoverTest.java
@@ -68,12 +68,12 @@ public class CoreAdminCreateDiscoverTest extends SolrTestCaseJ4 {
     Files.createDirectories(subHome);
 
     // Be sure we pick up sysvars when we create this
-    String srcDir = SolrTestCaseJ4.TEST_HOME() + "/collection1/conf";
-    Files.copy(Path.of(srcDir, "schema-tiny.xml"), subHome.resolve("schema_ren.xml"));
-    Files.copy(Path.of(srcDir, "solrconfig-minimal.xml"), subHome.resolve("solrconfig_ren.xml"));
+    Path srcDir = SolrTestCaseJ4.TEST_HOME().resolve("collection1").resolve("conf");
+    Files.copy(srcDir.resolve("schema-tiny.xml"), subHome.resolve("schema_ren.xml"));
+    Files.copy(srcDir.resolve("solrconfig-minimal.xml"), subHome.resolve("solrconfig_ren.xml"));
 
     Files.copy(
-        Path.of(srcDir, "solrconfig.snippet.randomindexconfig.xml"),
+        srcDir.resolve("solrconfig.snippet.randomindexconfig.xml"),
         subHome.resolve("solrconfig.snippet.randomindexconfig.xml"));
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/CoreAdminHandlerTest.java
@@ -77,11 +77,11 @@ public class CoreAdminHandlerTest extends SolrTestCaseJ4 {
     Files.createDirectories(subHome);
 
     // Be sure we pick up sysvars when we create this
-    String srcDir = SolrTestCaseJ4.TEST_HOME() + "/collection1/conf";
-    Files.copy(Path.of(srcDir, "schema-tiny.xml"), subHome.resolve("schema_ren.xml"));
-    Files.copy(Path.of(srcDir, "solrconfig-minimal.xml"), subHome.resolve("solrconfig_ren.xml"));
+    Path srcDir = SolrTestCaseJ4.TEST_HOME().resolve("collection1").resolve("conf");
+    Files.copy(srcDir.resolve("schema-tiny.xml"), subHome.resolve("schema_ren.xml"));
+    Files.copy(srcDir.resolve("solrconfig-minimal.xml"), subHome.resolve("solrconfig_ren.xml"));
     Files.copy(
-        Path.of(srcDir, "solrconfig.snippet.randomindexconfig.xml"),
+        srcDir.resolve("solrconfig.snippet.randomindexconfig.xml"),
         subHome.resolve("solrconfig.snippet.randomindexconfig.xml"));
 
     final CoreContainer cores = h.getCoreContainer();
@@ -475,9 +475,9 @@ public class CoreAdminHandlerTest extends SolrTestCaseJ4 {
     }
 
     Path subHome = solrHomeDirectory.resolve("corex").resolve("conf");
-    String top = SolrTestCaseJ4.TEST_HOME() + "/collection1/conf";
+    Path top = SolrTestCaseJ4.TEST_HOME().resolve("collection1").resolve("conf");
     Files.copy(
-        Path.of(top, "bad-error-solrconfig.xml"),
+        top.resolve("bad-error-solrconfig.xml"),
         subHome.resolve("solrconfig.xml"),
         StandardCopyOption.REPLACE_EXISTING);
 

--- a/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/TestRawTransformer.java
@@ -80,9 +80,9 @@ public class TestRawTransformer extends SolrCloudTestCase {
     final Path collDir = homeDir.resolve("collection1");
     final Path confDir = collDir.resolve("conf");
     Files.createDirectories(confDir);
-    String src_dir = TEST_HOME() + "/collection1/conf";
-    Files.copy(Path.of(src_dir, "schema_latest.xml"), confDir.resolve("schema.xml"));
-    Files.copy(Path.of(src_dir, "solrconfig-minimal.xml"), confDir.resolve("solrconfig.xml"));
+    Path srcDir = TEST_HOME().resolve("collection1").resolve("conf");
+    Files.copy(srcDir.resolve("schema_latest.xml"), confDir.resolve("schema.xml"));
+    Files.copy(srcDir.resolve("solrconfig-minimal.xml"), confDir.resolve("solrconfig.xml"));
     for (String file :
         new String[] {
           "solrconfig.snippet.randomindexconfig.xml",
@@ -92,7 +92,7 @@ public class TestRawTransformer extends SolrCloudTestCase {
           "currency.xml",
           "enumsConfig.xml"
         }) {
-      Files.copy(Path.of(src_dir, file), confDir.resolve(file));
+      Files.copy(srcDir.resolve(file), confDir.resolve(file));
     }
     Files.createFile(collDir.resolve("core.properties"));
     JSR =

--- a/solr/core/src/test/org/apache/solr/schema/TestBinaryField.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestBinaryField.java
@@ -52,9 +52,9 @@ public class TestBinaryField extends SolrTestCaseJ4 {
     copyMinConf(collDir, "name=collection1\n", "solrconfig-basic.xml");
 
     // Copy the custom schema for binary field tests
-    String sourceConfDir = TEST_HOME() + "/collection1/conf";
+    Path sourceConfDir = TEST_HOME().resolve("collection1").resolve("conf");
     Files.copy(
-        Path.of(sourceConfDir, "schema-binaryfield.xml"),
+        sourceConfDir.resolve("schema-binaryfield.xml"),
         collDir.resolve("conf/schema.xml"),
         StandardCopyOption.REPLACE_EXISTING);
 

--- a/solr/core/src/test/org/apache/solr/util/TestSystemIdResolver.java
+++ b/solr/core/src/test/org/apache/solr/util/TestSystemIdResolver.java
@@ -43,7 +43,7 @@ public class TestSystemIdResolver extends SolrTestCaseJ4 {
     final ResourceLoader loader =
         new SolrResourceLoader(testHome.resolve("collection1"), this.getClass().getClassLoader());
     final SystemIdResolver resolver = new SystemIdResolver(loader);
-    final String fileUri = Path.of(testHome + "/crazy-path-to-config.xml").toUri().toASCIIString();
+    final String fileUri = testHome.resolve("crazy-path-to-config.xml").toUri().toASCIIString();
 
     assertEquals("solrres:/test.xml", SystemIdResolver.createSystemIdFromResourceName("test.xml"));
     assertEquals(
@@ -84,9 +84,10 @@ public class TestSystemIdResolver extends SolrTestCaseJ4 {
         "TestSystemIdResolver.class");
     assertEntityResolving(
         resolver,
-        SystemIdResolver.createSystemIdFromResourceName(testHome + "/collection1/conf/schema.xml"),
         SystemIdResolver.createSystemIdFromResourceName(
-            testHome + "/collection1/conf/solrconfig.xml"),
+            testHome.resolve("collection1").resolve("conf").resolve("schema.xml").toString()),
+        SystemIdResolver.createSystemIdFromResourceName(
+            testHome.resolve("collection1").resolve("conf").resolve("solrconfig.xml").toString()),
         "schema.xml");
 
     // if somebody uses an absolute uri (e.g., file://) we should fail resolving:
@@ -132,8 +133,10 @@ public class TestSystemIdResolver extends SolrTestCaseJ4 {
 
     assertEntityResolving(
         resolver,
-        SystemIdResolver.createSystemIdFromResourceName(testHome + "/crazy-path-to-schema.xml"),
-        SystemIdResolver.createSystemIdFromResourceName(testHome + "/crazy-path-to-config.xml"),
+        SystemIdResolver.createSystemIdFromResourceName(
+            testHome.resolve("crazy-path-to-schema.xml").toString()),
+        SystemIdResolver.createSystemIdFromResourceName(
+            testHome.resolve("crazy-path-to-config.xml").toString()),
         "crazy-path-to-schema.xml");
   }
 }


### PR DESCRIPTION
This PR addresses [SOLR-18057](https://issues.apache.org/jira/browse/SOLR-18057) by eliminating unnecessary Path→String→Path conversions and using `Path.resolve(...)` when the base is already a Path (starting with BinaryFieldTest noted in the issue).

No intended behavior change; refactor only.

## What changed
- Refactored `TestBinaryField` to use `TEST_HOME().resolve("collection1").resolve("conf")` and `resolve(...)` for file paths.
- Applied the same cleanup pattern in related tests where path bases were already `Path`:
  - `TestRawTransformer`
  - `TestCustomCoreProperties`
  - `TestCoreDiscovery`
  - `TestLazyCores`
  - `CoreAdminCreateDiscoverTest`
  - `CoreAdminHandlerTest`
  - `ReplicationTestHelper`
  - `TestSystemIdResolver`

## Validation
- Focused tests passed:
  - `:solr:core:test --tests org.apache.solr.schema.TestBinaryField`
  - `:solr:core:test --tests org.apache.solr.util.TestSystemIdResolver`
  - `:solr:core:test --tests org.apache.solr.response.TestRawTransformer`
  - `:solr:core:test --tests org.apache.solr.TestCustomCoreProperties`
- `./gradlew check` was attempted and hit unrelated environment/flaky issues (`CloudSolrClientCacheTest` flake and RAT task wiring check in this local environment).
