### PR TITLE
Remove 4 unused fields from CachingDirectoryFactory

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/CachingDirectoryFactory.java
@@ -95,14 +95,6 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
 
   protected Set<CacheValue> removeEntries = new HashSet<>();
 
-  private Double maxWriteMBPerSecFlush;
-
-  private Double maxWriteMBPerSecMerge;
-
-  private Double maxWriteMBPerSecRead;
-
-  private Double maxWriteMBPerSecDefault;
-
   private boolean closed;
 
   public interface CloseListener {
@@ -471,11 +463,6 @@ public abstract class CachingDirectoryFactory extends DirectoryFactory {
 
   @Override
   public void init(NamedList<?> args) {
-    maxWriteMBPerSecFlush = (Double) args.get("maxWriteMBPerSecFlush");
-    maxWriteMBPerSecMerge = (Double) args.get("maxWriteMBPerSecMerge");
-    maxWriteMBPerSecRead = (Double) args.get("maxWriteMBPerSecRead");
-    maxWriteMBPerSecDefault = (Double) args.get("maxWriteMBPerSecDefault");
-
     // override global config
     if (args.get(SolrXmlConfig.SOLR_DATA_HOME) != null) {
       dataHomePath =

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-analytics-query.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-analytics-query.xml
@@ -39,10 +39,6 @@
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based and not persistent. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}">
-    <double name="maxWriteMBPerSecDefault">1000000</double>
-    <double name="maxWriteMBPerSecFlush">2000000</double>
-    <double name="maxWriteMBPerSecMerge">3000000</double>
-    <double name="maxWriteMBPerSecRead">4000000</double>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-collapseqparser.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-collapseqparser.xml
@@ -39,10 +39,6 @@
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based and not persistent. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}">
-    <double name="maxWriteMBPerSecDefault">1000000</double>
-    <double name="maxWriteMBPerSecFlush">2000000</double>
-    <double name="maxWriteMBPerSecMerge">3000000</double>
-    <double name="maxWriteMBPerSecRead">4000000</double>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
@@ -39,10 +39,6 @@
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based and not persistent. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}">
-    <double name="maxWriteMBPerSecDefault">1000000</double>
-    <double name="maxWriteMBPerSecFlush">2000000</double>
-    <double name="maxWriteMBPerSecMerge">3000000</double>
-    <double name="maxWriteMBPerSecRead">4000000</double>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
@@ -39,10 +39,6 @@
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based and not persistent. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}">
-    <double name="maxWriteMBPerSecDefault">1000000</double>
-    <double name="maxWriteMBPerSecFlush">2000000</double>
-    <double name="maxWriteMBPerSecMerge">3000000</double>
-    <double name="maxWriteMBPerSecRead">4000000</double>
   </directoryFactory>
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -39,10 +39,6 @@
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based and not persistent. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}">
-    <double name="maxWriteMBPerSecDefault">1000000</double>
-    <double name="maxWriteMBPerSecFlush">2000000</double>
-    <double name="maxWriteMBPerSecMerge">3000000</double>
-    <double name="maxWriteMBPerSecRead">4000000</double>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/test-framework/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/test-framework/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -39,10 +39,6 @@
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based and not persistent. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.MockDirectoryFactory}">
-    <double name="maxWriteMBPerSecDefault">1000000</double>
-    <double name="maxWriteMBPerSecFlush">2000000</double>
-    <double name="maxWriteMBPerSecMerge">3000000</double>
-    <double name="maxWriteMBPerSecRead">4000000</double>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>


### PR DESCRIPTION
I was reading index writer code and noticed these interesting attributes, but then found that they are completely unused. Since they are private fields there shouldn't be any API impact, so I see no reason not to clean them up. 