### PR TITLE
Fix flaky BATS integration tests for extraction

### DIFF
--- a/solr/packaging/test/test_extraction.bats
+++ b/solr/packaging/test/test_extraction.bats
@@ -41,7 +41,13 @@ setup_file() {
   if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
     export TIKA_PORT=$((SOLR_PORT+5))
     docker run --rm -p ${TIKA_PORT}:9998 --name bats_tika -d apache/tika:3.2.3.0-full >/dev/null 2>&1 || true
-    echo "Tika Server started on port ${TIKA_PORT}" >&3
+    echo "Waiting for Tika Server to be ready on port ${TIKA_PORT}" >&3
+    if ! wait_for 120 3 curl -s -f "http://localhost:${TIKA_PORT}/tika" -o /dev/null; then
+      export DOCKER_UNAVAILABLE=1
+      echo "WARNING: Tika Server did not become ready in time; Tika-dependent tests will be bypassed." >&3
+    else
+      echo "Tika Server is ready on port ${TIKA_PORT}" >&3
+    fi
   else
     export DOCKER_UNAVAILABLE=1
     echo "WARNING: Docker not available (CLI missing or daemon not running); Tika-dependent tests will be bypassed." >&3

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -80,7 +80,7 @@ teardown() {
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
 
   run cat ${SOLR_LOGS_DIR}/solr-${SOLR_PORT}-console.log
-  refute_output --partial 'Exception'
+  refute_output --partial 'Exception in thread'
 }
 
 @test "deprecated system properties converted to modern properties" {


### PR DESCRIPTION
- test_extraction.bats: wait for Tika Docker container to be ready before tests run; apache/tika:3.2.3.0-full takes 30+ s to start inside the container and there was no readiness check. Falls back to DOCKER_UNAVAILABLE (skip) if Tika never becomes ready within 120 s.
- test_start_solr.bats: narrow SOLR-16976 assertion from 'Exception' to 'Exception in thread' so a benign ShutdownMonitor BindException (port-reuse race from prior test teardown) no longer causes a false failure.

See [test history in develocity](https://develocity.apache.org/scans/failures?failures.failureClassification=all_failures&failures.failureMessage=Execution%20failed%20for%20task%20%27:solr:packaging:integrationTests%27.%0A%3E%20Process%20%27command%20%27%2Fhome%2Fjenkins%2Fjenkins-agent%2Fworkspace%2FSolr%2F*%2Fsolr%2Fpackaging%2F.gradle%2Fnode%2Fnode_modules%2Fbats%2Fbin%2Fbats%27%27%20finished%20with%20non-zero%20exit%20value%201&search.startTimeMax=1776290399999&search.startTimeMin=1775599200000&search.timeZoneId=Europe%2FOslo)