### PR TITLE
fix ci flakiness leaderelection test

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
@@ -61,7 +61,7 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
     String collection = "collection1";
     createCollection(collection);
 
-    cluster.waitForActiveCollection(collection, 10, TimeUnit.SECONDS, 2, 6);
+    cluster.waitForActiveCollection(collection, 60, TimeUnit.SECONDS, 2, 6);
     List<JettySolrRunner> stoppedRunners = new ArrayList<>();
     for (int i = 0; i < 4; i++) {
       // who is the leader?
@@ -107,15 +107,20 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
     assertNotNull(jetty);
     cluster.expireZkSession(jetty);
 
-    for (int i = 0; i < 60; i++) { // wait till leader is changed
-      if (jetty != getRunner(getLeader(collection))) {
-        break;
-      }
-      Thread.sleep(100);
-    }
+    // Wait until leadership has moved away from the expired-session node
+    waitForState(
+        "Expected leader to move away after expiring zk session",
+        collection,
+        c -> {
+          var l = c.getLeader("shard1");
+          return l != null && !jetty.getNodeName().equals(l.getNodeName());
+        });
 
-    // make sure we have waited long enough for the first leader to have come back
-    Thread.sleep(ZkTestServer.TICK_TIME * 2 + 100);
+    // Wait until the expired-session node is live again before stopping others
+    waitForState(
+        "Expected expired-session node to rejoin live nodes",
+        collection,
+        (liveNodes, c) -> liveNodes.contains(jetty.getNodeName()));
 
     // kill everyone but the first leader that should have reconnected by now
     for (JettySolrRunner jetty2 : cluster.getJettySolrRunners()) {
@@ -124,18 +129,13 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
       }
     }
 
