### PR TITLE
[SOLR-18176] HttpShardHandler query throughput bottleneck from ZooKeeper

### DIFF
--- a/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
+++ b/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
@@ -1,7 +1,9 @@
-title: Increased query throughput by removing a call to ZooKeeper for cluster state that should have been cached
+title: Fix query throughput bottleneck caused by uncached ZooKeeper get calls for queries with explicit 'collection' parameter
 type: changed
 authors:
   - name: Matthew Biscocho
 links:
   - name: SOLR-18176
     url: https://issues.apache.org/jira/browse/SOLR-18176
+  - name: SOLR-15352
+    url: https://issues.apache.org/jira/browse/SOLR-15352

--- a/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
+++ b/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
@@ -1,5 +1,5 @@
 title: Increased query throughput by removing a call to ZooKeeper for cluster state that should have been cached
-type: fixed
+type: changed
 authors:
   - name: Matthew Biscocho
 links:

--- a/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
+++ b/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
@@ -1,0 +1,7 @@
+title: Increased query throughput by removing a call to ZooKeeper for cluster state that should have been cached
+type: fixed
+authors:
+  - name: Matthew Biscocho
+links:
+  - name: SOLR-18176
+    url: https://issues.apache.org/jira/browse/SOLR-18176

--- a/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
+++ b/changelog/unreleased/SOLR-18176-shardhandler-bottleneck.yml
@@ -1,4 +1,4 @@
-title: Fix query throughput bottleneck caused by uncached ZooKeeper get calls for queries with explicit 'collection' parameter
+title: Increased query throughput by removing a call to ZooKeeper for cluster state that should have been cached. Happens when Solr does distributed search over multiple collections, and when the coordinator has no local replica for some of them.
 type: changed
 authors:
   - name: Matthew Biscocho

--- a/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
@@ -109,12 +109,14 @@ class CloudReplicaSource implements ReplicaSource {
       if (sliceOrUrl.indexOf('/') < 0) {
         // this is a logical shard
         this.slices[i] = sliceOrUrl;
+        DocCollection coll = clusterState.getCollectionOrNull(builder.collection, true);
+        if (coll == null) {
+          throw new SolrException(
+              SolrException.ErrorCode.BAD_REQUEST,
+              "Could not find collection to resolve replicas: " + builder.collection);
+        }
         replicas[i] =
-            findReplicas(
-                builder,
-                shardsParam,
-                clusterState,
-                clusterState.getCollection(builder.collection).getSlice(sliceOrUrl));
+            findReplicas(builder, shardsParam, clusterState, coll.getSlice(sliceOrUrl));
       } else {
         // this has urls
         this.replicas[i] = StrUtils.splitSmart(sliceOrUrl, "|", true);
@@ -189,7 +191,11 @@ class CloudReplicaSource implements ReplicaSource {
       String collectionName,
       String shardKeys,
       boolean multiCollection) {
-    DocCollection coll = state.getCollection(collectionName);
+    DocCollection coll = state.getCollectionOrNull(collectionName, true);
+    if (coll == null) {
+      throw new SolrException(
+          SolrException.ErrorCode.BAD_REQUEST, "Could not find collection to add slices: " + collectionName);
+    }
     Collection<Slice> slices = coll.getRouter().getSearchSlices(shardKeys, params, coll);
     ClientUtils.addSlices(target, collectionName, slices, multiCollection);
   }

--- a/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/CloudReplicaSource.java
@@ -115,8 +115,7 @@ class CloudReplicaSource implements ReplicaSource {
               SolrException.ErrorCode.BAD_REQUEST,
               "Could not find collection to resolve replicas: " + builder.collection);
         }
-        replicas[i] =
-            findReplicas(builder, shardsParam, clusterState, coll.getSlice(sliceOrUrl));
+        replicas[i] = findReplicas(builder, shardsParam, clusterState, coll.getSlice(sliceOrUrl));
       } else {
         // this has urls
         this.replicas[i] = StrUtils.splitSmart(sliceOrUrl, "|", true);
@@ -194,7 +193,8 @@ class CloudReplicaSource implements ReplicaSource {
     DocCollection coll = state.getCollectionOrNull(collectionName, true);
     if (coll == null) {
       throw new SolrException(
-          SolrException.ErrorCode.BAD_REQUEST, "Could not find collection to add slices: " + collectionName);
+          SolrException.ErrorCode.BAD_REQUEST,
+          "Could not find collection to add slices: " + collectionName);
     }
     Collection<Slice> slices = coll.getRouter().getSearchSlices(shardKeys, params, coll);
     ClientUtils.addSlices(target, collectionName, slices, multiCollection);

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
@@ -24,15 +24,19 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.BaseDistributedSearchTestCase;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.jetty.HttpJettySolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.cloud.SolrZKMetricsListener;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.embedded.JettySolrRunner;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -705,6 +709,55 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
     }
 
     return response;
