### PR TITLE
Fix flaky TestSchemaDesignerConfigSetHelper.testPersistSampleDocs (branch_9x)

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/designer/TestSchemaDesignerConfigSetHelper.java
+++ b/solr/core/src/test/org/apache/solr/handler/designer/TestSchemaDesignerConfigSetHelper.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.handler.designer;
 
-import static org.apache.solr.common.util.Utils.toJavabin;
 import static org.apache.solr.handler.admin.ConfigSetsHandler.DEFAULT_CONFIGSET_NAME;
 import static org.apache.solr.handler.designer.SchemaDesignerAPI.getMutableId;
 import static org.apache.solr.schema.IndexSchema.NEST_PATH_FIELD_NAME;
@@ -250,10 +249,7 @@ public class TestSchemaDesignerConfigSetHelper extends SolrCloudTestCase
     doc.setField("pages", 809);
     doc.setField("published_year", 1989);
 
-    helper.postDataToBlobStore(
-        cluster.getSolrClient(),
-        configSet + "_sample",
-        DefaultSampleDocumentsLoader.streamAsBytes(toJavabin(Collections.singletonList(doc))));
+    helper.storeSampleDocs(configSet, Collections.singletonList(doc));
 
     List<SolrInputDocument> docs = helper.getStoredSampleDocs(configSet);
     assertTrue(docs != null && docs.size() == 1);


### PR DESCRIPTION
The test was calling postDataToBlobStore(cluster.getSolrClient(), ...) which bypassed the cloudClient() method that ensures the .system blob store collection is created first. Using cluster.getSolrClient() also risks ZK cluster-state propagation lag. Replace with helper.storeSampleDocs() which correctly uses the internal cloudClient() path (createSystemColl + ZkController's own client).
