### PR TITLE
Add concurrency groups to all PR-triggered workflows (branch_9x)

### DIFF
--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -11,6 +11,10 @@ on:
       - 'solr/core/src/java/org/apache/solr/cli/**'
       - 'solr/prometheus-exporter/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Solr Script Tests

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -10,6 +10,10 @@ on:
       - 'solr/docker/**'
       - 'solr/packaging/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and test Docker image

--- a/.github/workflows/gradle-extraction-check.yml
+++ b/.github/workflows/gradle-extraction-check.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'solr/modules/extraction/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: extraction module tests with docker

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: gradle check

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/solrj-test.yml'
       - 'solr/solrj/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run SolrJ Tests

--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Solr Tests using Crave.io resources

--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -16,24 +16,30 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 40
 
+    env:
+      # Use a PR-scoped workspace path so that each new run for the same PR
+      # destroys any leftover resources from a previous run (including cancelled
+      # runs whose cleanup step may not have completed in time).
+      CRAVE_WORKSPACE: /crave-devspaces/pipeline/prs/${{ github.event.pull_request.number }}
+
     steps:
     - name: Destroy previous clone
-      run: crave clone destroy -y /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER} || echo "Clone did not exist"
+      run: crave clone destroy -y ${CRAVE_WORKSPACE} || echo "Clone did not exist"
       continue-on-error: true
     - name: Crave clone sources
-      run: crave clone create --projectID 39 /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
+      run: crave clone create --projectID 39 ${CRAVE_WORKSPACE}
     - name: Checkout the correct branch
       run: |
-        git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER} fetch origin ${GITHUB_REF}:${GITHUB_REF}
-        git -C /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER} checkout ${GITHUB_REF}
+        git -C ${CRAVE_WORKSPACE} fetch origin ${GITHUB_REF}:${GITHUB_REF}
+        git -C ${CRAVE_WORKSPACE} checkout ${GITHUB_REF}
     - name: Initialize, build, test
       run: |
-        cd /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
+        cd ${CRAVE_WORKSPACE}
         crave run --clean --message "PR: ${GITHUB_REF_NAME}" -- ./gradlew --console=plain test
     - name: Cleanup
       if: ${{ always() }}
       run: |
-        pushd /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
+        pushd ${CRAVE_WORKSPACE}
         crave stop --all
         popd
-        crave clone destroy -y /crave-devspaces/pipeline/runs/${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
+        crave clone destroy -y ${CRAVE_WORKSPACE}

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-changelog:
     name: Check changelog entry


### PR DESCRIPTION
This does the same for `branch_9x` that #4318 does for main.

## Changes

Add a `concurrency` block to all 7 GitHub Actions workflows that are triggered by `pull_request`:

- `bin-solr-test.yml`
- `docker-test.yml`
- `gradle-extraction-check.yml`
- `gradle-precommit.yml`
- `solrj-test.yml`
- `tests-via-crave.yml`
- `validate-changelog.yml`