+  }
+
+  /**
+   * When a node resolves collection state for a collection it doesn't host, queries should use
+   * cached state and not make ZK calls on every query.
+   */
+  @Test
+  public void testDistributedQueryDoesNotReadFromZk() throws Exception {
+    final String testCollection = "testCollection";
+
+    // Create a collection on only 1 node so the other node uses LazyCollectionRef for state
+    List<JettySolrRunner> jettys = cluster.getJettySolrRunners();
+    CollectionAdminRequest.createCollection(testCollection, "conf", 1, 1)
+        .setCreateNodeSet(jettys.get(0).getNodeName())
+        .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
+    cluster
+        .getZkStateReader()
+        .waitForState(
+            testCollection,
+            DEFAULT_TIMEOUT,
+            TimeUnit.SECONDS,
+            (n, c) -> SolrCloudTestCase.replicasForCollectionAreFullyActive(n, c, 1, 1));
+
+    try {
+      // Node 1 hosts COLLECTION but not testCollection.
+      // Send a multi-collection query to trigger LazyCollectionRef get call
+      JettySolrRunner nodeWithoutOther = jettys.get(1);
+      try (SolrClient client =
+          new HttpJettySolrClient.Builder(nodeWithoutOther.getBaseUrl().toString()).build()) {
+
+        String collectionsParameter = COLLECTION + "," + testCollection;
+
+        // Warm up LazyCollectionRef state cache with query
+        client.query(COLLECTION, new SolrQuery("q", "*:*", "collection", collectionsParameter));
+
+        SolrZKMetricsListener metrics = cluster.getZkStateReader().getZkClient().getMetrics();
+        long existsBefore = metrics.getExistsChecks();
+
+        // Query again and assert that exists call is not made
+        client.query(COLLECTION, new SolrQuery("q", "*:*", "collection", collectionsParameter));
+        assertEquals(
+            "Query should not cause ZK exists checks as collection state should be cached",
+            existsBefore,
+            metrics.getExistsChecks());
+      }
+    } finally {
+      CollectionAdminRequest.deleteCollection(testCollection)
+          .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
+    }
   }
 
   private int getNumRequests(

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
@@ -717,34 +717,40 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
    */
   @Test
   public void testDistributedQueryDoesNotReadFromZk() throws Exception {
-    final String testCollection = "testCollection";
+    final String secondColl = "secondColl";
 
     // Create a collection on only 1 node so the other node uses LazyCollectionRef for state
     List<JettySolrRunner> jettys = cluster.getJettySolrRunners();
-    CollectionAdminRequest.createCollection(testCollection, "conf", 1, 1)
+    CollectionAdminRequest.createCollection(secondColl, "conf", 1, 1)
         .setCreateNodeSet(jettys.get(0).getNodeName())
         .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
     cluster
         .getZkStateReader()
         .waitForState(
-            testCollection,
+            secondColl,
             DEFAULT_TIMEOUT,
             TimeUnit.SECONDS,
             (n, c) -> SolrCloudTestCase.replicasForCollectionAreFullyActive(n, c, 1, 1));
 
     try {
-      // Node 1 hosts COLLECTION but not testCollection.
+      // Node 1 hosts COLLECTION but not secondColl.
       // Send a multi-collection query to trigger LazyCollectionRef get call
-      JettySolrRunner nodeWithoutOther = jettys.get(1);
+      JettySolrRunner nodeWithoutSecondColl = jettys.get(1);
       try (SolrClient client =
-          new HttpJettySolrClient.Builder(nodeWithoutOther.getBaseUrl().toString()).build()) {
+          new HttpJettySolrClient.Builder(nodeWithoutSecondColl.getBaseUrl().toString()).build()) {
 
-        String collectionsParameter = COLLECTION + "," + testCollection;
+        String collectionsParameter = COLLECTION + "," + secondColl;
 
         // Warm up LazyCollectionRef state cache with query
         client.query(COLLECTION, new SolrQuery("q", "*:*", "collection", collectionsParameter));
 
-        SolrZKMetricsListener metrics = cluster.getZkStateReader().getZkClient().getMetrics();
+        // Get ZK metrics from the coordinator node (the one we're querying)
+        SolrZKMetricsListener metrics =
+            nodeWithoutSecondColl
+                .getCoreContainer()
+                .getZkController()
+                .getZkClient()
+                .getMetrics();
         long existsBefore = metrics.getExistsChecks();
 
         // Query again and assert that exists call is not made
@@ -755,7 +761,7 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
             metrics.getExistsChecks());
       }
     } finally {
-      CollectionAdminRequest.deleteCollection(testCollection)
+      CollectionAdminRequest.deleteCollection(secondColl)
           .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
@@ -746,11 +746,7 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
 
         // Get ZK metrics from the coordinator node (the one we're querying)
         SolrZKMetricsListener metrics =
-            nodeWithoutSecondColl
-                .getCoreContainer()
-                .getZkController()
-                .getZkClient()
-                .getMetrics();
+            nodeWithoutSecondColl.getCoreContainer().getZkController().getZkClient().getMetrics();
         long existsBefore = metrics.getExistsChecks();
 
         // Query again and assert that exists call is not made


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18176

HttpShardHandler was bottlenecking in throughput due to `CloudReplicaSource` recalling for ZooKeeper collection state with every `distrib` request due to the missing `allowCache=true` parameter. This resulted in large CPU utilization in ZooKeeper and the `synchronized` call blocking QTP threads waiting for zookeeper response.

See JIRA above for more detailed information.