### PR TITLE
SOLR-18215 JWT auth module now defaults to blockUnknown=true

### DIFF
--- a/changelog/unreleased/SOLR-18215-jwt-auth-blockUnknown-default-true.yml
+++ b/changelog/unreleased/SOLR-18215-jwt-auth-blockUnknown-default-true.yml
@@ -1,0 +1,8 @@
+title: JWT Authentication `blockUnknown` now defaults to `true`, blocking unauthenticated requests by default. Previously the code defaulted to `false` despite the reference guide documenting `true`. Users relying on pass-through must explicitly set `blockUnknown` to `false` in their security.json.
+type: changed
+authors:
+  - name: Jan Høydahl
+    url: https://home.apache.org/phonebook.html?uid=janhoy
+links:
+  - name: SOLR-18215
+    url: https://issues.apache.org/jira/browse/SOLR-18215

--- a/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
+++ b/solr/modules/jwt-auth/src/java/org/apache/solr/security/jwt/JWTAuthPlugin.java
@@ -171,7 +171,7 @@ public class JWTAuthPlugin extends AuthenticationPlugin
     }
 
     blockUnknown =
-        Boolean.parseBoolean(String.valueOf(pluginConfig.getOrDefault(PARAM_BLOCK_UNKNOWN, false)));
+        Boolean.parseBoolean(String.valueOf(pluginConfig.getOrDefault(PARAM_BLOCK_UNKNOWN, true)));
     requireIssuer =
         Boolean.parseBoolean(
             String.valueOf(pluginConfig.getOrDefault(PARAM_REQUIRE_ISSUER, "true")));

--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginTest.java
@@ -510,6 +510,7 @@ public class JWTAuthPluginTest extends SolrTestCaseJ4 {
             .toString();
     testConfig.put("wellKnownUrl", wellKnownUrl);
     testConfig.remove("jwk");
+    testConfig.put("blockUnknown", false);
     plugin.init(testConfig);
     JWTAuthPlugin.JWTAuthenticationResponse resp = plugin.authenticate(null);
     assertEquals(PASS_THROUGH, resp.getAuthCode());

--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginTest.java
@@ -484,6 +484,15 @@ public class JWTAuthPluginTest extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void noHeaderDefaultBlocksUnknown() {
+    // blockUnknown defaults to true — omitting it must block requests without a JWT
+    testConfig.remove("blockUnknown");
+    plugin.init(testConfig);
+    JWTAuthPlugin.JWTAuthenticationResponse resp = plugin.authenticate(null);
+    assertEquals(NO_AUTZ_HEADER, resp.getAuthCode());
+  }
+
+  @Test
   public void noHeaderNotBlockUnknown() {
     testConfig.put("blockUnknown", false);
     plugin.init(testConfig);

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -47,7 +47,7 @@ Users who deploy a proxy in front of Solr should also review this setup to ensur
 
 The `blockUnknown` setting in the JWT Authentication plugin now defaults to `true`, meaning requests without a valid JWT token are blocked by default.
 In Solr 10.0, the code default was `false` (pass-through), which contradicted the reference guide documentation that described `true` as the default.
-Users upgrading from 10.0 who relied on the pass-through behavior must explicitly set `blockUnknown: false` in their `security.json`.
+Users upgrading from 10.0 who relied on the pass-through behavior must explicitly set `"blockUnknown": false` in their `security.json`.
 
 == Solr 10.0
 

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -43,6 +43,12 @@ Former users of `solr.api.v2.enabled` looking to upgrade to Solr 10.1 or newer s
 
 Users who deploy a proxy in front of Solr should also review this setup to ensure that it allows access to the v2 API root path, `/api`.
 
+=== JWT Authentication
+
+The `blockUnknown` setting in the JWT Authentication plugin now defaults to `true`, meaning requests without a valid JWT token are blocked by default.
+In Solr 10.0, the code default was `false` (pass-through), which contradicted the reference guide documentation that described `true` as the default.
+Users upgrading from 10.0 who relied on the pass-through behavior must explicitly set `blockUnknown: false` in their `security.json`.
+
 == Solr 10.0
 
 === Solr Jetty parameters

--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -242,7 +242,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
     $scope.hideAll();
 
     $scope.tls = false;
-    $scope.blockUnknown = "false"; // default setting
+    $scope.blockUnknown = "true"; // default setting
     $scope.realmName = "solr";
     $scope.forwardCredentials = "false";
     $scope.multiAuthWithBasic = false;
@@ -371,7 +371,7 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
 
           //console.log(">> authn: "+JSON.stringify(authn));
 
-          $scope.blockUnknown = authn["blockUnknown"] === true ? "true" : "false";
+          $scope.blockUnknown = authn["blockUnknown"] === false ? "false" : "true";
           $scope.forwardCredentials = authn["forwardCredentials"] === true ? "true" : "false";
 
           if ("realm" in authn) {

--- a/solr/webapp/web/js/angular/controllers/security.js
+++ b/solr/webapp/web/js/angular/controllers/security.js
@@ -371,7 +371,8 @@ solrAdminApp.controller('SecurityController', function ($scope, $timeout, $cooki
 
           //console.log(">> authn: "+JSON.stringify(authn));
 
-          $scope.blockUnknown = authn["blockUnknown"] === false ? "false" : "true";
+          var blockUnknown = authn["blockUnknown"];
+          $scope.blockUnknown = (blockUnknown === false || blockUnknown === "false") ? "false" : "true";
           $scope.forwardCredentials = authn["forwardCredentials"] === true ? "true" : "false";
 
           if ("realm" in authn) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18215

Changes the default value of the `blockUnknown` setting in the JWT Authentication plugin from `false` to `true`.

A documentation bug introduced in v9.0 caused the reference guide to state `true` as the default, while the code has always defaulted to `false` (pass-through). Rather than reverting the docs as first proposed in #4337, this PR modifies the default to `true` which we planned to do at some point anyway, as this is the more secure and least surprising default.

## Changes

- **`JWTAuthPlugin.java`** — default for `blockUnknown` changed from `false` to `true`
- **`security.js` (Admin UI)** — initial display state and the fallback when `blockUnknown` is absent from `security.json` both corrected to default to `true`, so the checkbox reflects the actual plugin behavior
- **`JWTAuthPluginTest.java`** — `wellKnownConfigNoHeaderPassThrough` test now sets `blockUnknown: false` explicitly (it was the only test relying on the implicit `false` default)
- **`major-changes-in-solr-10.adoc`** — added a note under the Solr 10.1 section documenting the behavior change and the documentation error in 10.0

## Upgrade impact

Users who configured JWT auth in Solr 10.0 **without** explicitly setting `blockUnknown` and relied on unauthenticated requests passing through must add `"blockUnknown": false` to their `security.json` after upgrading.

Note: `solr auth enable` does not yet support JWT, so there is no CLI impact.