### PR TITLE
SOLR-18153: Fix File Upload in Documents Tab of Admin UI

### DIFF
--- a/changelog/unreleased/SOLR-18153.yml
+++ b/changelog/unreleased/SOLR-18153.yml
@@ -1,0 +1,7 @@
+title: Fixed file upload in the Documents tab of Admin UI.
+type: fixed
+authors:
+  - name: Eric Pugh
+links:
+  - name: SOLR-18153
+    url: https://issues.apache.org/jira/browse/SOLR-18153

--- a/solr/webapp/web/js/angular/services.js
+++ b/solr/webapp/web/js/angular/services.js
@@ -166,7 +166,11 @@ solrAdminServices.factory('System',
         $http.post(url, fd, {
             transformRequest: angular.identity,
             headers: {'Content-Type': undefined}
-        }).success(success).error(error);
+        }).then(function(response) {
+            success(response.data);
+        }, function(response) {
+            error(response.data);
+        });
     }
 })
 .filter('splitByComma', function() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18153


# Description

uploading a file works, but due to how success/error is handled, you get a brower console error and therefore no visual feedback.

# Solution

The `.success()` and `.error()` methods on the `$http` promise were **deprecated in AngularJS 1.4** and **removed in AngularJS 1.6+**. Since the documents are still actually indexed (the POST itself succeeds), the underlying `$http.post()` works fine — it's only the callback wiring that was broken.

# Tests

Tested both positive and negative cases manually and I see the appropriate feedback.

I also had claude check for OTHER situations like this, and this was the only one.
