### PR TITLE
SOLR-14687: {!parent} and {!child} qparsers now use NestPathField

### DIFF
--- a/changelog/unreleased/SOLR-14687-parentPath-param.yml
+++ b/changelog/unreleased/SOLR-14687-parentPath-param.yml
@@ -1,0 +1,6 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: The {!parent} and {!child} query parsers now support a parentPath local param that automatically derives the correct parent filter using the _nest_path_ field, making nested document queries easier to write correctly.
+type: added # added, changed, fixed, deprecated, removed, dependency_update, security, other
+links:
+  - name: SOLR-14687
+    url: https://issues.apache.org/jira/browse/SOLR-14687

--- a/changelog/unreleased/SOLR-14687-parentPath-param.yml
+++ b/changelog/unreleased/SOLR-14687-parentPath-param.yml
@@ -1,6 +1,9 @@
 # See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
 title: The {!parent} and {!child} query parsers now support a parentPath local param that automatically derives the correct parent filter using the _nest_path_ field, making nested document queries easier to write correctly.
 type: added # added, changed, fixed, deprecated, removed, dependency_update, security, other
+authors:
+  - name: David Smiley
+  - name: hossman
 links:
   - name: SOLR-14687
     url: https://issues.apache.org/jira/browse/SOLR-14687

--- a/changelog/unreleased/SOLR-14687-parentPath-param.yml
+++ b/changelog/unreleased/SOLR-14687-parentPath-param.yml
@@ -1,5 +1,5 @@
 # See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-title: The {!parent} and {!child} query parsers now support a parentPath local param that automatically derives the correct parent filter using the _nest_path_ field, making nested document queries easier to write correctly.
+title: The {!parent} and {!child} query parsers now support a parentPath local param that automatically derives the correct parent filter using the _nest_path_ field, making nested document queries easier to write correctly.  childPath is also added.
 type: added # added, changed, fixed, deprecated, removed, dependency_update, security, other
 authors:
   - name: David Smiley

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -81,11 +81,9 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    */
   @Override
   protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
-    final boolean isRoot = parentPath.equals("/");
-
     // allParents filter: (*:* -{prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(isRoot, parentPath);
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
     final BooleanQuery parsedParentQuery = parseImpl();
 
@@ -104,12 +102,12 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
     // For root: (+<original_parent> -_nest_path_:*)
     final BooleanQuery.Builder constrainedBuilder =
         new BooleanQuery.Builder().add(parsedParentQuery, Occur.MUST);
-    if (isRoot) {
+    if (parentPath.equals("/")) {
       constrainedBuilder.add(
           new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
     } else {
       constrainedBuilder.add(
-          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.MUST);
+          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.FILTER);
     }
     final Query constrainedParentQuery = constrainedBuilder.build();
 

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -21,7 +21,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.SyntaxError;
@@ -35,8 +34,8 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
   }
 
   @Override
-  protected Query createQuery(Query parentListQuery, Query query, String scoreMode) {
-    return new ToChildBlockJoinQuery(query, getBitSetProducer(parentListQuery));
+  protected Query createQuery(Query parentListQuery, Query fromQuery, String scoreMode) {
+    return new ToChildBlockJoinQuery(fromQuery, getBitSetProducer(parentListQuery));
   }
 
   @Override
@@ -56,7 +55,7 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
   }
 
   /**
-   * Parses the query using the {@code parentPath} localparam for the child parser.
+   * Parses the query using the {@code parentPath} local-param for the child parser.
    *
    * <p>For the {@code child} parser with {@code parentPath="/a/b/c"}:
    *
@@ -74,42 +73,25 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    *      ff=(*:* -_nest_path_:*)
    *      vv=(+p_title:dad -_nest_path_:*)</pre>
    *
-   * <p>The optional {@code childPath} localparam narrows the returned children to docs at exactly
+   * <p>The optional {@code childPath} local-param narrows the returned children to docs at exactly
    * {@code parentPath/childPath}.
    *
    * @param parentPath the normalized parent path (starts with "/", no trailing slash except for
    *     root "/")
+   * @param childPath optional path constraining the children relative to parentPath
    */
   @Override
-  protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
-    String childPath = localParams.get(CHILD_PATH_PARAM);
-    if (childPath != null) {
-      if (childPath.startsWith("/")) {
-        throw new SolrException(
-            SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not start with '/'");
-      }
-      if (childPath.isEmpty()) {
-        childPath = null; // treat empty as not specified
-      }
-    }
+  protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
+
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
     final BooleanQuery parsedParentQuery = parseImpl();
 
-    if (parsedParentQuery.clauses().isEmpty()) {
-      // no parent query: return all children of parents at this level
-      final BooleanQuery notParents =
-          new BooleanQuery.Builder()
-              .add(new MatchAllDocsQuery(), Occur.MUST)
-              .add(allParentsFilter, Occur.MUST_NOT)
-              .build();
-      Query result = new BitSetProducerQuery(getBitSetProducer(notParents));
-      if (childPath != null) {
-        result = buildChildQueryWithPathConstraint(parentPath, childPath, result);
-      }
-      return result;
+    if (parsedParentQuery.clauses().isEmpty()) { // i.e. match all parents
+      // no block-join needed; just filter to certain children
+      return wrapWithChildPathConstraint(parentPath, childPath, new MatchAllDocsQuery());
     }
 
     // constrain the parent query to only match docs at exactly parentPath
@@ -119,7 +101,7 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
 
     Query joinQuery = createQuery(allParentsFilter, constrainedParentQuery, null);
     if (childPath != null) {
-      return buildChildQueryWithPathConstraint(parentPath, childPath, joinQuery);
+      return wrapWithChildPathConstraint(parentPath, childPath, joinQuery);
     }
     return joinQuery;
   }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -16,13 +16,17 @@
  */
 package org.apache.solr.search.join;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.SyntaxError;
 
 public class BlockJoinChildQParser extends BlockJoinParentQParser {
@@ -51,5 +55,64 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
             .add(parents, Occur.MUST_NOT)
             .build();
     return new BitSetProducerQuery(getBitSetProducer(notParents));
+  }
+
+  /**
+   * Parses the query using the {@code parentPath} localparam for the child parser.
+   *
+   * <p>For the {@code child} parser with {@code parentPath="/a/b/c"}:
+   *
+   * <pre>NEW: q={!child parentPath="/a/b/c"}p_title:dad
+   *
+   * OLD: q={!child of=$ff v=$vv}
+   *      ff=(*:* -{prefix f="_nest_path_" v="/a/b/c/"})
+   *      vv=(+p_title:dad +{field f="_nest_path_" v="/a/b/c"})</pre>
+   *
+   * <p>For {@code parentPath="/"}:
+   *
+   * <pre>NEW: q={!child parentPath="/"}p_title:dad
+   *
+   * OLD: q={!child of=$ff v=$vv}
+   *      ff=(*:* -_nest_path_:*)
+   *      vv=(+p_title:dad -_nest_path_:*)</pre>
+   *
+   * @param parentPath the normalized parent path (starts with "/", no trailing slash except for
+   *     root "/")
+   */
+  @Override
+  protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
+    final boolean isRoot = parentPath.equals("/");
+
+    // allParents filter: (*:* -{prefix f="_nest_path_" v="<parentPath>/"})
+    // For root: (*:* -_nest_path_:*)
+    final Query allParentsFilter = buildAllParentsFilterFromPath(isRoot, parentPath);
+
+    final BooleanQuery parsedParentQuery = parseImpl();
+
+    if (parsedParentQuery.clauses().isEmpty()) {
+      // no parent query: return all children of parents at this level
+      final BooleanQuery notParents =
+          new BooleanQuery.Builder()
+              .add(new MatchAllDocsQuery(), Occur.MUST)
+              .add(allParentsFilter, Occur.MUST_NOT)
+              .build();
+      return new BitSetProducerQuery(getBitSetProducer(notParents));
+    }
+
+    // constrain the parent query to only match docs at exactly parentPath
+    // (+<original_parent> +{field f="_nest_path_" v="<parentPath>"})
+    // For root: (+<original_parent> -_nest_path_:*)
+    final BooleanQuery.Builder constrainedBuilder =
+        new BooleanQuery.Builder().add(parsedParentQuery, Occur.MUST);
+    if (isRoot) {
+      constrainedBuilder.add(
+          new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
+    } else {
+      constrainedBuilder.add(
+          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.MUST);
+    }
+    final Query constrainedParentQuery = constrainedBuilder.build();
+
+    return createQuery(allParentsFilter, constrainedParentQuery, null);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -74,15 +74,23 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    *      ff=(*:* -_nest_path_:*)
    *      vv=(+p_title:dad -_nest_path_:*)</pre>
    *
+   * <p>The optional {@code childPath} localparam narrows the returned children to docs at exactly
+   * {@code parentPath/childPath}.
+   *
    * @param parentPath the normalized parent path (starts with "/", no trailing slash except for
    *     root "/")
    */
   @Override
   protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
-    if (localParams.get(CHILD_PATH_PARAM) != null) {
-      throw new SolrException(
-          SolrException.ErrorCode.BAD_REQUEST,
-          CHILD_PATH_PARAM + " is not supported by the {!child} parser");
+    String childPath = localParams.get(CHILD_PATH_PARAM);
+    if (childPath != null) {
+      if (childPath.startsWith("/")) {
+        throw new SolrException(
+            SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not start with '/'");
+      }
+      if (childPath.isEmpty()) {
+        childPath = null; // treat empty as not specified
+      }
     }
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
@@ -97,7 +105,11 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
               .add(new MatchAllDocsQuery(), Occur.MUST)
               .add(allParentsFilter, Occur.MUST_NOT)
               .build();
-      return new BitSetProducerQuery(getBitSetProducer(notParents));
+      Query result = new BitSetProducerQuery(getBitSetProducer(notParents));
+      if (childPath != null) {
+        result = buildChildQueryWithPathConstraint(parentPath, childPath, result);
+      }
+      return result;
     }
 
     // constrain the parent query to only match docs at exactly parentPath
@@ -105,6 +117,10 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
     // For root: (+<original_parent> -_nest_path_:*)
     Query constrainedParentQuery = wrapWithParentPathConstraint(parentPath, parsedParentQuery);
 
-    return createQuery(allParentsFilter, constrainedParentQuery, null);
+    Query joinQuery = createQuery(allParentsFilter, constrainedParentQuery, null);
+    if (childPath != null) {
+      return buildChildQueryWithPathConstraint(parentPath, childPath, joinQuery);
+    }
+    return joinQuery;
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.SyntaxError;
@@ -78,6 +79,11 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    */
   @Override
   protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
+    if (localParams.get(CHILD_PATH_PARAM) != null) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST,
+          CHILD_PATH_PARAM + " is not supported by the {!child} parser");
+    }
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -16,19 +16,16 @@
  */
 package org.apache.solr.search.join;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
-import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.SyntaxError;
 
+/** Matches child documents based on parent doc criteria. */
 public class BlockJoinChildQParser extends BlockJoinParentQParser {
 
   public BlockJoinChildQParser(
@@ -65,8 +62,8 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    * <pre>NEW: q={!child parentPath="/a/b/c"}p_title:dad
    *
    * OLD: q={!child of=$ff v=$vv}
-   *      ff=(*:* -{prefix f="_nest_path_" v="/a/b/c/"})
-   *      vv=(+p_title:dad +{field f="_nest_path_" v="/a/b/c"})</pre>
+   *      ff=(*:* -{!prefix f="_nest_path_" v="/a/b/c/"})
+   *      vv=(+p_title:dad +{!field f="_nest_path_" v="/a/b/c"})</pre>
    *
    * <p>For {@code parentPath="/"}:
    *
@@ -81,7 +78,7 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    */
   @Override
   protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
-    // allParents filter: (*:* -{prefix f="_nest_path_" v="<parentPath>/"})
+    // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
@@ -98,18 +95,9 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
     }
 
     // constrain the parent query to only match docs at exactly parentPath
-    // (+<original_parent> +{field f="_nest_path_" v="<parentPath>"})
+    // (+<original_parent> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<original_parent> -_nest_path_:*)
-    final BooleanQuery.Builder constrainedBuilder =
-        new BooleanQuery.Builder().add(parsedParentQuery, Occur.MUST);
-    if (parentPath.equals("/")) {
-      constrainedBuilder.add(
-          new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
-    } else {
-      constrainedBuilder.add(
-          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.FILTER);
-    }
-    final Query constrainedParentQuery = constrainedBuilder.build();
+    Query constrainedParentQuery = wrapWithParentPathConstraint(parentPath, parsedParentQuery);
 
     return createQuery(allParentsFilter, constrainedParentQuery, null);
   }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -83,10 +83,6 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
   @Override
   protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
 
-    // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
-    // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
-
     final BooleanQuery parsedParentQuery = parseImpl();
 
     if (parsedParentQuery.clauses().isEmpty()) { // i.e. match all parents
@@ -94,15 +90,21 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
       return wrapWithChildPathConstraint(parentPath, childPath, new MatchAllDocsQuery());
     }
 
+    // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
+    // For root: (*:* -_nest_path_:*)
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
+
     // constrain the parent query to only match docs at exactly parentPath
     // (+<original_parent> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<original_parent> -_nest_path_:*)
     Query constrainedParentQuery = wrapWithParentPathConstraint(parentPath, parsedParentQuery);
 
     Query joinQuery = createQuery(allParentsFilter, constrainedParentQuery, null);
-    if (childPath != null) {
-      return wrapWithChildPathConstraint(parentPath, childPath, joinQuery);
+    // matches all children of matching parents
+    if (childPath == null) {
+      return joinQuery;
     }
-    return joinQuery;
+    // need to constrain to certain children
+    return wrapWithChildPathConstraint(parentPath, childPath, joinQuery);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -18,14 +18,11 @@ package org.apache.solr.search.join;
 
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
-import org.apache.solr.schema.IndexSchema;
-import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.SyntaxError;
 
 /** Matches child documents based on parent doc criteria. */
@@ -88,28 +85,19 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
 
     final BooleanQuery parsedParentQuery = parseImpl();
 
-    final SchemaField nestPathField =
-        req.getSchema().getFieldOrNull(IndexSchema.NEST_PATH_FIELD_NAME);
-    final Query nestPathExistsQuery =
-        nestPathField != null
-            ? nestPathField.getType().getExistenceQuery(this, nestPathField)
-            : new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
-
     if (parsedParentQuery.clauses().isEmpty()) { // i.e. match all parents
       // no block-join needed; just filter to certain children
-      return wrapWithChildPathConstraint(
-          parentPath, childPath, new MatchAllDocsQuery(), nestPathExistsQuery);
+      return wrapWithChildPathConstraint(parentPath, childPath, new MatchAllDocsQuery());
     }
 
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath, nestPathExistsQuery);
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
     // constrain the parent query to only match docs at exactly parentPath
     // (+<original_parent> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<original_parent> -_nest_path_:*)
-    Query constrainedParentQuery =
-        wrapWithParentPathConstraint(parentPath, parsedParentQuery, nestPathExistsQuery);
+    Query constrainedParentQuery = wrapWithParentPathConstraint(parentPath, parsedParentQuery);
 
     Query joinQuery = createQuery(allParentsFilter, constrainedParentQuery, null);
     // matches all children of matching parents
@@ -117,6 +105,6 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
       return joinQuery;
     }
     // need to constrain to certain children
-    return wrapWithChildPathConstraint(parentPath, childPath, joinQuery, nestPathExistsQuery);
+    return wrapWithChildPathConstraint(parentPath, childPath, joinQuery);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -44,8 +44,8 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
   }
 
   @Override
