### PR TITLE
Fix for GPU accelerated vector indexing silently falling back to using CPU 

### DIFF
--- a/changelog/unreleased/SOLR-18210-fix-GPU-vector-indexing.yml
+++ b/changelog/unreleased/SOLR-18210-fix-GPU-vector-indexing.yml
@@ -1,0 +1,31 @@
+# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
+
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+
+# If the change is minor, don't bother adding a changelog entry.
+# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
+
+# title:
+#  * The audience is end-users and administrators, not committers.
+#  * Be short and focused on the user impact.  Multiple sentences is fine!
+#  * For technical/geeky details, prefer the commit message instead of changelog.
+#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
+
+# type:
+#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
+#  `changed` for improvements; not opt-in
+#  `fixed` for improvements that are deemed to have fixed buggy behavior
+#  `deprecated` for marking things deprecated
+#  `removed` for code removed
+#  `dependency_update` for updates to dependencies
+#  `other` for anything else, like large/significant refactorings, build changes,
+#    test infrastructure, or documentation.
+#    Most such changes are too small/minor to bother with a changelog entry.
+
+title: Fix GPU vector indexing
+type: fixed
+authors:
+  - name: Rahul Goswami
+links:
+  - name: SOLR-18210
+    url: https://issues.apache.org/jira/browse/SOLR-18210

--- a/changelog/unreleased/SOLR-18210-fix-GPU-vector-indexing.yml
+++ b/changelog/unreleased/SOLR-18210-fix-GPU-vector-indexing.yml
@@ -1,28 +1,4 @@
-# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
-
-# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-
-# If the change is minor, don't bother adding a changelog entry.
-# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
-
-# title:
-#  * The audience is end-users and administrators, not committers.
-#  * Be short and focused on the user impact.  Multiple sentences is fine!
-#  * For technical/geeky details, prefer the commit message instead of changelog.
-#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
-
-# type:
-#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
-#  `changed` for improvements; not opt-in
-#  `fixed` for improvements that are deemed to have fixed buggy behavior
-#  `deprecated` for marking things deprecated
-#  `removed` for code removed
-#  `dependency_update` for updates to dependencies
-#  `other` for anything else, like large/significant refactorings, build changes,
-#    test infrastructure, or documentation.
-#    Most such changes are too small/minor to bother with a changelog entry.
-
-title: Fix GPU vector indexing
+title: Fix for GPU vector indexing silently falling back to using CPU instead
 type: fixed
 authors:
   - name: Rahul Goswami

