### PR TITLE
Run checkWorkingCopyClean as a Test-task finalizer on CI

### DIFF
--- a/gradle/validation/git-status.gradle
+++ b/gradle/validation/git-status.gradle
@@ -49,11 +49,9 @@ configure(rootProject) {
         def ref = repository.findRef("HEAD").getObjectId()
         project.ext.gitRev = ref.name()
         project.ext.gitRevShort = ref.abbreviate(8).name()
-        project.ext.gitStatus = new Git(repository).status().call()
       } catch (RepositoryNotFoundException | NoWorkTreeException e) {
         project.ext.gitRev = "(not a git checkout)"
         project.ext.gitRevShort = "(not a git checkout)"
-        project.ext.gitStatus = null
       } catch (NotSupportedException e) {
         throw new GradleException("jgit does not support git repository version at this location: ${dir}",
             e)
@@ -62,10 +60,19 @@ configure(rootProject) {
   }
 
   // Verify git working copy does not have any unstaged modified files.
+  // Status is captured here (not in gitStatus) so it reflects changes from tests that finalize with this task.
   task checkWorkingCopyClean() {
-    dependsOn gitStatus
     doFirst {
-      def status = rootProject.ext.gitStatus
+      def status
+      try {
+        def repository = new FileRepositoryBuilder()
+            .setWorkTree(rootProject.projectDir)
+            .setMustExist(true)
+            .build()
+        status = new Git(repository).status().call()
+      } catch (RepositoryNotFoundException | NoWorkTreeException e) {
+        status = null
+      }
       if (status == null) {
         if (file("${rootProject.projectDir}/.git").exists()) {
           // Ignore git worktree branches until jgit supports them.
@@ -118,6 +125,18 @@ configure(rootProject) {
             logger.warn("NOTE: ${msg}")
           }
         }
+      }
+    }
+  }
+
+  // Catch tests that write into the working tree.
+  // On CI: finalize every Test task with the clean check (runs even on test failure).
+  // Locally: only enforce ordering when both are already scheduled (e.g. via `check`).
+  allprojects {
+    tasks.withType(Test).configureEach { testTask ->
+      rootProject.checkWorkingCopyClean.mustRunAfter(testTask)
+      if (isCIBuild) {
+        testTask.finalizedBy(rootProject.checkWorkingCopyClean)
       }
     }
   }


### PR DESCRIPTION
Previously the working-tree cleanliness check
(gradle/validation/git-status.gradle's checkWorkingCopyClean) only ran as part of `precommit`. CI jobs that invoke just `test` therefore never noticed when a test wrote files into the working tree.

Wire every Test task across all projects so that:

  - On CI (isCIBuild), each Test task is `finalizedBy :checkWorkingCopyClean`. The finalizer runs after every test task -- de-duped when multiple test tasks are scheduled, and still fires when the test itself fails -- but does not pull tests in when `checkWorkingCopyClean` is invoked standalone.
  - Locally, only a `mustRunAfter` is wired. Running `gradlew test` locally is not surprised by an auto-running clean check; but when both tasks are scheduled together (e.g. via `check`, which depends on both `precommit` and `test`), the clean check is guaranteed to run after the tests.

Also move the `Git#status()` call out of the `gitStatus` task and into `checkWorkingCopyClean` itself. Previously the working-tree snapshot was captured in `gitStatus.doFirst` and merely consulted later by `checkWorkingCopyClean`. Because `gitStatus` is a dependency of Jar tasks (via jar-manifest.gradle, which needs the git revision for the manifest), it always ran early in the task graph -- so the snapshot was taken before any Test task could pollute the tree. Now the status is captured at the check's own execution time, which (thanks to the finalizer/ordering) is after all Test tasks have completed. `gitStatus` still captures `gitRev`/`gitRevShort` for the jar manifest consumer.

Verified by adding a temporary test that writes a file into the project root, then running with `-Pvalidation.git.failOnModified=true`: the finalizer fires after the test and the build fails with the polluted file listed under "(untracked)". Also confirmed the finalizer runs when the test itself fails, and that the local mustRunAfter-only path correctly avoids triggering the check from a bare `gradlew test`.

----

_(I reviewed the LLM generated output completely)_

This is motivated by the Java SecurityManager going away which was helping us tame our tests from bad behavior.  This solution seems very pragmatic and leverages something we already have.  It's not as comprehensive as the JSM but I think it's adequate.