### PR TITLE
New SolrJ CollectionScopedSolrClient

### DIFF
--- a/changelog/unreleased/CollectionScopedSolrClient.yml
+++ b/changelog/unreleased/CollectionScopedSolrClient.yml
@@ -1,0 +1,7 @@
+title: New SolrJ CollectionScopedSolrClient
+type: added
+authors:
+  - name: David Smiley
+links:
+  - name: PR#4418
+    url: https://github.com/apache/solr/pull/4418

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CollectionScopedSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CollectionScopedSolrClient.java
@@ -18,22 +18,23 @@
 package org.apache.solr.client.solrj.impl;
 
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.util.NamedList;
 
 /**
- * This SolrClient delegates to a backing client with a specified collection.  Simple attempts to
- * refer to another collection will fail.  DISCLAIMER: this isn't a security mechanism.
+ * This SolrClient delegates to a backing client with a specified collection. Simple attempts to
+ * refer to another collection will fail. DISCLAIMER: this isn't a security mechanism.
  */
 public class CollectionScopedSolrClient extends SolrClient {
 
   private final SolrClient delegate;
 
   public CollectionScopedSolrClient(SolrClient delegate, String defaultCollection) {
-    this.delegate = delegate;
-    this.defaultCollection = defaultCollection;
+    this.delegate = Objects.requireNonNull(delegate);
+    this.defaultCollection = Objects.requireNonNull(defaultCollection);
   }
 
   @Override
@@ -46,6 +47,11 @@ public class CollectionScopedSolrClient extends SolrClient {
           "Restricted to default collection " + defaultCollection + " but was given " + collection);
     }
     return delegate.request(request, collection);
+  }
+
+  @Override
+  public String toString() {
+    return delegate + "/" + defaultCollection;
   }
 
   @Override

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CollectionScopedSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CollectionScopedSolrClient.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.client.solrj.impl;
+
+import java.io.IOException;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.util.NamedList;
+
+/**
+ * This SolrClient delegates to a backing client with a specified collection.  Simple attempts to
+ * refer to another collection will fail.  DISCLAIMER: this isn't a security mechanism.
+ */
+public class CollectionScopedSolrClient extends SolrClient {
+
+  private final SolrClient delegate;
+
+  public CollectionScopedSolrClient(SolrClient delegate, String defaultCollection) {
+    this.delegate = delegate;
+    this.defaultCollection = defaultCollection;
+  }
+
+  @Override
+  public NamedList<Object> request(SolrRequest<?> request, String collection)
+      throws SolrServerException, IOException {
+    if (collection == null) {
+      collection = defaultCollection;
+    } else if (!collection.equals(defaultCollection)) {
+      throw new IllegalArgumentException(
+          "Restricted to default collection " + defaultCollection + " but was given " + collection);
+    }
+    return delegate.request(request, collection);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}


### PR DESCRIPTION
This SolrClient delegates to a backing client with a specified collection.  Simple attempts to refer to another collection will fail.  DISCLAIMER: this isn't a security mechanism.

There are tests and places in client code I've seen that would benefit from this.  For one thing, it enables taking an existing SolrClient that doesn't have a defaultCollection (e.g. JettySolrRunner.getSolrClient()) and simply wrap it.  Voila.  I'm working on Jetty -> Apache transition and in the process I'm moving needless client creations to use existing clients, and I want to use this.  I don't want this to "sneak in" within a test-focused PR.

I'll probably add a changelog but wasn't going to add a JIRA.