### PR TITLE
Force renovatebot to run with java 21

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "includePaths": ["gradle/libs.versions.toml", "versions.*", "build.gradle", ".github/workflows/*"],
   "postUpgradeTasks": {
     "commands": [
+      "java -version 2>&1 | grep -q '21\\.' || install-tool java 21.0.11+10.0.LTS",
       "./gradlew resolveAndLockAll --write-locks",
       "./gradlew kotlinUpgradeYarnLock",
       "./gradlew updateLicenses"


### PR DESCRIPTION
The latest version of renovatebot docker image embeds JDK25 instead of JDK21. Our build (gradle 8.10) cannot use JDK>=23, so this now crashes. Soution, until we upgrade gradle, is to install jdk21 in the renovate run. This must be done in renovate.json in the repo.

The command below is NOP if jdk21 is already installed, else it triggers install, that takes some 20 seconds. 