### PR TITLE
Add backport GitHub Action 

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,6 @@
+{
+  "targetBranchChoices": ["branch_10x", "branch_9x"],
+  "branchLabelMapping": {
+    "^backport-to-(.+)$": "$1"
+  }
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,32 @@
+# This workflow automatically backports merged PRs to maintenance branches when
+# a backport label is applied (e.g. "backport-to-branch_10x" or "backport-to-branch_9x").
+#
+# For more information, see https://github.com/marketplace/actions/backport-action
+name: Backport PR
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    if: github.repository == 'apache/solr' && github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v11
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
Adds automated PR backporting via [sorenlouv/backport-github-action](https://github.com/marketplace/actions/backport-action) to streamline cherry-picking merged PRs onto maintenance branches.

## Changes

- **`.github/workflows/backport.yml`** — Workflow triggered on `pull_request_target` (`labeled`/`closed`). Runs only on merged PRs that don't carry the `backport` label (prevents re-backporting auto-created backport PRs). Requires `contents: write` and `pull-requests: write` permissions.

- **`.backportrc.json`** — Configures available target branches and the label-to-branch mapping:
  ```json
  {
    "targetBranchChoices": ["branch_10x", "branch_9x"],
    "branchLabelMapping": {
      "^backport-to-(.+)$": "$1"
    }
  }
  ```

## Usage

Apply a label to a PR before or after merging:

| Label | Target branch |
|---|---|
| `backport-to-branch_10x` | `branch_10x` |
| `backport-to-branch_9x` | `branch_9x` |

On merge, the action opens a new PR with the cherry-picked commit(s) against the target branch.
