### PR TITLE
SOLR-18165 Complete dot-separated metric name migration

### DIFF
--- a/changelog/unreleased/SOLR-18165-More-dot-separated-metric-names.yml
+++ b/changelog/unreleased/SOLR-18165-More-dot-separated-metric-names.yml
@@ -1,0 +1,8 @@
+title: Complete dot-separated metric name migration
+type: changed
+authors:
+  - name: Jan Høydahl
+    url: https://home.apache.org/phonebook.html?uid=janhoy
+links:
+  - name: SOLR-18165
+    url: https://issues.apache.org/jira/browse/SOLR-18165

--- a/solr/core/src/java/org/apache/solr/core/ZkContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/ZkContainer.java
@@ -206,18 +206,10 @@ public class ZkContainer {
                     });
 
                 ctx.observableLongCounter(
-                    "solr.zk.child.fetches",
-                    "Total number of ZooKeeper child node fetches",
+                    "solr.zk.get_children.ops",
+                    "Total number of ZooKeeper getChildren calls",
                     measurement -> {
                       measurement.record(metricsListener.getChildFetches(), attributes);
-                    });
-
-                ctx.observableLongCounter(
-                    "solr.zk.cumulative.children_fetched",
-                    "Total cumulative children fetched count",
-                    measurement -> {
-                      measurement.record(
-                          metricsListener.getCumulativeChildrenFetched(), attributes);
                     });
               }
 

