### PR TITLE
Exclude test_rolling_upgrade from integrationTests; add testSmokeBats task

### DIFF
--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -310,6 +310,55 @@ task integrationTests(type: BatsTask) {
   environment BATS_LIB_PREFIX: "$nodeProjectDir/node_modules"
 }
 
+task testSmokeBats(type: BatsTask) {
+  description = 'Run smoke BATS tests (e.g. rolling upgrade via Docker) separately from the main integration tests'
+  group = 'verification'
+  dependsOn installFullDist
+  dependsOn downloadBats
+
+  testDir = 'test/smoke'
+
+  def integrationTestOutput = "$buildDir/test-output"
+  def solrHome = "$integrationTestOutput/solr-home"
+  def solrTestFailuresDir = "$integrationTestOutput/failure-snapshots"
+  var solrPort = Integer
+      .parseInt((String) project.findProperty('bats.port') ?: System.getProperty("bats.port", "-1"))
+  while (solrPort > 64000 || solrPort < 0) {
+    try (ServerSocket s = new ServerSocket(0)) {
+      solrPort = s.getLocalPort()
+    } catch (Exception e) {
+      println("WARN: Could not assign random port for Bats tests. Using default port 8983.")
+      solrPort = 8983
+    }
+  }
+
+  inputs.dir(distDir)
+  outputs.dir(integrationTestOutput)
+
+  doFirst {
+    mkdir integrationTestOutput
+    mkdir solrHome
+    mkdir solrTestFailuresDir
+
+    standardOutput = new TeeOutputStream(System.out,
+        new FileOutputStream("$integrationTestOutput/test-output-smoke.txt"))
+    println("Running smoke BATS tests with Solr base port ${solrPort}")
+  }
+
+  environment SOLR_TIP: distDir.toString()
+  environment SOLR_HOME: solrHome
+  environment SOLR_PID_DIR: solrHome
+  environment SOLR_PORT_LISTEN: solrPort
+  environment SOLR_PORT: solrPort
+  environment SOLR2_PORT: solrPort + 1
+  environment SOLR3_PORT: solrPort + 2
+  environment ZK_PORT: solrPort + 1000
+  environment SOLR_LOGS_DIR: "$solrHome/logs"
+  environment TEST_OUTPUT_DIR: integrationTestOutput
+  environment TEST_FAILURE_DIR: solrTestFailuresDir
+  environment BATS_LIB_PREFIX: "$nodeProjectDir/node_modules"
+}
+
 class BatsTask extends Exec {
   @InputDirectory
   String testDir = 'test'

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -334,6 +334,7 @@ task testSmokeBats(type: BatsTask) {
 
   inputs.dir(distDir)
   outputs.dir(integrationTestOutput)
+  outputs.upToDateWhen { false }
 
   doFirst {
     mkdir integrationTestOutput

--- a/solr/packaging/test/smoke/test_rolling_upgrade.bats
+++ b/solr/packaging/test/smoke/test_rolling_upgrade.bats
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load bats_helper
+load "../bats_helper"
 
 # You can test alternative images via
 # export SOLR_BEGIN_IMAGE="apache/solr-nightly:9.9.0-slim" and then running

--- a/solr/packaging/test/smoke/test_rolling_upgrade.bats
+++ b/solr/packaging/test/smoke/test_rolling_upgrade.bats
@@ -17,9 +17,9 @@
 
 load bats_helper
 
-# You can test alternative images via 
+# You can test alternative images via
 # export SOLR_BEGIN_IMAGE="apache/solr-nightly:9.9.0-slim" and then running
-# ./gradlew iTest --tests test_rolling_upgrade.bats
+# ./gradlew :solr:packaging:testSmokeBats
 SOLR_BEGIN_IMAGE="${SOLR_BEGIN_IMAGE:-apache/solr-nightly:9.10.0-SNAPSHOT-slim}"
 SOLR_END_IMAGE="${SOLR_END_IMAGE:-apache/solr-nightly:10.0.0-SNAPSHOT-slim}"
 


### PR DESCRIPTION
See https://github.com/dsmiley/solr/pull/27

`test_rolling_upgrade.bats` requires Docker and published images, making it unsuitable for the standard `integrationTests` run. Since bats does not recurse into subdirectories, moving the file is sufficient to exclude it.

## Changes

- **`test/smoke/test_rolling_upgrade.bats`** — moved from `test/` into a new `test/smoke/` subdirectory; `integrationTests` (which runs `bats test/`) will no longer discover it
- **`build.gradle`** — adds a `testSmokeBats` task (type `BatsTask`, `testDir = 'test/smoke'`) with the same env-var setup as `integrationTests`, intended for standalone invocation (e.g. from `smokeTestRelease.py` when Docker is present)

```bash
# Run smoke tests explicitly
./gradlew :solr:packaging:testSmokeBats
# or directly
bats solr/packaging/test/smoke/test_rolling_upgrade.bats
```