### PR TITLE
Remove "crawling a web site" from test_post.bats

### DIFF
--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -138,17 +138,8 @@ teardown() {
   assert_output --partial '"numFound":45'
 }
 
-# this test doesn't complete due to issues in posting to the /extract handler
 @test "crawling a web site" {
   solr create -c webcrawl -d _default
-
-  curl -X POST -H 'Content-type:application/json' -d '{
-    "add-requesthandler": {
-      "name": "/update/extract",
-      "class": "solr.extraction.ExtractingRequestHandler",
-      "defaults":{ "lowernames": "true", "captureAttr":"true"}
-    }
-  }' "http://localhost:${SOLR_PORT}/solr/webcrawl/config"
 
   run solr post --mode web -c webcrawl --recursive 1 --delay 1 https://solr.apache.org
   assert_output --partial 'Entering crawl at level 0'

--- a/solr/packaging/test/test_post.bats
+++ b/solr/packaging/test/test_post.bats
@@ -138,13 +138,6 @@ teardown() {
   assert_output --partial '"numFound":45'
 }
 
-@test "crawling a web site" {
-  solr create -c webcrawl -d _default
-
-  run solr post --mode web -c webcrawl --recursive 1 --delay 1 https://solr.apache.org
-  assert_output --partial 'Entering crawl at level 0'
-}
-
 @test "skipcommit and optimize and delete" {
 
   run solr create -c monitors2 -d _default


### PR DESCRIPTION
Remove test "crawling a web site" for post tool. It was causing failures and not really that useful either now that we don't have embedded tika.