### PR TITLE
SOLR-16458: Bugfix that we don't want to assume everything is a string.  

### DIFF
--- a/solr/api/src/java/org/apache/solr/client/api/model/NodeSystemResponse.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/NodeSystemResponse.java
@@ -48,7 +48,7 @@ public class NodeSystemResponse extends SolrJerseyResponse {
   @JsonProperty public JVM jvm;
   @JsonProperty public Security security;
   @JsonProperty public GPU gpu;
-  @JsonProperty public Map<String, String> system;
+  @JsonProperty public Map<String, Object> system;
 
   /** /node/system/security */
   public static class Security {

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoProvider.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoProvider.java
@@ -180,8 +180,8 @@ public class SystemInfoProvider {
   }
 
   /** Get system info */
-  public Map<String, String> getSystemInfo() {
-    Map<String, String> info = new HashMap<>();
+  public Map<String, Object> getSystemInfo() {
+    Map<String, Object> info = new HashMap<>();
 
     OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
     info.put(NAME, os.getName()); // add at least this one
@@ -193,7 +193,7 @@ public class SystemInfoProvider {
         MetricUtils.OS_MXBEAN_CLASSES,
         (name, value) -> {
           if (info.get(name) == null) {
-            info.put(name, String.valueOf(value));
+            info.put(name, value);
           }
         });
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/SystemInfoProviderUnitTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/SystemInfoProviderUnitTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.admin;
+
+import static org.apache.solr.SolrTestCaseJ4.assumeWorkingMockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.apache.solr.SolrTestCase;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.request.SolrQueryRequest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Pure unit tests for {@link SystemInfoProvider}. */
+public class SystemInfoProviderUnitTest extends SolrTestCase {
+
+  @BeforeClass
+  public static void ensureWorkingMockito() {
+    assumeWorkingMockito();
+  }
+
+  @Test
+  public void testNumericOsMetricsArePreservedAsNumbers() {
+    SolrQueryRequest req = mock(SolrQueryRequest.class);
+    when(req.getParams()).thenReturn(new ModifiableSolrParams());
+    when(req.getCoreContainer()).thenReturn(null);
+
+    Map<String, Object> info = new SystemInfoProvider(req).getSystemInfo();
+
+    // The Admin UI calls .toFixed(2) on systemLoadAverage — must be a Number, not a String.
+    Object loadAvg = info.get("systemLoadAverage");
+    if (loadAvg != null) {
+      assertTrue(
+          "systemLoadAverage must be a Number, got " + loadAvg.getClass(),
+          loadAvg instanceof Number);
+    }
+  }
+}


### PR DESCRIPTION
SystemLoadAverage is a number for example and was burping in the Solr Admin.

https://issues.apache.org/jira/browse/SOLR-16458


# Description
Burp in Admin UI:
<img width="920" height="101" alt="image" src="https://github.com/user-attachments/assets/f71a49da-3059-4c2c-8c95-8785be88697d" />

# Solution
Don't assume String!

# Tests

Added one for the specific case that was failing in the Solr Admin