-    for (int i = 0; i < 320; i++) { // wait till leader is changed
-      try {
-        if (jetty == getRunner(getLeader(collection))) {
-          break;
-        }
-        Thread.sleep(100);
-      } catch (Exception e) {
-        continue;
-      }
-    }
-
-    assertEquals(jetty, getRunner(getLeader(collection)));
+    waitForState(
+        "Expected original node to become leader after others stopped",
+        collection,
+        c -> {
+          var l = c.getLeader("shard1");
+          return l != null && jetty.getNodeName().equals(l.getNodeName());
+        });
   }
 
   private JettySolrRunner getRunner(String nodeName) {

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionIntegrationTest.java
@@ -19,7 +19,6 @@ package org.apache.solr.cloud;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.cloud.ZkNodeProps;
@@ -61,7 +60,10 @@ public class LeaderElectionIntegrationTest extends SolrCloudTestCase {
     String collection = "collection1";
     createCollection(collection);
 
-    cluster.waitForActiveCollection(collection, 60, TimeUnit.SECONDS, 2, 6);
+    waitForState(
+        "Timeout waiting for collection to become active",
+        collection,
+        clusterShape(2, NUM_REPLICAS_OF_SHARD1 + 1));
     List<JettySolrRunner> stoppedRunners = new ArrayList<>();
     for (int i = 0; i < 4; i++) {
       // who is the leader?

--- a/solr/core/src/test/org/apache/solr/cloud/ZkFailoverTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkFailoverTest.java
@@ -23,9 +23,7 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.embedded.JettySolrRunner;
-import org.apache.zookeeper.KeeperException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -60,12 +58,16 @@ public class ZkFailoverTest extends SolrCloudTestCase {
     // This attempt will fail since it will time out after 1 second
     System.setProperty("solr.cloud.wait.for.zk.seconds", "1");
     restartSolrAndZk();
-    waitForLiveNodes(0);
+    waitForState(
+        "Timeout waiting for 0 live nodes", coll, (liveNodes, c) -> liveNodes.isEmpty());
 
     // This attempt will succeed since there will be enough time to connect
     System.setProperty("solr.cloud.wait.for.zk.seconds", "20");
     restartSolrAndZk();
-    waitForLiveNodes(cluster.getJettySolrRunners().size());
+    waitForState(
+        "Timeout waiting for all nodes to come up",
+        coll,
+        (liveNodes, c) -> liveNodes.size() == cluster.getJettySolrRunners().size());
     waitForState("Timeout waiting for " + coll, coll, clusterShape(2, 2));
     QueryResponse rsp =
         new QueryRequest(new SolrQuery("*:*")).process(cluster.getSolrClient(), coll);
@@ -100,13 +102,4 @@ public class ZkFailoverTest extends SolrCloudTestCase {
     }
   }
 
-  private void waitForLiveNodes(int numNodes) throws InterruptedException, KeeperException {
-    ZkStateReader zkStateReader = cluster.getZkStateReader();
-    for (int i = 0; i < 100; i++) {
-      zkStateReader.updateLiveNodes();
-      if (zkStateReader.getClusterState().getLiveNodes().size() == numNodes) return;
-      Thread.sleep(200);
-    }
-    fail("Timeout waiting for number of live nodes = " + numNodes);
-  }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/ZkFailoverTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkFailoverTest.java
@@ -58,8 +58,7 @@ public class ZkFailoverTest extends SolrCloudTestCase {
     // This attempt will fail since it will time out after 1 second
     System.setProperty("solr.cloud.wait.for.zk.seconds", "1");
     restartSolrAndZk();
-    waitForState(
-        "Timeout waiting for 0 live nodes", coll, (liveNodes, c) -> liveNodes.isEmpty());
+    waitForState("Timeout waiting for 0 live nodes", coll, (liveNodes, c) -> liveNodes.isEmpty());
 
     // This attempt will succeed since there will be enough time to connect
     System.setProperty("solr.cloud.wait.for.zk.seconds", "20");
@@ -101,5 +100,4 @@ public class ZkFailoverTest extends SolrCloudTestCase {
       thread.join();
     }
   }
-
 }

--- a/solr/core/src/test/org/apache/solr/cloud/ZkShardTermsRecoveryTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkShardTermsRecoveryTest.java
@@ -52,14 +52,20 @@ public class ZkShardTermsRecoveryTest extends SolrCloudTestCase {
         CollectionAdminRequest.createCollection(COLLECTION, "conf", NUM_SHARDS, NUM_REPLICAS)
             .process(cluster.getSolrClient())
             .getStatus());
-    cluster.waitForActiveCollection(COLLECTION, 10, TimeUnit.SECONDS, 2, NUM_SHARDS * NUM_REPLICAS);
+    waitForState(
+        "Timeout waiting for collection to be active after creation",
+        COLLECTION,
+        clusterShape(NUM_SHARDS, NUM_SHARDS * NUM_REPLICAS));
   }
 
   @Before
   public void waitForActiveState() throws Exception {
     CollectionAdminRequest.modifyCollection(COLLECTION, Map.of("readOnly", false))
         .process(cluster.getSolrClient());
-    cluster.waitForActiveCollection(COLLECTION, 10, TimeUnit.SECONDS, 2, NUM_SHARDS * NUM_REPLICAS);
+    waitForState(
+        "Timeout waiting for active collection",
+        COLLECTION,
+        clusterShape(NUM_SHARDS, NUM_SHARDS * NUM_REPLICAS));
   }
 
   @Test


### PR DESCRIPTION
I found this while running some tests on Crave:

```
./gradlew :solr:core:test --tests "org.apache.solr.cloud.LeaderElectionIntegrationTest.testSimpleSliceLeaderElection" "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 -XX:ReservedCodeCacheSize=120m" -Ptests.seed=F08428E6CA23E0C6 -Ptests.timeoutSuite=600000! -Ptests.useSecurityManager=true -Ptests.file.encoding=UTF-8

```

I asked for a tip from copilot on what was failing, and this is what it gave me.  I *believe* that I've basically seen this same timing fix proposed on other flaky tests..