--- a/solr/core/src/java/org/apache/solr/core/ZkContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/ZkContainer.java
@@ -155,7 +155,7 @@ public class ZkContainer {
                 var metricsListener = zkController.getZkClient().getMetrics();
 
                 ctx.observableLongCounter(
-                    "solr_zk_ops",
+                    "solr.zk.ops",
                     "Total number of ZooKeeper operations",
                     measurement -> {
                       measurement.record(
@@ -176,7 +176,7 @@ public class ZkContainer {
                     });
 
                 ctx.observableLongCounter(
-                    "solr_zk_read",
+                    "solr.zk.read",
                     "Total bytes read from ZooKeeper",
                     measurement -> {
                       measurement.record(metricsListener.getBytesRead(), attributes);
@@ -184,14 +184,14 @@ public class ZkContainer {
                     OtelUnit.BYTES);
 
                 ctx.observableLongCounter(
-                    "solr_zk_watches_fired",
+                    "solr.zk.watches_fired",
                     "Total number of ZooKeeper watches fired",
                     measurement -> {
                       measurement.record(metricsListener.getWatchesFired(), attributes);
                     });
 
                 ctx.observableLongCounter(
-                    "solr_zk_written",
+                    "solr.zk.written",
                     "Total bytes written to ZooKeeper",
                     measurement -> {
                       measurement.record(metricsListener.getBytesWritten(), attributes);
@@ -199,21 +199,21 @@ public class ZkContainer {
                     OtelUnit.BYTES);
 
                 ctx.observableLongCounter(
-                    "solr_zk_cumulative_multi_ops_total",
+                    "solr.zk.cumulative.multi_ops.total",
                     "Total cumulative multi-operations count",
                     measurement -> {
                       measurement.record(metricsListener.getCumulativeMultiOps(), attributes);
                     });
 
                 ctx.observableLongCounter(
-                    "solr_zk_child_fetches",
+                    "solr.zk.child.fetches",
                     "Total number of ZooKeeper child node fetches",
                     measurement -> {
                       measurement.record(metricsListener.getChildFetches(), attributes);
                     });
 
                 ctx.observableLongCounter(
-                    "solr_zk_cumulative_children_fetched",
+                    "solr.zk.cumulative.children_fetched",
                     "Total cumulative children fetched count",
                     measurement -> {
                       measurement.record(

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -488,7 +488,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
 
     ObservableLongMeasurement sizeMetric =
         solrMetricsContext.longGaugeMeasurement(
-            metricName + ".size", "Current number cache entries");
+            metricName + ".size", "Current number of cache entries");
 
     ObservableLongMeasurement ramBytesUsedMetric =
         solrMetricsContext.longGaugeMeasurement(

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -469,7 +469,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
 
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, Attributes attributes) {
-    initializeMetrics(parentContext, attributes, "solr_caffeine_cache");
+    initializeMetrics(parentContext, attributes, "solr.caffeine_cache");
   }
 
   public void initializeMetrics(
@@ -480,23 +480,23 @@ public class CaffeineCache<K, V> extends SolrCacheBase
 
     ObservableLongMeasurement cacheLookupsMetric =
         solrMetricsContext.longCounterMeasurement(
-            metricName + "_lookups", "Number of cumulative cache lookup results (hits and misses)");
+            metricName + ".lookups", "Number of cumulative cache lookup results (hits and misses)");
 
     ObservableLongMeasurement cacheOperationMetric =
         solrMetricsContext.longCounterMeasurement(
-            metricName + "_ops", "Number of cumulative cache operations (inserts and evictions)");
+            metricName + ".ops", "Number of cumulative cache operations (inserts and evictions)");
 
     ObservableLongMeasurement sizeMetric =
         solrMetricsContext.longGaugeMeasurement(
-            metricName + "_size", "Current number cache entries");
+            metricName + ".size", "Current number cache entries");
 
     ObservableLongMeasurement ramBytesUsedMetric =
         solrMetricsContext.longGaugeMeasurement(
-            metricName + "_ram_used", "RAM bytes used by cache", OtelUnit.BYTES);
+            metricName + ".ram_used", "RAM bytes used by cache", OtelUnit.BYTES);
 
     ObservableLongMeasurement warmupTimeMetric =
         solrMetricsContext.longGaugeMeasurement(
-            metricName + "_warmup_time", "Cache warmup time (most recent)", OtelUnit.MILLISECONDS);
+            metricName + ".warmup_time", "Cache warmup time (most recent)", OtelUnit.MILLISECONDS);
 
     solrMetricsContext.batchCallback(
         () -> {

--- a/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/AuditLoggerPlugin.java
@@ -277,31 +277,31 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
     numLogged =
         new AttributedLongCounter(
             solrMetricsContext.longCounter(
-                "solr_auditlogger_count",
+                "solr.auditlogger.count",
                 "The number of audit events that were successfully logged."),
             attrsWithCategory);
     numErrors =
         new AttributedLongCounter(
             solrMetricsContext.longCounter(
-                "solr_auditlogger_errors", "The number of audit events that resulted in errors."),
+                "solr.auditlogger.errors", "The number of audit events that resulted in errors."),
             attrsWithCategory);
     numLost =
         new AttributedLongCounter(
             solrMetricsContext.longCounter(
-                "solr_auditlogger_lost",
+                "solr.auditlogger.lost",
                 "The number of audit events that were lost due to async queue being full."),
             attrsWithCategory);
     requestTimes =
         new AttributedLongTimer(
             this.solrMetricsContext.longHistogram(
-                "solr_auditlogger_request_times",
+                "solr.auditlogger.request_times",
                 "Distribution of audit event request durations",
                 OtelUnit.NANOSECONDS),
             attrsWithCategory);
 
     if (async) {
       solrMetricsContext.observableLongGauge(
-          "solr_auditlogger_queue",
+          "solr.auditlogger.queue",
           "Metrics around the audit logger queue when running in async mode",
           (observableLongMeasurement -> {
             observableLongMeasurement.record(
@@ -314,7 +314,7 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
       queuedTime =
           new AttributedLongTimer(
               solrMetricsContext.longHistogram(
-                  "solr_auditlogger_queued_time",
+                  "solr.auditlogger.queued_time",
                   "Distribution of time events spend queued before processing",
                   OtelUnit.NANOSECONDS),
               attrsWithCategory);
@@ -323,7 +323,7 @@ public abstract class AuditLoggerPlugin implements Closeable, Runnable, SolrInfo
     AttributedLongGauge asyncEnabledGauge =
         new AttributedLongGauge(
             solrMetricsContext.longGauge(
-                "solr_auditlogger_async_enabled",
+                "solr.auditlogger.async_enabled",
                 "Whether the audit logger is running in async mode (1) or not (0)"),
             attrsWithCategory);
     asyncEnabledGauge.set(async ? 1L : 0L);

--- a/solr/core/src/test/org/apache/solr/metrics/SolrMetricsIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/SolrMetricsIntegrationTest.java
@@ -126,12 +126,8 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
     try (SolrClient solrClient = j.newClient()) {
       assertNotNull(solrClient);
       HttpClient httpClient = j.getSolrClient().getHttpClient();
-      var initialChildrenFetched =
-          SolrMetricTestUtils.getCounterDatapoint(
-                  reader, "solr_zk_cumulative_children_fetched", baseLabels)
-              .getValue();
       var initialChildFetches =
-          SolrMetricTestUtils.getCounterDatapoint(reader, "solr_zk_child_fetches", baseLabels)
+          SolrMetricTestUtils.getCounterDatapoint(reader, "solr_zk_get_children_ops", baseLabels)
               .getValue();
       var initialExistsOp =
           SolrMetricTestUtils.getCounterDatapoint(
@@ -141,19 +137,14 @@ public class SolrMetricsIntegrationTest extends SolrTestCaseJ4 {
       // Send GET request to trigger some metrics
       httpClient.GET(j.getBaseURLV2() + "/cluster/zookeeper/children/live_nodes");
 
-      var childrenFetched =
-          SolrMetricTestUtils.getCounterDatapoint(
-                  reader, "solr_zk_cumulative_children_fetched", baseLabels)
-              .getValue();
       var childFetches =
-          SolrMetricTestUtils.getCounterDatapoint(reader, "solr_zk_child_fetches", baseLabels)
+          SolrMetricTestUtils.getCounterDatapoint(reader, "solr_zk_get_children_ops", baseLabels)
               .getValue();
       var existsOp =
           SolrMetricTestUtils.getCounterDatapoint(
                   reader, "solr_zk_ops", builder.label("ops", "exists").build())
               .getValue();
 
-      assertTrue(childrenFetched - initialChildrenFetched >= 3.0);
       assertTrue(childFetches - initialChildFetches >= 1.0);
       assertTrue(existsOp - initialExistsOp >= 4.0);
     }

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/OtelMetrics.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/OtelMetrics.java
@@ -32,8 +32,8 @@ import org.apache.solr.opentelemetry.OtlpExporterFactory;
 
 public class OtelMetrics implements ConsumerMetrics {
 
-  public static final String REGISTRY = "crossdc.consumer.registry";
-  public static final String NAME_PREFIX = "crossdc.consumer.";
+  public static final String REGISTRY = "solr.crossdc.consumer.registry";
+  public static final String NAME_PREFIX = "solr.crossdc.consumer.";
   public static final String ATTR_TYPE = "type";
   public static final String ATTR_SUBTYPE = "subtype";
   public static final String ATTR_RESULT = "result";

--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/OtelMetrics.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/consumer/OtelMetrics.java
@@ -33,7 +33,7 @@ import org.apache.solr.opentelemetry.OtlpExporterFactory;
 public class OtelMetrics implements ConsumerMetrics {
 
   public static final String REGISTRY = "crossdc.consumer.registry";
-  public static final String NAME_PREFIX = "crossdc_consumer_";
+  public static final String NAME_PREFIX = "crossdc.consumer.";
   public static final String ATTR_TYPE = "type";
   public static final String ATTR_SUBTYPE = "subtype";
   public static final String ATTR_RESULT = "result";
@@ -61,36 +61,36 @@ public class OtelMetrics implements ConsumerMetrics {
 
     inputMsg =
         metricsContext.longCounter(
-            NAME_PREFIX + "input_msg_total", "Total number of input Kafka messages");
+            NAME_PREFIX + "input.msg.total", "Total number of input Kafka messages");
 
     inputReq =
         metricsContext.longCounter(
-            NAME_PREFIX + "input_req_total", "Total number of input Solr requests");
+            NAME_PREFIX + "input.req.total", "Total number of input Solr requests");
 
     collapsed =
         metricsContext.longCounter(
-            NAME_PREFIX + "collapsed_total", "Total number of collapsed update requests");
+            NAME_PREFIX + "collapsed.total", "Total number of collapsed update requests");
 
     output =
-        metricsContext.longCounter(NAME_PREFIX + "output_total", "Total number of output requests");
+        metricsContext.longCounter(NAME_PREFIX + "output.total", "Total number of output requests");
 
     outputBatchSizeHistogram =
         metricsContext.longHistogram(
-            NAME_PREFIX + "output_batch_size", "Histogram of output batch sizes");
+            NAME_PREFIX + "output.batch_size", "Histogram of output batch sizes");
 
     outputBackoffHistogram =
         metricsContext.longHistogram(
-            NAME_PREFIX + "output_backoff_time", "Histogram of output backoff sleep times");
+            NAME_PREFIX + "output.backoff_time", "Histogram of output backoff sleep times");
 
     outputTimeHistogram =
         metricsContext.longHistogram(
-            NAME_PREFIX + "output_time",
+            NAME_PREFIX + "output.time",
             "Histogram of output request times",
             OtelUnit.MILLISECONDS);
 
     outputFirstAttemptHistogram =
         metricsContext.longHistogram(
-            NAME_PREFIX + "output_first_attempt_time",
+            NAME_PREFIX + "output.first_attempt_time",
             "Histogram of first attempt request times",
             OtelUnit.MILLISECONDS);
   }

--- a/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SolrAndKafkaIntegrationTest.java
+++ b/solr/cross-dc-manager/src/test/org/apache/solr/crossdc/manager/SolrAndKafkaIntegrationTest.java
@@ -407,7 +407,7 @@ public class SolrAndKafkaIntegrationTest extends SolrCloudTestCase {
       String content =
           IOUtils.toString(
               (InputStream) rsp.get(InputStreamResponseParser.STREAM_KEY), StandardCharsets.UTF_8);
-      assertTrue(content, content.contains("crossdc_consumer_output_total"));
+      assertTrue(content, content.contains("solr_crossdc_consumer_output_total"));
 
       // test the healtcheck endpoint
       req = new GenericSolrRequest(SolrRequest.METHOD.GET, "/health");

--- a/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/update/processor/ProducerMetrics.java
+++ b/solr/modules/cross-dc/src/java/org/apache/solr/crossdc/update/processor/ProducerMetrics.java
@@ -24,7 +24,7 @@ import org.apache.solr.metrics.otel.OtelUnit;
 import org.apache.solr.metrics.otel.instruments.AttributedLongCounter;
 import org.apache.solr.metrics.otel.instruments.AttributedLongHistogram;
 
-/** Metrics presented for each SolrCore using `crossdc.producer.` path. */
+/** Metrics presented for each SolrCore using `solr.crossdc.producer.` path. */
 public class ProducerMetrics {
 
   private final AttributedLongCounter local;
@@ -47,36 +47,36 @@ public class ProducerMetrics {
 
     var localProcessed =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.local.processed",
+            "solr.crossdc.producer.local.processed",
             "The number of local documents processed (success or error)");
     var localSubmitted =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.submitted",
+            "solr.crossdc.producer.submitted",
             "The number of documents submitted to the Kafka topic (success or error)");
     var localSubmittedAdd =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.submitted.add",
+            "solr.crossdc.producer.submitted.add",
             "The number of add requests submitted to the Kafka topic (success or error)");
     var localSubmittedDbi =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.submitted.delete_by_id",
+            "solr.crossdc.producer.submitted.delete_by_id",
             "The number of Delete-By-Id requests submitted to the Kafka topic (success or error)");
     var localSubmittedDbq =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.submitted.delete_by_query",
+            "solr.crossdc.producer.submitted.delete_by_query",
             "The number of Delete-By-Query requests submitted to the Kafka topic (success or error)");
     var localSubmittedCommit =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.submitted.commit",
+            "solr.crossdc.producer.submitted.commit",
             "The number of standalone Commit requests submitted to the Kafka topic (success or error)");
     var histogramDocSizes =
         solrMetricsContext.longHistogram(
-            "solr.core.crossdc.producer.document_size",
+            "solr.crossdc.producer.document_size",
             "Histogram of the processed document sizes processed",
             OtelUnit.BYTES);
     var tooLargeErrors =
         solrMetricsContext.longCounter(
-            "solr.core.crossdc.producer.doc_too_large_errors",
+            "solr.crossdc.producer.doc_too_large_errors",
             "The number of documents that were too large to send to the Kafka topic");
 
     this.local =

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -318,10 +318,13 @@ For example, `solr_core_requests` is now `solr.core.requests`, and `solr_node_ex
 *Workaround for OTLP consumers depending on the old names:*
 Users who consume Solr metrics via OTLP and rely on the 10.0 underscore-format names can use metric renaming or transformation features in their OpenTelemetry Collector pipeline to convert the new dot-separated names back to the old format during the transition.
 
-==== Metric `solr_core_indexsearcher_open_warmup_time` removed
+==== Metric that are Removed or Changed
 
-The metric `solr_core_indexsearcher_open_warmup_time` has been removed as it duplicated `solr_core_indexsearcher_warmup_time`.
-Update your dashboards to use `solr_core_indexsearcher_warmup_time` instead.
+* The metric `solr_core_indexsearcher_open_warmup_time` has been removed as it duplicated `solr_core_indexsearcher_warmup_time`
+* The metric `solr.zk.cumulative.children_fetched` has been removed
+* The metric `solr.zk.child.fetches` is now `solr.zk.get_children.ops`
+
+Update your dashboards or other metrics consumers accordingly.
 
 === Lucene Codec Change
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -323,6 +323,10 @@ Users who consume Solr metrics via OTLP and rely on the 10.0 underscore-format n
 * The metric `solr_core_indexsearcher_open_warmup_time` has been removed as it duplicated `solr_core_indexsearcher_warmup_time`
 * The metric `solr.zk.cumulative.children_fetched` has been removed
 * The metric `solr.zk.child.fetches` is now `solr.zk.get_children.ops`
+* All CrossDC consumer metrics have been renamed: `crossdc.consumer.*` → `solr.crossdc.consumer.*`
+  (e.g., `crossdc.consumer.output.total` → `solr.crossdc.consumer.output.total`)
+* All CrossDC producer metrics have been renamed: `solr.core.crossdc.producer.*` → `solr.crossdc.producer.*`
+  (e.g., `solr.core.crossdc.producer.submitted` → `solr.crossdc.producer.submitted`)
 
 Update your dashboards or other metrics consumers accordingly.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18165

PR #4223 converted the majority of Solr metric instrument names from `underscore_delimited`
to `dot.separated` OTel standard naming. Several files were missed or only partially converted.
This PR completes that work.

### Files changed

**`AuditLoggerPlugin.java`** — all 7 metric names were still in old `solr_auditlogger_*` format;
converted to `solr.auditlogger.*`.

**`CaffeineCache.java`** — the default base metric name `"solr_caffeine_cache"` and the five
metric name suffixes (`_lookups`, `_ops`, `_size`, `_ram_used`, `_warmup_time`) were still using
underscores as namespace separators. Converted to `"solr.caffeine_cache"` base with
dot-prefixed suffixes (`.lookups`, `.ops`, `.size`, `.ram_used`, `.warmup_time`).

**`ZkContainer.java`** — all 7 metrics still in old `solr_zk_*` format; converted to `solr.zk.*`.

**`OtelMetrics.java` (cross-dc-manager)** — all 8 metric names were in old `crossdc_consumer_*`
format. The `NAME_PREFIX` constant is updated to `"crossdc.consumer."` and all suffix strings
are converted to dot-separated.

### Metric name mapping                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  | Old name | New name | Comments |                                                                                                                                                                                                                
  |---|---|---|
  | `solr_auditlogger_count` | `solr.auditlogger.count` | |                                                                                                                                                                                         
  | `solr_auditlogger_errors` | `solr.auditlogger.errors` | |
  | `solr_auditlogger_lost` | `solr.auditlogger.lost` | |                                                                                                                                                                                           
  | `solr_auditlogger_request_times` | `solr.auditlogger.request_times` | Leaf kept as compound word |
  | `solr_auditlogger_queue` | `solr.auditlogger.queue` | |                                                                                                                                                                                         
  | `solr_auditlogger_queued_time` | `solr.auditlogger.queued_time` | Leaf kept as compound word |                                                                                                                                                  
  | `solr_auditlogger_async_enabled` | `solr.auditlogger.async_enabled` | Leaf kept as compound word |                                                                                                                                              
  | `solr_caffeine_cache_lookups` | `solr.caffeine_cache.lookups` | `caffeine_cache` is the cache type name |                                                                                                                                       
  | `solr_caffeine_cache_ops` | `solr.caffeine_cache.ops` | |                                                                                                                                                                                       
  | `solr_caffeine_cache_size` | `solr.caffeine_cache.size` | |                                                                                                                                                                                     
  | `solr_caffeine_cache_ram_used` | `solr.caffeine_cache.ram_used` | Leaf kept as compound word |                                                                                                                                                  
  | `solr_caffeine_cache_warmup_time` | `solr.caffeine_cache.warmup_time` | Leaf kept as compound word |                                                                                                                                            
  | `solr_zk_ops` | `solr.zk.ops` | |                       
  | `solr_zk_read` | `solr.zk.read` | |                                                                                                                                                                 
  | `solr_zk_watches_fired` | `solr.zk.watches_fired` | Leaf kept as compound word |                                                                                                                                                                
  | `solr_zk_written` | `solr.zk.written` | |                                                                                                                                                        
  | `solr_zk_cumulative_multi_ops_total` | `solr.zk.cumulative.multi_ops.total` | Leaf kept as compound word; |                                                                                             
  | `solr_zk_child_fetches` | `solr.zk.child.fetches` | |                                                                                                                                                                                           
  | `solr_zk_cumulative_children_fetched` | `solr.zk.cumulative.children_fetched` | Leaf kept as compound word |                                                                                                                                    
  | `crossdc_consumer_input_msg_total` | `crossdc.consumer.input.msg.total` | Consider `_total`? |                                                                                                                      
  | `crossdc_consumer_input_req_total` | `crossdc.consumer.input.req.total` |  |                                                                                                                      
  | `crossdc_consumer_collapsed_total` | `crossdc.consumer.collapsed.total` |  |                                                                                                                      
  | `crossdc_consumer_output_total` | `crossdc.consumer.output.total` |  |                                                                                                                            
  | `crossdc_consumer_output_batch_size` | `crossdc.consumer.output.batch_size` | Leaf kept as compound word |                                                                                                                                      
  | `crossdc_consumer_output_backoff_time` | `crossdc.consumer.output.backoff_time` | Leaf kept as compound word |                                                                                                                                  
  | `crossdc_consumer_output_time` | `crossdc.consumer.output.time` | |                                                                                                                                                                             
  | `crossdc_consumer_output_first_attempt_time` | `crossdc.consumer.output.first_attempt_time` | Leaf kept as compound word |
  | `solr_zk_child_fetches` | `solr.zk.get_children.ops` | | 
  | `solr_zk_cumulative_children_fetched` |  | Discontinued | 

**Questions:**

* Do you agree with the name mappings above?
* The two existing `solr_zk_child_fetches` and `solr_zk_cumulative_children_fetched` both talk about the same thing, only cumulative is total? So a bit strange that they use `child_fetches` vs `children_fetched`. Should `solr.zk.child.fetches` instead be `solr.zk.child_fetches` to align with `solr_zk_cumulative_children_fetched`? Or should we do a breaking change here and align naming?
* The crossdc consumer metrics do not have a `solr.` prefix. The corresponsing producer metrics use `solr.core.crossdc.producer.XXX`. So ideally consumer would also use `solr.core.crossdc.consumer.XXX`. Or why the **core** part in there? Should we do a breaking change here, for one or for both?