### PR TITLE
Migrate CancelTaskAPI to JAX-RS 

### DIFF
--- a/changelog/unreleased/migrate-cancel-task-api.yml
+++ b/changelog/unreleased/migrate-cancel-task-api.yml
@@ -1,0 +1,7 @@
+title: Migrate CancelTasksAPI to JAX-RS.  Cancel Task API now has OpenAPI and SolrJ support.
+type: changed
+authors:
+  - name: Eric Pugh
+links:
+- name: PR#4180
+  url: https://github.com/apache/solr/pull/4180

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.client.api.endpoint;
+
+import static org.apache.solr.client.api.util.Constants.INDEX_PATH_PREFIX;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.util.StoreApiParameters;
+
+/**
+ * V2 API definition for cancelling a currently-running task.
+ *
+ * <p>This API (GET /v2/collections/collectionName/tasks/cancel) is analogous to the v1
+ * /solr/collectionName/tasks/cancel API.
+ */
+@Path(INDEX_PATH_PREFIX + "/tasks/cancel")
+public interface CancelTaskApi {
+
+  @GET
+  @StoreApiParameters
+  @Operation(
+      summary = "Cancel a currently-running task",
+      tags = {"tasks"})
+  SolrJerseyResponse cancelTask(@QueryParam("queryUUID") String queryUUID) throws Exception;
+}

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
@@ -29,7 +29,8 @@ import org.apache.solr.client.api.util.StoreApiParameters;
 /**
  * V2 API definition for cancelling a currently-running task.
  *
- * <p>This API (GET /v2/collections/collectionName/tasks/cancel) is analogous to the v1
+ * <p>This API (GET /v2/collections/{collectionName}/tasks/cancel and
+ * GET /v2/cores/{coreName}/tasks/cancel) is analogous to the v1
  * /solr/collectionName/tasks/cancel API.
  */
 @Path(INDEX_PATH_PREFIX + "/tasks/cancel")

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.model.FlexibleSolrJerseyResponse;
 import org.apache.solr.client.api.util.StoreApiParameters;
 
 /**
@@ -40,5 +40,5 @@ public interface CancelTaskApi {
   @Operation(
       summary = "Cancel a currently-running task",
       tags = {"tasks"})
-  SolrJerseyResponse cancelTask(@QueryParam("queryUUID") String queryUUID) throws Exception;
+  FlexibleSolrJerseyResponse cancelTask(@QueryParam("queryUUID") String queryUUID) throws Exception;
 }

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/CancelTaskApi.java
@@ -29,9 +29,8 @@ import org.apache.solr.client.api.util.StoreApiParameters;
 /**
  * V2 API definition for cancelling a currently-running task.
  *
- * <p>This API (GET /v2/collections/{collectionName}/tasks/cancel and
- * GET /v2/cores/{coreName}/tasks/cancel) is analogous to the v1
- * /solr/collectionName/tasks/cancel API.
+ * <p>This API (GET /v2/collections/{collectionName}/tasks/cancel and GET
+ * /v2/cores/{coreName}/tasks/cancel) is analogous to the v1 /solr/collectionName/tasks/cancel API.
  */
 @Path(INDEX_PATH_PREFIX + "/tasks/cancel")
 public interface CancelTaskApi {

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
@@ -17,12 +17,13 @@
 
 package org.apache.solr.handler.admin.api;
 
+import static org.apache.solr.response.SolrQueryResponse.RESPONSE_HEADER_KEY;
 import static org.apache.solr.security.PermissionNameProvider.Name.READ_PERM;
 
 import jakarta.inject.Inject;
 import org.apache.solr.api.JerseyResource;
 import org.apache.solr.client.api.endpoint.CancelTaskApi;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.model.FlexibleSolrJerseyResponse;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.component.QueryCancellationHandler;
 import org.apache.solr.jersey.PermissionName;
@@ -49,11 +50,21 @@ public class CancelTaskAPI extends JerseyResource implements CancelTaskApi {
 
   @Override
   @PermissionName(READ_PERM)
-  public SolrJerseyResponse cancelTask(String queryUUID) throws Exception {
-    final SolrJerseyResponse response = instantiateJerseyResponse(SolrJerseyResponse.class);
+  public FlexibleSolrJerseyResponse cancelTask(String queryUUID) throws Exception {
+    final FlexibleSolrJerseyResponse response =
+        instantiateJerseyResponse(FlexibleSolrJerseyResponse.class);
     final QueryCancellationHandler cancellationHandler =
         (QueryCancellationHandler) solrCore.getRequestHandler("/tasks/cancel");
     cancellationHandler.handleRequestBody(solrQueryRequest, solrQueryResponse);
+    // Copy response data added by the handler into the jersey response object
+    solrQueryResponse
+        .getValues()
+        .forEach(
+            (key, value) -> {
+              if (!RESPONSE_HEADER_KEY.equals(key)) {
+                response.setUnknownProperty(key, value);
+              }
+            });
     return response;
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
@@ -33,8 +33,9 @@ import org.apache.solr.response.SolrQueryResponse;
 /**
  * V2 API for cancelling a currently running "task".
  *
- * <p>This API (GET /v2/collections/collectionName/tasks/cancel) is analogous to the v1
- * /solr/collectionName/tasks/cancel API.
+ * <p>This API (GET /v2/collections/{collectionName}/tasks/cancel and
+ * GET /v2/cores/{coreName}/tasks/cancel) is analogous to the v1
+ * /solr/{collectionName|coreName}/tasks/cancel API.
  */
 public class CancelTaskAPI extends JerseyResource implements CancelTaskApi {
   private final SolrCore solrCore;

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
@@ -33,8 +33,8 @@ import org.apache.solr.response.SolrQueryResponse;
 /**
  * V2 API for cancelling a currently running "task".
  *
- * <p>This API (GET /v2/collections/{collectionName}/tasks/cancel and
- * GET /v2/cores/{coreName}/tasks/cancel) is analogous to the v1
+ * <p>This API (GET /v2/collections/{collectionName}/tasks/cancel and GET
+ * /v2/cores/{coreName}/tasks/cancel) is analogous to the v1
  * /solr/{collectionName|coreName}/tasks/cancel API.
  */
 public class CancelTaskAPI extends JerseyResource implements CancelTaskApi {

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
@@ -54,6 +54,7 @@ public class CancelTaskAPI extends JerseyResource implements CancelTaskApi {
   public FlexibleSolrJerseyResponse cancelTask(String queryUUID) throws Exception {
     final FlexibleSolrJerseyResponse response =
         instantiateJerseyResponse(FlexibleSolrJerseyResponse.class);
+    ensureRequiredParameterProvided("queryUUID", queryUUID);
     final QueryCancellationHandler cancellationHandler =
         (QueryCancellationHandler) solrCore.getRequestHandler("/tasks/cancel");
     cancellationHandler.handleRequestBody(solrQueryRequest, solrQueryResponse);

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CancelTaskAPI.java
@@ -17,13 +17,17 @@
 
 package org.apache.solr.handler.admin.api;
 
-import static org.apache.solr.client.solrj.SolrRequest.METHOD.GET;
+import static org.apache.solr.security.PermissionNameProvider.Name.READ_PERM;
 
-import org.apache.solr.api.EndPoint;
+import jakarta.inject.Inject;
+import org.apache.solr.api.JerseyResource;
+import org.apache.solr.client.api.endpoint.CancelTaskApi;
+import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.component.QueryCancellationHandler;
+import org.apache.solr.jersey.PermissionName;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.security.PermissionNameProvider;
 
 /**
  * V2 API for cancelling a currently running "task".
@@ -31,18 +35,25 @@ import org.apache.solr.security.PermissionNameProvider;
  * <p>This API (GET /v2/collections/collectionName/tasks/cancel) is analogous to the v1
  * /solr/collectionName/tasks/cancel API.
  */
-public class CancelTaskAPI {
-  private final QueryCancellationHandler cancellationHandler;
+public class CancelTaskAPI extends JerseyResource implements CancelTaskApi {
+  private final SolrCore solrCore;
+  private final SolrQueryRequest solrQueryRequest;
+  private final SolrQueryResponse solrQueryResponse;
 
-  public CancelTaskAPI(QueryCancellationHandler cancellationHandler) {
-    this.cancellationHandler = cancellationHandler;
+  @Inject
+  public CancelTaskAPI(SolrCore solrCore, SolrQueryRequest req, SolrQueryResponse rsp) {
+    this.solrCore = solrCore;
+    this.solrQueryRequest = req;
+    this.solrQueryResponse = rsp;
   }
 
-  @EndPoint(
-      path = {"/tasks/cancel"},
-      method = GET,
-      permission = PermissionNameProvider.Name.READ_PERM)
-  public void cancelActiveTask(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    cancellationHandler.handleRequestBody(req, rsp);
+  @Override
+  @PermissionName(READ_PERM)
+  public SolrJerseyResponse cancelTask(String queryUUID) throws Exception {
+    final SolrJerseyResponse response = instantiateJerseyResponse(SolrJerseyResponse.class);
+    final QueryCancellationHandler cancellationHandler =
+        (QueryCancellationHandler) solrCore.getRequestHandler("/tasks/cancel");
+    cancellationHandler.handleRequestBody(solrQueryRequest, solrQueryResponse);
+    return response;
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryCancellationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryCancellationHandler.java
@@ -95,7 +95,7 @@ public class QueryCancellationHandler extends TaskManagementHandler {
 
   @Override
   public Collection<Api> getApis() {
-    return Collections.emptyList();
+    return List.of();
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryCancellationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryCancellationHandler.java
@@ -19,7 +19,6 @@ package org.apache.solr.handler.component;
 import static org.apache.solr.common.params.CommonParams.QUERY_UUID;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ import org.apache.solr.security.PermissionNameProvider;
 
 /** Handles requests for query cancellation for cancellable queries */
 public class QueryCancellationHandler extends TaskManagementHandler {
-  // This can be a parent level member but we keep it here to allow future handlers to have
+  // This can be a parent level member, but we keep it here to allow future handlers to have
   // a custom list of components
   private List<SearchComponent> components;
 

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryCancellationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryCancellationHandler.java
@@ -19,11 +19,12 @@ package org.apache.solr.handler.component;
 import static org.apache.solr.common.params.CommonParams.QUERY_UUID;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.solr.api.AnnotatedApi;
 import org.apache.solr.api.Api;
+import org.apache.solr.api.JerseyResource;
 import org.apache.solr.handler.admin.api.CancelTaskAPI;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
@@ -94,7 +95,12 @@ public class QueryCancellationHandler extends TaskManagementHandler {
 
   @Override
   public Collection<Api> getApis() {
-    return AnnotatedApi.getApis(new CancelTaskAPI(this));
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<Class<? extends JerseyResource>> getJerseyResources() {
+    return List.of(CancelTaskAPI.class);
   }
 
   private List<SearchComponent> getComponentsList() {

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
@@ -50,7 +50,8 @@ public class CancelTaskAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testCancelNonExistentTask() throws Exception {
-    final TasksApi.CancelTask request = new TasksApi.CancelTask(IndexType.CORE, DEFAULT_TEST_COLLECTION_NAME);
+    final TasksApi.CancelTask request =
+        new TasksApi.CancelTask(IndexType.CORE, DEFAULT_TEST_COLLECTION_NAME);
     request.setQueryUUID("nonexistent-uuid");
 
     final FlexibleSolrJerseyResponse response =

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
@@ -20,14 +20,10 @@ import static org.apache.solr.core.CoreContainer.ALLOW_PATHS_SYSPROP;
 import static org.apache.solr.security.AllowListUrlChecker.ENABLE_URL_ALLOW_LIST;
 
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
-import org.apache.solr.client.solrj.apache.HttpSolrClient;
-import org.apache.solr.client.solrj.request.GenericSolrRequest;
-import org.apache.solr.common.params.CommonParams;
-import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.client.api.model.FlexibleSolrJerseyResponse;
+import org.apache.solr.client.api.model.IndexType;
+import org.apache.solr.client.solrj.request.TasksApi;
 import org.apache.solr.common.util.EnvUtils;
-import org.apache.solr.common.util.NamedList;
 import org.apache.solr.util.ExternalPaths;
 import org.apache.solr.util.SolrJettyTestRule;
 import org.junit.BeforeClass;
@@ -56,21 +52,12 @@ public class CancelTaskAPITest extends SolrTestCaseJ4 {
 
   @Test
   public void testCancelNonExistentTask() throws Exception {
-    ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set(CommonParams.QUERY_UUID, "nonexistent-uuid");
+    final TasksApi.CancelTask request = new TasksApi.CancelTask(IndexType.CORE, COLLECTION_NAME);
+    request.setQueryUUID("nonexistent-uuid");
 
-    // Test via the V2 JAX-RS endpoint
-    String v2BaseUrl = solrTestRule.getJetty().getBaseURLV2().toString();
-    try (HttpSolrClient v2Client = new HttpSolrClient.Builder(v2BaseUrl).build()) {
-      GenericSolrRequest request =
-          new GenericSolrRequest(
-              SolrRequest.METHOD.GET,
-              "/cores/" + COLLECTION_NAME + "/tasks/cancel",
-              SolrRequestType.ADMIN,
-              params);
-      NamedList<Object> response = v2Client.request(request);
-      assertNotNull(response);
-      assertEquals("not found", response.get("cancellationResult"));
-    }
+    final FlexibleSolrJerseyResponse response =
+        request.process(solrTestRule.getSolrClient(COLLECTION_NAME));
+    assertNotNull(response);
+    assertEquals("not found", response.unknownProperties().get("cancellationResult"));
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
@@ -35,8 +35,6 @@ public class CancelTaskAPITest extends SolrTestCaseJ4 {
 
   @ClassRule public static SolrJettyTestRule solrTestRule = new SolrJettyTestRule();
 
-  private static final String COLLECTION_NAME = "collection1";
-
   @BeforeClass
   public static void beforeTest() throws Exception {
     EnvUtils.setProperty(
@@ -45,18 +43,18 @@ public class CancelTaskAPITest extends SolrTestCaseJ4 {
     EnvUtils.setProperty(ENABLE_URL_ALLOW_LIST, "false");
     solrTestRule.startSolr(createTempDir());
     solrTestRule
-        .newCollection(COLLECTION_NAME)
+        .newCollection(DEFAULT_TEST_COLLECTION_NAME)
         .withConfigSet(ExternalPaths.DEFAULT_CONFIGSET)
         .create();
   }
 
   @Test
   public void testCancelNonExistentTask() throws Exception {
-    final TasksApi.CancelTask request = new TasksApi.CancelTask(IndexType.CORE, COLLECTION_NAME);
+    final TasksApi.CancelTask request = new TasksApi.CancelTask(IndexType.CORE, DEFAULT_TEST_COLLECTION_NAME);
     request.setQueryUUID("nonexistent-uuid");
 
     final FlexibleSolrJerseyResponse response =
-        request.process(solrTestRule.getSolrClient(COLLECTION_NAME));
+        request.process(solrTestRule.getSolrClient(DEFAULT_TEST_COLLECTION_NAME));
     assertNotNull(response);
     assertEquals("not found", response.unknownProperties().get("cancellationResult"));
   }

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/CancelTaskAPITest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.admin.api;
+
+import static org.apache.solr.core.CoreContainer.ALLOW_PATHS_SYSPROP;
+import static org.apache.solr.security.AllowListUrlChecker.ENABLE_URL_ALLOW_LIST;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
+import org.apache.solr.client.solrj.apache.HttpSolrClient;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.EnvUtils;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.util.ExternalPaths;
+import org.apache.solr.util.SolrJettyTestRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Integration tests for the {@link CancelTaskAPI} V2 endpoint. */
+public class CancelTaskAPITest extends SolrTestCaseJ4 {
+
+  @ClassRule public static SolrJettyTestRule solrTestRule = new SolrJettyTestRule();
+
+  private static final String COLLECTION_NAME = "collection1";
+
+  @BeforeClass
+  public static void beforeTest() throws Exception {
+    EnvUtils.setProperty(
+        ALLOW_PATHS_SYSPROP, ExternalPaths.SERVER_HOME.toAbsolutePath().toString());
+    // Disable URL allow-list checks to allow standalone shard dispatch in non-cloud mode
+    EnvUtils.setProperty(ENABLE_URL_ALLOW_LIST, "false");
+    solrTestRule.startSolr(createTempDir());
+    solrTestRule
+        .newCollection(COLLECTION_NAME)
+        .withConfigSet(ExternalPaths.DEFAULT_CONFIGSET)
+        .create();
+  }
+
+  @Test
+  public void testCancelNonExistentTask() throws Exception {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.set(CommonParams.QUERY_UUID, "nonexistent-uuid");
+
+    // Test via the V2 JAX-RS endpoint
+    String v2BaseUrl = solrTestRule.getJetty().getBaseURLV2().toString();
+    try (HttpSolrClient v2Client = new HttpSolrClient.Builder(v2BaseUrl).build()) {
+      GenericSolrRequest request =
+          new GenericSolrRequest(
+              SolrRequest.METHOD.GET,
+              "/cores/" + COLLECTION_NAME + "/tasks/cancel",
+              SolrRequestType.ADMIN,
+              params);
+      NamedList<Object> response = v2Client.request(request);
+      assertNotNull(response);
+      assertEquals("not found", response.get("cancellationResult"));
+    }
+  }
+}


### PR DESCRIPTION
Migrates `CancelTaskAPI` from the homegrown `@EndPoint` annotation to standard JAX-RS, and replaces the manual `GenericSolrRequest` usage in the integration test with the code-generated `TasksApi.CancelTask` SolrJ client.

## API interface (`solr/api`)
- New `CancelTaskApi` interface with `@Path`, `@GET`, `@QueryParam` JAX-RS annotations using `@StoreApiParameters` for core/collection path support
- Returns `FlexibleSolrJerseyResponse` (instead of `SolrJerseyResponse`) so the dynamic `cancellationResult` field is captured via `@JsonAnySetter` when deserializing

## Server implementation (`solr/core`)
- `CancelTaskAPI` extends `JerseyResource`, implements `CancelTaskApi`, uses `@Inject` for `SolrCore`/`SolrQueryRequest`/`SolrQueryResponse`
- Delegates to `QueryCancellationHandler.handleRequestBody()` (logic stays in V1 handler), then copies non-header entries from `solrQueryResponse` into the returned jersey response — required because Jersey's JSON path serializes the returned object directly, not `solrQueryResponse`
- `QueryCancellationHandler` now uses `getJerseyResources()` / empty `getApis()` instead of `AnnotatedApi`

## Test
Uses the generated `TasksApi.CancelTask` with `SolrJettyTestRule`. The generated class handles V2 URL routing (`/api/…` vs `/solr/…`) automatically via `getApiVersion() == V2`, eliminating the need to construct a separate V2 `HttpSolrClient`.
