### PR TITLE
NO-JIRA: Flaky test fix testDistributedQueryDoesNotReadFromZk 

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
@@ -724,7 +724,12 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
     CollectionAdminRequest.createCollection(secondColl, "conf", 1, 1)
         .setCreateNodeSet(jettys.get(0).getNodeName())
         .processAndWait(cluster.getSolrClient(), DEFAULT_TIMEOUT);
-    cluster
+
+    // Wait on node 1's ZkStateReader (not the cluster client's) to check for ready state
+    JettySolrRunner nodeWithoutSecondColl = jettys.get(1);
+    nodeWithoutSecondColl
+        .getCoreContainer()
+        .getZkController()
         .getZkStateReader()
         .waitForState(
             secondColl,
@@ -735,7 +740,6 @@ public class DistributedQueryComponentOptimizationTest extends SolrCloudTestCase
     try {
       // Node 1 hosts COLLECTION but not secondColl.
       // Send a multi-collection query to trigger LazyCollectionRef get call
-      JettySolrRunner nodeWithoutSecondColl = jettys.get(1);
       try (SolrClient client =
           new HttpJettySolrClient.Builder(nodeWithoutSecondColl.getBaseUrl().toString()).build()) {
 


### PR DESCRIPTION
`testDistributedQueryDoesNotReadFromZk` is a flaky test on Crave and Jenkins. I am not able to reproduce this locally but the error is:
```
2> 38735 INFO  (TEST-DistributedQueryComponentOptimizationTest.testDistributedQueryDoesNotReadFromZk-seed#[2DA40BF573442949]) [] o.a.s.SolrTestCaseJ4 ###Ending testDistributedQueryDoesNotReadFromZk
   >     org.apache.solr.client.solrj.RemoteSolrException: Error from server at http://127.0.0.1:46591/solr/optimize/select?q=*%3A*&collection=optimize%2CsecondColl&wt=javabin: org.apache.solr.common.SolrException: no active servers hosting shard: secondColl_shard1
```

My suspicion is that there is a race condition making it flaky where the jetty node has not yet seen the updated state of the collection that it is ready but the client has because we were waiting on separate `zkStateReader` which is separate from the cached state from the actually jetty node and collection. So instead, we wait on that jetty nodes ready state using it's zkStateReader and not clients.