### PR TITLE
SOLR-17959: Remove issues key from changelog YAML

### DIFF
--- a/changelog/unreleased/SOLR-17959-alwaysStopwords.yml
+++ b/changelog/unreleased/SOLR-17959-alwaysStopwords.yml
@@ -5,5 +5,3 @@ authors:
 links:
   - name: SOLR-17959
     url: https://issues.apache.org/jira/browse/SOLR-17959
-issues:
-  - 17959


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17959

# Description

This removes the `issues` key from the changelog YAML, ref Jan's comment in [SOLR-17959](https://issues.apache.org/jira/browse/SOLR-17959)

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change
