### PR TITLE
SOLR-18192: Pin all GitHub Actions to full commit SHAs as per ASF policy (branch_9x)

### DIFF
--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -26,7 +26,7 @@ runs:
         java-package: jdk
 
     - name: Cache gradle-wrapper.jar
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: gradle/wrapper/gradle-wrapper.jar
         key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.jar.sha256') }}

--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - uses: ./.github/actions/prepare-for-build
 
@@ -29,7 +29,7 @@ jobs:
 
     - name: Archive logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: logs
         path: solr/packaging/build/test-output

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - uses: ./.github/actions/prepare-for-build
 

--- a/.github/workflows/gradle-extraction-check.yml
+++ b/.github/workflows/gradle-extraction-check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: ./.github/actions/prepare-for-build
 

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - uses: ./.github/actions/prepare-for-build
 

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - uses: ./.github/actions/prepare-for-build
 

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
This is for branch_9x

https://issues.apache.org/jira/browse/SOLR-18192