-  protected Query noClausesQuery() throws SyntaxError {
-    final Query parents = parseParentFilter();
+  protected Query noClausesQueryLegacy() throws SyntaxError {
+    final Query parents = parseLegacyParentFilter();
     final BooleanQuery notParents =
         new BooleanQuery.Builder()
             .add(new MatchAllDocsQuery(), Occur.MUST)
@@ -82,7 +82,6 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
    */
   @Override
   protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
-
     final BooleanQuery parsedParentQuery = parseImpl();
 
     if (parsedParentQuery.clauses().isEmpty()) { // i.e. match all parents

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -39,7 +39,7 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
   }
 
   @Override
-  protected String getParentFilterLocalParamName() {
+  protected String getLegacyParentFilterParamName() {
     return "of";
   }
 

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinChildQParser.java
@@ -18,11 +18,14 @@ package org.apache.solr.search.join;
 
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.SyntaxError;
 
 /** Matches child documents based on parent doc criteria. */
@@ -85,19 +88,28 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
 
     final BooleanQuery parsedParentQuery = parseImpl();
 
+    final SchemaField nestPathField =
+        req.getSchema().getFieldOrNull(IndexSchema.NEST_PATH_FIELD_NAME);
+    final Query nestPathExistsQuery =
+        nestPathField != null
+            ? nestPathField.getType().getExistenceQuery(this, nestPathField)
+            : new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
+
     if (parsedParentQuery.clauses().isEmpty()) { // i.e. match all parents
       // no block-join needed; just filter to certain children
-      return wrapWithChildPathConstraint(parentPath, childPath, new MatchAllDocsQuery());
+      return wrapWithChildPathConstraint(
+          parentPath, childPath, new MatchAllDocsQuery(), nestPathExistsQuery);
     }
 
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath, nestPathExistsQuery);
 
     // constrain the parent query to only match docs at exactly parentPath
     // (+<original_parent> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<original_parent> -_nest_path_:*)
-    Query constrainedParentQuery = wrapWithParentPathConstraint(parentPath, parsedParentQuery);
+    Query constrainedParentQuery =
+        wrapWithParentPathConstraint(parentPath, parsedParentQuery, nestPathExistsQuery);
 
     Query joinQuery = createQuery(allParentsFilter, constrainedParentQuery, null);
     // matches all children of matching parents
@@ -105,6 +117,6 @@ public class BlockJoinChildQParser extends BlockJoinParentQParser {
       return joinQuery;
     }
     // need to constrain to certain children
-    return wrapWithChildPathConstraint(parentPath, childPath, joinQuery);
+    return wrapWithChildPathConstraint(parentPath, childPath, joinQuery, nestPathExistsQuery);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -111,8 +112,22 @@ public class BlockJoinParentQParser extends FiltersQParser {
       if (parentPath.length() > 1 && parentPath.endsWith("/")) {
         parentPath = parentPath.substring(0, parentPath.length() - 1);
       }
-      return parseUsingParentPath(parentPath);
+
+      String childPath = localParams.get(CHILD_PATH_PARAM);
+      if (childPath != null) {
+        if (childPath.startsWith("/")) {
+          throw new SolrException(
+              SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not start with '/'");
+        }
+        if (childPath.isEmpty()) {
+          childPath = null; // treat empty as not specified
+        }
+      }
+      return parseUsingParentPath(parentPath, childPath);
     }
+
+    // NO parentPath; use classic/advanced/DIY code path:
+
     if (localParams.get(CHILD_PATH_PARAM) != null) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " requires " + PARENT_PATH_PARAM);
@@ -142,22 +157,12 @@ public class BlockJoinParentQParser extends FiltersQParser {
    *
    * @param parentPath the normalized parent path (starts with "/", no trailing slash except for
    *     root "/")
+   * @param childPath optional path constraining the children relative to parentPath
    */
-  protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
+  protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
-
-    String childPath = localParams.get(CHILD_PATH_PARAM);
-    if (childPath != null) {
-      if (childPath.startsWith("/")) {
-        throw new SolrException(
-            SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not start with '/'");
-      }
-      if (childPath.isEmpty()) {
-        childPath = null; // treat empty as not specified
-      }
-    }
 
     final BooleanQuery parsedChildQuery = parseImpl();
 
@@ -171,7 +176,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
     // If childPath specified: (+<original_child> +{!term f="_nest_path_"
     // v="<parentPath>/<childPath>"})
     final Query constrainedChildQuery =
-        buildChildQueryWithPathConstraint(parentPath, childPath, parsedChildQuery);
+        wrapWithChildPathConstraint(parentPath, childPath, parsedChildQuery);
 
     final String scoreMode = localParams.get("score", ScoreMode.None.name());
     final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
@@ -210,30 +215,31 @@ public class BlockJoinParentQParser extends FiltersQParser {
   }
 
   /**
-   * Wraps the given query with a constraint ensuring only docs at exactly the {@code parentPath}
-   * level are matched. For root, this excludes docs that have a {@code _nest_path_} value. For
-   * non-root, this requires an exact match on {@code _nest_path_}.
+   * Wraps the given query with a constraint ensuring only docs at exactly {@code parentPath} are
+   * matched.
    */
   protected static Query wrapWithParentPathConstraint(String parentPath, Query query) {
     final BooleanQuery.Builder builder = new BooleanQuery.Builder().add(query, Occur.MUST);
     if (parentPath.equals("/")) {
       builder.add(new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
     } else {
-      builder.add(
-          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.FILTER);
+      final Query constraint =
+          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath));
+      if (query instanceof MatchAllDocsQuery) {
+        return new ConstantScoreQuery(constraint);
+      }
+      builder.add(constraint, Occur.FILTER);
     }
     return builder.build();
   }
 
   /**
-   * Constrains the child query to only match docs strictly below the given {@code parentPath}. For
-   * the parent parser, the child query must match docs with a {@code _nest_path_} that is a
-   * sub-path of the parent path (i.e. starts with {@code parentPath/}). For root, any doc with a
-   * {@code _nest_path_} is a "child". If {@code childPath} is non-null, the constraint is an exact
-   * term match on {@code parentPath/childPath} instead of a prefix query.
+   * Wraps the sub-query with a constraint ensuring only docs that are descendants of {@code
+   * parentPath} are matched. If {@code childPath} is non-null, further narrows to docs at exactly
+   * {@code parentPath/childPath}.
    */
-  protected static Query buildChildQueryWithPathConstraint(
-      String parentPath, String childPath, Query childQuery) {
+  protected static Query wrapWithChildPathConstraint(
+      String parentPath, String childPath, Query subQuery) {
     final Query nestPathConstraint;
     if (childPath != null) {
       String effectiveChildPath =
@@ -246,8 +252,11 @@ public class BlockJoinParentQParser extends FiltersQParser {
       nestPathConstraint =
           new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));
     }
+    if (subQuery instanceof MatchAllDocsQuery) {
+      return new ConstantScoreQuery(nestPathConstraint);
+    }
     return new BooleanQuery.Builder()
-        .add(childQuery, Occur.MUST)
+        .add(subQuery, Occur.MUST)
         .add(nestPathConstraint, Occur.FILTER)
         .build();
   }
@@ -268,19 +277,33 @@ public class BlockJoinParentQParser extends FiltersQParser {
 
   @Override
   protected Query noClausesQuery() throws SyntaxError {
+    assert false : "dead code";
     return new BitSetProducerQuery(getBitSetProducer(parseParentFilter()));
   }
 
-  protected Query createQuery(final Query parentList, Query query, String scoreMode)
+  /**
+   * Create the block-join query, the core Query of the QParser.
+   *
+   * @param parentList the "parent" query. The result will internally be cached.
+   * @param fromQuery source/from query. For {!parent}, this is a child, otherwise it's a parent
+   * @param scoreMode see {@link ScoreMode}
+   * @return non-null
+   * @throws SyntaxError Only if scoreMode doesn't parse
+   */
+  protected Query createQuery(final Query parentList, Query fromQuery, String scoreMode)
       throws SyntaxError {
     return new AllParentsAware(
-        query, getBitSetProducer(parentList), ScoreModeParser.parse(scoreMode), parentList);
+        fromQuery, getBitSetProducer(parentList), ScoreModeParser.parse(scoreMode), parentList);
   }
 
   BitSetProducer getBitSetProducer(Query query) {
     return getCachedBitSetProducer(req, query);
   }
 
+  /**
+   * Returns a Lucene {@link BitSetProducer}, typically cached by query. Note that BSP itself
+   * internally caches a per-segment {@link BitSet}.
+   */
   public static BitSetProducer getCachedBitSetProducer(
       final SolrQueryRequest request, Query query) {
     @SuppressWarnings("unchecked")
@@ -297,6 +320,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
     }
   }
 
+  /** A {@link ToParentBlockJoinQuery} exposing the query underlying the {@link BitSetProducer}. */
   static final class AllParentsAware extends ToParentBlockJoinQuery {
     private final Query parentQuery;
 

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -58,7 +58,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
   public static final String CACHE_NAME = "perSegFilter";
 
   /**
-   * Optional localparam that, when specified, makes this parser natively aware of the {@link
+   * Optional local-param that, when specified, makes this parser natively aware of the {@link
    * IndexSchema#NEST_PATH_FIELD_NAME} field to automatically derive the parent filter (the {@code
    * which} param). The value must be an absolute path starting with {@code /} using {@code /} as
    * separator, e.g. {@code /} for root-level parents or {@code /skus} for parents nested at that
@@ -69,7 +69,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
   public static final String PARENT_PATH_PARAM = "parentPath";
 
   /**
-   * Optional localparam, only valid together with {@link #PARENT_PATH_PARAM} on the {@code parent}
+   * Optional local-param, only valid together with {@link #PARENT_PATH_PARAM} on the {@code parent}
    * parser. When specified, the subordinate (child) query is constrained to docs at exactly the
    * path formed by concatenating {@code parentPath + "/" + childPath}, instead of the default
    * behavior of matching all descendants. For example, {@code parentPath="/skus"
@@ -160,16 +160,16 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * @param childPath optional path constraining the children relative to parentPath
    */
   protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
+    final BooleanQuery parsedChildQuery = parseImpl();
+
+    if (parsedChildQuery.clauses().isEmpty()) { // i.e. all children
+      // no block-join needed; just return all "parent" docs at this level
+      return wrapWithParentPathConstraint(parentPath, new MatchAllDocsQuery());
+    }
+
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
-
-    final BooleanQuery parsedChildQuery = parseImpl();
-
-    if (parsedChildQuery.clauses().isEmpty()) {
-      // no child query: return all "parent" docs at this level
-      return wrapWithParentPathConstraint(parentPath, allParentsFilter);
-    }
 
     // constrain child query: (+<original_child> +{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (+<original_child> +_nest_path_:*)

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -232,7 +232,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * {@code _nest_path_} is a "child". If {@code childPath} is non-null, the constraint is an exact
    * term match on {@code parentPath/childPath} instead of a prefix query.
    */
-  private static Query buildChildQueryWithPathConstraint(
+  protected static Query buildChildQueryWithPathConstraint(
       String parentPath, String childPath, Query childQuery) {
     final Query nestPathConstraint;
     if (childPath != null) {

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -150,13 +150,12 @@ public class BlockJoinParentQParser extends FiltersQParser {
 
     String childPath = localParams.get(CHILD_PATH_PARAM);
     if (childPath != null) {
-      // strip leading slash if present
       if (childPath.startsWith("/")) {
-        childPath = childPath.substring(1);
+        throw new SolrException(
+            SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not start with '/'");
       }
       if (childPath.isEmpty()) {
-        throw new SolrException(
-            SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not be empty");
+        childPath = null; // treat empty as not specified
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -129,30 +129,28 @@ public class BlockJoinParentQParser extends FiltersQParser {
    *     root "/")
    */
   protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
-    final boolean isRoot = parentPath.equals("/");
-
     // allParents filter: (*:* -{prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(isRoot, parentPath);
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
     final BooleanQuery parsedChildQuery = parseImpl();
 
     if (parsedChildQuery.clauses().isEmpty()) {
       // no child query: return all "parent" docs at this level
-      return wrapWithParentPathConstraint(isRoot, parentPath, allParentsFilter);
+      return wrapWithParentPathConstraint(parentPath, allParentsFilter);
     }
 
     // constrain child query: (+<original_child> +{prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (+<original_child> +_nest_path_:*)
     final Query constrainedChildQuery =
-        buildChildQueryWithPathConstraint(isRoot, parentPath, parsedChildQuery);
+        buildChildQueryWithPathConstraint(parentPath, parsedChildQuery);
 
     final String scoreMode = localParams.get("score", ScoreMode.None.name());
     final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
 
     // wrap result: (+<parent_join> +{field f="_nest_path_" v="<parentPath>"})
     // For root: (+<parent_join> -_nest_path_:*)
-    return wrapWithParentPathConstraint(isRoot, parentPath, parentJoinQuery);
+    return wrapWithParentPathConstraint(parentPath, parentJoinQuery);
   }
 
   /**
@@ -170,9 +168,9 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * <p>Equivalent to: {@code (*:* -{prefix f="_nest_path_" v="<parentPath>/"})} For root ({@code
    * /}): {@code (*:* -_nest_path_:*)}
    */
-  protected static Query buildAllParentsFilterFromPath(boolean isRoot, String parentPath) {
+  protected static Query buildAllParentsFilterFromPath(String parentPath) {
     final Query excludeQuery;
-    if (isRoot) {
+    if (parentPath.equals("/")) {
       excludeQuery = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
     } else {
       excludeQuery = new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));
@@ -188,14 +186,13 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * level are matched. For root, this excludes docs that have a {@code _nest_path_} value. For
    * non-root, this requires an exact match on {@code _nest_path_}.
    */
-  private static Query wrapWithParentPathConstraint(
-      boolean isRoot, String parentPath, Query query) {
+  private static Query wrapWithParentPathConstraint(String parentPath, Query query) {
     final BooleanQuery.Builder builder = new BooleanQuery.Builder().add(query, Occur.MUST);
-    if (isRoot) {
+    if (parentPath.equals("/")) {
       builder.add(new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
     } else {
       builder.add(
-          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.MUST);
+          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.FILTER);
     }
     return builder.build();
   }
@@ -206,10 +203,9 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * sub-path of the parent path (i.e. starts with {@code parentPath/}). For root, any doc with a
    * {@code _nest_path_} is a "child".
    */
-  private static Query buildChildQueryWithPathConstraint(
-      boolean isRoot, String parentPath, Query childQuery) {
+  private static Query buildChildQueryWithPathConstraint(String parentPath, Query childQuery) {
     final Query nestPathConstraint;
-    if (isRoot) {
+    if (parentPath.equals("/")) {
       nestPathConstraint = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
     } else {
       nestPathConstraint =
@@ -217,7 +213,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
     }
     return new BooleanQuery.Builder()
         .add(childQuery, Occur.MUST)
-        .add(nestPathConstraint, Occur.MUST)
+        .add(nestPathConstraint, Occur.FILTER)
         .build();
   }
 

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -20,13 +20,20 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Objects;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.QueryBitSetProducer;
@@ -34,8 +41,10 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.ExtendedQueryBase;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SolrCache;
@@ -45,6 +54,17 @@ import org.apache.solr.util.SolrDefaultScorerSupplier;
 public class BlockJoinParentQParser extends FiltersQParser {
   /** implementation detail subject to change */
   public static final String CACHE_NAME = "perSegFilter";
+
+  /**
+   * Optional localparam that, when specified, makes this parser natively aware of the {@link
+   * IndexSchema#NEST_PATH_FIELD_NAME} field to automatically derive the parent filter (the {@code
+   * which} param). The value must be an absolute path starting with {@code /} using {@code /} as
+   * separator, e.g. {@code /} for root-level parents or {@code /skus} for parents nested at that
+   * path. When specified, the {@code which} param must not also be specified.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/SOLR-14687">SOLR-14687</a>
+   */
+  public static final String PARENT_PATH_PARAM = "parentPath";
 
   protected String getParentFilterLocalParamName() {
     return "which";
@@ -58,6 +78,147 @@ public class BlockJoinParentQParser extends FiltersQParser {
   BlockJoinParentQParser(
       String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req) {
     super(qstr, localParams, params, req);
+  }
+
+  @Override
+  public Query parse() throws SyntaxError {
+    String parentPath = localParams.get(PARENT_PATH_PARAM);
+    if (parentPath != null) {
+      if (localParams.get(getParentFilterLocalParamName()) != null) {
+        throw new SolrException(
+            SolrException.ErrorCode.BAD_REQUEST,
+            PARENT_PATH_PARAM
+                + " and "
+                + getParentFilterLocalParamName()
+                + " local params are mutually exclusive");
+      }
+      if (!parentPath.startsWith("/")) {
+        throw new SolrException(
+            SolrException.ErrorCode.BAD_REQUEST, PARENT_PATH_PARAM + " must start with '/'");
+      }
+      // strip trailing slash (except for root "/")
+      if (parentPath.length() > 1 && parentPath.endsWith("/")) {
+        parentPath = parentPath.substring(0, parentPath.length() - 1);
+      }
+      return parseUsingParentPath(parentPath);
+    }
+    return super.parse();
+  }
+
+  /**
+   * Parses the query using the {@code parentPath} localparam to automatically derive the parent
+   * filter and child query constraints from {@link IndexSchema#NEST_PATH_FIELD_NAME}.
+   *
+   * <p>For the {@code parent} parser with {@code parentPath="/a/b/c"}:
+   *
+   * <pre>NEW: q={!parent parentPath="/a/b/c"}c_title:son
+   *
+   * OLD: q=(+{!field f="_nest_path_" v="/a/b/c"} +{!parent which=$ff v=$vv})
+   *      ff=(*:* -{prefix f="_nest_path_" v="/a/b/c/"})
+   *      vv=(+c_title:son +{prefix f="_nest_path_" v="/a/b/c/"})</pre>
+   *
+   * <p>For {@code parentPath="/"}:
+   *
+   * <pre>NEW: q={!parent parentPath="/"}c_title:son
+   *
+   * OLD: q=(+(*:* -_nest_path_:*) +{!parent which=$ff v=$vv})
+   *      ff=(*:* -_nest_path_:*)
+   *      vv=(+c_title:son +_nest_path_:*)</pre>
+   *
+   * @param parentPath the normalized parent path (starts with "/", no trailing slash except for
+   *     root "/")
+   */
+  protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
+    final boolean isRoot = parentPath.equals("/");
+
+    // allParents filter: (*:* -{prefix f="_nest_path_" v="<parentPath>/"})
+    // For root: (*:* -_nest_path_:*)
+    final Query allParentsFilter = buildAllParentsFilterFromPath(isRoot, parentPath);
+
+    final BooleanQuery parsedChildQuery = parseImpl();
+
+    if (parsedChildQuery.clauses().isEmpty()) {
+      // no child query: return all "parent" docs at this level
+      return wrapWithParentPathConstraint(isRoot, parentPath, allParentsFilter);
+    }
+
+    // constrain child query: (+<original_child> +{prefix f="_nest_path_" v="<parentPath>/"})
+    // For root: (+<original_child> +_nest_path_:*)
+    final Query constrainedChildQuery =
+        buildChildQueryWithPathConstraint(isRoot, parentPath, parsedChildQuery);
+
+    final String scoreMode = localParams.get("score", ScoreMode.None.name());
+    final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
+
+    // wrap result: (+<parent_join> +{field f="_nest_path_" v="<parentPath>"})
+    // For root: (+<parent_join> -_nest_path_:*)
+    return wrapWithParentPathConstraint(isRoot, parentPath, parentJoinQuery);
+  }
+
+  /**
+   * Builds the "all parents" filter query from the given {@code parentPath}. This query matches all
+   * documents that are NOT strictly below (nested inside) the given path. This includes:
+   *
+   * <ul>
+   *   <li>documents without any {@code _nest_path_} (root-level, non-nested docs)
+   *   <li>documents at the same level as {@code parentPath} (i.e. with exactly that path)
+   *   <li>documents at levels above {@code parentPath}
+   *   <li>documents at completely orthogonal paths (e.g. {@code /x/y/z} when parentPath is {@code
+   *       /a/b/c})
+   * </ul>
+   *
+   * <p>Equivalent to: {@code (*:* -{prefix f="_nest_path_" v="<parentPath>/"})} For root ({@code
+   * /}): {@code (*:* -_nest_path_:*)}
+   */
+  protected static Query buildAllParentsFilterFromPath(boolean isRoot, String parentPath) {
+    final Query excludeQuery;
+    if (isRoot) {
+      excludeQuery = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
+    } else {
+      excludeQuery = new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));
+    }
+    return new BooleanQuery.Builder()
+        .add(new MatchAllDocsQuery(), Occur.MUST)
+        .add(excludeQuery, Occur.MUST_NOT)
+        .build();
+  }
+
+  /**
+   * Wraps the given query with a constraint ensuring only docs at exactly the {@code parentPath}
+   * level are matched. For root, this excludes docs that have a {@code _nest_path_} value. For
+   * non-root, this requires an exact match on {@code _nest_path_}.
+   */
+  private static Query wrapWithParentPathConstraint(
+      boolean isRoot, String parentPath, Query query) {
+    final BooleanQuery.Builder builder = new BooleanQuery.Builder().add(query, Occur.MUST);
+    if (isRoot) {
+      builder.add(new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
+    } else {
+      builder.add(
+          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath)), Occur.MUST);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Constrains the child query to only match docs strictly below the given {@code parentPath}. For
+   * the parent parser, the child query must match docs with a {@code _nest_path_} that is a
+   * sub-path of the parent path (i.e. starts with {@code parentPath/}). For root, any doc with a
+   * {@code _nest_path_} is a "child".
+   */
+  private static Query buildChildQueryWithPathConstraint(
+      boolean isRoot, String parentPath, Query childQuery) {
+    final Query nestPathConstraint;
+    if (isRoot) {
+      nestPathConstraint = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
+    } else {
+      nestPathConstraint =
+          new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));
+    }
+    return new BooleanQuery.Builder()
+        .add(childQuery, Occur.MUST)
+        .add(nestPathConstraint, Occur.MUST)
+        .build();
   }
 
   protected Query parseParentFilter() throws SyntaxError {

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -67,6 +67,16 @@ public class BlockJoinParentQParser extends FiltersQParser {
    */
   public static final String PARENT_PATH_PARAM = "parentPath";
 
+  /**
+   * Optional localparam, only valid together with {@link #PARENT_PATH_PARAM} on the {@code parent}
+   * parser. When specified, the subordinate (child) query is constrained to docs at exactly the
+   * path formed by concatenating {@code parentPath + "/" + childPath}, instead of the default
+   * behavior of matching all descendants. For example, {@code parentPath="/skus"
+   * childPath="manuals"} constrains children to docs whose {@code _nest_path_} is exactly {@code
+   * /skus/manuals}.
+   */
+  public static final String CHILD_PATH_PARAM = "childPath";
+
   protected String getParentFilterLocalParamName() {
     return "which";
   }
@@ -103,6 +113,10 @@ public class BlockJoinParentQParser extends FiltersQParser {
       }
       return parseUsingParentPath(parentPath);
     }
+    if (localParams.get(CHILD_PATH_PARAM) != null) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " requires " + PARENT_PATH_PARAM);
+    }
     return super.parse();
   }
 
@@ -134,6 +148,18 @@ public class BlockJoinParentQParser extends FiltersQParser {
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
+    String childPath = localParams.get(CHILD_PATH_PARAM);
+    if (childPath != null) {
+      // strip leading slash if present
+      if (childPath.startsWith("/")) {
+        childPath = childPath.substring(1);
+      }
+      if (childPath.isEmpty()) {
+        throw new SolrException(
+            SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " must not be empty");
+      }
+    }
+
     final BooleanQuery parsedChildQuery = parseImpl();
 
     if (parsedChildQuery.clauses().isEmpty()) {
@@ -143,8 +169,10 @@ public class BlockJoinParentQParser extends FiltersQParser {
 
     // constrain child query: (+<original_child> +{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (+<original_child> +_nest_path_:*)
+    // If childPath specified: (+<original_child> +{!term f="_nest_path_"
+    // v="<parentPath>/<childPath>"})
     final Query constrainedChildQuery =
-        buildChildQueryWithPathConstraint(parentPath, parsedChildQuery);
+        buildChildQueryWithPathConstraint(parentPath, childPath, parsedChildQuery);
 
     final String scoreMode = localParams.get("score", ScoreMode.None.name());
     final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
@@ -202,11 +230,18 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * Constrains the child query to only match docs strictly below the given {@code parentPath}. For
    * the parent parser, the child query must match docs with a {@code _nest_path_} that is a
    * sub-path of the parent path (i.e. starts with {@code parentPath/}). For root, any doc with a
-   * {@code _nest_path_} is a "child".
+   * {@code _nest_path_} is a "child". If {@code childPath} is non-null, the constraint is an exact
+   * term match on {@code parentPath/childPath} instead of a prefix query.
    */
-  private static Query buildChildQueryWithPathConstraint(String parentPath, Query childQuery) {
+  private static Query buildChildQueryWithPathConstraint(
+      String parentPath, String childPath, Query childQuery) {
     final Query nestPathConstraint;
-    if (parentPath.equals("/")) {
+    if (childPath != null) {
+      String effectiveChildPath =
+          parentPath.equals("/") ? "/" + childPath : parentPath + "/" + childPath;
+      nestPathConstraint =
+          new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, effectiveChildPath));
+    } else if (parentPath.equals("/")) {
       nestPathConstraint = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
     } else {
       nestPathConstraint =

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -51,6 +51,7 @@ import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.util.SolrDefaultScorerSupplier;
 
+/** Matches parent documents based on child doc criteria. */
 public class BlockJoinParentQParser extends FiltersQParser {
   /** implementation detail subject to change */
   public static final String CACHE_NAME = "perSegFilter";
@@ -114,8 +115,8 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * <pre>NEW: q={!parent parentPath="/a/b/c"}c_title:son
    *
    * OLD: q=(+{!field f="_nest_path_" v="/a/b/c"} +{!parent which=$ff v=$vv})
-   *      ff=(*:* -{prefix f="_nest_path_" v="/a/b/c/"})
-   *      vv=(+c_title:son +{prefix f="_nest_path_" v="/a/b/c/"})</pre>
+   *      ff=(*:* -{!prefix f="_nest_path_" v="/a/b/c/"})
+   *      vv=(+c_title:son +{!prefix f="_nest_path_" v="/a/b/c/"})</pre>
    *
    * <p>For {@code parentPath="/"}:
    *
@@ -129,7 +130,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
    *     root "/")
    */
   protected Query parseUsingParentPath(String parentPath) throws SyntaxError {
-    // allParents filter: (*:* -{prefix f="_nest_path_" v="<parentPath>/"})
+    // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
     final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
@@ -140,7 +141,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
       return wrapWithParentPathConstraint(parentPath, allParentsFilter);
     }
 
-    // constrain child query: (+<original_child> +{prefix f="_nest_path_" v="<parentPath>/"})
+    // constrain child query: (+<original_child> +{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (+<original_child> +_nest_path_:*)
     final Query constrainedChildQuery =
         buildChildQueryWithPathConstraint(parentPath, parsedChildQuery);
@@ -148,7 +149,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
     final String scoreMode = localParams.get("score", ScoreMode.None.name());
     final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
 
-    // wrap result: (+<parent_join> +{field f="_nest_path_" v="<parentPath>"})
+    // wrap result: (+<parent_join> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<parent_join> -_nest_path_:*)
     return wrapWithParentPathConstraint(parentPath, parentJoinQuery);
   }
@@ -165,7 +166,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
    *       /a/b/c})
    * </ul>
    *
-   * <p>Equivalent to: {@code (*:* -{prefix f="_nest_path_" v="<parentPath>/"})} For root ({@code
+   * <p>Equivalent to: {@code (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})} For root ({@code
    * /}): {@code (*:* -_nest_path_:*)}
    */
   protected static Query buildAllParentsFilterFromPath(String parentPath) {
@@ -186,7 +187,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * level are matched. For root, this excludes docs that have a {@code _nest_path_} value. For
    * non-root, this requires an exact match on {@code _nest_path_}.
    */
-  private static Query wrapWithParentPathConstraint(String parentPath, Query query) {
+  protected static Query wrapWithParentPathConstraint(String parentPath, Query query) {
     final BooleanQuery.Builder builder = new BooleanQuery.Builder().add(query, Occur.MUST);
     if (parentPath.equals("/")) {
       builder.add(new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -134,13 +134,11 @@ public class BlockJoinParentQParser extends FiltersQParser {
     }
     if (localParams.get(getParentFilterLocalParamName()) == null) {
       throw new SyntaxError(
-          "'"
-              + getParentFilterLocalParamName()
-              + "' or '"
-              + PARENT_PATH_PARAM
-              + "' is required for the '"
-              + localParams.get("type", "parent")
-              + "' query parser");
+          String.format(
+              "'%s' or '%s' is required for the '%s' query parser",
+              getParentFilterLocalParamName(),
+              PARENT_PATH_PARAM,
+              localParams.get("type", "parent")));
     }
     return super.parse();
   }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -132,6 +132,16 @@ public class BlockJoinParentQParser extends FiltersQParser {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " requires " + PARENT_PATH_PARAM);
     }
+    if (localParams.get(getParentFilterLocalParamName()) == null) {
+      throw new SyntaxError(
+          "'"
+              + getParentFilterLocalParamName()
+              + "' or '"
+              + PARENT_PATH_PARAM
+              + "' is required for the '"
+              + localParams.get("type", "parent")
+              + "' query parser");
+    }
     return super.parse();
   }
 
@@ -277,7 +287,6 @@ public class BlockJoinParentQParser extends FiltersQParser {
 
   @Override
   protected Query noClausesQuery() throws SyntaxError {
-    assert false : "dead code";
     return new BitSetProducerQuery(getBitSetProducer(parseParentFilter()));
   }
 

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -18,6 +18,7 @@ package org.apache.solr.search.join;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Locale;
 import java.util.Objects;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
@@ -132,6 +133,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
     if (localParams.get(getLegacyParentFilterParamName()) == null) {
       throw new SyntaxError(
           String.format(
+              Locale.ROOT,
               "'%s' or '%s' is required for the '%s' query parser",
               getLegacyParentFilterParamName(),
               PARENT_PATH_PARAM,

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -27,7 +27,6 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -171,35 +170,28 @@ public class BlockJoinParentQParser extends FiltersQParser {
   protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
     final BooleanQuery parsedChildQuery = parseImpl();
 
-    final SchemaField nestPathField =
-        req.getSchema().getFieldOrNull(IndexSchema.NEST_PATH_FIELD_NAME);
-    final Query nestPathExistsQuery =
-        nestPathField != null
-            ? nestPathField.getType().getExistenceQuery(this, nestPathField)
-            : new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
-
     if (parsedChildQuery.clauses().isEmpty()) { // i.e. all children
       // no block-join needed; just return all "parent" docs at this level
-      return wrapWithParentPathConstraint(parentPath, new MatchAllDocsQuery(), nestPathExistsQuery);
+      return wrapWithParentPathConstraint(parentPath, new MatchAllDocsQuery());
     }
 
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath, nestPathExistsQuery);
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
 
     // constrain child query: (+<original_child> +{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (+<original_child> +_nest_path_:*)
     // If childPath specified: (+<original_child> +{!term f="_nest_path_"
     // v="<parentPath>/<childPath>"})
     final Query constrainedChildQuery =
-        wrapWithChildPathConstraint(parentPath, childPath, parsedChildQuery, nestPathExistsQuery);
+        wrapWithChildPathConstraint(parentPath, childPath, parsedChildQuery);
 
     final String scoreMode = localParams.get("score", ScoreMode.None.name());
     final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
 
     // wrap result: (+<parent_join> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<parent_join> -_nest_path_:*)
-    return wrapWithParentPathConstraint(parentPath, parentJoinQuery, nestPathExistsQuery);
+    return wrapWithParentPathConstraint(parentPath, parentJoinQuery);
   }
 
   /**
@@ -217,11 +209,10 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * <p>Equivalent to: {@code (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})} For root ({@code
    * /}): {@code (*:* -_nest_path_:*)}
    */
-  protected static Query buildAllParentsFilterFromPath(
-      String parentPath, Query nestPathExistsQuery) {
+  protected Query buildAllParentsFilterFromPath(String parentPath) {
     final Query excludeQuery;
     if (parentPath.equals("/")) {
-      excludeQuery = nestPathExistsQuery;
+      excludeQuery = newNestPathExistsQuery();
     } else {
       excludeQuery = new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));
     }
@@ -235,20 +226,24 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * Wraps the given query with a constraint ensuring only docs at exactly {@code parentPath} are
    * matched.
    */
-  protected static Query wrapWithParentPathConstraint(
-      String parentPath, Query query, Query nestPathExistsQuery) {
+  protected Query wrapWithParentPathConstraint(String parentPath, Query query) {
     final BooleanQuery.Builder builder = new BooleanQuery.Builder().add(query, Occur.MUST);
     if (parentPath.equals("/")) {
-      builder.add(nestPathExistsQuery, Occur.MUST_NOT);
+      builder.add(newNestPathExistsQuery(), Occur.MUST_NOT);
     } else {
       final Query constraint =
           new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath));
       if (query instanceof MatchAllDocsQuery) {
-        return new ConstantScoreQuery(constraint);
+        return isFilter() ? constraint : new ConstantScoreQuery(constraint);
       }
       builder.add(constraint, Occur.FILTER);
     }
     return builder.build();
+  }
+
+  protected Query newNestPathExistsQuery() {
+    final SchemaField nestPathField = req.getSchema().getField(IndexSchema.NEST_PATH_FIELD_NAME);
+    return nestPathField.getType().getExistenceQuery(this, nestPathField);
   }
 
   /**
@@ -256,8 +251,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * parentPath} are matched. If {@code childPath} is non-null, further narrows to docs at exactly
    * {@code parentPath/childPath}.
    */
-  protected static Query wrapWithChildPathConstraint(
-      String parentPath, String childPath, Query subQuery, Query nestPathExistsQuery) {
+  protected Query wrapWithChildPathConstraint(String parentPath, String childPath, Query subQuery) {
     final Query nestPathConstraint;
     if (childPath != null) {
       String effectiveChildPath =
@@ -265,7 +259,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
       nestPathConstraint =
           new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, effectiveChildPath));
     } else if (parentPath.equals("/")) {
-      nestPathConstraint = nestPathExistsQuery;
+      nestPathConstraint = newNestPathExistsQuery();
     } else {
       nestPathConstraint =
           new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -46,6 +46,7 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.ExtendedQueryBase;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SolrCache;
@@ -170,28 +171,35 @@ public class BlockJoinParentQParser extends FiltersQParser {
   protected Query parseUsingParentPath(String parentPath, String childPath) throws SyntaxError {
     final BooleanQuery parsedChildQuery = parseImpl();
 
+    final SchemaField nestPathField =
+        req.getSchema().getFieldOrNull(IndexSchema.NEST_PATH_FIELD_NAME);
+    final Query nestPathExistsQuery =
+        nestPathField != null
+            ? nestPathField.getType().getExistenceQuery(this, nestPathField)
+            : new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
+
     if (parsedChildQuery.clauses().isEmpty()) { // i.e. all children
       // no block-join needed; just return all "parent" docs at this level
-      return wrapWithParentPathConstraint(parentPath, new MatchAllDocsQuery());
+      return wrapWithParentPathConstraint(parentPath, new MatchAllDocsQuery(), nestPathExistsQuery);
     }
 
     // allParents filter: (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (*:* -_nest_path_:*)
-    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath);
+    final Query allParentsFilter = buildAllParentsFilterFromPath(parentPath, nestPathExistsQuery);
 
     // constrain child query: (+<original_child> +{!prefix f="_nest_path_" v="<parentPath>/"})
     // For root: (+<original_child> +_nest_path_:*)
     // If childPath specified: (+<original_child> +{!term f="_nest_path_"
     // v="<parentPath>/<childPath>"})
     final Query constrainedChildQuery =
-        wrapWithChildPathConstraint(parentPath, childPath, parsedChildQuery);
+        wrapWithChildPathConstraint(parentPath, childPath, parsedChildQuery, nestPathExistsQuery);
 
     final String scoreMode = localParams.get("score", ScoreMode.None.name());
     final Query parentJoinQuery = createQuery(allParentsFilter, constrainedChildQuery, scoreMode);
 
     // wrap result: (+<parent_join> +{!field f="_nest_path_" v="<parentPath>"})
     // For root: (+<parent_join> -_nest_path_:*)
-    return wrapWithParentPathConstraint(parentPath, parentJoinQuery);
+    return wrapWithParentPathConstraint(parentPath, parentJoinQuery, nestPathExistsQuery);
   }
 
   /**
@@ -209,10 +217,11 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * <p>Equivalent to: {@code (*:* -{!prefix f="_nest_path_" v="<parentPath>/"})} For root ({@code
    * /}): {@code (*:* -_nest_path_:*)}
    */
-  protected static Query buildAllParentsFilterFromPath(String parentPath) {
+  protected static Query buildAllParentsFilterFromPath(
+      String parentPath, Query nestPathExistsQuery) {
     final Query excludeQuery;
     if (parentPath.equals("/")) {
-      excludeQuery = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
+      excludeQuery = nestPathExistsQuery;
     } else {
       excludeQuery = new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));
     }
@@ -226,10 +235,11 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * Wraps the given query with a constraint ensuring only docs at exactly {@code parentPath} are
    * matched.
    */
-  protected static Query wrapWithParentPathConstraint(String parentPath, Query query) {
+  protected static Query wrapWithParentPathConstraint(
+      String parentPath, Query query, Query nestPathExistsQuery) {
     final BooleanQuery.Builder builder = new BooleanQuery.Builder().add(query, Occur.MUST);
     if (parentPath.equals("/")) {
-      builder.add(new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME), Occur.MUST_NOT);
+      builder.add(nestPathExistsQuery, Occur.MUST_NOT);
     } else {
       final Query constraint =
           new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath));
@@ -247,7 +257,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
    * {@code parentPath/childPath}.
    */
   protected static Query wrapWithChildPathConstraint(
-      String parentPath, String childPath, Query subQuery) {
+      String parentPath, String childPath, Query subQuery, Query nestPathExistsQuery) {
     final Query nestPathConstraint;
     if (childPath != null) {
       String effectiveChildPath =
@@ -255,7 +265,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
       nestPathConstraint =
           new TermQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, effectiveChildPath));
     } else if (parentPath.equals("/")) {
-      nestPathConstraint = new FieldExistsQuery(IndexSchema.NEST_PATH_FIELD_NAME);
+      nestPathConstraint = nestPathExistsQuery;
     } else {
       nestPathConstraint =
           new PrefixQuery(new Term(IndexSchema.NEST_PATH_FIELD_NAME, parentPath + "/"));

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -78,7 +78,8 @@ public class BlockJoinParentQParser extends FiltersQParser {
    */
   public static final String CHILD_PATH_PARAM = "childPath";
 
-  protected String getParentFilterLocalParamName() {
+  // most users should use parentPath instead
+  protected String getLegacyParentFilterParamName() {
     return "which";
   }
 
@@ -96,12 +97,12 @@ public class BlockJoinParentQParser extends FiltersQParser {
   public Query parse() throws SyntaxError {
     String parentPath = localParams.get(PARENT_PATH_PARAM);
     if (parentPath != null) {
-      if (localParams.get(getParentFilterLocalParamName()) != null) {
+      if (localParams.get(getLegacyParentFilterParamName()) != null) {
         throw new SolrException(
             SolrException.ErrorCode.BAD_REQUEST,
             PARENT_PATH_PARAM
                 + " and "
-                + getParentFilterLocalParamName()
+                + getLegacyParentFilterParamName()
                 + " local params are mutually exclusive");
       }
       if (!parentPath.startsWith("/")) {
@@ -132,11 +133,11 @@ public class BlockJoinParentQParser extends FiltersQParser {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, CHILD_PATH_PARAM + " requires " + PARENT_PATH_PARAM);
     }
-    if (localParams.get(getParentFilterLocalParamName()) == null) {
+    if (localParams.get(getLegacyParentFilterParamName()) == null) {
       throw new SyntaxError(
           String.format(
               "'%s' or '%s' is required for the '%s' query parser",
-              getParentFilterLocalParamName(),
+              getLegacyParentFilterParamName(),
               PARENT_PATH_PARAM,
               localParams.get("type", "parent")));
     }
@@ -274,7 +275,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
   }
 
   protected Query parseParentFilter() throws SyntaxError {
-    String filter = localParams.get(getParentFilterLocalParamName());
+    String filter = localParams.get(getLegacyParentFilterParamName());
     QParser parentParser = subQuery(filter, null);
     Query parentQ = parentParser.getQuery();
     return parentQ;

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -47,7 +47,6 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.ExtendedQueryBase;
-import org.apache.solr.search.QParser;
 import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.util.SolrDefaultScorerSupplier;
@@ -78,11 +77,6 @@ public class BlockJoinParentQParser extends FiltersQParser {
    */
   public static final String CHILD_PATH_PARAM = "childPath";
 
-  // most users should use parentPath instead
-  protected String getLegacyParentFilterParamName() {
-    return "which";
-  }
-
   @Override
   protected String getFiltersParamName() {
     return "filters";
@@ -95,6 +89,8 @@ public class BlockJoinParentQParser extends FiltersQParser {
 
   @Override
   public Query parse() throws SyntaxError {
+    // Dispatch based on parentPath or none (DIY/legacy)
+
     String parentPath = localParams.get(PARENT_PATH_PARAM);
     if (parentPath != null) {
       if (localParams.get(getLegacyParentFilterParamName()) != null) {
@@ -127,7 +123,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
       return parseUsingParentPath(parentPath, childPath);
     }
 
-    // NO parentPath; use classic/advanced/DIY code path:
+    // NO parentPath; use legacy/advanced/DIY code path:
 
     if (localParams.get(CHILD_PATH_PARAM) != null) {
       throw new SolrException(
@@ -141,7 +137,7 @@ public class BlockJoinParentQParser extends FiltersQParser {
               PARENT_PATH_PARAM,
               localParams.get("type", "parent")));
     }
-    return super.parse();
+    return parseWithLegacyParam();
   }
 
   /**
@@ -274,23 +270,32 @@ public class BlockJoinParentQParser extends FiltersQParser {
         .build();
   }
 
-  protected Query parseParentFilter() throws SyntaxError {
-    String filter = localParams.get(getLegacyParentFilterParamName());
-    QParser parentParser = subQuery(filter, null);
-    Query parentQ = parentParser.getQuery();
-    return parentQ;
-  }
+  //
+  // Advanced/DIY parsing follows
+  //
 
-  @Override
-  protected Query wrapSubordinateClause(Query subordinate) throws SyntaxError {
+  protected Query parseWithLegacyParam() throws SyntaxError {
+    BooleanQuery subordinateQuery = parseImpl();
+
+    if (subordinateQuery.clauses().isEmpty()) { // i.e. all children
+      return noClausesQueryLegacy();
+    }
+
     String scoreMode = localParams.get("score", ScoreMode.None.name());
-    Query parentQ = parseParentFilter();
-    return createQuery(parentQ, subordinate, scoreMode);
+    Query parentQ = parseLegacyParentFilter();
+    return createQuery(parentQ, subordinateQuery, scoreMode);
   }
 
-  @Override
-  protected Query noClausesQuery() throws SyntaxError {
-    return new BitSetProducerQuery(getBitSetProducer(parseParentFilter()));
+  protected Query parseLegacyParentFilter() throws SyntaxError {
+    return subQuery(localParams.get(getLegacyParentFilterParamName()), null).getQuery();
+  }
+
+  protected Query noClausesQueryLegacy() throws SyntaxError {
+    return new BitSetProducerQuery(getBitSetProducer(parseLegacyParentFilter()));
+  }
+
+  protected String getLegacyParentFilterParamName() {
+    return "which";
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/join/FiltersQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/FiltersQParser.java
@@ -49,9 +49,10 @@ public class FiltersQParser extends QParser {
   @Override
   public Query parse() throws SyntaxError {
     BooleanQuery query = parseImpl();
-    return !query.clauses().isEmpty() ? wrapSubordinateClause(query) : noClausesQuery();
+    return !query.clauses().isEmpty() ? query : new MatchAllDocsQuery();
   }
 
+  /** Parses the subQuery, applying filters and exclusions. Caller must check if empty. */
   protected BooleanQuery parseImpl() throws SyntaxError {
     Map<QParser, Occur> clauses = clauses();
 
@@ -71,14 +72,6 @@ public class FiltersQParser extends QParser {
 
   protected Query unwrapQuery(Query query, BooleanClause.Occur occur) {
     return query;
-  }
-
-  protected Query wrapSubordinateClause(Query subordinate) throws SyntaxError {
-    return subordinate;
-  }
-
-  protected Query noClausesQuery() throws SyntaxError {
-    return new MatchAllDocsQuery();
   }
 
   protected void exclude(Collection<QParser> clauses) {
@@ -127,14 +120,14 @@ public class FiltersQParser extends QParser {
 
   private Collection<QParser> excludeSet(Map<?, ?> tagMap, Set<String> tagsToExclude) {
 
-    IdentityHashMap<QParser, Boolean> excludeSet = new IdentityHashMap<>();
+    IdentityHashMap<QParser, Object> excludeSet = new IdentityHashMap<>();
     for (String excludeTag : tagsToExclude) {
       Object olst = tagMap.get(excludeTag);
       // tagMap has entries of List<String,List<QParser>>, but subject to change in the future
       if (!(olst instanceof Collection)) continue;
       for (Object o : (Collection<?>) olst) {
         if (!(o instanceof QParser qp)) continue;
-        excludeSet.put(qp, Boolean.TRUE);
+        excludeSet.put(qp, null); // dummy value
       }
     }
     return excludeSet.keySet();

--- a/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
@@ -20,22 +20,14 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.FuzzyQuery;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.numericrange.IntRangeQParserPlugin;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -744,35 +736,21 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
     // docs. This is a useful trick to query docs at a specific nest path without using _nest_path_
     // directly.
     try (SolrQueryRequest req = req()) {
-      // {!parent parentPath=/ v=''} returns BooleanQuery:
-      //   clause 0: MUST  MatchAllDocsQuery
-      //   clause 1: MUST_NOT FieldExistsQuery(_nest_path_)
       Query q =
           assertQueryEqualsAndReturn(
               "parent",
               req,
               "{!parent parentPath=/ v=''}",
               "{!parent parentPath=/}"); // omitting v is equivalent to empty v
-      assertTrue(q instanceof BooleanQuery);
-      BooleanQuery bq = (BooleanQuery) q;
-      assertEquals(2, bq.clauses().size()); // MUST MatchAllDocs + MUST_NOT FieldExists
-      assertEquals(Occur.MUST, bq.clauses().get(0).occur());
-      assertTrue(bq.clauses().get(0).query() instanceof MatchAllDocsQuery);
-      assertEquals(Occur.MUST_NOT, bq.clauses().get(1).occur());
-      assertTrue(bq.clauses().get(1).query() instanceof FieldExistsQuery);
+      assertEquals("+*:* -FieldExistsQuery [field=_nest_path_]", q.toString());
 
-      // {!parent parentPath=/aa/bb v=''} returns ConstantScoreQuery(TermQuery(_nest_path_:/aa/bb))
       q =
           assertQueryEqualsAndReturn(
               "parent",
               req,
-              "{!parent parentPath=/aa/bb v=''}",
+              "{!parent parentPath=/aa/bb v=}",
               "{!parent parentPath=/aa/bb}"); // omitting v is equivalent to empty v
-      assertTrue(q instanceof ConstantScoreQuery);
-      Query innerQ = ((ConstantScoreQuery) q).getQuery();
-      assertTrue(innerQ instanceof TermQuery);
-      assertEquals(
-          new Term(IndexSchema.NEST_PATH_FIELD_NAME, "/aa/bb"), ((TermQuery) innerQ).getTerm());
+      assertEquals("ConstantScore(_nest_path_:/aa/bb)", q.toString());
     }
 
     // Test that {!parent} and {!child} without required 'which'/'of' or 'parentPath' throw error

--- a/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
@@ -20,14 +20,22 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.numericrange.IntRangeQParserPlugin;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -731,6 +739,44 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
               + parent_path.replace("/", "\\/")
               + ")");
     }
+
+    // Test parentPath with empty v: {!parent parentPath=/ v=''} returns all root-level docs.
+    // This is a useful trick to query docs at a specific nest path without using _nest_path_
+    // directly.
+    try (SolrQueryRequest req = req()) {
+      // {!parent parentPath=/ v=''} returns BooleanQuery: +MatchAllDocs,
+      // -FieldExistsQuery(_nest_path_)
+      Query q =
+          assertQueryEqualsAndReturn(
+              "parent",
+              req,
+              "{!parent parentPath=/ v=''}",
+              "{!parent parentPath=/}"); // omitting v is equivalent to empty v
+      assertTrue(q instanceof BooleanQuery);
+      BooleanQuery bq = (BooleanQuery) q;
+      assertEquals(2, bq.clauses().size());
+      assertEquals(Occur.MUST, bq.clauses().get(0).occur());
+      assertTrue(bq.clauses().get(0).query() instanceof MatchAllDocsQuery);
+      assertEquals(Occur.MUST_NOT, bq.clauses().get(1).occur());
+      assertTrue(bq.clauses().get(1).query() instanceof FieldExistsQuery);
+
+      // {!parent parentPath=/aa/bb v=''} returns ConstantScoreQuery(TermQuery(_nest_path_:/aa/bb))
+      q =
+          assertQueryEqualsAndReturn(
+              "parent",
+              req,
+              "{!parent parentPath=/aa/bb v=''}",
+              "{!parent parentPath=/aa/bb}"); // omitting v is equivalent to empty v
+      assertTrue(q instanceof ConstantScoreQuery);
+      Query innerQ = ((ConstantScoreQuery) q).getQuery();
+      assertTrue(innerQ instanceof TermQuery);
+      assertEquals(
+          new Term(IndexSchema.NEST_PATH_FIELD_NAME, "/aa/bb"), ((TermQuery) innerQ).getTerm());
+    }
+
+    // Test that {!parent} and {!child} without required 'which'/'of' or 'parentPath' throw error
+    expectThrows(SyntaxError.class, () -> QParser.getParser("{!parent}", req()).getQuery());
+    expectThrows(SyntaxError.class, () -> QParser.getParser("{!child}", req()).getQuery());
   }
 
   public void testFilters() throws Exception {

--- a/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
@@ -740,12 +740,13 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
               + ")");
     }
 
-    // Test parentPath with empty v: {!parent parentPath=/ v=''} returns all root-level docs.
-    // This is a useful trick to query docs at a specific nest path without using _nest_path_
+    // Test parentPath with no subordinate query: {!parent parentPath=/ v=''} returns all root-level
+    // docs. This is a useful trick to query docs at a specific nest path without using _nest_path_
     // directly.
     try (SolrQueryRequest req = req()) {
-      // {!parent parentPath=/ v=''} returns BooleanQuery: +MatchAllDocs,
-      // -FieldExistsQuery(_nest_path_)
+      // {!parent parentPath=/ v=''} returns BooleanQuery:
+      //   clause 0: MUST  MatchAllDocsQuery
+      //   clause 1: MUST_NOT FieldExistsQuery(_nest_path_)
       Query q =
           assertQueryEqualsAndReturn(
               "parent",
@@ -754,7 +755,7 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
               "{!parent parentPath=/}"); // omitting v is equivalent to empty v
       assertTrue(q instanceof BooleanQuery);
       BooleanQuery bq = (BooleanQuery) q;
-      assertEquals(2, bq.clauses().size());
+      assertEquals(2, bq.clauses().size()); // MUST MatchAllDocs + MUST_NOT FieldExists
       assertEquals(Occur.MUST, bq.clauses().get(0).occur());
       assertTrue(bq.clauses().get(0).query() instanceof MatchAllDocsQuery);
       assertEquals(Occur.MUST_NOT, bq.clauses().get(1).occur());

--- a/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
+++ b/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
@@ -439,6 +439,60 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
               "//result/@numFound=1",
               "//doc/str[@name='id'][.='" + ancestorId + "']");
 
+          // additionally test childPath: find the immediate parent of descendentId and use
+          // childPath to constrain to that exact child path level
+          final String directParentPath =
+              doc_path.contains("/")
+                  ? (doc_path.lastIndexOf("/") == 0
+                      ? "/"
+                      : doc_path.substring(0, doc_path.lastIndexOf("/")))
+                  : "/";
+          final String childSegment = doc_path.substring(doc_path.lastIndexOf("/") + 1);
+          // find the ancestor ID whose path is directParentPath
+          for (Object candAncestorId : allAncestorIds) {
+            final String candPath =
+                allDocs.get(candAncestorId.toString()).getFieldValue("test_path_s").toString();
+            if (candPath.equals(directParentPath)) {
+              // childPath constrains the child query to exactly doc_path, so we should find
+              // the direct parent
+              assertQ(
+                  req(
+                      params(
+                          "q",
+                          "{!parent parentPath='"
+                              + directParentPath
+                              + "' childPath='"
+                              + childSegment
+                              + "'}id:"
+                              + descendentId),
+                      "_trace_childPath_tested",
+                      directParentPath + "/" + childSegment,
+                      "fl",
+                      "id",
+                      "indent",
+                      "true"),
+                  "//result/@numFound=1",
+                  "//doc/str[@name='id'][.='" + candAncestorId + "']");
+              // a childPath that doesn't match descendentId's path should return 0 results
+              assertQ(
+                  req(
+                      params(
+                          "q",
+                          "{!parent parentPath='"
+                              + directParentPath
+                              + "' childPath='xxx_yyy'}id:"
+                              + descendentId),
+                      "_trace_childPath_tested",
+                      directParentPath + "/xxx_yyy",
+                      "fl",
+                      "id",
+                      "indent",
+                      "true"),
+                  "//result/@numFound=0");
+              break;
+            }
+          }
+
           // meanwhile, a 'child' query wrapped around a query for the ancestorId, using the
           // ancestor_path, should match all of its descendents (for simplicity we'll check just
           // the numFound and the 'descendentId' we started with)

--- a/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
+++ b/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
@@ -489,6 +489,43 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
                       "indent",
                       "true"),
                   "//result/@numFound=0");
+              // childPath for {!child}: constrain returned children to exactly doc_path
+              assertQ(
+                  req(
+                      params(
+                          "q",
+                          "{!child parentPath='"
+                              + directParentPath
+                              + "' childPath='"
+                              + childSegment
+                              + "'}id:"
+                              + candAncestorId),
+                      "_trace_child_childPath_tested",
+                      directParentPath + "/" + childSegment,
+                      "rows",
+                      "9999",
+                      "fl",
+                      "id",
+                      "indent",
+                      "true"),
+                  "count(//doc)>=1",
+                  "//doc/str[@name='id'][.='" + descendentId + "']");
+              // a childPath that doesn't match should return 0 results
+              assertQ(
+                  req(
+                      params(
+                          "q",
+                          "{!child parentPath='"
+                              + directParentPath
+                              + "' childPath='xxx_yyy'}id:"
+                              + candAncestorId),
+                      "_trace_child_childPath_tested",
+                      directParentPath + "/xxx_yyy",
+                      "fl",
+                      "id",
+                      "indent",
+                      "true"),
+                  "//result/@numFound=0");
               break;
             }
           }

--- a/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
+++ b/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
@@ -545,7 +545,14 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
      */
     private SolrParams parentQueryMaker(String parent_path, String inner_child_query) {
       assertValidPathSyntax(parent_path);
-      final boolean verbose = random().nextBoolean();
+      final int variant = random().nextInt(3);
+
+      if (variant == 2) {
+        // new parentPath sugar
+        return params("q", "{!parent parentPath='" + parent_path + "'}" + inner_child_query);
+      } // else old-style with explicit which/of...
+
+      final boolean verbose = variant == 1;
 
       if (parent_path.equals("/")) {
         if (verbose) {
@@ -633,7 +640,14 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
      */
     private SolrParams childQueryMaker(String parent_path, String inner_parent_query) {
       assertValidPathSyntax(parent_path);
-      final boolean verbose = random().nextBoolean();
+      final int variant = random().nextInt(3);
+
+      if (variant == 2) {
+        // new parentPath sugar
+        return params("q", "{!child parentPath='" + parent_path + "'}" + inner_parent_query);
+      } // else old-style with explicit which/of...
+
+      final boolean verbose = variant == 1;
 
       if (parent_path.equals("/")) {
         if (verbose) {

--- a/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
+++ b/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
@@ -278,6 +278,44 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
     assertU(commit());
   }
 
+  /** Test the {@code filters} local-param works with {@code parentPath}. */
+  @Test
+  public void testFiltersWithParentPath() {
+    // integer IDs required: schema copies id→id_i (int) so auto-generated "p1/items#0" would fail
+    SolrInputDocument p1 = sdoc("id", "1", "name_s", "p1");
+    p1.addField("items", sdoc("id", "11", "status_s", "active"));
+    p1.addField("items", sdoc("id", "12", "status_s", "inactive"));
+    assertU(adoc(p1));
+
+    SolrInputDocument p2 = sdoc("id", "2", "name_s", "p2");
+    p2.addField("items", sdoc("id", "21", "status_s", "inactive"));
+    assertU(adoc(p2));
+
+    SolrInputDocument p3 = sdoc("id", "3", "name_s", "p3");
+    p3.addField("items", sdoc("id", "31", "status_s", "active"));
+    assertU(adoc(p3));
+
+    assertU(commit());
+
+    // {!parent parentPath=/}: parents with children matching v AND filters
+    assertQ(
+        req(
+            "q", "{!parent parentPath=/ filters=$cf}*:*",
+            "cf", "status_s:active",
+            "fl", "id",
+            "sort", "id asc"),
+        "//*[@numFound='2']",
+        "//doc[1]/str[@name='id']='1'",
+        "//doc[2]/str[@name='id']='3'");
+
+    // {!child parentPath=/}: children of parents matching v AND filters
+    assertQ(
+        req(
+            "q", "{!child parentPath=/ filters=$pf}*:*",
+            "pf", "name_s:p1"),
+        "//*[@numFound='2']");
+  }
+
   /**
    * Randomized test to look for flaws in the documented approach for building "safe" values of the
    * <code>of</code> / <code>which</code> params in the <code>child</code> / <code>parent</code>

--- a/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
@@ -51,10 +51,10 @@ The example usage of the query parsers below assumes the following documents hav
 
 This parser wraps a query that matches some parent documents and returns the children of those documents.
 
-=== Using `parentPath` (Recommended for `_nest_path_`-based Nesting)
+=== Using `parentPath`
 
-When using xref:indexing-guide:indexing-nested-documents.adoc[`_nest_path_`-based nested documents], the `parentPath` parameter is the simplest and most reliable way to use this parser.
-Instead of constructing a manual Block Mask with escaped `_nest_path_` prefixes, you simply specify the path at which the parent documents live:
+If your schema supports xref:indexing-guide:indexing-nested-documents.adoc[nested documents], you _should_ specify `parentPath`.
+Specify the path at which the parent documents live:
 
 [source,text]
 q={!child parentPath=<path>}<someParents>
@@ -62,10 +62,9 @@ q={!child parentPath=<path>}<someParents>
 Key points about `parentPath`:
 
 * Must start with `/`.
-* Use `parentPath="/"` to treat root-level documents (those without a `_nest_path_`) as the parents.
+* Use `parentPath="/"` to treat root-level documents as the parents.
 * A trailing `/` is stripped automatically (e.g., `"/skus/"` is treated as `"/skus"`).
 * `parentPath` and `of` are mutually exclusive; specifying both returns a `400 Bad Request` error.
-* The parser automatically derives the Block Mask and constrains the subordinate query to the correct `_nest_path_` level — no manual escaping of `/` characters is required.
 
 For example, using the deeply nested documents described in xref:searching-nested-documents.adoc[], the following query returns all children of root-level product documents that match a description query:
 
@@ -79,7 +78,9 @@ q={!child parentPath="/skus"}price_i:[* TO 50]
 
 === Using the `of` Parameter
 
-The traditional syntax for this parser is: `q={!child of=<blockMask>}<someParents>`.
+This approach is used with anonymous child documents (schemas without `_nest_path_`).
+It is more verbose and has some <<block-mask,gotchas>>.
+The syntax is: `q={!child of=<blockMask>}<someParents>`.
 
 * The inner subordinate query string (`someParents`) must be a query that will match some parent documents.
 * The `of` parameter must be a query string to use as a <<block-mask,Block Mask>> -- typically a query that matches the set of all possible parent documents.
@@ -139,10 +140,10 @@ More precisely, `q={!child of=<blockMask>}` is equivalent to `q=\*:* -<blockMask
 
 This parser takes a query that matches child documents and returns their parents.
 
-=== Using `parentPath` (Recommended for `_nest_path_`-based Nesting)
+=== Using `parentPath`
 
-When using xref:indexing-guide:indexing-nested-documents.adoc[`_nest_path_`-based nested documents], the `parentPath` parameter is the simplest and most reliable way to use this parser.
-Instead of constructing a manual Block Mask with escaped `_nest_path_` prefixes, you simply specify the path at which the parent documents live:
+If your schema supports xref:indexing-guide:indexing-nested-documents.adoc[nested documents], you _should_ specify `parentPath`.
+Specify the path at which the parent documents live:
 
 [source,text]
 q={!parent parentPath=<path>}<someChildren>
@@ -150,10 +151,9 @@ q={!parent parentPath=<path>}<someChildren>
 Key points about `parentPath`:
 
 * Must start with `/`.
-* Use `parentPath="/"` to treat root-level documents (those without a `_nest_path_`) as the parents.
+* Use `parentPath="/"` to treat root-level documents as the parents.
 * A trailing `/` is stripped automatically (e.g., `"/skus/"` is treated as `"/skus"`).
 * `parentPath` and `which` are mutually exclusive; specifying both returns a `400 Bad Request` error.
-* The parser automatically derives the Block Mask and constrains the subordinate query to the correct `_nest_path_` level — no manual escaping of `/` characters is required.
 
 For example, using the deeply nested documents described in xref:searching-nested-documents.adoc[], the following query returns the root-level product documents that are ancestors of manuals with exactly one page:
 
@@ -167,7 +167,9 @@ q={!parent parentPath="/skus"}(+_nest_path_:"/skus/manuals" +pages_i:1)
 
 === Using the `which` Parameter
 
-The traditional syntax for this parser is: `q={!parent which=<blockMask>}<someChildren>`.
+This approach is used with anonymous child documents (schemas without `_nest_path_`).
+It is more verbose and has some <<block-mask,gotchas>>.
+The syntax is: `q={!parent which=<blockMask>}<someChildren>`.
 
 * The inner subordinate query string (`someChildren`) must be a query that will match some child documents.
 * The `which` parameter must be a query string to use as a <<block-mask,Block Mask>> -- typically a query that matches the set of all possible parent documents.

--- a/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
@@ -65,16 +65,17 @@ Key points about `parentPath`:
 * Use `parentPath="/"` to treat root-level documents as the parents.
 * A trailing `/` is stripped automatically (e.g., `"/skus/"` is treated as `"/skus"`).
 * `parentPath` and `of` are mutually exclusive; specifying both returns a `400 Bad Request` error.
+* Optionally, use `childPath` to narrow the returned children to docs at exactly `parentPath/childPath`. Without `childPath`, all descendants of parents at `parentPath` are returned.
 
 For example, using the deeply nested documents described in xref:searching-nested-documents.adoc[], the following query returns all children of root-level product documents that match a description query:
 
 [source,text]
 q={!child parentPath="/"}description_t:staplers
 
-To return only children of `skus` documents with a price under 50:
+To return only `skus` children of root documents matching a description query (excluding other child types):
 
 [source,text]
-q={!child parentPath="/skus"}price_i:[* TO 50]
+q={!child parentPath="/" childPath="skus"}description_t:staplers
 
 === Using the `of` Parameter
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
@@ -154,16 +154,17 @@ Key points about `parentPath`:
 * Use `parentPath="/"` to treat root-level documents as the parents.
 * A trailing `/` is stripped automatically (e.g., `"/skus/"` is treated as `"/skus"`).
 * `parentPath` and `which` are mutually exclusive; specifying both returns a `400 Bad Request` error.
+* Optionally, use `childPath` to constrain the child query to docs at exactly `parentPath/childPath`. Without `childPath`, all descendants of `parentPath` are eligible as children.
 
 For example, using the deeply nested documents described in xref:searching-nested-documents.adoc[], the following query returns the root-level product documents that are ancestors of manuals with exactly one page:
 
 [source,text]
 q={!parent parentPath="/"}pages_i:1
 
-To instead return the `skus` that are ancestors of those same one-page manuals:
+To instead return the `skus` that are ancestors of one-page _manuals_ (only manuals, not other sku children):
 
 [source,text]
-q={!parent parentPath="/skus"}(+_nest_path_:"/skus/manuals" +pages_i:1)
+q={!parent parentPath="/skus" childPath="manuals"}pages_i:1
 
 === Using the `which` Parameter
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
@@ -51,10 +51,38 @@ The example usage of the query parsers below assumes the following documents hav
 
 This parser wraps a query that matches some parent documents and returns the children of those documents.
 
-The syntax for this parser is: `q={!child of=<blockMask>}<someParents>`.
+=== Using `parentPath` (Recommended for `_nest_path_`-based Nesting)
 
-* The inner subordinate query string (`someParents`) must be a query that will match some parent documents
-* The `of` parameter must be a query string to use as a <<block-mask,Block Mask>> -- typically a query that matches the set of all possible parent documents
+When using xref:indexing-guide:indexing-nested-documents.adoc[`_nest_path_`-based nested documents], the `parentPath` parameter is the simplest and most reliable way to use this parser.
+Instead of constructing a manual Block Mask with escaped `_nest_path_` prefixes, you simply specify the path at which the parent documents live:
+
+[source,text]
+q={!child parentPath=<path>}<someParents>
+
+Key points about `parentPath`:
+
+* Must start with `/`.
+* Use `parentPath="/"` to treat root-level documents (those without a `_nest_path_`) as the parents.
+* A trailing `/` is stripped automatically (e.g., `"/skus/"` is treated as `"/skus"`).
+* `parentPath` and `of` are mutually exclusive; specifying both returns a `400 Bad Request` error.
+* The parser automatically derives the Block Mask and constrains the subordinate query to the correct `_nest_path_` level — no manual escaping of `/` characters is required.
+
+For example, using the deeply nested documents described in xref:searching-nested-documents.adoc[], the following query returns all children of root-level product documents that match a description query:
+
+[source,text]
+q={!child parentPath="/"}description_t:staplers
+
+To return only children of `skus` documents with a price under 50:
+
+[source,text]
+q={!child parentPath="/skus"}price_i:[* TO 50]
+
+=== Using the `of` Parameter
+
+The traditional syntax for this parser is: `q={!child of=<blockMask>}<someParents>`.
+
+* The inner subordinate query string (`someParents`) must be a query that will match some parent documents.
+* The `of` parameter must be a query string to use as a <<block-mask,Block Mask>> -- typically a query that matches the set of all possible parent documents.
 
 The resulting query will match all documents which do _not_ match the `<blockMask>` query and are children (or descendents) of the documents matched by `<someParents>`.
 
@@ -111,10 +139,38 @@ More precisely, `q={!child of=<blockMask>}` is equivalent to `q=\*:* -<blockMask
 
 This parser takes a query that matches child documents and returns their parents.
 
-The syntax for this parser is similar to the `child` parser: `q={!parent which=<blockMask>}<someChildren>`.
+=== Using `parentPath` (Recommended for `_nest_path_`-based Nesting)
 
-* The inner subordinate query string (`someChildren`) must be a query that will match some child documents
-* The `which` parameter must be a query string to use as a <<block-mask,Block Mask>> -- typically a query that matches the set of all possible parent documents
+When using xref:indexing-guide:indexing-nested-documents.adoc[`_nest_path_`-based nested documents], the `parentPath` parameter is the simplest and most reliable way to use this parser.
+Instead of constructing a manual Block Mask with escaped `_nest_path_` prefixes, you simply specify the path at which the parent documents live:
+
+[source,text]
+q={!parent parentPath=<path>}<someChildren>
+
+Key points about `parentPath`:
+
+* Must start with `/`.
+* Use `parentPath="/"` to treat root-level documents (those without a `_nest_path_`) as the parents.
+* A trailing `/` is stripped automatically (e.g., `"/skus/"` is treated as `"/skus"`).
+* `parentPath` and `which` are mutually exclusive; specifying both returns a `400 Bad Request` error.
+* The parser automatically derives the Block Mask and constrains the subordinate query to the correct `_nest_path_` level — no manual escaping of `/` characters is required.
+
+For example, using the deeply nested documents described in xref:searching-nested-documents.adoc[], the following query returns the root-level product documents that are ancestors of manuals with exactly one page:
+
+[source,text]
+q={!parent parentPath="/"}pages_i:1
+
+To instead return the `skus` that are ancestors of those same one-page manuals:
+
+[source,text]
+q={!parent parentPath="/skus"}(+_nest_path_:"/skus/manuals" +pages_i:1)
+
+=== Using the `which` Parameter
+
+The traditional syntax for this parser is: `q={!parent which=<blockMask>}<someChildren>`.
+
+* The inner subordinate query string (`someChildren`) must be a query that will match some child documents.
+* The `which` parameter must be a query string to use as a <<block-mask,Block Mask>> -- typically a query that matches the set of all possible parent documents.
 
 The resulting query will match all documents which _do_ match the `<blockMask>` query and are parents (or ancestors) of the documents matched by `<someChildren>`.
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/block-join-query-parser.adoc
@@ -167,6 +167,19 @@ To instead return the `skus` that are ancestors of one-page _manuals_ (only manu
 [source,text]
 q={!parent parentPath="/skus" childPath="manuals"}pages_i:1
 
+==== Filtering to a Specific Nest Path
+
+When the subordinate query is omitted (empty), `{!parent parentPath=<path>}` is a convenient way to filter documents to exactly a specific nest path without needing to reference `_nest_path_` directly:
+
+[source,text]
+----
+# Return all root-level documents (no _nest_path_):
+q={!parent parentPath=/}
+
+# Return all documents at exactly /skus (not deeper descendants like /skus/manuals):
+q={!parent parentPath=/skus}
+----
+
 === Using the `which` Parameter
 
 This approach is used with anonymous child documents (schemas without `_nest_path_`).

--- a/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
@@ -112,7 +112,7 @@ Let's consider again the `description_t:staplers` query used above -- if we wrap
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!child parentPath="/"}description_t:staplers'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!child parentPath="/"}description_t:staplers'
 {
   "response":{"numFound":5,"start":0,"maxScore":0.30136836,"numFoundExact":true,"docs":[
       {
@@ -146,14 +146,14 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
   }}
 ----
 
-In this example `parentPath="/"` indicates we want to consider all root-level documents (those with no `_nest_path_`) as the set of possible parents.
+In this example `parentPath="/"` indicates we want to consider all root-level documents as the set of possible parents.
 
 By changing the `parentPath` to a specific `_nest_path_` level, we can narrow down the list of children we return.
 In the query below, we search for all children of `skus` with a `price_i` less than `50`:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!child parentPath="/skus"}price_i:[* TO 50]'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!child parentPath="/skus"}price_i:[* TO 50]'
 {
   "response":{"numFound":1,"start":0,"maxScore":1.0,"numFoundExact":true,"docs":[
       {
@@ -164,9 +164,6 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
         "_version_":1675662666752851968}]
   }}
 ----
-
-The `parentPath` parameter handles `_nest_path_` construction and escaping automatically.
-The traditional `of` parameter approach (constructing a Block Mask manually with escaped `_nest_path_` prefixes) continues to work for cases where `_nest_path_` is not in use or for greater control.
 
 === Parent Query Parser
 
@@ -205,7 +202,7 @@ We can wrap that query in a `{!parent}` query with `parentPath="/"` to return th
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!parent parentPath="/"}pages_i:1'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!parent parentPath="/"}pages_i:1'
 {
   "response":{"numFound":2,"start":0,"maxScore":1.4E-45,"numFoundExact":true,"docs":[
       {
@@ -221,14 +218,14 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
   }}
 ----
 
-In this example `parentPath="/"` indicates we want root-level documents (those with no `_nest_path_`) to be the parents.
+In this example `parentPath="/"` indicates we want root-level documents to be the parents.
 
 By changing `parentPath` to a specific path, we can change the type of ancestors we return.
 In the query below, we search for the `skus` that are the ancestors of `manuals` with exactly `1` page:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!parent parentPath="/skus"}pages_i:1'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!parent parentPath="/skus"}pages_i:1'
 {
   "response":{"numFound":2,"start":0,"maxScore":1.4E-45,"numFoundExact":true,"docs":[
       {
@@ -243,9 +240,6 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
         "_version_":1676585794347728896}]
   }}
 ----
-
-The `parentPath` parameter handles `_nest_path_` construction and escaping automatically.
-The traditional `which` parameter approach (constructing a Block Mask manually with escaped `_nest_path_` prefixes) continues to work for cases where `_nest_path_` is not in use or for greater control.
 
 === Combining Block Join Query Parsers with Child Doc Transformer
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
@@ -221,11 +221,12 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
 In this example `parentPath="/"` indicates we want root-level documents to be the parents.
 
 By changing `parentPath` to a specific path, we can change the type of ancestors we return.
-In the query below, we search for the `skus` that are the ancestors of `manuals` with exactly `1` page:
+In the query below, we search for the `skus` that are the ancestors of `manuals` with exactly `1` page.
+Adding `childPath="manuals"` constrains the child query to only docs nested at `/skus/manuals`, preventing pages from other child types from matching:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!parent parentPath="/skus"}pages_i:1'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!parent parentPath="/skus" childPath="manuals"}pages_i:1'
 {
   "response":{"numFound":2,"start":0,"maxScore":1.4E-45,"numFoundExact":true,"docs":[
       {

--- a/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/searching-nested-documents.adoc
@@ -108,11 +108,11 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select?omitHeader=true&q=descr
 The `{!child}` query parser can be used to search for the _descendent_ documents of parent documents matching a wrapped query.
 For a detailed explanation of this parser, see the section xref:block-join-query-parser.adoc#block-join-children-query-parser[Block Join Children Query Parser].
 
-Let's consider again the `description_t:staplers` query used above -- if we wrap that query in a `{!child}` query parser then instead of "matching" & returning the product level documents, we instead match all of the _descendent_ child documents of the original query:
+Let's consider again the `description_t:staplers` query used above -- if we wrap that query in a `{!child}` query parser with `parentPath="/"` then instead of "matching" & returning the product level documents, we instead match all of the _descendent_ child documents of the original query:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!child of="*:* -_nest_path_:*"}description_t:staplers'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!child parentPath="/"}description_t:staplers'
 {
   "response":{"numFound":5,"start":0,"maxScore":0.30136836,"numFoundExact":true,"docs":[
       {
@@ -146,14 +146,14 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
   }}
 ----
 
-In this example we've used `\*:* -\_nest_path_:*` as our xref:block-join-query-parser.adoc#block-mask[`of` parameter] to indicate we want to consider all documents which don't have a nest path -- i.e., all "root" level document -- as the set of possible parents.
+In this example `parentPath="/"` indicates we want to consider all root-level documents (those with no `_nest_path_`) as the set of possible parents.
 
-By changing the `of` parameter to match ancestors at specific `\_nest_path_` levels, we can narrow down the list of children we return.
-In the query below, we search for all descendants of `skus` (using an `of` parameter that identifies all documents that do _not_ have a `\_nest_path_` with the prefix `/skus/*`) with a `price_i` less than `50`:
+By changing the `parentPath` to a specific `_nest_path_` level, we can narrow down the list of children we return.
+In the query below, we search for all children of `skus` with a `price_i` less than `50`:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!child of="*:* -_nest_path_:\\/skus\\/*"}(+price_i:[* TO 50] +_nest_path_:\/skus)'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!child parentPath="/skus"}price_i:[* TO 50]'
 {
   "response":{"numFound":1,"start":0,"maxScore":1.0,"numFoundExact":true,"docs":[
       {
@@ -165,24 +165,8 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
   }}
 ----
 
-[#double-escaping-nest-path-slashes]
-[CAUTION]
-.Double Escaping `\_nest_path_` slashes in `of`
-====
-Note that in the above example, the `/` characters in the `\_nest_path_` were "double escaped" in the `of` parameter:
-
-* One level of `\` escaping is necessary to prevent the `/` from being interpreted as a {lucene-javadocs}/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Regexp_Searches[Regex Query]
-* An additional level of "escaping the escape character" is necessary because the `of` local parameter is a quoted string; so we need a second `\` to ensure the first `\` is preserved and passed as is to the query parser.
-
-(You can see that only a single level of `\` escaping is needed in the body of the query string -- to prevent the Regex syntax --  because it's not a quoted string local param).
-
-You may find it more convenient to use xref:local-params.adoc#parameter-dereferencing[parameter references] in conjunction with xref:other-parsers.adoc[other parsers] that do not treat `/` as a special character to express the same query in a more verbose form:
-
-[source,text]
-----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!child of=$block_mask}(+price_i:[* TO 50] +{!field f="_nest_path_" v="/skus"})' --data-urlencode 'block_mask=(*:* -{!prefix f="_nest_path_" v="/skus/"})'
-----
-====
+The `parentPath` parameter handles `_nest_path_` construction and escaping automatically.
+The traditional `of` parameter approach (constructing a Block Mask manually with escaped `_nest_path_` prefixes) continues to work for cases where `_nest_path_` is not in use or for greater control.
 
 === Parent Query Parser
 
@@ -217,11 +201,11 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select?omitHeader=true&q=pages
   }}
 ----
 
-We can wrap that query in a `{!parent}` query to return the details of all products that are ancestors of these manuals:
+We can wrap that query in a `{!parent}` query with `parentPath="/"` to return the details of all root-level products that are ancestors of these manuals:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!parent which="*:* -_nest_path_:*"}(+_nest_path_:\/skus\/manuals +pages_i:1)'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!parent parentPath="/"}pages_i:1'
 {
   "response":{"numFound":2,"start":0,"maxScore":1.4E-45,"numFoundExact":true,"docs":[
       {
@@ -237,14 +221,14 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
   }}
 ----
 
-In this example we've used `\*:* -\_nest_path_:*` as our xref:block-join-query-parser.adoc#block-mask[`which` parameter] to indicate we want to consider all documents which don't have a nest path -- i.e., all "root" level document -- as the set of possible parents.
+In this example `parentPath="/"` indicates we want root-level documents (those with no `_nest_path_`) to be the parents.
 
-By changing the `which` parameter to match ancestors at specific `\_nest_path_` levels, we can change the type of ancestors we return.
-In the query below, we search for `skus` (using an `which` parameter that identifies all documents that do _not_ have a `\_nest_path_` with the prefix `/skus/*`) that are the ancestors of `manuals` with exactly `1` page:
+By changing `parentPath` to a specific path, we can change the type of ancestors we return.
+In the query below, we search for the `skus` that are the ancestors of `manuals` with exactly `1` page:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' --data-urlencode 'q={!parent which="*:* -_nest_path_:\\/skus\\/*"}(+_nest_path_:\/skus\/manuals +pages_i:1)'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'q={!parent parentPath="/skus"}pages_i:1'
 {
   "response":{"numFound":2,"start":0,"maxScore":1.4E-45,"numFoundExact":true,"docs":[
       {
@@ -260,10 +244,8 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -
   }}
 ----
 
-[CAUTION]
-====
-Note that in the above example, the `/` characters in the `\_nest_path_` were "double escaped" in the `which` parameter, for the <<double-escaping-nest-path-slashes,same reasons discussed above>> regarding the `{!child} pasers `of` parameter.
-====
+The `parentPath` parameter handles `_nest_path_` construction and escaping automatically.
+The traditional `which` parameter approach (constructing a Block Mask manually with escaped `_nest_path_` prefixes) continues to work for cases where `_nest_path_` is not in use or for greater control.
 
 === Combining Block Join Query Parsers with Child Doc Transformer
 
@@ -279,7 +261,7 @@ Here for example is a query where:
 
 [source,text]
 ----
-$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'fq=color_s:RED' --data-urlencode 'q={!child of="*:* -_nest_path_:*" filters=$parent_fq}' --data-urlencode 'parent_fq={!parent which="*:* -_nest_path_:*"}(+_nest_path_:"/manuals" +content_t:"lifetime guarantee")' -d 'fl=*,[child]'
+$ curl 'http://localhost:8983/solr/gettingstarted/select' -d 'omitHeader=true' -d 'fq=color_s:RED' --data-urlencode 'q={!child parentPath="/" filters=$parent_fq}' --data-urlencode 'parent_fq={!parent parentPath="/"}content_t:"lifetime guarantee"' -d 'fl=*,[child]'
 {
   "response":{"numFound":1,"start":0,"maxScore":1.4E-45,"numFoundExact":true,"docs":[
       {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14687

Developed with GitHub Copilot Agent / Sonnet, doing basically all the work.  The JIRA issue was so well specified, and the existing test was well structured, that it made implementing this very straight-forward.