### PR TITLE
SOLR-18203 Improve ChaosMonkeySafeLeaderWithPullReplicasTest frequent failures

### DIFF
--- a/changelog/unreleased/SOLR-18203-chaos-monkey-503-wait-for-leader.yml
+++ b/changelog/unreleased/SOLR-18203-chaos-monkey-503-wait-for-leader.yml
@@ -1,0 +1,11 @@
+title: >
+  CloudSolrClient now waits for cluster state refresh before retrying updates that fail with
+  503 (no leader). Previously all retries fired immediately, exhausting the retry budget before
+  leader election completed and causing spurious update failures during node restarts.
+type: fixed
+authors:
+  - name: Jan Høydahl
+    url: https://home.apache.org/phonebook.html?uid=janhoy
+links:
+  - name: SOLR-18203
+    url: https://issues.apache.org/jira/browse/SOLR-18203

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -1285,15 +1285,10 @@ public abstract class CloudSolrClient extends SolrClient {
             String name = ext.getName();
             ExpiringCachedDocCollection cacheEntry = collectionStateCache.peek(name);
             if (cacheEntry != null) {
-              if (wasCommError) {
-                cacheEntry.maybeStale = true;
-              } else {
-                boolean markedStale =
-                    cacheEntry.markMaybeStaleIfOutsideBackoff(retryExpiryTimeNano);
-                if (markedStale && cacheEntry.shouldRetry()) {
-                  triggerCollectionRefresh(name);
-                }
-              }
+              // For both comm errors and 503 (no leader), mark state as stale immediately.
+              // For 503 we bypass the backoff since we will wait for the refresh below
+              // before retrying, which naturally throttles the retry rate.
+              cacheEntry.maybeStale = true;
             } else {
               triggerCollectionRefresh(name);
             }
@@ -1313,6 +1308,16 @@ public abstract class CloudSolrClient extends SolrClient {
               MAX_STALE_RETRIES,
               wasCommError,
               errorCode);
+          // For 503 "no leader" errors (not plain comm errors where the node is fully dead),
+          // wait for the cluster state to refresh from ZooKeeper before retrying.
+          // Without this wait, all MAX_STALE_RETRIES retries fire within milliseconds of each
+          // other using the same stale routes, hitting the same dead leader repeatedly and
+          // exhausting all retries before leader election can complete.
+          if (!wasCommError && requestedCollections != null && !requestedCollections.isEmpty()) {
+            for (DocCollection ext : requestedCollections) {
+              waitForCollectionRefresh(ext.getName(), triggerCollectionRefresh(ext.getName()));
+            }
+          }
           return requestWithRetryOnStaleState(
               request,
               retryCount + 1,

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -1313,9 +1313,26 @@ public abstract class CloudSolrClient extends SolrClient {
           // Without this wait, all MAX_STALE_RETRIES retries fire within milliseconds of each
           // other using the same stale routes, hitting the same dead leader repeatedly and
           // exhausting all retries before leader election can complete.
+          // We use a bounded wait (10 s) so a stuck ZK / stalled election cannot block
+          // the caller thread indefinitely; on timeout we log and continue with the retry
+          // using whatever state is currently available.
           if (!wasCommError && requestedCollections != null && !requestedCollections.isEmpty()) {
             for (DocCollection ext : requestedCollections) {
-              waitForCollectionRefresh(ext.getName(), triggerCollectionRefresh(ext.getName()));
+              try {
+                triggerCollectionRefresh(ext.getName()).get(10, TimeUnit.SECONDS);
+              } catch (TimeoutException te) {
+                log.warn(
+                    "Timed out waiting for cluster state refresh for collection {} before retry; "
+                        + "proceeding with retry using current state",
+                    ext.getName());
+              } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+              } catch (ExecutionException ee) {
+                log.warn(
+                    "Error refreshing cluster state for collection {} before retry",
+                    ext.getName(),
+                    ee.getCause());
+              }
             }
           }
           return requestWithRetryOnStaleState(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18203

Below problem/fix description and the fix is done by Claude AI. I have limited insight into the actual chaos test and the CloudSolrClient's retry logic. Thus the problem description could be mistaken, and even if the fix seems to work, there could exist a more correct fix. Please give your 5 cents.

### Problem

`ChaosMonkeySafeLeaderWithPullReplicasTest` has been failing at 82–100% for months ([fucit report](http://fucit.org/solr-jenkins-reports/failure-report.html)).
<img width="1137" height="242" alt="Skjermbilde 2026-04-21 kl  15 00 00" src="https://github.com/user-attachments/assets/c1ba21d7-3543-4147-bed8-a04bf39ecc65" />

The test asserts zero update exceptions during chaos monkey (random node kills). The failure chain:

1. Chaos monkey kills the shard leader → node enters **graceful Jetty shutdown** (15s timeout, introduced in [SOLR-17744](https://issues.apache.org/jira/browse/SOLR-17744) April 2025), physically alive but logically dead
2. `CloudSolrClient` routes the next update to the cached (dead) leader → **503 SERVICE_UNAVAILABLE**
3. `requestWithRetryOnStaleState()` sees `RouteException(503)` and retries — but all **5 retries fire within milliseconds** of each other, using the same stale routes
4. A 3-second backoff suppresses the ZK state refresh, so every retry hits the same dead leader → all 503 → update fails → test assertion `assertEquals(0, getFailCount())` fails

Note that even if `SOLR_JETTY_GRACEFUL` is `false` by default in production, the Test runner always enables it. So this bug would only appear in tests.

### Fix

In the 503 retry path, **wait for a ZooKeeper cluster-state refresh** (blocking, ~100ms) before each retry attempt. This spreads retries over the leader election period so the next retry routes to the newly elected leader.

Also bypass the `markMaybeStaleIfOutsideBackoff` 3-second backoff for 503 errors, since the per-retry wait already throttles the rate naturally.

The `waitForCollectionRefresh` / `triggerCollectionRefresh` pattern is already used for `INVALID_STATE`/404 stale-state handling — this extends it to the 503 case.

### Testing

Ran `ChaosMonkeySafeLeaderWithPullReplicasTest` several times both on main and this feature branch. On main I got 8 failures out of 20 runs. On this pr branch I got 5 failures for 20 runs. Thus the fix is no 100% or there may be other code paths in play.