--- a/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
+++ b/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
@@ -81,9 +81,7 @@ public class GpuMetricsService implements GpuMetricsProvider {
       try {
         System.loadLibrary("cudart");
       } catch (UnsatisfiedLinkError e) {
-        if (log.isWarnEnabled()) {
-          log.warn("Could not load CUDA runtime library (libcudart not available) ", e);
-        }
+        log.warn("Could not load CUDA runtime library (libcudart not available) ", e);
       }
       this.metricManager = coreContainer.getMetricManager();
       startBackgroundService();

--- a/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
+++ b/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
@@ -77,6 +77,13 @@ public class GpuMetricsService implements GpuMetricsProvider {
 
   public void initialize(CoreContainer coreContainer) {
     if (initialized.compareAndSet(false, true)) {
+      // Ensure CUDA runtime is loaded before any cuVS provider access
+      try {
+        System.loadLibrary("cudart");
+      } catch (UnsatisfiedLinkError e) {
+        log.warn(
+            "Could not load CUDA runtime library (libcudart not available): {}", e.getMessage());
+      }
       this.metricManager = coreContainer.getMetricManager();
       startBackgroundService();
       log.info("GPU metrics service initialized");

--- a/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
+++ b/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
@@ -81,8 +81,9 @@ public class GpuMetricsService implements GpuMetricsProvider {
       try {
         System.loadLibrary("cudart");
       } catch (UnsatisfiedLinkError e) {
-        log.warn(
-            "Could not load CUDA runtime library (libcudart not available): {}", e.getMessage());
+        if (log.isWarnEnabled()) {
+          log.warn("Could not load CUDA runtime library (libcudart not available) ", e);
+        }
       }
       this.metricManager = coreContainer.getMetricManager();
       startBackgroundService();

--- a/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
+++ b/solr/modules/cuvs/src/java/org/apache/solr/cuvs/GpuMetricsService.java
@@ -81,7 +81,12 @@ public class GpuMetricsService implements GpuMetricsProvider {
       try {
         System.loadLibrary("cudart");
       } catch (UnsatisfiedLinkError e) {
-        log.warn("Could not load CUDA runtime library (libcudart not available) ", e);
+        String msg = e.getMessage();
+        if (msg != null && msg.contains("already loaded in another classloader")) {
+          // cudart is available, just loaded elsewhere - safe to continue
+        } else {
+          log.warn("Could not load CUDA runtime library (libcudart not available) ", e);
+        }
       }
       this.metricManager = coreContainer.getMetricManager();
       startBackgroundService();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18210

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA.
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

GPU accelerated vector indexing uses the Lucene99AcceleratedHNSWVectorsFormat coming from [cuvs-lucene](https://github.com/rapidsai/cuvs-lucene) library. It currently falls back to using Lucene99HnswVectorsWriter (which uses the CPU instead) due to a library loading issue.

Log lines observed:

2026-04-23 06:20:37.554 INFO  (qtp858232531-60-null-3) [ x:techproducts t:null-3] o.a.s.c.CuVSCodec Initializing Lucene99AcceleratedHNSWVectorsFormat with parameter values: cuvsWriterThreads 32, cuvsIntGraphDegree 128, cuvsGraphDegree 64, cuvsHnswLayers 1, cuvsHnswM 16, cuvsHnswEfConstruction 100
2026-04-23 06:20:37.556 WARN  (qtp858232531-60-null-3) [ x:techproducts t:null-3] c.n.c.l.Utils Exception occurred during creation of cuVS resources. java.lang.NoClassDefFoundError: Could not initialize class com.nvidia.cuvs.spi.CuVSServiceProvider$Holder
2026-04-23 06:20:37.556 INFO  (qtp858232531-60-null-3) [ x:techproducts t:null-3] o.a.s.c.CuVSCodec Initializing Lucene99AcceleratedHNSWVectorsFormat with parameter values: cuvsWriterThreads 32, cuvsIntGraphDegree 128, cuvsGraphDegree 64, cuvsHnswLayers 1, cuvsHnswM 16, cuvsHnswEfConstruction 100
2026-04-23 06:20:37.559 WARN  (qtp858232531-60-null-3) [ x:techproducts t:null-3] c.n.c.l.Lucene99AcceleratedHNSWVectorsFormat GPU based indexing not supported, falling back to using the Lucene99HnswVectorsWriter
2026-04-23 06:20:38.104 WARN  (qtp858232531-60-null-3) [ x:techproducts t:null-3] c.n.c.l.Utils Exception occurred during creation of cuVS resources. java.lang.NoClassDefFoundError: Could not initialize class com.nvidia.cuvs.spi.CuVSServiceProvider$Holder


# Solution

 Root Cause: Initialization Race Between Two Independent Code Paths
 
   There are two independent code paths that access com.nvidia.cuvs.spi.CuVSServiceProvider$Holder.INSTANCE, but only one of them loads the required libcudart.so native library first. The wrong one wins the race.

  <ins> Path A </ins> : GpuMetricsService (runs FIRST, does NOT load libcudart)

  org.apache.solr.cuvs.GpuMetricsService is started on a ScheduledExecutorService during CoreContainer initialization. Its updateGpuMetrics() method directly
  calls:

  GpuMetricsService.updateGpuMetrics()            // scheduled executor thread
    → CuVSProvider.provider()                      // cuvs-java: CuVSProvider.java:159
      → CuVSServiceProvider$Holder.INSTANCE        // triggers $Holder.<clinit>

  This triggers $Holder class init → loadProvider() → builtinProvider(), → eventually lands in "throws UnsatisfiedLinkError: unresolved symbol: cudaMemcpyAsync" , causing $Holder init to fail.

Once the class initializer fails, all future access throws NoClassDefFoundError.

<ins> Path B </ins> : Utils.cuVSResourcesOrNull() (runs SECOND, DOES load libcudart)

 During an indexing call, Lucene99AcceleratedHNSWVectorsFormat class init calls Utils.cuVSResourcesOrNull() (class com.nvidia.cuvs.lucene.Utils):

  ```java
  static CuVSResources cuVSResourcesOrNull() {
      try {
          System.loadLibrary("cudart");            // loads libcudart.so into this classloader
      } catch (UnsatisfiedLinkError e) {
          log.warning("Could not load CUDA runtime library: " + e.getMessage());
      }
      return CuVSResources.create();               // would trigger $Holder.<clinit> successfully
  }
```

  This method correctly calls System.loadLibrary("cudart") before touching $Holder. If it ran first, cudaMemcpyAsync would be resolvable and GPU init would succeed. But by the time this path runs, $Holder is already poisoned by Path A and an access attempt throws NoClassDefFoundError. 

This causes Lucene99AcceleratedHNSWVectorsFormat.supported() to return false, causing a silent fallback to Lucene99HnswVectorsWriter, whereby the indexing succeeds successfully with a log warning "GPU based indexing not supported, falling back to using the Lucene99HnswVectorsWriter"

<ins> Fix </ins>:  
Load the cuda runtime library when GpuMetricsService initializes 

# Tests

Built the solr-cuvs.jar locally and placed it in WEB-INF/lib of the solr web app. Then ran vector indexing on an L40S GPU machine with the configuration mentioned in the document https://solr.apache.org/guide/solr/latest/query-guide/dense-vector-search.html#gpu-acceleration.  
The log then prints "cuVS is supported so using the Lucene99AcceleratedHNSWVectorsWriter" coming from cuvs-lucene's Lucene99AcceleratedHNSWVectorsFormat


