### PR TITLE
SOLR-17353 Bump gosu binary to v1.19 in docker images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,19 @@
   "enabled": true,
   "gitIgnoredAuthors": ["renovate-bot <renovate-bot@noreply.github.com>"],
   "dependencyDashboard": false,
-  "enabledManagers": ["gradle", "github-actions"],
+  "enabledManagers": ["gradle", "github-actions", "regex"],
   "labels": ["exempt-stale"],
-  "includePaths": ["gradle/libs.versions.toml", "versions.*", "build.gradle", ".github/workflows/*"],
+  "includePaths": ["gradle/libs.versions.toml", "versions.*", "build.gradle", ".github/workflows/*", "solr/docker/templates/Dockerfile.body.template"],
+  "customManagers": [
+    {
+      "description": "Track gosu GitHub releases and update ARG GOSU_VERSION in Dockerfile template",
+      "customType": "regex",
+      "fileMatch": ["^solr/docker/templates/Dockerfile\\.body\\.template$"],
+      "matchStrings": ["ARG GOSU_VERSION=(?<currentValue>[^\\s]+)"],
+      "depNameTemplate": "tianon/gosu",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "postUpgradeTasks": {
     "commands": [
       "./gradlew resolveAndLockAll --write-locks",

--- a/changelog/unreleased/SOLR-17353-docker-gosu-upgrade.yml
+++ b/changelog/unreleased/SOLR-17353-docker-gosu-upgrade.yml
@@ -1,29 +1,5 @@
-# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
-
-# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-
-# If the change is minor, don't bother adding a changelog entry.
-# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
-
-# title:
-#  * The audience is end-users and administrators, not committers.
-#  * Be short and focused on the user impact.  Multiple sentences is fine!
-#  * For technical/geeky details, prefer the commit message instead of changelog.
-#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
-
-# type:
-#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
-#  `changed` for improvements; not opt-in
-#  `fixed` for improvements that are deemed to have fixed buggy behavior
-#  `deprecated` for marking things deprecated
-#  `removed` for code removed
-#  `dependency_update` for updates to dependencies
-#  `other` for anything else, like large/significant refactorings, build changes,
-#    test infrastructure, or documentation.
-#    Most such changes are too small/minor to bother with a changelog entry.
-
-title: Docker gosu upgrade
-type:
+title: Bump gosu binary to v1.19 in docker images
+type: dependency_update
 authors:
   - name: Jan Høydahl
     url: https://home.apache.org/phonebook.html?uid=janhoy

--- a/changelog/unreleased/SOLR-17353-docker-gosu-upgrade.yml
+++ b/changelog/unreleased/SOLR-17353-docker-gosu-upgrade.yml
@@ -1,0 +1,32 @@
+# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
+
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+
+# If the change is minor, don't bother adding a changelog entry.
+# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
+
+# title:
+#  * The audience is end-users and administrators, not committers.
+#  * Be short and focused on the user impact.  Multiple sentences is fine!
+#  * For technical/geeky details, prefer the commit message instead of changelog.
+#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
+
+# type:
+#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
+#  `changed` for improvements; not opt-in
+#  `fixed` for improvements that are deemed to have fixed buggy behavior
+#  `deprecated` for marking things deprecated
+#  `removed` for code removed
+#  `dependency_update` for updates to dependencies
+#  `other` for anything else, like large/significant refactorings, build changes,
+#    test infrastructure, or documentation.
+#    Most such changes are too small/minor to bother with a changelog entry.
+
+title: Docker gosu upgrade
+type:
+authors:
+  - name: Jan Høydahl
+    url: https://home.apache.org/phonebook.html?uid=janhoy
+links:
+  - name: SOLR-17353
+    url: https://issues.apache.org/jira/browse/SOLR-17353

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -48,6 +48,25 @@ ENV SOLR_USER="solr" \
     SOLR_HOST_BIND="0.0.0.0" \
     SOLR_ZOOKEEPER_EMBEDDED_HOST="0.0.0.0"
 
+ARG GOSU_VERSION=1.19
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y --no-install-recommends install curl acl lsof procps wget netcat-openbsd tini jattach gpg gnupg dirmngr; \
+    rm -rf /var/lib/apt/lists/*; \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"; \
+    wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org \
+        --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /tmp/gosu.asc /usr/local/bin/gosu; \
+    gpgconf --kill gpg-agent; \
+    rm -rf "$GNUPGHOME" /tmp/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true; \
+    apt-get -y remove gpg dirmngr && apt-get -y autoremove
+
 RUN set -ex; \
   groupadd -r --gid "$SOLR_GID" "$SOLR_GROUP"; \
   useradd -r --uid "$SOLR_UID" --gid "$SOLR_GID" "$SOLR_USER"
@@ -66,11 +85,6 @@ RUN set -ex; \
   chmod 0664 /etc/default/solr.in.sh; \
   mkdir -p -m0770 /var/solr; \
   chown -R "$SOLR_USER:0" /var/solr;
-
-RUN set -ex; \
-    apt-get update; \
-    apt-get -y --no-install-recommends install curl acl lsof procps wget netcat-openbsd gosu tini jattach; \
-    rm -rf /var/lib/apt/lists/*;
 
 VOLUME /var/solr
 EXPOSE 8983

--- a/solr/docker/templates/Dockerfile.body.template
+++ b/solr/docker/templates/Dockerfile.body.template
@@ -57,6 +57,7 @@ RUN set -eux; \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"; \
     wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"; \
     export GNUPGHOME="$(mktemp -d)"; \
+    chmod 700 "$GNUPGHOME"; \
     gpg --batch --keyserver hkps://keys.openpgp.org \
         --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --verify /tmp/gosu.asc /usr/local/bin/gosu; \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17353

A majority of flagged security issues in our docker image stems from "go", which again stems from the bundled go version in the `gosu` binary that we provide for advanced users of docker images. 

<img width="842" height="48" alt="Skjermbilde 2026-04-09 kl  09 31 28" src="https://github.com/user-attachments/assets/e7565a30-f763-4f6c-a45f-ded7bc9ec541" />
<img width="921" height="114" alt="Skjermbilde 2026-04-09 kl  09 33 00" src="https://github.com/user-attachments/assets/7adc74e4-6da6-41fc-a6d0-e1372d683a71" />

Earlier we installed gosu with apt, but Canonical is slow to patch (re-build on newer go), so it is better to install latest binary from github which is newer.

In addition to installing from github releases, this PR also tries to add a mechanism for which RenovateBot / SolrBot can watch new versions and file a PR for bumping the version in our dockerfile template.

PS: I'm not super attached to gosu myself, have never had the need for it, so I can be convinced to an alternative approach, just skip it. I can't even find documentation in our docker folder on how to use it. Here are some refs on the topic.
* https://github.com/docker-solr/docker-solr/issues/270
* https://stackoverflow.com/questions/36781372/docker-using-gosu-vs-user