### PR TITLE
Migrate to proper circuit breakers.

### DIFF
--- a/changelog/unreleased/qos-filter-circuit-breaker-migration.yml
+++ b/changelog/unreleased/qos-filter-circuit-breaker-migration.yml
@@ -1,0 +1,14 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: |
+  Move circuit breaker enforcement from request handlers into a new SolrQoSFilter that
+  asynchronously suspends requests by priority lane (admin/probe > query > update) instead of
+  failing fast. Async queueing is enabled by default; per-priority admission caps prevent a
+  flood of low-priority traffic from rejecting high-priority probes; clients can opt into a
+  specific lane with the Solr-Request-Priority header. The drain budget auto-scales with
+  maxSuspendedRequests so saturated queues drain before the suspension timeout. Add
+  GcOverheadCircuitBreaker and TTL-cache CPU/load-average samples. Rewrite MemoryCircuitBreaker
+  to read post-GC live bytes from the old/tenured pool instead of the raw heap usage moving
+  average.
+type: changed
+authors:
+  - name: Mark Robert Miller

--- a/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
@@ -16,9 +16,6 @@
  */
 package org.apache.solr.handler;
 
-import java.lang.invoke.MethodHandles;
-import java.util.List;
-import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
@@ -29,19 +26,12 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.update.SolrCoreState;
 import org.apache.solr.update.processor.UpdateRequestProcessor;
 import org.apache.solr.update.processor.UpdateRequestProcessorChain;
-import org.apache.solr.util.circuitbreaker.CircuitBreaker;
-import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
-import org.apache.solr.util.circuitbreaker.CircuitBreakerUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Shares common code between various handlers that manipulate {@link
  * org.apache.solr.common.util.ContentStream} objects.
  */
 public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
   public void init(NamedList<?> args) {
@@ -59,10 +49,6 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
 
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    if (checkCircuitBreakers(req, rsp)) {
-      return; // Circuit breaker tripped, return immediately
-    }
-
     /*
        We track update requests so that we can preserve consistency by waiting for them to complete
        on a node shutdown and then immediately trigger a leader election without waiting for the core to close.
@@ -114,28 +100,6 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
     } finally {
       solrCoreState.deregisterInFlightUpdate();
     }
-  }
-
-  /**
-   * Check if {@link SolrRequestType#UPDATE} circuit breakers are tripped. Override this method in
-   * sub classes that do not want to check circuit breakers.
-   *
-   * @return true if circuit breakers are tripped, false otherwise.
-   */
-  protected boolean checkCircuitBreakers(SolrQueryRequest req, SolrQueryResponse rsp) {
-    if (isInternalShardRequest(req)) {
-      if (log.isTraceEnabled()) {
-        log.trace("Internal request, skipping circuit breaker check");
-      }
-      return false;
-    }
-    CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
-      List<CircuitBreaker> trippedCircuitBreakers =
-          circuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE);
-      return CircuitBreakerUtils.reportErrorIfBreakersTripped(rsp, trippedCircuitBreakers);
-    }
-    return false;
   }
 
   protected abstract ContentStreamLoader newLoader(

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -44,7 +44,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.search.TotalHits;
-import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrDocumentList;
@@ -75,9 +74,6 @@ import org.apache.solr.security.PermissionNameProvider;
 import org.apache.solr.util.RTimerTree;
 import org.apache.solr.util.SolrPluginUtils;
 import org.apache.solr.util.ThreadCpuTimer;
-import org.apache.solr.util.circuitbreaker.CircuitBreaker;
-import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
-import org.apache.solr.util.circuitbreaker.CircuitBreakerUtils;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
 import org.slf4j.Logger;
@@ -231,10 +227,6 @@ public class SearchHandler extends RequestHandlerBase
       SolrPluginUtils.getDebugInterests(req.getParams().getParams(CommonParams.DEBUG), rb);
     }
 
-    if (checkCircuitBreakers(req, rsp, rb)) {
-      return; // Circuit breaker tripped, return immediately
-    }
-
     processComponents(req, rsp, rb, components);
   }
 
@@ -358,42 +350,6 @@ public class SearchHandler extends RequestHandlerBase
   protected ResponseBuilder newResponseBuilder(
       SolrQueryRequest req, SolrQueryResponse rsp, List<SearchComponent> components) {
     return new ResponseBuilder(req, rsp, components);
-  }
-
-  /**
-   * Check if {@link SolrRequestType#QUERY} circuit breakers are tripped. Override this method in
-   * sub classes that do not want to check circuit breakers.
-   *
-   * @return true if circuit breakers are tripped, false otherwise.
-   */
-  protected boolean checkCircuitBreakers(
-      SolrQueryRequest req, SolrQueryResponse rsp, ResponseBuilder rb) {
-    if (isInternalShardRequest(req)) {
-      if (log.isTraceEnabled()) {
-        log.trace("Internal request, skipping circuit breaker check");
-      }
-      return false;
-    }
-    final RTimerTree timer = rb.isDebug() ? req.getRequestTimer() : null;
-
-    final CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
-      List<CircuitBreaker> trippedCircuitBreakers;
-
-      if (timer != null) {
-        RTimerTree subt = timer.sub("circuitbreaker");
-        rb.setTimer(subt);
-
-        trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
-
-        rb.getTimer().stop();
-      } else {
-        trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
-      }
-
-      return CircuitBreakerUtils.reportErrorIfBreakersTripped(rsp, trippedCircuitBreakers);
-    }
-    return false;
   }
 
   protected void processComponents(

--- a/solr/core/src/java/org/apache/solr/servlet/InternalRequestUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/InternalRequestUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.servlet;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.common.params.CommonParams;
+
+/**
+ * Shared detection for internal intra-cluster server-to-server requests. Filter-tier admission
+ * control (e.g. {@link SolrQoSFilter}, {@link RateLimitManager}) consults this so sub-shard
+ * requests are unconditionally admitted — refusing them would risk distributed deadlock, since the
+ * parent request is already blocking on the sub-shard.
+ *
+ * <p>Mirrors {@code RequestHandlerBase.isInternalShardRequest} at the HTTP layer so the filter-tier
+ * definition stays consistent with the handler-tier one.
+ */
+final class InternalRequestUtils {
+
+  private InternalRequestUtils() {}
+
+  /**
+   * Whether {@code req} is an internal intra-cluster shard / admin request. Identified by any of:
+   *
+   * <ul>
+   *   <li>{@code Solr-Request-Context: SERVER} header — set by SolrJ on server-to-server traffic.
+   *   <li>{@code isShard=true} query parameter — set by {@code ShardHandler} on sub-shard fan-out.
+   *   <li>{@code distrib.from=…} query parameter — set by {@code DistributedUpdateProcessor} when
+   *       forwarding update requests between replicas.
+   * </ul>
+   */
+  static boolean isInternalServerRequest(HttpServletRequest req) {
+    String ctx = req.getHeader(CommonParams.SOLR_REQUEST_CONTEXT_PARAM);
+    if (ctx != null && SolrRequest.SolrClientContext.SERVER.toString().equals(ctx)) {
+      return true;
+    }
+    String qs = req.getQueryString();
+    if (qs == null) {
+      return false;
+    }
+    return qs.contains("isShard=true") || qs.contains("distrib.from=");
+  }
+}

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import static org.apache.solr.common.params.CommonParams.SOLR_REQUEST_CONTEXT_PARAM;
 import static org.apache.solr.common.params.CommonParams.SOLR_REQUEST_TYPE_PARAM;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -82,22 +81,21 @@ public class RateLimitManager implements ClusterPropertiesListener {
   }
 
   // Handles an incoming request. The main orchestration code path, this method will
-  // identify which (if any) rate limiter can handle this request. Internal requests will not be
-  // rate limited
-  // Returns true if request is accepted for processing, false if it should be rejected
+  // identify which (if any) rate limiter can handle this request. Internal requests
+  // (sub-shard fan-out, server-context SolrJ traffic) are unconditionally admitted to
+  // mirror the SolrQoSFilter bypass and avoid distributed deadlock.
+  // Returns a SlotReservation when accepted, null when rejected.
   public RequestRateLimiter.SlotReservation handleRequest(HttpServletRequest request)
       throws InterruptedException {
-    String requestContext = request.getHeader(SOLR_REQUEST_CONTEXT_PARAM);
-    String typeOfRequest = request.getHeader(SOLR_REQUEST_TYPE_PARAM);
-
-    if (typeOfRequest == null) {
-      // Cannot determine if this request should be throttled
+    // Do not throttle internal intra-cluster requests. Detection mirrors SolrQoSFilter so the
+    // two filter-tier admission checks agree on what counts as "internal".
+    if (InternalRequestUtils.isInternalServerRequest(request)) {
       return RequestRateLimiter.UNLIMITED;
     }
 
-    // Do not throttle internal requests
-    if (requestContext != null
-        && requestContext.equals(SolrRequest.SolrClientContext.SERVER.toString())) {
+    String typeOfRequest = request.getHeader(SOLR_REQUEST_TYPE_PARAM);
+    if (typeOfRequest == null) {
+      // Cannot determine if this request should be throttled
       return RequestRateLimiter.UNLIMITED;
     }
 

--- a/solr/core/src/java/org/apache/solr/servlet/SolrQoSFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrQoSFilter.java
@@ -1,0 +1,733 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.servlet;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.UnavailableException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Locale;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.util.EnvUtils;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.util.circuitbreaker.CircuitBreaker;
+import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Quality-of-Service filter that asynchronously suspends requests when circuit breakers (global or
+ * per-core) are tripped, instead of failing fast with a {@code 429}. Suspended requests are queued
+ * by priority (and request type) and resumed by a periodic scheduler that re-checks the {@link
+ * CircuitBreakerRegistry}; once no breaker is tripped for a request's type, the request is
+ * dispatched to the rest of the chain.
+ *
+ * <p>Designed after Jetty's {@code QoSFilter}/{@code QoSHandler}: instead of dropping load during
+ * transient spikes (e.g. GC pauses), the filter buffers requests, prioritizes intra-cluster shard /
+ * admin / health-check traffic over user queries over background updates, and shed-loads only when
+ * the suspension queue saturates or a request's suspension timeout elapses.
+ *
+ * <p>This filter always synchronously checks circuit breakers on the request path. When QoS
+ * queueing is enabled (the default; toggle via {@value #SYSPROP_QOS_ENABLED}), a tripped breaker
+ * causes the request to be suspended (via {@link HttpServletRequest#startAsync()}) and queued by
+ * priority + type until the breaker clears. When QoS queueing is disabled, a tripped breaker causes
+ * a synchronous fail-fast {@code 429} — preserving the legacy {@code SearchHandler} / {@code
+ * ContentStreamHandlerBase} behavior that previously enforced the same check inside the handlers.
+ *
+ * <p>Internal intra-cluster shard requests (those carrying {@code Solr-Request-Context: SERVER})
+ * always bypass both the breaker check and suspension to avoid distributed deadlock — sub-shard
+ * requests cannot be queued waiting on a parent that is itself waiting.
+ *
+ * <p>All filters and the SolrServlet on the request path must declare {@code
+ * <async-supported>true</async-supported>}; otherwise {@link HttpServletRequest#startAsync()} will
+ * throw at runtime when a circuit breaker first trips.
+ *
+ * @lucene.experimental
+ */
+public class SolrQoSFilter extends CoreContainerAwareHttpFilter {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  public static final String SYSPROP_QOS_ENABLED =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.enabled";
+  public static final String SYSPROP_MAX_SUSPENDED =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.maxSuspendedRequests";
+  public static final String SYSPROP_SUSPEND_TIMEOUT_MS =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.suspendTimeoutMs";
+  public static final String SYSPROP_CHECK_INTERVAL_MS =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.checkIntervalMs";
+  public static final String SYSPROP_EVAL_INTERVAL_MS =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.evaluationIntervalMs";
+  public static final String SYSPROP_DRAIN_BUDGET =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.drainBudget";
+  public static final String SYSPROP_HIGH_SHARE =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.priority.high.share";
+  public static final String SYSPROP_MEDIUM_SHARE =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.priority.medium.share";
+  public static final String SYSPROP_HIGH_DRAIN_MULTIPLIER =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.drainBudget.highMultiplier";
+  public static final String SYSPROP_LOW_DRAIN_MULTIPLIER =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "qos.drainBudget.lowMultiplier";
+
+  /**
+   * Optional client-supplied priority hint. Values are case-insensitive {@code HIGH}, {@code
+   * MEDIUM}, or {@code LOW}. Unknown values are ignored and the filter falls back to its path /
+   * type heuristic. Trusted callers (internal admin tooling, well-behaved SolrJ extensions) may use
+   * this to override the default lane assignment without the filter having to inspect the request
+   * body.
+   */
+  public static final String HEADER_REQUEST_PRIORITY = "Solr-Request-Priority";
+
+  static final int DEFAULT_MAX_SUSPENDED_REQUESTS = 1024;
+  static final long DEFAULT_SUSPEND_TIMEOUT_MS = 5000L;
+  static final long DEFAULT_CHECK_INTERVAL_MS = 100L;
+  static final long DEFAULT_EVAL_INTERVAL_MS = 200L;
+  static final int DEFAULT_DRAIN_BUDGET = 200;
+  static final double DEFAULT_HIGH_SHARE = 0.10;
+  static final double DEFAULT_MEDIUM_SHARE = 0.60;
+  static final double DEFAULT_HIGH_DRAIN_MULTIPLIER = 4.0;
+  static final double DEFAULT_LOW_DRAIN_MULTIPLIER = 0.5;
+
+  static final int PRIORITY_HIGH = 2; // admin/ping/health-check
+  static final int PRIORITY_MEDIUM = 1; // user QUERY
+  static final int PRIORITY_LOW = 0; // UPDATE
+  static final int N_PRIORITIES = 3;
+
+  static final int TYPE_QUERY = 0;
+  static final int TYPE_UPDATE = 1;
+  static final int N_TYPES = 2;
+
+  private static final String ATTR_RESUMED = SolrQoSFilter.class.getName() + ".resumed";
+
+  private static final String METRIC_PREFIX = "qos.";
+
+  private boolean enabled;
+  private int maxSuspendedRequests;
+  private long suspendTimeoutMs;
+  private long checkIntervalMs;
+  private long evaluationIntervalNanos;
+  private int drainBudget;
+  private final int[] priorityCap = new int[N_PRIORITIES];
+  private final int[] priorityDrainBudget = new int[N_PRIORITIES];
+
+  // Cache of the last circuit-breaker scan per request type. Several admission-control checks
+  // (load average, CPU) are expensive and sourced from metrics that don't update faster than
+  // ~once per second anyway, so polling them per-request scales badly under load. We share
+  // one evaluation across all callers within evaluationIntervalNanos.
+  private volatile TrippedScan queryScan;
+  private volatile TrippedScan updateScan;
+
+  private final Queue<AsyncContext>[][] queues;
+  private final AtomicInteger suspendedCount = new AtomicInteger();
+  private final AtomicInteger[] suspendedByPriority = new AtomicInteger[N_PRIORITIES];
+  private final AtomicLong totalSuspended = new AtomicLong();
+  private final AtomicLong totalResumed = new AtomicLong();
+  private final AtomicLong totalExpired = new AtomicLong();
+  private final AtomicLong totalRejected = new AtomicLong();
+
+  private ScheduledExecutorService scheduler;
+  private ScheduledFuture<?> drainTask;
+
+  private LongCounter metricSuspended;
+  private LongCounter metricResumed;
+  private LongCounter metricExpired;
+  private LongCounter metricRejected;
+  private ObservableLongGauge metricCurrentSuspendedGauge;
+
+  // Test seam: when non-null, used in place of {@link #getCores()} so unit tests can run
+  // without spinning up a full CoreContainerProvider/servlet context.
+  private CoreContainer testCoreContainer;
+  private boolean skipContainerLookup;
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public SolrQoSFilter() {
+    queues = new Queue[N_PRIORITIES][N_TYPES];
+    for (int p = 0; p < N_PRIORITIES; p++) {
+      suspendedByPriority[p] = new AtomicInteger();
+      for (int t = 0; t < N_TYPES; t++) {
+        queues[p][t] = new ConcurrentLinkedQueue<>();
+      }
+    }
+  }
+
+  private void registerMetrics() {
+    SolrMetricManager mm;
+    try {
+      CoreContainer cc = resolveCoreContainer();
+      mm = (cc == null) ? null : cc.getMetricManager();
+    } catch (UnavailableException e) {
+      log.warn("CoreContainer unavailable at SolrQoSFilter init; metrics not registered", e);
+      return;
+    }
+    if (mm == null) {
+      return;
+    }
+    String registry = SolrMetricManager.NODE_REGISTRY;
+    metricSuspended =
+        mm.longCounter(
+            registry,
+            METRIC_PREFIX + "suspended.total",
+            "Requests suspended by SolrQoSFilter waiting for a tripped circuit breaker to clear",
+            null);
+    metricResumed =
+        mm.longCounter(
+            registry,
+            METRIC_PREFIX + "resumed.total",
+            "Suspended requests dispatched by SolrQoSFilter once their circuit breaker cleared",
+            null);
+    metricExpired =
+        mm.longCounter(
+            registry,
+            METRIC_PREFIX + "expired.total",
+            "Suspended requests rejected by SolrQoSFilter after the suspension timeout elapsed",
+            null);
+    metricRejected =
+        mm.longCounter(
+            registry,
+            METRIC_PREFIX + "rejected.total",
+            "Requests rejected fast by SolrQoSFilter because the suspension queue was full",
+            null);
+    metricCurrentSuspendedGauge =
+        mm.observableLongGauge(
+            registry,
+            METRIC_PREFIX + "suspended.current",
+            "Requests currently suspended by SolrQoSFilter",
+            measurement -> measurement.record(suspendedCount.get()),
+            null);
+  }
+
+  @Override
+  public void destroy() {
+    if (drainTask != null) {
+      drainTask.cancel(false);
+    }
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+    }
+    if (metricCurrentSuspendedGauge != null) {
+      metricCurrentSuspendedGauge.close();
+    }
+    super.destroy();
+  }
+
+  @Override
+  protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+      throws IOException, ServletException {
+    if (Boolean.TRUE.equals(req.getAttribute(ATTR_RESUMED))) {
+      // Resumed dispatch from drainQueue — already passed the breaker check; let it through.
+      chain.doFilter(req, res);
+      return;
+    }
+
+    if (InternalRequestUtils.isInternalServerRequest(req)) {
+      // Sub-shard requests must not be queued or fail-fast — the parent request is blocking on
+      // them and refusing them would cause distributed deadlock.
+      chain.doFilter(req, res);
+      return;
+    }
+
+    SolrRequestType type = inferRequestType(req);
+    CoreContainer cc;
+    try {
+      cc = resolveCoreContainer();
+    } catch (UnavailableException ex) {
+      // Container shutting down or not yet up — pass through.
+      chain.doFilter(req, res);
+      return;
+    }
+    List<CircuitBreaker> tripped = trippedCached(cc, type);
+    if (tripped == null) {
+      chain.doFilter(req, res);
+      return;
+    }
+
+    if (!enabled) {
+      // QoS queueing disabled: preserve the legacy SearchHandler / ContentStreamHandlerBase
+      // behavior of failing fast with a 429 when a breaker is tripped.
+      res.sendError(
+          CircuitBreaker.getExceptionErrorCode().code,
+          CircuitBreakerRegistry.toErrorMessage(tripped));
+      return;
+    }
+
+    if (suspendedCount.get() >= maxSuspendedRequests) {
+      rejectQueueFull(res, "Server overloaded; suspended-request queue full");
+      return;
+    }
+
+    int priority = inferPriority(req, type);
+    int typeIdx = typeIndex(type);
+    if (suspendedByPriority[priority].get() >= priorityCap[priority]) {
+      // Lane saturated — refuse fast, but only at this priority. A flood of LOW-priority work
+      // cannot starve HIGH-priority probes because each lane has its own cap.
+      rejectQueueFull(res, "Server overloaded; priority lane queue full");
+      return;
+    }
+
+    AsyncContext asyncContext = req.startAsync();
+    asyncContext.setTimeout(suspendTimeoutMs);
+    asyncContext.addListener(new TimeoutListener(priority, typeIdx));
+    suspendedCount.incrementAndGet();
+    suspendedByPriority[priority].incrementAndGet();
+    totalSuspended.incrementAndGet();
+    if (metricSuspended != null) {
+      metricSuspended.add(1);
+    }
+    queues[priority][typeIdx].add(asyncContext);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "SolrQoSFilter suspended request priority={} type={} ({} now suspended)",
+          priority,
+          type,
+          suspendedCount.get());
+    }
+  }
+
+  private void rejectQueueFull(HttpServletResponse res, String message) throws IOException {
+    totalRejected.incrementAndGet();
+    if (metricRejected != null) {
+      metricRejected.add(1);
+    }
+    res.sendError(CircuitBreaker.getExceptionErrorCode().code, message);
+  }
+
+  private void drainAll() {
+    try {
+      CoreContainer cc;
+      try {
+        cc = resolveCoreContainer();
+      } catch (UnavailableException ex) {
+        return;
+      }
+      for (int p = N_PRIORITIES - 1; p >= 0; p--) {
+        for (int t = 0; t < N_TYPES; t++) {
+          drainQueue(queues[p][t], p, typeFromIndex(t), cc, priorityDrainBudget[p]);
+        }
+      }
+    } catch (Throwable t) {
+      log.error("SolrQoSFilter drain failed", t);
+    }
+  }
+
+  private void drainQueue(
+      Queue<AsyncContext> q, int priority, SolrRequestType type, CoreContainer cc, int budgetCap) {
+    if (q.isEmpty()) {
+      return;
+    }
+    List<CircuitBreaker> tripped = trippedCached(cc, type);
+    if (tripped != null) {
+      return;
+    }
+    int budget = budgetCap;
+    while (budget-- > 0) {
+      AsyncContext popped = q.poll();
+      if (popped == null) {
+        return;
+      }
+      try {
+        HttpServletRequest req = (HttpServletRequest) popped.getRequest();
+        req.setAttribute(ATTR_RESUMED, Boolean.TRUE);
+        popped.dispatch();
+        suspendedCount.decrementAndGet();
+        suspendedByPriority[priority].decrementAndGet();
+        totalResumed.incrementAndGet();
+        if (metricResumed != null) {
+          metricResumed.add(1);
+        }
+      } catch (IllegalStateException ise) {
+        // Async context already terminal (timed out or errored). The TimeoutListener already
+        // decremented both counters; just discard the dead entry.
+        if (log.isDebugEnabled()) {
+          log.debug("SolrQoSFilter dispatch raced with completion", ise);
+        }
+      }
+    }
+  }
+
+  /**
+   * Determine request type from the {@code Solr-Request-Type} header, falling back to a crude path
+   * heuristic. Anything not recognized as UPDATE is treated as QUERY for circuit-breaker
+   * accounting.
+   *
+   * <p>The path fallback only matches paths containing {@code /update}; everything else (including
+   * admin endpoints such as {@code /solr/admin/collections}, security APIs, and core admin actions)
+   * is classified as QUERY. The current circuit-breaker registry only differentiates QUERY from
+   * UPDATE breakers, so this coarseness is acceptable, but if a future breaker type is added (e.g.
+   * ADMIN) this heuristic will need refinement.
+   */
+  static SolrRequestType inferRequestType(HttpServletRequest req) {
+    String typeHeader = req.getHeader(CommonParams.SOLR_REQUEST_TYPE_PARAM);
+    if (typeHeader != null) {
+      try {
+        SolrRequestType t = SolrRequestType.valueOf(typeHeader);
+        if (t == SolrRequestType.UPDATE) {
+          return SolrRequestType.UPDATE;
+        }
+        return SolrRequestType.QUERY;
+      } catch (IllegalArgumentException ignored) {
+        // fall through to path heuristic
+      }
+    }
+    String path = req.getRequestURI();
+    if (path != null && path.contains("/update")) {
+      return SolrRequestType.UPDATE;
+    }
+    return SolrRequestType.QUERY;
+  }
+
+  /**
+   * Higher priorities are dispatched first. The {@value #HEADER_REQUEST_PRIORITY} header wins when
+   * present and recognized; otherwise admin/ping outranks user queries, and updates have the lowest
+   * priority so background batch ingest yields to interactive load.
+   *
+   * <p>Internal cluster (server-context) traffic is detected separately by {@link
+   * InternalRequestUtils#isInternalServerRequest(HttpServletRequest)} and bypasses suspension
+   * entirely; it does not receive a priority here.
+   */
+  static int inferPriority(HttpServletRequest req, SolrRequestType type) {
+    String hint = req.getHeader(HEADER_REQUEST_PRIORITY);
+    if (hint != null) {
+      switch (hint.toUpperCase(Locale.ROOT)) {
+        case "HIGH":
+          return PRIORITY_HIGH;
+        case "MEDIUM":
+          return PRIORITY_MEDIUM;
+        case "LOW":
+          return PRIORITY_LOW;
+        default:
+          // Unknown value — fall through to default heuristic instead of erroring on bad input.
+      }
+    }
+    String path = req.getRequestURI();
+    if (path != null && (path.contains("/admin/ping") || path.contains("/admin/info"))) {
+      return PRIORITY_HIGH;
+    }
+    if (type == SolrRequestType.UPDATE) {
+      return PRIORITY_LOW;
+    }
+    return PRIORITY_MEDIUM;
+  }
+
+  private static int typeIndex(SolrRequestType type) {
+    return type == SolrRequestType.UPDATE ? TYPE_UPDATE : TYPE_QUERY;
+  }
+
+  private static SolrRequestType typeFromIndex(int idx) {
+    return idx == TYPE_UPDATE ? SolrRequestType.UPDATE : SolrRequestType.QUERY;
+  }
+
+  public long getTotalSuspendedCount() {
+    return totalSuspended.get();
+  }
+
+  public long getTotalResumedCount() {
+    return totalResumed.get();
+  }
+
+  public long getTotalExpiredCount() {
+    return totalExpired.get();
+  }
+
+  public long getTotalRejectedCount() {
+    return totalRejected.get();
+  }
+
+  public int getSuspendedCount() {
+    return suspendedCount.get();
+  }
+
+  @VisibleForTesting
+  int getSuspendedCountForPriority(int priority) {
+    return suspendedByPriority[priority].get();
+  }
+
+  @VisibleForTesting
+  int getPriorityCap(int priority) {
+    return priorityCap[priority];
+  }
+
+  @VisibleForTesting
+  int getPriorityDrainBudget(int priority) {
+    return priorityDrainBudget[priority];
+  }
+
+  @VisibleForTesting
+  void drainNow() {
+    drainAll();
+  }
+
+  @VisibleForTesting
+  void initForTest(CoreContainer testContainer) {
+    this.skipContainerLookup = true;
+    this.testCoreContainer = testContainer;
+    readConfig();
+  }
+
+  @Override
+  public void init(FilterConfig config) throws ServletException {
+    super.init(config);
+    readConfig();
+
+    if (!enabled) {
+      log.info(
+          "SolrQoSFilter QoS queueing disabled; tripped circuit breakers will fail-fast "
+              + "synchronously (set {}=true to enable async suspension instead)",
+          SYSPROP_QOS_ENABLED);
+      return;
+    }
+    registerMetrics();
+    scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "solr-qos-drain");
+              t.setDaemon(true);
+              return t;
+            });
+    drainTask =
+        scheduler.scheduleWithFixedDelay(
+            this::drainAll, checkIntervalMs, checkIntervalMs, TimeUnit.MILLISECONDS);
+    log.info(
+        "SolrQoSFilter enabled (maxSuspended={}, suspendTimeoutMs={}, checkIntervalMs={})",
+        maxSuspendedRequests,
+        suspendTimeoutMs,
+        checkIntervalMs);
+  }
+
+  private void readConfig() {
+    enabled = Boolean.parseBoolean(EnvUtils.getProperty(SYSPROP_QOS_ENABLED, "true"));
+    maxSuspendedRequests =
+        EnvUtils.getPropertyAsInteger(SYSPROP_MAX_SUSPENDED, DEFAULT_MAX_SUSPENDED_REQUESTS);
+    suspendTimeoutMs =
+        EnvUtils.getPropertyAsLong(SYSPROP_SUSPEND_TIMEOUT_MS, DEFAULT_SUSPEND_TIMEOUT_MS);
+    checkIntervalMs =
+        EnvUtils.getPropertyAsLong(SYSPROP_CHECK_INTERVAL_MS, DEFAULT_CHECK_INTERVAL_MS);
+    evaluationIntervalNanos =
+        TimeUnit.MILLISECONDS.toNanos(
+            EnvUtils.getPropertyAsLong(SYSPROP_EVAL_INTERVAL_MS, DEFAULT_EVAL_INTERVAL_MS));
+    String drainOverride = EnvUtils.getProperty(SYSPROP_DRAIN_BUDGET);
+    if (drainOverride != null && !drainOverride.isEmpty()) {
+      drainBudget = Integer.parseInt(drainOverride);
+    } else {
+      drainBudget = autoDrainBudget();
+    }
+    computePriorityCaps();
+    computePriorityDrainBudgets();
+  }
+
+  /**
+   * Choose a drain budget such that a fully-saturated queue can drain within the suspension timeout
+   * (with 2× safety margin), so requests don't expire while waiting their turn. Floors at {@link
+   * #DEFAULT_DRAIN_BUDGET} so small/default deployments behave exactly as before. Users with
+   * workloads outside this envelope can override via {@value #SYSPROP_DRAIN_BUDGET}.
+   *
+   * <p>Without this scaling, very large {@code maxSuspendedRequests} configurations (e.g. 100k)
+   * paired with the default 200 budget would let suspended requests sit past their timeout and fail
+   * with a 429 — defeating the point of queueing them.
+   */
+  private int autoDrainBudget() {
+    if (suspendTimeoutMs <= 0 || checkIntervalMs <= 0) {
+      return DEFAULT_DRAIN_BUDGET;
+    }
+    long ticksPerTimeout = Math.max(1, suspendTimeoutMs / checkIntervalMs);
+    long auto = 2L * maxSuspendedRequests / ticksPerTimeout;
+    if (auto > Integer.MAX_VALUE) {
+      auto = Integer.MAX_VALUE;
+    }
+    return Math.max(DEFAULT_DRAIN_BUDGET, (int) auto);
+  }
+
+  /**
+   * Partition {@code maxSuspendedRequests} across the three priority lanes. HIGH and MEDIUM share
+   * fractions are configurable; LOW takes the remainder. A flood of LOW-priority requests can fill
+   * its lane but cannot evict HIGH/MEDIUM headroom — so admin/health-check probes still get queued
+   * even during a sustained indexing storm.
+   */
+  private void computePriorityCaps() {
+    double highShare = parseShare(SYSPROP_HIGH_SHARE, DEFAULT_HIGH_SHARE);
+    double mediumShare = parseShare(SYSPROP_MEDIUM_SHARE, DEFAULT_MEDIUM_SHARE);
+    int high = Math.max(1, (int) Math.round(maxSuspendedRequests * highShare));
+    int medium = Math.max(1, (int) Math.round(maxSuspendedRequests * mediumShare));
+    if (high + medium > maxSuspendedRequests) {
+      // Shares exceed 100%; clamp so the sum can never exceed maxSuspendedRequests.
+      medium = Math.max(0, maxSuspendedRequests - high);
+      if (medium == 0) {
+        high = maxSuspendedRequests;
+      }
+    }
+    int low = Math.max(0, maxSuspendedRequests - high - medium);
+    priorityCap[PRIORITY_HIGH] = high;
+    priorityCap[PRIORITY_MEDIUM] = medium;
+    priorityCap[PRIORITY_LOW] = low;
+  }
+
+  /**
+   * Compute per-lane drain throughput. HIGH gets the bulk so probe traffic never queues long; LOW
+   * gets the smallest share so updates back off gently after a breaker recovers. Defaults yield 800
+   * / 200 / 100 dispatches per tick at the default {@code drainBudget=200}.
+   */
+  private void computePriorityDrainBudgets() {
+    double highMultiplier =
+        getPropertyAsDouble(SYSPROP_HIGH_DRAIN_MULTIPLIER, DEFAULT_HIGH_DRAIN_MULTIPLIER);
+    double lowMultiplier =
+        getPropertyAsDouble(SYSPROP_LOW_DRAIN_MULTIPLIER, DEFAULT_LOW_DRAIN_MULTIPLIER);
+    priorityDrainBudget[PRIORITY_HIGH] =
+        Math.max(1, (int) Math.round(drainBudget * highMultiplier));
+    priorityDrainBudget[PRIORITY_MEDIUM] = Math.max(1, drainBudget);
+    priorityDrainBudget[PRIORITY_LOW] = Math.max(1, (int) Math.round(drainBudget * lowMultiplier));
+  }
+
+  private static double parseShare(String prop, double dflt) {
+    double v = getPropertyAsDouble(prop, dflt);
+    if (v < 0.0) {
+      return 0.0;
+    }
+    if (v > 1.0) {
+      return 1.0;
+    }
+    return v;
+  }
+
+  private static double getPropertyAsDouble(String prop, double dflt) {
+    String raw = EnvUtils.getProperty(prop);
+    if (raw == null || raw.isEmpty()) {
+      return dflt;
+    }
+    try {
+      return Double.parseDouble(raw);
+    } catch (NumberFormatException nfe) {
+      log.warn("Invalid double for {}={}; using default {}", prop, raw, dflt);
+      return dflt;
+    }
+  }
+
+  private CoreContainer resolveCoreContainer() throws UnavailableException {
+    if (skipContainerLookup) {
+      return testCoreContainer;
+    }
+    return getCores();
+  }
+
+  /**
+   * Cache the result of {@link CircuitBreakerRegistry#checkTrippedAcrossCores} for {@code
+   * evaluationIntervalNanos} so that high-QPS request flows don't repeatedly hit expensive
+   * underlying metrics. Each request type maintains its own cache slot; concurrent callers may
+   * occasionally race and produce duplicate evaluations, which is bounded and acceptable.
+   *
+   * @return null when nothing is tripped; otherwise a non-empty list (matching the registry's
+   *     contract — never an empty list).
+   */
+  private List<CircuitBreaker> trippedCached(CoreContainer cc, SolrRequestType type) {
+    long now = System.nanoTime();
+    TrippedScan cached = (type == SolrRequestType.UPDATE) ? updateScan : queryScan;
+    if (cached != null && (now - cached.evaluatedNanos) < evaluationIntervalNanos) {
+      return cached.tripped;
+    }
+    List<CircuitBreaker> fresh = CircuitBreakerRegistry.checkTrippedAcrossCores(cc, type);
+    TrippedScan next = new TrippedScan(now, fresh);
+    if (type == SolrRequestType.UPDATE) {
+      updateScan = next;
+    } else {
+      queryScan = next;
+    }
+    return fresh;
+  }
+
+  private static final class TrippedScan {
+    final long evaluatedNanos;
+    final List<CircuitBreaker> tripped;
+
+    TrippedScan(long evaluatedNanos, List<CircuitBreaker> tripped) {
+      this.evaluatedNanos = evaluatedNanos;
+      this.tripped = tripped;
+    }
+  }
+
+  /**
+   * AsyncListener for suspended requests. Both {@link #onTimeout} and {@link #onError} are terminal
+   * states that account the request as expired and decrement {@link #suspendedCount}; the
+   * underlying {@link AsyncContext} is left in its priority queue and will be polled and discarded
+   * lazily by {@link #drainQueue} (which catches the resulting {@link IllegalStateException}). This
+   * avoids the {@code O(N)} {@link ConcurrentLinkedQueue#remove(Object)} cost during overload.
+   */
+  private final class TimeoutListener implements AsyncListener {
+    private final int priority;
+    private final int typeIdx;
+
+    TimeoutListener(int priority, int typeIdx) {
+      this.priority = priority;
+      this.typeIdx = typeIdx;
+    }
+
+    @Override
+    public void onComplete(AsyncEvent event) {}
+
+    @Override
+    public void onStartAsync(AsyncEvent event) {}
+
+    @Override
+    public void onTimeout(AsyncEvent event) throws IOException {
+      accountExpiration();
+      ((HttpServletResponse) event.getSuppliedResponse())
+          .sendError(
+              CircuitBreaker.getExceptionErrorCode().code,
+              "Server overloaded; suspended request timed out");
+      event.getAsyncContext().complete();
+    }
+
+    @Override
+    public void onError(AsyncEvent event) {
+      // Client likely disconnected mid-suspension — release the slot. We cannot safely write to
+      // the response here (it may already be unusable), so just account the expiration; the
+      // container will complete the async cycle.
+      accountExpiration();
+    }
+
+    private void accountExpiration() {
+      suspendedCount.decrementAndGet();
+      suspendedByPriority[priority].decrementAndGet();
+      totalExpired.incrementAndGet();
+      if (metricExpired != null) {
+        metricExpired.add(1);
+      }
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "SolrQoSFilter suspended request expired priority={} typeIdx={}", priority, typeIdx);
+      }
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Locale;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.metrics.OtelRuntimeJvmMetrics;
@@ -34,6 +35,11 @@ import org.slf4j.LoggerFactory;
  * <p>This circuit breaker gets the recent average CPU usage and uses that data to take a decision.
  * We depend on OperatingSystemMXBean which does not allow a configurable interval of collection of
  * data.
+ *
+ * <p>Polling the underlying Prometheus metric per request is wasteful since the metric updates on a
+ * coarser cadence. Successive {@link #isTripped()} invocations reuse a sample for {@link
+ * CircuitBreakerRegistry#SYSPROP_SAMPLE_TTL_MS} (default {@value
+ * CircuitBreakerRegistry#DEFAULT_SAMPLE_TTL_MS} ms).
  */
 public class CPUCircuitBreaker extends CircuitBreaker implements SolrCoreAware {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -41,6 +47,12 @@ public class CPUCircuitBreaker extends CircuitBreaker implements SolrCoreAware {
   private boolean enabled = false;
   private double cpuUsageThreshold;
   private CoreContainer cc;
+
+  private final TtlSampledMetric cpuUsageCache =
+      new TtlSampledMetric(
+          EnvUtils.getPropertyAsLong(
+              CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS,
+              CircuitBreakerRegistry.DEFAULT_SAMPLE_TTL_MS));
 
   private static final ThreadLocal<Double> seenCPUUsage = ThreadLocal.withInitial(() -> 0.0);
 
@@ -65,7 +77,7 @@ public class CPUCircuitBreaker extends CircuitBreaker implements SolrCoreAware {
       return false;
     }
     double localAllowedCPUUsage = getCpuUsageThreshold();
-    double localSeenCPUUsage = calculateLiveCPUUsage();
+    double localSeenCPUUsage = cpuUsageCache.get(this::calculateLiveCPUUsage);
 
     allowedCPUUsage.set(localAllowedCPUUsage);
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -52,15 +52,26 @@ import org.slf4j.LoggerFactory;
 public class CircuitBreakerRegistry implements Closeable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final Pattern SYSPROP_REGEX =
-      Pattern.compile("solr.circuitbreaker\\.(update|query)\\.(cpu|mem|loadavg)");
+      Pattern.compile("solr.circuitbreaker\\.(update|query)\\.(cpu|mem|loadavg|gcoverhead)");
   public static final String SYSPROP_PREFIX = "solr.circuitbreaker.";
   public static final String SYSPROP_UPDATE_CPU = SYSPROP_PREFIX + "update.cpu";
   public static final String SYSPROP_UPDATE_MEM = SYSPROP_PREFIX + "update.mem";
   public static final String SYSPROP_UPDATE_LOADAVG = SYSPROP_PREFIX + "update.loadavg";
+  public static final String SYSPROP_UPDATE_GCOVERHEAD = SYSPROP_PREFIX + "update.gcoverhead";
   public static final String SYSPROP_QUERY_CPU = SYSPROP_PREFIX + "query.cpu";
   public static final String SYSPROP_QUERY_MEM = SYSPROP_PREFIX + "query.mem";
   public static final String SYSPROP_QUERY_LOADAVG = SYSPROP_PREFIX + "query.loadavg";
+  public static final String SYSPROP_QUERY_GCOVERHEAD = SYSPROP_PREFIX + "query.gcoverhead";
   public static final String SYSPROP_WARN_ONLY_SUFFIX = ".warnonly";
+
+  /**
+   * Default TTL (ms) of cached load-average / CPU samples consulted by {@link
+   * LoadAverageCircuitBreaker} and {@link CPUCircuitBreaker}. Override per-process via the {@value
+   * #SYSPROP_SAMPLE_TTL_MS} system property.
+   */
+  public static final long DEFAULT_SAMPLE_TTL_MS = 1000L;
+
+  public static final String SYSPROP_SAMPLE_TTL_MS = SYSPROP_PREFIX + "sampleTtlMs";
 
   private static boolean globalsInitialized = false;
   private static final Map<SolrRequestType, List<CircuitBreaker>> globalCircuitBreakerMap =
@@ -103,6 +114,11 @@ public class CircuitBreakerRegistry implements Closeable {
                 case "loadavg":
                   breaker =
                       new LoadAverageCircuitBreaker()
+                          .setThreshold(Double.parseDouble(breakerAndValueArr[1]));
+                  break;
+                case "gcoverhead":
+                  breaker =
+                      new GcOverheadCircuitBreaker()
                           .setThreshold(Double.parseDouble(breakerAndValueArr[1]));
                   break;
                 default:
@@ -208,6 +224,85 @@ public class CircuitBreakerRegistry implements Closeable {
     }
 
     return triggeredCircuitBreakers;
+  }
+
+  /**
+   * Check globally-registered (process-wide) circuit breakers for the given request type. Warn-only
+   * breakers are excluded from the result so that callers performing admission control do not act
+   * on them.
+   *
+   * <p>Filter-level callers (e.g. {@link org.apache.solr.servlet.SolrQoSFilter}) do not have
+   * per-core context and therefore consult only the static global map.
+   *
+   * @return null if no global breakers are registered for {@code requestType} or none are tripped;
+   *     otherwise a non-empty list of tripped breakers
+   */
+  public static List<CircuitBreaker> checkTrippedGlobal(SolrRequestType requestType) {
+    return selectTripped(globalCircuitBreakerMap.get(requestType));
+  }
+
+  /**
+   * Per-core variant of {@link #checkTrippedGlobal(SolrRequestType)} that consults only this
+   * registry's local breakers. Warn-only breakers are excluded.
+   */
+  public List<CircuitBreaker> checkTrippedLocal(SolrRequestType requestType) {
+    List<CircuitBreaker> snapshot;
+    synchronized (circuitBreakerMap) {
+      List<CircuitBreaker> breakersOfType = circuitBreakerMap.get(requestType);
+      snapshot = (breakersOfType == null) ? null : new ArrayList<>(breakersOfType);
+    }
+    return selectTripped(snapshot);
+  }
+
+  private static List<CircuitBreaker> selectTripped(List<CircuitBreaker> breakers) {
+    if (breakers == null || breakers.isEmpty()) {
+      return null;
+    }
+    List<CircuitBreaker> tripped = null;
+    for (CircuitBreaker cb : breakers) {
+      if (cb.isTripped() && !cb.isWarnOnly()) {
+        if (tripped == null) {
+          tripped = new ArrayList<>();
+        }
+        tripped.add(cb);
+      }
+    }
+    return tripped;
+  }
+
+  /**
+   * Filter-level admission control helper: combine globally-registered and every
+   * per-core-registered circuit breaker for {@code requestType}. Returns null if nothing is
+   * tripped, otherwise a non-empty list of tripped breakers.
+   *
+   * <p>Iteration is over all cores in {@code cc}. If any core has a tripped breaker for the type,
+   * the request is treated as tripped cluster-wide; this is intentionally conservative since the
+   * filter does not yet know which core a request will resolve to.
+   */
+  public static List<CircuitBreaker> checkTrippedAcrossCores(
+      CoreContainer cc, SolrRequestType requestType) {
+    List<CircuitBreaker> tripped = checkTrippedGlobal(requestType);
+    if (cc == null) {
+      return tripped;
+    }
+    @SuppressWarnings("deprecation")
+    List<org.apache.solr.core.SolrCore> cores = cc.getCores();
+    for (org.apache.solr.core.SolrCore core : cores) {
+      CircuitBreakerRegistry reg = core.getCircuitBreakerRegistry();
+      if (reg == null) {
+        continue;
+      }
+      List<CircuitBreaker> coreTripped = reg.checkTrippedLocal(requestType);
+      if (coreTripped == null || coreTripped.isEmpty()) {
+        continue;
+      }
+      if (tripped == null) {
+        tripped = new ArrayList<>(coreTripped);
+      } else {
+        tripped.addAll(coreTripped);
+      }
+    }
+    return tripped;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GcOverheadCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GcOverheadCircuitBreaker.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.util.circuitbreaker;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.solr.common.util.EnvUtils;
+
+/**
+ * Trips when the JVM is spending more than a configured percentage of wall-clock time in garbage
+ * collection over a sliding window.
+ *
+ * <p>Complementary to {@link MemoryCircuitBreaker}: that breaker fires when post-GC live data is
+ * exhausting the heap; this one fires when GC is keeping up (live data may even be small) but
+ * consuming so much CPU that the application is starving. Both conditions usually precede an OOM
+ * but each catches the other's blind spot.
+ *
+ * <p>The percentage is computed as
+ *
+ * <pre>{@code
+ * sum(GarbageCollectorMXBean.getCollectionTime()) over window
+ *   ─────────────────────────────────────────────────────────  × 100
+ *                       wall-clock window
+ * }</pre>
+ *
+ * <p>The window length defaults to {@link #DEFAULT_WINDOW_SECONDS} seconds and is configurable via
+ * {@value #SYSPROP_WINDOW_SECONDS}. Within one window the breaker reports the GC ratio over the
+ * time elapsed since the anchor sample; once the window length is exceeded, the anchor slides
+ * forward to the most recent sample so the ratio reflects only recent behavior.
+ *
+ * <p>{@link #isTripped()} is rate-limited by the same {@code TtlSampledMetric} used by the
+ * load-average and CPU breakers ({@value CircuitBreakerRegistry#SYSPROP_SAMPLE_TTL_MS}), so
+ * concurrent admission-control callers share one ratio computation per cache window.
+ */
+public class GcOverheadCircuitBreaker extends CircuitBreaker {
+
+  public static final String SYSPROP_WINDOW_SECONDS =
+      CircuitBreakerRegistry.SYSPROP_PREFIX + "gcoverhead.windowSeconds";
+  public static final long DEFAULT_WINDOW_SECONDS = 30L;
+
+  private static final List<GarbageCollectorMXBean> GC_BEANS =
+      List.copyOf(ManagementFactory.getGarbageCollectorMXBeans());
+
+  private double overheadThresholdPercent;
+  private final long windowNanos;
+  private final TtlSampledMetric ratioCache;
+  private final AtomicReference<Sample> anchor = new AtomicReference<>();
+
+  private static final ThreadLocal<Double> seenOverheadPercent = ThreadLocal.withInitial(() -> 0.0);
+  private static final ThreadLocal<Double> allowedOverheadPercent =
+      ThreadLocal.withInitial(() -> 0.0);
+
+  public GcOverheadCircuitBreaker() {
+    super();
+    long windowSeconds = EnvUtils.getPropertyAsLong(SYSPROP_WINDOW_SECONDS, DEFAULT_WINDOW_SECONDS);
+    if (windowSeconds <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid GC overhead window: " + windowSeconds + "s (must be positive)");
+    }
+    this.windowNanos = TimeUnit.SECONDS.toNanos(windowSeconds);
+    this.ratioCache =
+        new TtlSampledMetric(
+            EnvUtils.getPropertyAsLong(
+                CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS,
+                CircuitBreakerRegistry.DEFAULT_SAMPLE_TTL_MS));
+  }
+
+  public GcOverheadCircuitBreaker setThreshold(double thresholdValueInPercentage) {
+    if (thresholdValueInPercentage <= 0 || thresholdValueInPercentage > 100) {
+      throw new IllegalArgumentException(
+          "GC overhead threshold must be in (0, 100]; got " + thresholdValueInPercentage);
+    }
+    this.overheadThresholdPercent = thresholdValueInPercentage;
+    return this;
+  }
+
+  public double getOverheadThresholdPercent() {
+    return overheadThresholdPercent;
+  }
+
+  @Override
+  public boolean isTripped() {
+    double localAllowed = overheadThresholdPercent;
+    double localSeen = ratioCache.get(this::computeGcOverheadPercent);
+
+    allowedOverheadPercent.set(localAllowed);
+    seenOverheadPercent.set(localSeen);
+
+    return localSeen >= localAllowed;
+  }
+
+  /**
+   * Compute the percentage of wall time spent in GC since the anchor sample. The first call after
+   * construction installs the anchor and returns 0; once the window length is exceeded, the anchor
+   * advances to the current sample so future readings reflect only recent activity.
+   */
+  protected double computeGcOverheadPercent() {
+    long nowNs = System.nanoTime();
+    long nowGcMs = totalGcCollectionMs();
+
+    Sample existing = anchor.get();
+    if (existing == null) {
+      anchor.compareAndSet(null, new Sample(nowNs, nowGcMs));
+      return 0.0;
+    }
+
+    long elapsedNs = nowNs - existing.nanos;
+    if (elapsedNs <= 0) {
+      return 0.0;
+    }
+    long deltaGcMs = nowGcMs - existing.gcMs;
+    double pct = 100.0 * deltaGcMs * 1_000_000.0 / elapsedNs;
+
+    if (elapsedNs >= windowNanos) {
+      // Slide the anchor forward so subsequent readings cover only recent activity.
+      anchor.compareAndSet(existing, new Sample(nowNs, nowGcMs));
+    }
+    return pct;
+  }
+
+  protected long totalGcCollectionMs() {
+    long sum = 0;
+    for (GarbageCollectorMXBean b : GC_BEANS) {
+      long t = b.getCollectionTime();
+      if (t > 0) {
+        sum += t;
+      }
+    }
+    return sum;
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return "GC Overhead Circuit Breaker triggered: JVM has spent "
+        + String.format(Locale.ROOT, "%.1f", seenOverheadPercent.get())
+        + "% of wall time in garbage collection (allowed threshold "
+        + String.format(Locale.ROOT, "%.1f", allowedOverheadPercent.get())
+        + "%)";
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        Locale.ROOT,
+        "%s(threshold=%f%%, windowSeconds=%d, warnOnly=%b)",
+        getClass().getSimpleName(),
+        overheadThresholdPercent,
+        TimeUnit.NANOSECONDS.toSeconds(windowNanos),
+        isWarnOnly());
+  }
+
+  private static final class Sample {
+    final long nanos;
+    final long gcMs;
+
+    Sample(long nanos, long gcMs) {
+      this.nanos = nanos;
+      this.gcMs = gcMs;
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
@@ -21,6 +21,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.util.Locale;
+import org.apache.solr.common.util.EnvUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,11 @@ import org.slf4j.LoggerFactory;
  * uses that data to take a decision. We depend on OperatingSystemMXBean which does not allow a
  * configurable interval of collection of data.
  *
+ * <p>Because the OS load average is a one-minute moving average, polling the metric per request is
+ * wasted work. Successive {@link #isTripped()} invocations reuse a sample for {@link
+ * CircuitBreakerRegistry#SYSPROP_SAMPLE_TTL_MS} (default {@value
+ * CircuitBreakerRegistry#DEFAULT_SAMPLE_TTL_MS} ms).
+ *
  * <p>This Circuit breaker is dependent on the operating system, and may typically not work on
  * Microsoft Windows.
  */
@@ -40,6 +46,11 @@ public class LoadAverageCircuitBreaker extends CircuitBreaker {
       ManagementFactory.getOperatingSystemMXBean();
 
   private double loadAverageThreshold;
+  private final TtlSampledMetric loadAverageCache =
+      new TtlSampledMetric(
+          EnvUtils.getPropertyAsLong(
+              CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS,
+              CircuitBreakerRegistry.DEFAULT_SAMPLE_TTL_MS));
 
   // Assumption -- the value of these parameters will be set correctly before invoking
   // getDebugInfo()
@@ -54,7 +65,7 @@ public class LoadAverageCircuitBreaker extends CircuitBreaker {
   @Override
   public boolean isTripped() {
     double localAllowedLoadAverage = getLoadAverageThreshold();
-    double localSeenLoadAverage = calculateLiveLoadAverage();
+    double localSeenLoadAverage = loadAverageCache.get(this::calculateLiveLoadAverage);
 
     if (localSeenLoadAverage < 0) {
       if (log.isWarnEnabled()) {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
@@ -17,75 +17,65 @@
 
 package org.apache.solr.util.circuitbreaker;
 
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
 import java.util.Locale;
-import org.apache.solr.util.RefCounted;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.solr.common.util.EnvUtils;
 
 /**
- * Tracks the current JVM heap usage and triggers if a moving heap usage average over 30 seconds
- * exceeds the defined percentage of the maximum heap size allocated to the JVM. Once the average
- * memory usage goes below the threshold, it will start allowing queries again.
+ * Trips when post-collection live data in the JVM heap exceeds a configured percentage of the
+ * maximum heap size.
  *
- * <p>The memory threshold is defined as a percentage of the maximum memory allocated -- see
- * memThreshold in <code>solrconfig.xml</code>.
+ * <p>The signal is read from {@link MemoryPoolMXBean#getCollectionUsage()} on the old/tenured heap
+ * pool, which reports memory usage immediately after the most recent collection that affected that
+ * pool. This is the only memory reading that distinguishes "live data" from "garbage waiting to be
+ * collected."
+ *
+ * <p>Earlier versions of this breaker sampled {@link MemoryMXBean#getHeapMemoryUsage()} on a
+ * 30-second moving average, which produced a high signal during normal operation: with a
+ * generational collector, {@code used} climbs toward {@code max} between collections — that's the
+ * steady-state shape, not a problem. The new signal updates only when an old-gen GC runs, which is
+ * the only point at which "how full is the heap really?" has a defined answer.
+ *
+ * <p>Pool selection by collector:
+ *
+ * <ul>
+ *   <li><b>G1 / Parallel / Serial / generational ZGC:</b> uses the pool whose name contains {@code
+ *       Old} or {@code Tenured}.
+ *   <li><b>Non-generational ZGC and Shenandoah:</b> single combined heap pool — the breaker sums
+ *       {@code getCollectionUsage()} across every {@link MemoryType#HEAP} pool instead.
+ * </ul>
+ *
+ * <p>The threshold semantics are unchanged: configure a percentage of the maximum heap size, and
+ * the breaker trips when post-GC live data exceeds that percentage.
  */
 public class MemoryCircuitBreaker extends CircuitBreaker {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
-  // One shared provider / executor for all instances of this class
-  private static RefCounted<AveragingMetricProvider> averagingMetricProvider;
 
   private long heapMemoryThreshold;
+  private final TtlSampledMetric heapLiveCache =
+      new TtlSampledMetric(
+          EnvUtils.getPropertyAsLong(
+              CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS,
+              CircuitBreakerRegistry.DEFAULT_SAMPLE_TTL_MS));
 
   private static final ThreadLocal<Long> seenMemory = ThreadLocal.withInitial(() -> 0L);
   private static final ThreadLocal<Long> allowedMemory = ThreadLocal.withInitial(() -> 0L);
 
-  /** Creates an instance which averages over 6 samples during last 30 seconds. */
   public MemoryCircuitBreaker() {
-    this(6, 5);
-  }
-
-  /**
-   * Constructor that allows override of sample interval for which the memory usage is fetched. This
-   * is provided for testing, not intended for general use because the average metric provider
-   * implementation is the same for all instances of the class.
-   *
-   * @param numSamples number of samples to calculate average for
-   * @param sampleInterval interval between each sample
-   */
-  protected MemoryCircuitBreaker(int numSamples, int sampleInterval) {
     super();
-    synchronized (MemoryCircuitBreaker.class) {
-      if (averagingMetricProvider == null || averagingMetricProvider.getRefcount() == 0) {
-        averagingMetricProvider =
-            new RefCounted<>(
-                new AveragingMetricProvider(
-                    () -> MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed(),
-                    numSamples,
-                    sampleInterval)) {
-              @Override
-              protected void close() {
-                get().close();
-              }
-            };
-      }
-      averagingMetricProvider.incref();
-    }
   }
 
   public MemoryCircuitBreaker setThreshold(double thresholdValueInPercentage) {
     long currentMaxHeap = MEMORY_MX_BEAN.getHeapMemoryUsage().getMax();
-
     if (currentMaxHeap <= 0) {
       throw new IllegalArgumentException("Invalid JVM state for the max heap usage");
     }
 
-    double thresholdInFraction = thresholdValueInPercentage / (double) 100;
+    double thresholdInFraction = thresholdValueInPercentage / 100.0;
     heapMemoryThreshold = (long) (currentMaxHeap * thresholdInFraction);
 
     if (heapMemoryThreshold <= 0) {
@@ -96,19 +86,65 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
 
   @Override
   public boolean isTripped() {
-
-    long localAllowedMemory = getCurrentMemoryThreshold();
+    long localAllowedMemory = heapMemoryThreshold;
     long localSeenMemory = getAvgMemoryUsage();
 
     allowedMemory.set(localAllowedMemory);
-
     seenMemory.set(localSeenMemory);
 
-    return (localSeenMemory >= localAllowedMemory);
+    return localSeenMemory >= localAllowedMemory;
   }
 
+  /**
+   * Returns post-GC live bytes in the old-gen pool (or the sum across all heap pools when no
+   * dedicated old-gen pool exists). Cached for {@link CircuitBreakerRegistry#SYSPROP_SAMPLE_TTL_MS}
+   * so high-QPS callers don't repeatedly walk {@link MemoryPoolMXBean} list.
+   *
+   * <p>The historical name is preserved for source-compatibility with subclasses that override the
+   * value source for testing; the implementation no longer averages anything.
+   */
   protected long getAvgMemoryUsage() {
-    return (long) averagingMetricProvider.get().getMetricValue();
+    return (long) heapLiveCache.get(MemoryCircuitBreaker::samplePostGcLiveBytes);
+  }
+
+  /**
+   * Sum of {@code getCollectionUsage().getUsed()} across the old/tenured heap pool, falling back to
+   * the union of all {@link MemoryType#HEAP} pools when no pool name contains "Old" or "Tenured"
+   * (non-generational ZGC, Shenandoah).
+   *
+   * @return post-GC live bytes, or {@code 0} if no GC has yet run on a heap pool
+   */
+  static double samplePostGcLiveBytes() {
+    long oldGenTotal = 0;
+    boolean foundOld = false;
+    for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+      if (pool.getType() != MemoryType.HEAP) {
+        continue;
+      }
+      String name = pool.getName();
+      if (name != null && (name.contains("Old") || name.contains("Tenured"))) {
+        foundOld = true;
+        MemoryUsage cu = pool.getCollectionUsage();
+        if (cu != null) {
+          oldGenTotal += cu.getUsed();
+        }
+      }
+    }
+    if (foundOld) {
+      return oldGenTotal;
+    }
+
+    long allHeapTotal = 0;
+    for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+      if (pool.getType() != MemoryType.HEAP) {
+        continue;
+      }
+      MemoryUsage cu = pool.getCollectionUsage();
+      if (cu != null) {
+        allHeapTotal += cu.getUsed();
+      }
+    }
+    return allHeapTotal;
   }
 
   @Override
@@ -118,19 +154,6 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
         + seenMemory.get()
         + " and allocated threshold "
         + allowedMemory.get();
-  }
-
-  private long getCurrentMemoryThreshold() {
-    return heapMemoryThreshold;
-  }
-
-  @Override
-  public void close() throws IOException {
-    synchronized (MemoryCircuitBreaker.class) {
-      if (averagingMetricProvider != null && averagingMetricProvider.getRefcount() > 0) {
-        averagingMetricProvider.decref();
-      }
-    }
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/TtlSampledMetric.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/TtlSampledMetric.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.util.circuitbreaker;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Time-bounded cache around an expensive double-valued metric sample. Concurrent readers within one
+ * TTL window share a single computed value; on cache miss, multiple threads may each compute before
+ * the latest store wins, which is bounded and acceptable.
+ *
+ * <p>Used by {@link LoadAverageCircuitBreaker} and {@link CPUCircuitBreaker} so that high-QPS
+ * admission control does not poll OS load-average syscalls or Prometheus metric scans more often
+ * than the underlying signals can move.
+ */
+final class TtlSampledMetric {
+
+  private final long ttlNanos;
+  private final AtomicReference<Sample> sample = new AtomicReference<>();
+
+  TtlSampledMetric(long ttlMs) {
+    this.ttlNanos = TimeUnit.MILLISECONDS.toNanos(ttlMs);
+  }
+
+  double get(DoubleSupplier source) {
+    long now = System.nanoTime();
+    Sample s = sample.get();
+    if (s != null && (now - s.nanos) < ttlNanos) {
+      return s.value;
+    }
+    double v = source.getAsDouble();
+    sample.set(new Sample(now, v));
+    return v;
+  }
+
+  private static final class Sample {
+    final long nanos;
+    final double value;
+
+    Sample(long nanos, double value) {
+      this.nanos = nanos;
+      this.value = value;
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/servlet/InternalRequestUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/InternalRequestUtilsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.servlet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.solr.SolrTestCase;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.core.RateLimiterConfig;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class InternalRequestUtilsTest extends SolrTestCase {
+
+  @BeforeClass
+  public static void beforeClass() {
+    SolrTestCaseJ4.assumeWorkingMockito();
+  }
+
+  @Test
+  public void detectedViaHeader() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(CommonParams.SOLR_REQUEST_CONTEXT_PARAM))
+        .thenReturn(SolrRequest.SolrClientContext.SERVER.toString());
+    assertTrue(InternalRequestUtils.isInternalServerRequest(req));
+  }
+
+  @Test
+  public void detectedViaIsShardParam() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getQueryString()).thenReturn("q=*&isShard=true&wt=javabin");
+    assertTrue(InternalRequestUtils.isInternalServerRequest(req));
+  }
+
+  @Test
+  public void detectedViaDistribFromParam() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getQueryString()).thenReturn("distrib.from=node1&commit=true");
+    assertTrue(InternalRequestUtils.isInternalServerRequest(req));
+  }
+
+  @Test
+  public void falseForNormalRequest() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getQueryString()).thenReturn("q=test&wt=json");
+    assertFalse(InternalRequestUtils.isInternalServerRequest(req));
+  }
+
+  // Regression: RateLimitManager must consult InternalRequestUtils so that internal traffic
+  // identified only by the isShard / distrib.from query params (and lacking the
+  // Solr-Request-Context header) is still admitted unconditionally. Previously the manager
+  // only checked the header, so a sub-shard request without it could be rate-limited and
+  // cause distributed deadlock.
+  @Test
+  public void rateLimitManager_bypassesInternalShardRequestWithoutHeader() throws Exception {
+    RateLimitManager manager = new RateLimitManager();
+    manager.registerRequestRateLimiter(
+        new AlwaysRejectRateLimiter(), SolrRequest.SolrRequestType.QUERY);
+
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(CommonParams.SOLR_REQUEST_TYPE_PARAM))
+        .thenReturn(SolrRequest.SolrRequestType.QUERY.toString());
+    when(req.getQueryString()).thenReturn("q=*&isShard=true");
+
+    RequestRateLimiter.SlotReservation result = manager.handleRequest(req);
+    assertNotNull(
+        "Internal sub-shard request must bypass rate limiting even when the limiter would reject",
+        result);
+    result.close();
+  }
+
+  @Test
+  public void rateLimitManager_stillRejectsNonInternalQuery() throws Exception {
+    RateLimitManager manager = new RateLimitManager();
+    manager.registerRequestRateLimiter(
+        new AlwaysRejectRateLimiter(), SolrRequest.SolrRequestType.QUERY);
+
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(CommonParams.SOLR_REQUEST_TYPE_PARAM))
+        .thenReturn(SolrRequest.SolrRequestType.QUERY.toString());
+    when(req.getQueryString()).thenReturn("q=test&wt=json");
+
+    RequestRateLimiter.SlotReservation result = manager.handleRequest(req);
+    assertNull("Non-internal request must be subject to the registered limiter", result);
+  }
+
+  private static final class AlwaysRejectRateLimiter extends RequestRateLimiter {
+    AlwaysRejectRateLimiter() {
+      super(new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY));
+    }
+
+    @Override
+    public SlotReservation handleRequest() {
+      return null;
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/servlet/SolrQoSFilterTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/SolrQoSFilterTest.java
@@ -1,0 +1,666 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.servlet;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.solr.SolrTestCase;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.util.circuitbreaker.CircuitBreaker;
+import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SolrQoSFilterTest extends SolrTestCase {
+
+  @BeforeClass
+  public static void beforeClass() {
+    SolrTestCaseJ4.assumeWorkingMockito();
+  }
+
+  @After
+  public void cleanup() {
+    System.clearProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED);
+    System.clearProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED);
+    System.clearProperty(SolrQoSFilter.SYSPROP_SUSPEND_TIMEOUT_MS);
+    System.clearProperty(SolrQoSFilter.SYSPROP_CHECK_INTERVAL_MS);
+    System.clearProperty(SolrQoSFilter.SYSPROP_EVAL_INTERVAL_MS);
+    System.clearProperty(SolrQoSFilter.SYSPROP_DRAIN_BUDGET);
+    System.clearProperty(SolrQoSFilter.SYSPROP_HIGH_SHARE);
+    System.clearProperty(SolrQoSFilter.SYSPROP_MEDIUM_SHARE);
+    System.clearProperty(SolrQoSFilter.SYSPROP_HIGH_DRAIN_MULTIPLIER);
+    System.clearProperty(SolrQoSFilter.SYSPROP_LOW_DRAIN_MULTIPLIER);
+    CircuitBreakerRegistry.deregisterGlobal();
+  }
+
+  // -------- inferRequestType --------
+
+  @Test
+  public void inferRequestType_usesHeaderWhenPresent() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(CommonParams.SOLR_REQUEST_TYPE_PARAM)).thenReturn("UPDATE");
+    assertEquals(SolrRequestType.UPDATE, SolrQoSFilter.inferRequestType(req));
+  }
+
+  @Test
+  public void inferRequestType_unknownHeaderFallsBackToPath() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(CommonParams.SOLR_REQUEST_TYPE_PARAM)).thenReturn("BOGUS");
+    when(req.getRequestURI()).thenReturn("/solr/c1/update");
+    assertEquals(SolrRequestType.UPDATE, SolrQoSFilter.inferRequestType(req));
+  }
+
+  @Test
+  public void inferRequestType_defaultsToQuery() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getRequestURI()).thenReturn("/solr/c1/select");
+    assertEquals(SolrRequestType.QUERY, SolrQoSFilter.inferRequestType(req));
+  }
+
+  @Test
+  public void inferRequestType_securityOrAdminTreatedAsQuery() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(CommonParams.SOLR_REQUEST_TYPE_PARAM)).thenReturn("ADMIN");
+    assertEquals(SolrRequestType.QUERY, SolrQoSFilter.inferRequestType(req));
+  }
+
+  // -------- inferPriority --------
+
+  @Test
+  public void inferPriority_pingIsHigh() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getRequestURI()).thenReturn("/solr/c1/admin/ping");
+    assertEquals(
+        SolrQoSFilter.PRIORITY_HIGH, SolrQoSFilter.inferPriority(req, SolrRequestType.QUERY));
+  }
+
+  @Test
+  public void inferPriority_userQueryIsMedium() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getRequestURI()).thenReturn("/solr/c1/select");
+    assertEquals(
+        SolrQoSFilter.PRIORITY_MEDIUM, SolrQoSFilter.inferPriority(req, SolrRequestType.QUERY));
+  }
+
+  @Test
+  public void inferPriority_updateIsLow() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getRequestURI()).thenReturn("/solr/c1/update");
+    assertEquals(
+        SolrQoSFilter.PRIORITY_LOW, SolrQoSFilter.inferPriority(req, SolrRequestType.UPDATE));
+  }
+
+  // -------- end-to-end suspend/drain --------
+
+  @Test
+  public void disabled_isPassThrough() throws Exception {
+    SolrQoSFilter filter = newFilter(false);
+    try {
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+      filter.doFilter(req, res, chain);
+      verify(chain, times(1)).doFilter(req, res);
+      verify(req, never()).startAsync();
+      assertEquals(0, filter.getSuspendedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void disabled_failsFastWhenBreakerTripped() throws Exception {
+    // Regression: when QoS queueing is disabled (the default), a tripped breaker must still
+    // reject the request synchronously — preserving the pre-filter SearchHandler /
+    // ContentStreamHandlerBase behavior. Without this, upgrading users would silently lose
+    // circuit-breaker enforcement.
+    ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+    breaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+    breaker.tripped = true;
+
+    SolrQoSFilter filter = newFilter(false);
+    try {
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      when(req.getRequestURI()).thenReturn("/solr/c1/select");
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+
+      filter.doFilter(req, res, chain);
+
+      verify(chain, never()).doFilter(req, res);
+      verify(req, never()).startAsync();
+      verify(res).sendError(eq(CircuitBreaker.getExceptionErrorCode().code), anyString());
+      assertEquals(0, filter.getSuspendedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void disabled_internalShardRequestBypassesFailFast() throws Exception {
+    // Internal sub-shard requests must always pass through, even when a breaker is tripped and
+    // QoS is disabled — refusing them would risk distributed deadlock.
+    ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+    breaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+    breaker.tripped = true;
+
+    SolrQoSFilter filter = newFilter(false);
+    try {
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      when(req.getRequestURI()).thenReturn("/solr/c1/select");
+      when(req.getQueryString()).thenReturn("q=*&isShard=true");
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+
+      filter.doFilter(req, res, chain);
+
+      verify(chain, times(1)).doFilter(req, res);
+      verify(res, never()).sendError(anyInt(), anyString());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void noBreakerTripped_passesThrough() throws Exception {
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      when(req.getRequestURI()).thenReturn("/solr/c1/select");
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+
+      filter.doFilter(req, res, chain);
+
+      verify(chain, times(1)).doFilter(req, res);
+      verify(req, never()).startAsync();
+      assertEquals(0, filter.getSuspendedCount());
+      assertEquals(0L, filter.getTotalSuspendedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void breakerTripped_suspendsRequest() throws Exception {
+    ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+    breaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+    breaker.tripped = true;
+
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      when(req.getRequestURI()).thenReturn("/solr/c1/select");
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+
+      AsyncContext ac = mock(AsyncContext.class);
+      when(req.startAsync()).thenReturn(ac);
+      when(ac.getRequest()).thenReturn(req);
+
+      filter.doFilter(req, res, chain);
+
+      // Request was suspended, NOT dispatched downstream.
+      verify(chain, never()).doFilter(req, res);
+      verify(req, times(1)).startAsync();
+      verify(ac, times(1)).setTimeout(anyLong());
+      verify(ac, atLeastOnce()).addListener(org.mockito.ArgumentMatchers.<AsyncListener>any());
+      assertEquals(1, filter.getSuspendedCount());
+      assertEquals(1L, filter.getTotalSuspendedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void drainDispatchesWhenBreakerClears() throws Exception {
+    ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+    breaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+    breaker.tripped = true;
+
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      when(req.getRequestURI()).thenReturn("/solr/c1/select");
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+
+      AtomicReference<Object> resumedAttr = new AtomicReference<>();
+      Map<String, Object> attrs = new HashMap<>();
+      org.mockito.Mockito.doAnswer(
+              inv -> {
+                attrs.put(inv.getArgument(0), inv.getArgument(1));
+                return null;
+              })
+          .when(req)
+          .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
+      when(req.getAttribute(anyString())).thenAnswer(inv -> attrs.get(inv.getArgument(0)));
+
+      AsyncContext ac = mock(AsyncContext.class);
+      when(req.startAsync()).thenReturn(ac);
+      when(ac.getRequest()).thenReturn(req);
+      org.mockito.Mockito.doAnswer(
+              inv -> {
+                resumedAttr.set(attrs.get(SolrQoSFilter.class.getName() + ".resumed"));
+                return null;
+              })
+          .when(ac)
+          .dispatch();
+
+      filter.doFilter(req, res, chain);
+      assertEquals(1, filter.getSuspendedCount());
+
+      // Clear the breaker and drain.
+      breaker.tripped = false;
+      filter.drainNow();
+
+      verify(ac, times(1)).dispatch();
+      assertEquals(0, filter.getSuspendedCount());
+      assertEquals(1L, filter.getTotalResumedCount());
+      assertEquals(Boolean.TRUE, resumedAttr.get());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void evaluationCacheAmortizesBreakerChecks() throws Exception {
+    CountingTrippedBreaker breaker = new CountingTrippedBreaker();
+    breaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+
+    // Long eval interval — many successive calls should share one underlying isTripped() call.
+    System.setProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED, "true");
+    System.setProperty(SolrQoSFilter.SYSPROP_CHECK_INTERVAL_MS, "60000");
+    System.setProperty(SolrQoSFilter.SYSPROP_EVAL_INTERVAL_MS, "60000");
+    SolrQoSFilter filter = new SolrQoSFilter();
+    filter.initForTest(null);
+    try {
+      HttpServletResponse res = mock(HttpServletResponse.class);
+      FilterChain chain = mock(FilterChain.class);
+      for (int i = 0; i < 50; i++) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURI()).thenReturn("/solr/c1/select");
+        filter.doFilter(req, res, chain);
+      }
+      assertEquals(
+          "isTripped() should be invoked once per evaluation interval, not per request",
+          1,
+          breaker.calls.get());
+      // All 50 requests passed through (breaker reports not-tripped).
+      verify(chain, times(50)).doFilter(org.mockito.ArgumentMatchers.any(), eq(res));
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void rejectsWhenSuspendedQueueFull() throws Exception {
+    ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+    breaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+    breaker.tripped = true;
+
+    // maxSuspended=2 partitions to HIGH=1, MEDIUM=1, LOW=0 under default shares — enough for one
+    // MEDIUM-lane request before the next is rejected by the per-priority cap.
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "2");
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      // Fill the single MEDIUM slot.
+      HttpServletRequest req1 = mock(HttpServletRequest.class);
+      when(req1.getRequestURI()).thenReturn("/solr/c1/select");
+      AsyncContext ac1 = mock(AsyncContext.class);
+      when(req1.startAsync()).thenReturn(ac1);
+      when(ac1.getRequest()).thenReturn(req1);
+      filter.doFilter(req1, mock(HttpServletResponse.class), mock(FilterChain.class));
+      assertEquals(1, filter.getSuspendedCount());
+
+      // Second MEDIUM request should be rejected because the MEDIUM lane cap is hit.
+      HttpServletRequest req2 = mock(HttpServletRequest.class);
+      when(req2.getRequestURI()).thenReturn("/solr/c1/select");
+      HttpServletResponse res2 = mock(HttpServletResponse.class);
+      FilterChain chain2 = mock(FilterChain.class);
+      filter.doFilter(req2, res2, chain2);
+
+      verify(req2, never()).startAsync();
+      verify(chain2, never()).doFilter(req2, res2);
+      verify(res2).sendError(anyInt(), anyString());
+      assertEquals(1L, filter.getTotalRejectedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  // -------- priority header / per-priority caps / drain budget --------
+
+  @Test
+  public void inferPriority_headerOverridesPathHeuristic() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(SolrQoSFilter.HEADER_REQUEST_PRIORITY)).thenReturn("HIGH");
+    when(req.getRequestURI()).thenReturn("/solr/c1/update");
+    // Without the header, /update + UPDATE type would be PRIORITY_LOW. The header wins.
+    assertEquals(
+        SolrQoSFilter.PRIORITY_HIGH, SolrQoSFilter.inferPriority(req, SolrRequestType.UPDATE));
+  }
+
+  @Test
+  public void inferPriority_headerCaseInsensitive() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(SolrQoSFilter.HEADER_REQUEST_PRIORITY)).thenReturn("low");
+    when(req.getRequestURI()).thenReturn("/solr/c1/select");
+    assertEquals(
+        SolrQoSFilter.PRIORITY_LOW, SolrQoSFilter.inferPriority(req, SolrRequestType.QUERY));
+  }
+
+  @Test
+  public void inferPriority_unknownHeaderFallsBackToHeuristic() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader(SolrQoSFilter.HEADER_REQUEST_PRIORITY)).thenReturn("BOGUS");
+    when(req.getRequestURI()).thenReturn("/solr/c1/admin/ping");
+    // Unknown value — fall through to the path heuristic, which classifies admin/ping as HIGH.
+    assertEquals(
+        SolrQoSFilter.PRIORITY_HIGH, SolrQoSFilter.inferPriority(req, SolrRequestType.QUERY));
+  }
+
+  @Test
+  public void priorityCaps_partitionMaxSuspendedAcrossLanes() {
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "1000");
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      int high = filter.getPriorityCap(SolrQoSFilter.PRIORITY_HIGH);
+      int medium = filter.getPriorityCap(SolrQoSFilter.PRIORITY_MEDIUM);
+      int low = filter.getPriorityCap(SolrQoSFilter.PRIORITY_LOW);
+      assertEquals(
+          "lanes must sum to maxSuspendedRequests so the global cap is implicit",
+          1000,
+          high + medium + low);
+      assertTrue("HIGH lane must reserve some headroom for probes", high >= 1);
+      assertTrue("MEDIUM lane should be the largest under default shares", medium > high);
+      assertTrue("MEDIUM lane should be the largest under default shares", medium > low);
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void lowFloodDoesNotRejectHigh() throws Exception {
+    // Regression: under the old single-counter cap, a flood of LOW-priority updates could fill
+    // all 1024 slots and reject incoming admin/ping probes. Per-priority caps must prevent that.
+    ToggleCircuitBreaker queryBreaker = new ToggleCircuitBreaker();
+    queryBreaker.setRequestTypes(java.util.List.of("QUERY"));
+    CircuitBreakerRegistry.registerGlobal(queryBreaker);
+    ToggleCircuitBreaker updateBreaker = new ToggleCircuitBreaker();
+    updateBreaker.setRequestTypes(java.util.List.of("UPDATE"));
+    CircuitBreakerRegistry.registerGlobal(updateBreaker);
+    queryBreaker.tripped = true;
+    updateBreaker.tripped = true;
+
+    // Small total so we can saturate the LOW lane without spinning thousands of mocks.
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "20");
+    // Force a deterministic split: HIGH=2, MEDIUM=10, LOW=8 (rounded from share math).
+    System.setProperty(SolrQoSFilter.SYSPROP_HIGH_SHARE, "0.10");
+    System.setProperty(SolrQoSFilter.SYSPROP_MEDIUM_SHARE, "0.50");
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      int lowCap = filter.getPriorityCap(SolrQoSFilter.PRIORITY_LOW);
+      int highCap = filter.getPriorityCap(SolrQoSFilter.PRIORITY_HIGH);
+      assertTrue("test setup must yield non-zero LOW cap", lowCap > 0);
+      assertTrue("test setup must yield non-zero HIGH cap", highCap > 0);
+
+      // Saturate LOW with updates.
+      for (int i = 0; i < lowCap; i++) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURI()).thenReturn("/solr/c1/update");
+        AsyncContext ac = mock(AsyncContext.class);
+        when(req.startAsync()).thenReturn(ac);
+        when(ac.getRequest()).thenReturn(req);
+        filter.doFilter(req, mock(HttpServletResponse.class), mock(FilterChain.class));
+      }
+      assertEquals(lowCap, filter.getSuspendedCountForPriority(SolrQoSFilter.PRIORITY_LOW));
+      assertEquals(0L, filter.getTotalRejectedCount());
+
+      // Now an admin/ping request (HIGH) must still be admitted, not rejected — even though LOW
+      // is at its cap.
+      HttpServletRequest highReq = mock(HttpServletRequest.class);
+      when(highReq.getRequestURI()).thenReturn("/solr/c1/admin/ping");
+      AsyncContext highAc = mock(AsyncContext.class);
+      when(highReq.startAsync()).thenReturn(highAc);
+      when(highAc.getRequest()).thenReturn(highReq);
+      filter.doFilter(highReq, mock(HttpServletResponse.class), mock(FilterChain.class));
+
+      assertEquals(
+          "HIGH lane must accept the probe even when LOW is saturated",
+          1,
+          filter.getSuspendedCountForPriority(SolrQoSFilter.PRIORITY_HIGH));
+      assertEquals("HIGH probe must not be rejected", 0L, filter.getTotalRejectedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void priorityCapEnforcedPerLane() throws Exception {
+    ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+    breaker.setRequestTypes(java.util.List.of("UPDATE"));
+    CircuitBreakerRegistry.registerGlobal(breaker);
+    breaker.tripped = true;
+
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "20");
+    System.setProperty(SolrQoSFilter.SYSPROP_HIGH_SHARE, "0.10");
+    System.setProperty(SolrQoSFilter.SYSPROP_MEDIUM_SHARE, "0.50");
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      int lowCap = filter.getPriorityCap(SolrQoSFilter.PRIORITY_LOW);
+      assertTrue(lowCap > 0);
+      // Saturate LOW.
+      for (int i = 0; i < lowCap; i++) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURI()).thenReturn("/solr/c1/update");
+        AsyncContext ac = mock(AsyncContext.class);
+        when(req.startAsync()).thenReturn(ac);
+        when(ac.getRequest()).thenReturn(req);
+        filter.doFilter(req, mock(HttpServletResponse.class), mock(FilterChain.class));
+      }
+      // Next LOW request must be rejected — its lane is full.
+      HttpServletRequest extra = mock(HttpServletRequest.class);
+      when(extra.getRequestURI()).thenReturn("/solr/c1/update");
+      HttpServletResponse extraRes = mock(HttpServletResponse.class);
+      FilterChain extraChain = mock(FilterChain.class);
+      filter.doFilter(extra, extraRes, extraChain);
+
+      verify(extra, never()).startAsync();
+      verify(extraChain, never()).doFilter(extra, extraRes);
+      verify(extraRes).sendError(anyInt(), anyString());
+      assertEquals(1L, filter.getTotalRejectedCount());
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void drainBudgetScalesByPriority() {
+    System.setProperty(SolrQoSFilter.SYSPROP_DRAIN_BUDGET, "100");
+    System.setProperty(SolrQoSFilter.SYSPROP_HIGH_DRAIN_MULTIPLIER, "5.0");
+    System.setProperty(SolrQoSFilter.SYSPROP_LOW_DRAIN_MULTIPLIER, "0.25");
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      assertEquals(500, filter.getPriorityDrainBudget(SolrQoSFilter.PRIORITY_HIGH));
+      assertEquals(100, filter.getPriorityDrainBudget(SolrQoSFilter.PRIORITY_MEDIUM));
+      assertEquals(25, filter.getPriorityDrainBudget(SolrQoSFilter.PRIORITY_LOW));
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void drainBudget_autoScalesForLargeMaxSuspended() {
+    // Without an explicit drainBudget override, very large maxSuspendedRequests must auto-scale
+    // the budget so a saturated queue can drain before requests time out.
+    System.setProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED, "true");
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "100000");
+    System.setProperty(SolrQoSFilter.SYSPROP_SUSPEND_TIMEOUT_MS, "5000");
+    System.setProperty(SolrQoSFilter.SYSPROP_CHECK_INTERVAL_MS, "100");
+    System.setProperty(SolrQoSFilter.SYSPROP_EVAL_INTERVAL_MS, "0");
+    SolrQoSFilter filter = new SolrQoSFilter();
+    filter.initForTest(null);
+    try {
+      // Formula: 2 × maxSuspended / (timeout / interval) = 2 × 100000 / 50 = 4000.
+      assertEquals(4000, filter.getPriorityDrainBudget(SolrQoSFilter.PRIORITY_MEDIUM));
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void drainBudget_floorsAtDefaultForSmallConfigs() {
+    // For default-sized deployments the auto formula yields a small number; floor at the static
+    // default so behavior is unchanged for users who didn't tune.
+    System.setProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED, "true");
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "1024");
+    System.setProperty(SolrQoSFilter.SYSPROP_SUSPEND_TIMEOUT_MS, "5000");
+    System.setProperty(SolrQoSFilter.SYSPROP_CHECK_INTERVAL_MS, "100");
+    System.setProperty(SolrQoSFilter.SYSPROP_EVAL_INTERVAL_MS, "0");
+    SolrQoSFilter filter = new SolrQoSFilter();
+    filter.initForTest(null);
+    try {
+      assertEquals(
+          SolrQoSFilter.DEFAULT_DRAIN_BUDGET,
+          filter.getPriorityDrainBudget(SolrQoSFilter.PRIORITY_MEDIUM));
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void drainBudget_explicitOverrideWinsOverAutoScale() {
+    // Even with maxSuspended that would auto-scale to a higher number, an explicit user value
+    // must be honored exactly.
+    System.setProperty(SolrQoSFilter.SYSPROP_MAX_SUSPENDED, "100000");
+    System.setProperty(SolrQoSFilter.SYSPROP_DRAIN_BUDGET, "50");
+    SolrQoSFilter filter = newFilter(true);
+    try {
+      assertEquals(50, filter.getPriorityDrainBudget(SolrQoSFilter.PRIORITY_MEDIUM));
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  @Test
+  public void qosEnabledByDefault() {
+    // The default flipped to enabled=true once per-priority caps closed the priority-inversion
+    // bug. New deployments get async suspend/queueing without having to opt in.
+    System.clearProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED);
+    SolrQoSFilter filter = new SolrQoSFilter();
+    try {
+      filter.initForTest(null);
+      // With QoS enabled, a tripped breaker on a normal /select request should result in async
+      // suspension (startAsync called), not a synchronous fail-fast.
+      ToggleCircuitBreaker breaker = new ToggleCircuitBreaker();
+      breaker.setRequestTypes(java.util.List.of("QUERY"));
+      CircuitBreakerRegistry.registerGlobal(breaker);
+      breaker.tripped = true;
+
+      HttpServletRequest req = mock(HttpServletRequest.class);
+      when(req.getRequestURI()).thenReturn("/solr/c1/select");
+      AsyncContext ac = mock(AsyncContext.class);
+      when(req.startAsync()).thenReturn(ac);
+      when(ac.getRequest()).thenReturn(req);
+      filter.doFilter(req, mock(HttpServletResponse.class), mock(FilterChain.class));
+
+      verify(req, times(1)).startAsync();
+      assertEquals(1, filter.getSuspendedCount());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      filter.destroy();
+    }
+  }
+
+  // -------- helpers --------
+
+  private static SolrQoSFilter newFilter(boolean enabled) {
+    if (enabled) {
+      System.setProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED, "true");
+    } else {
+      System.setProperty(SolrQoSFilter.SYSPROP_QOS_ENABLED, "false");
+    }
+    // Long check interval so the background scheduler doesn't fire during tests
+    // that drive drain manually via drainNow().
+    System.setProperty(SolrQoSFilter.SYSPROP_CHECK_INTERVAL_MS, "60000");
+    // Disable evaluation cache so suspend/drain transitions in tests aren't masked by a
+    // stale cached scan.
+    System.setProperty(SolrQoSFilter.SYSPROP_EVAL_INTERVAL_MS, "0");
+    SolrQoSFilter f = new SolrQoSFilter();
+    f.initForTest(null);
+    return f;
+  }
+
+  private static final class ToggleCircuitBreaker extends CircuitBreaker {
+    volatile boolean tripped = false;
+
+    @Override
+    public boolean isTripped() {
+      return tripped;
+    }
+
+    @Override
+    public String getErrorMessage() {
+      return "test breaker tripped";
+    }
+  }
+
+  private static final class CountingTrippedBreaker extends CircuitBreaker {
+    final java.util.concurrent.atomic.AtomicInteger calls =
+        new java.util.concurrent.atomic.AtomicInteger();
+
+    @Override
+    public boolean isTripped() {
+      calls.incrementAndGet();
+      return false;
+    }
+
+    @Override
+    public String getErrorMessage() {
+      return "counting breaker";
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/util/TestCircuitBreakers.java
+++ b/solr/core/src/test/org/apache/solr/util/TestCircuitBreakers.java
@@ -17,25 +17,18 @@
 
 package org.apache.solr.util;
 
-import static org.hamcrest.CoreMatchers.containsString;
-
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
-import org.apache.solr.common.util.ExecutorUtil;
-import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.util.circuitbreaker.CPUCircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
@@ -106,15 +99,17 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
                 }
                 CircuitBreaker circuitBreaker = new MockCircuitBreaker(true);
                 h.getCore().getCircuitBreakerRegistry().register(circuitBreaker);
-                SolrException ex =
-                    expectThrows(
-                        SolrException.class,
-                        () -> {
-                          h.query(req("name:\"john smith\""));
-                        });
+                int expected = (code == -1) ? SolrException.ErrorCode.TOO_MANY_REQUESTS.code : code;
                 assertEquals(
-                    (code == -1) ? SolrException.ErrorCode.TOO_MANY_REQUESTS.code : code,
-                    ex.code());
+                    "Configured circuit-breaker error code",
+                    expected,
+                    CircuitBreaker.getExceptionErrorCode().code);
+                List<CircuitBreaker> tripped =
+                    h.getCore()
+                        .getCircuitBreakerRegistry()
+                        .checkTripped(SolrRequest.SolrRequestType.QUERY);
+                assertNotNull("Tripped breaker should be reported by registry", tripped);
+                assertEquals(1, tripped.size());
                 System.clearProperty(CircuitBreaker.SYSPROP_SOLR_CIRCUITBREAKER_ERRORCODE);
               });
     }
@@ -124,14 +119,13 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
     removeAllExistingCircuitBreakers();
 
     CircuitBreaker circuitBreaker = new MockCircuitBreaker(true);
-
     CircuitBreakerRegistry.registerGlobal(circuitBreaker);
 
-    expectThrows(
-        SolrException.class,
-        () -> {
-          h.query(req("name:\"john smith\""));
-        });
+    List<CircuitBreaker> tripped =
+        CircuitBreakerRegistry.checkTrippedGlobal(SolrRequest.SolrRequestType.QUERY);
+    assertNotNull("Global breaker should be reported as tripped", tripped);
+    assertEquals(1, tripped.size());
+    assertSame(circuitBreaker, tripped.get(0));
   }
 
   public void testCBsCanBeMarkedAsWarnOnly() throws Exception {
@@ -140,19 +134,21 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
     final var warnCircuitBreaker = new MockCircuitBreaker(true);
     CircuitBreakerRegistry.registerGlobal(warnCircuitBreaker);
 
-    // CB is warnOnly=false by default, so error is thrown.
-    expectThrows(
-        SolrException.class,
-        () -> {
-          h.query(req("name:\"john smith\""));
-        });
+    // CB is warnOnly=false by default — registry reports it as tripped.
+    assertNotNull(
+        "Hard-tripped breaker should be returned by checkTrippedGlobal",
+        CircuitBreakerRegistry.checkTrippedGlobal(SolrRequest.SolrRequestType.QUERY));
 
-    // When warnOnly=true is set, CB will trip but requests will not fail
+    // When warnOnly=true is set, checkTripped (per-core) still includes it (legacy behavior),
+    // but checkTrippedGlobal — the admission-control variant — filters it out.
     warnCircuitBreaker.setWarnOnly(true);
     final var tripList =
         h.getCore().getCircuitBreakerRegistry().checkTripped(SolrRequest.SolrRequestType.QUERY);
     assertEquals(1, tripList.size());
     assertEquals(warnCircuitBreaker, tripList.get(0));
+    assertNull(
+        "Warn-only breakers must not be admission-control-tripped",
+        CircuitBreakerRegistry.checkTrippedGlobal(SolrRequest.SolrRequestType.QUERY));
     h.query(req("name:\"john smith\""));
   }
 
@@ -213,34 +209,34 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
 
   public void testCBFakeMemoryPressure() throws Exception {
     removeAllExistingCircuitBreakers();
+    CircuitBreakerRegistry registry = h.getCore().getCircuitBreakerRegistry();
 
-    // Update and query will not trip
-    h.update(
-        "<add><doc><field name=\"id\">1</field><field name=\"name\">john smith</field></doc></add>");
-    h.query(req("name:\"john smith\""));
+    // No breakers registered: registry reports nothing tripped.
+    assertNull(registry.checkTrippedLocal(SolrRequest.SolrRequestType.QUERY));
+    assertNull(registry.checkTrippedLocal(SolrRequest.SolrRequestType.UPDATE));
 
     MemoryCircuitBreaker searchBreaker = new FakeMemoryPressureCircuitBreaker();
     searchBreaker.setThreshold(80);
     // Default request type is "query"
-    // searchBreaker.setRequestTypes(List.of("query"));
-    h.getCore().getCircuitBreakerRegistry().register(searchBreaker);
+    registry.register(searchBreaker);
 
-    // Query will trip, but not update due to defaults
-    expectThrows(SolrException.class, () -> h.query(req("name:\"john smith\"")));
-    h.update(
-        "<add><doc><field name=\"id\">2</field><field name=\"name\">john smith</field></doc></add>");
+    // Query type now reports tripped, update does not (different default request type set).
+    List<CircuitBreaker> queryTripped =
+        registry.checkTrippedLocal(SolrRequest.SolrRequestType.QUERY);
+    assertNotNull(queryTripped);
+    assertEquals(1, queryTripped.size());
+    List<CircuitBreaker> updateTripped =
+        registry.checkTrippedLocal(SolrRequest.SolrRequestType.UPDATE);
+    assertTrue("Update breakers should be empty", updateTripped == null || updateTripped.isEmpty());
 
     MemoryCircuitBreaker updateBreaker = new FakeMemoryPressureCircuitBreaker();
     updateBreaker.setThreshold(75);
     updateBreaker.setRequestTypes(List.of("update"));
-    h.getCore().getCircuitBreakerRegistry().register(updateBreaker);
+    registry.register(updateBreaker);
 
-    // Now also update will trip
-    expectThrows(
-        SolrException.class,
-        () ->
-            h.update(
-                "<add><doc><field name=\"id\">1</field><field name=\"name\">john smith</field></doc></add>"));
+    updateTripped = registry.checkTrippedLocal(SolrRequest.SolrRequestType.UPDATE);
+    assertNotNull(updateTripped);
+    assertEquals(1, updateTripped.size());
   }
 
   public void testBadRequestType() {
@@ -272,51 +268,27 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
   }
 
   /**
-   * Common assert method to be reused in tests
+   * Common assert method to be reused in tests. Verifies that the breaker's {@code isTripped()}
+   * method returns true the expected number of times across {@code numIterations} successive
+   * invocations.
    *
    * @param circuitBreaker the breaker to test
-   * @param numShouldTrip the number of queries that should trip the breaker
+   * @param numShouldTrip the number of {@code isTripped()} calls (out of 5) that should report the
+   *     breaker as tripped
    */
   private void assertThatHighQueryLoadTrips(CircuitBreaker circuitBreaker, int numShouldTrip) {
     removeAllExistingCircuitBreakers();
 
     h.getCore().getCircuitBreakerRegistry().register(circuitBreaker);
 
-    AtomicInteger failureCount = new AtomicInteger();
-
-    ExecutorService executor =
-        ExecutorUtil.newMDCAwareCachedThreadPool(new SolrNamedThreadFactory("TestCircuitBreaker"));
-    try {
-      List<Future<?>> futures = new ArrayList<>();
-
-      for (int i = 0; i < 5; i++) {
-        Future<?> future =
-            executor.submit(
-                () -> {
-                  try {
-                    h.query(req("name:\"john smith\""));
-                  } catch (SolrException e) {
-                    assertThat(e.getMessage(), containsString("Circuit Breakers tripped"));
-                    failureCount.incrementAndGet();
-                  } catch (Exception e) {
-                    throw new RuntimeException(e.getMessage());
-                  }
-                });
-
-        futures.add(future);
+    int trippedCount = 0;
+    for (int i = 0; i < 5; i++) {
+      if (circuitBreaker.isTripped()) {
+        trippedCount++;
       }
-
-      for (Future<?> future : futures) {
-        try {
-          future.get();
-        } catch (Exception e) {
-          throw new RuntimeException(e.getMessage());
-        }
-      }
-    } finally {
-      ExecutorUtil.shutdownAndAwaitTermination(executor);
-      assertEquals("Number of failed queries is not correct", numShouldTrip, failureCount.get());
     }
+    assertEquals(
+        "Number of tripped reports does not match expectation", numShouldTrip, trippedCount);
   }
 
   public void testResponseWithCBTiming() {
@@ -340,6 +312,9 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
         "count(//lst[@name='process']/*)>0",
         "//lst[@name='process']/double[@name='time']");
 
+    // Registering a (non-tripped) circuit breaker no longer adds an entry to the handler-level
+    // timing tree — admission control has been moved to SolrQoSFilter and no longer wraps
+    // SearchHandler.processComponents in an RTimerTree subtree.
     CircuitBreaker circuitBreaker = new MockCircuitBreaker(false);
     h.getCore().getCircuitBreakerRegistry().register(circuitBreaker);
 
@@ -354,10 +329,8 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
         "//lst[@name='explain']/str[@name='2']",
         "//lst[@name='explain']/str[@name='3']",
         "//str[@name='QParser']",
-        "count(//lst[@name='timing']/*)=4",
+        "count(//lst[@name='timing']/*)=3",
         "//lst[@name='timing']/double[@name='time']",
-        "count(//lst[@name='circuitbreaker']/*)>0",
-        "//lst[@name='circuitbreaker']/double[@name='time']",
         "count(//lst[@name='prepare']/*)>0",
         "//lst[@name='prepare']/double[@name='time']",
         "count(//lst[@name='process']/*)>0",
@@ -388,7 +361,7 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
 
   private static class FakeMemoryPressureCircuitBreaker extends MemoryCircuitBreaker {
     public FakeMemoryPressureCircuitBreaker() {
-      super(1, 1);
+      super();
     }
 
     @Override
@@ -401,7 +374,7 @@ public class TestCircuitBreakers extends SolrTestCaseJ4 {
     private AtomicInteger count;
 
     public BuildingUpMemoryPressureCircuitBreaker() {
-      super(1, 1);
+      super();
       this.count = new AtomicInteger(0);
     }
 

--- a/solr/core/src/test/org/apache/solr/util/TestGlobalCircuitBreaker.java
+++ b/solr/core/src/test/org/apache/solr/util/TestGlobalCircuitBreaker.java
@@ -17,9 +17,11 @@
 
 package org.apache.solr.util;
 
+import java.util.List;
 import org.apache.commons.exec.OS;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.common.SolrException;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -55,29 +57,35 @@ public class TestGlobalCircuitBreaker extends SolrTestCaseJ4 {
   }
 
   /**
-   * Index some docs and see that load avg is tripped. This test will not run on Windows, as it does
-   * not support load average. See <a
+   * Index some docs and see that load avg is reported as tripped by the registry. This test will
+   * not run on Windows, as it does not support load average. See <a
    * href="https://issues.apache.org/jira/browse/SOLR-17082">SOLR-17082</a>.
+   *
+   * <p>Prior to the SolrQoSFilter migration this test asserted that {@code assertU(adoc...)} threw
+   * a {@link org.apache.solr.common.SolrException} once the load-average breaker tripped. Now that
+   * synchronous circuit-breaker enforcement has moved out of the request handlers and into the
+   * filter chain, this verifies the breaker is detectable through the registry instead.
    */
   @Test
   public void testIndexingTripsLoadavgCb() {
     Assume.assumeFalse(OS.isFamilyWindows());
-    try {
-      for (int i = 0; i < 100; i++) {
-        assertU(adoc("name", "john smith", "id", "1"));
-        assertU(adoc("name", "johathon smith", "id", "2"));
-        assertU(adoc("name", "john percival smith", "id", "3"));
-        assertU(adoc("id", "1", "title", "this is a title.", "inStock_b1", "true"));
-        assertU(adoc("id", "2", "title", "this is another title.", "inStock_b1", "true"));
-        assertU(adoc("id", "3", "title", "Mary had a little lamb.", "inStock_b1", "false"));
+    for (int i = 0; i < 100; i++) {
+      assertU(adoc("name", "john smith", "id", "1"));
+      assertU(adoc("name", "johathon smith", "id", "2"));
+      assertU(adoc("name", "john percival smith", "id", "3"));
+      assertU(adoc("id", "1", "title", "this is a title.", "inStock_b1", "true"));
+      assertU(adoc("id", "2", "title", "this is another title.", "inStock_b1", "true"));
+      assertU(adoc("id", "3", "title", "Mary had a little lamb.", "inStock_b1", "false"));
 
-        // commit inside the loop to get multiple segments to make search as realistic as possible
-        assertU(commit());
+      // commit inside the loop to get multiple segments to make search as realistic as possible
+      assertU(commit());
+
+      List<CircuitBreaker> tripped =
+          CircuitBreakerRegistry.checkTrippedGlobal(SolrRequest.SolrRequestType.UPDATE);
+      if (tripped != null && !tripped.isEmpty()) {
+        return; // Load average exceeded the 0.1 threshold during indexing.
       }
-      fail("Should have tripped");
-    } catch (SolrException e) {
-      // We get a load average above 0.1, which trips the breaker
-      assertEquals(SolrException.ErrorCode.TOO_MANY_REQUESTS.code, e.code());
     }
+    fail("Should have tripped");
   }
 }

--- a/solr/core/src/test/org/apache/solr/util/circuitbreaker/TestHeapPressureCircuitBreakers.java
+++ b/solr/core/src/test/org/apache/solr/util/circuitbreaker/TestHeapPressureCircuitBreakers.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.util.circuitbreaker;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.solr.SolrTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link MemoryCircuitBreaker} reads post-GC live data — not the raw, garbage-
+ * inflated heap usage — and that {@link GcOverheadCircuitBreaker} computes a sensible GC ratio that
+ * trips on sustained collection pressure.
+ */
+public class TestHeapPressureCircuitBreakers extends SolrTestCase {
+
+  @Before
+  public void setUpProps() {
+    System.setProperty(CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS, "0");
+  }
+
+  @After
+  public void tearDownProps() {
+    System.clearProperty(CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS);
+    System.clearProperty(GcOverheadCircuitBreaker.SYSPROP_WINDOW_SECONDS);
+  }
+
+  // -------- MemoryCircuitBreaker --------
+
+  @Test
+  public void memoryBreakerReadsRealHeapPools() {
+    // Sanity: the in-process JVM exposes at least one heap pool. samplePostGcLiveBytes() must
+    // return a non-negative value computed from real pool data, regardless of which collector
+    // is active. (Pre-first-GC, getCollectionUsage() can be zero on every pool — accept that.)
+    boolean hasHeapPool = false;
+    for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+      if (pool.getType() == MemoryType.HEAP) {
+        hasHeapPool = true;
+        break;
+      }
+    }
+    assertTrue("JVM must expose at least one HEAP MemoryPoolMXBean", hasHeapPool);
+
+    double bytes = MemoryCircuitBreaker.samplePostGcLiveBytes();
+    assertTrue("post-GC live bytes must be non-negative, got " + bytes, bytes >= 0);
+  }
+
+  @Test
+  public void memoryBreakerTripsWhenOverThreshold() {
+    MemoryCircuitBreaker breaker =
+        new MemoryCircuitBreaker() {
+          @Override
+          protected long getAvgMemoryUsage() {
+            return Long.MAX_VALUE; // simulate "heap is exhausted post-GC"
+          }
+        };
+    breaker.setThreshold(50.0);
+    assertTrue(breaker.isTripped());
+  }
+
+  @Test
+  public void memoryBreakerDoesNotTripWhenUnderThreshold() {
+    MemoryCircuitBreaker breaker =
+        new MemoryCircuitBreaker() {
+          @Override
+          protected long getAvgMemoryUsage() {
+            return 0L; // simulate "post-GC live data is empty"
+          }
+        };
+    breaker.setThreshold(50.0);
+    assertFalse(breaker.isTripped());
+  }
+
+  // -------- GcOverheadCircuitBreaker --------
+
+  @Test
+  public void gcOverheadBreakerSetThresholdValidates() {
+    GcOverheadCircuitBreaker breaker = new GcOverheadCircuitBreaker();
+    expectThrows(IllegalArgumentException.class, () -> breaker.setThreshold(0));
+    expectThrows(IllegalArgumentException.class, () -> breaker.setThreshold(-1));
+    expectThrows(IllegalArgumentException.class, () -> breaker.setThreshold(101));
+  }
+
+  @Test
+  public void gcOverheadFirstCallReturnsFalse() {
+    GcOverheadCircuitBreaker breaker = new GcOverheadCircuitBreaker();
+    breaker.setThreshold(1.0);
+    assertFalse("first call has no anchor sample yet — must not trip", breaker.isTripped());
+  }
+
+  @Test
+  public void gcOverheadComputesRatioOverWindow() throws Exception {
+    // Use a fake breaker that controls GC time so we can assert ratios without depending on
+    // real GC behavior.
+    final AtomicLong gcMs = new AtomicLong(0);
+    GcOverheadCircuitBreaker breaker =
+        new GcOverheadCircuitBreaker() {
+          @Override
+          protected long totalGcCollectionMs() {
+            return gcMs.get();
+          }
+        };
+    breaker.setThreshold(20.0);
+
+    // First call installs the anchor and returns 0%.
+    double first = breaker.computeGcOverheadPercent();
+    assertEquals("first call returns 0", 0.0, first, 0.001);
+
+    // Second call: time has advanced, GC has not — expect ~0%.
+    Thread.sleep(20);
+    double second = breaker.computeGcOverheadPercent();
+    assertEquals("no GC time elapsed: ratio is 0%", 0.0, second, 0.001);
+  }
+
+  @Test
+  public void gcOverheadFakeBreakerRatioMath() {
+    // Drive a controllable breaker: spoof totalGcCollectionMs() to grow predictably. Use a
+    // very long window so the anchor never slides during the test.
+    System.setProperty(GcOverheadCircuitBreaker.SYSPROP_WINDOW_SECONDS, "3600");
+    AtomicLong gcMs = new AtomicLong(0);
+    GcOverheadCircuitBreaker breaker =
+        new GcOverheadCircuitBreaker() {
+          @Override
+          protected long totalGcCollectionMs() {
+            return gcMs.get();
+          }
+        };
+    breaker.setThreshold(50.0);
+
+    // Anchor at 0 GC, then add GC time and let real wall time elapse.
+    breaker.computeGcOverheadPercent(); // installs anchor
+    sleepMs(50);
+    gcMs.set(40); // 40ms of GC over ~50ms of wall time → ~80% — over threshold.
+    assertTrue("80% > 50%, breaker should trip", breaker.isTripped());
+
+    // Now zero-out the additional GC delta over a fresh window: install a new fake.
+    AtomicLong gcMs2 = new AtomicLong(0);
+    GcOverheadCircuitBreaker quiet =
+        new GcOverheadCircuitBreaker() {
+          @Override
+          protected long totalGcCollectionMs() {
+            return gcMs2.get();
+          }
+        };
+    quiet.setThreshold(50.0);
+    quiet.computeGcOverheadPercent(); // anchor at 0
+    sleepMs(50);
+    // gcMs2 stays at 0 → 0% overhead → must not trip.
+    assertFalse(quiet.isTripped());
+  }
+
+  private static void sleepMs(long ms) {
+    try {
+      Thread.sleep(ms);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(ie);
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/util/circuitbreaker/TestLoadAverageCircuitBreakerSampling.java
+++ b/solr/core/src/test/org/apache/solr/util/circuitbreaker/TestLoadAverageCircuitBreakerSampling.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.util.circuitbreaker;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.solr.SolrTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link LoadAverageCircuitBreaker} caches the result of {@code
+ * calculateLiveLoadAverage()} for the configured TTL so that high-QPS admission control does not
+ * re-poll {@code OperatingSystemMXBean.getSystemLoadAverage()} per request.
+ */
+public class TestLoadAverageCircuitBreakerSampling extends SolrTestCase {
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    // Long TTL so successive isTripped() calls within one test stay in the same cache window.
+    System.setProperty(CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS, "60000");
+  }
+
+  @After
+  public void tearDownProps() {
+    System.clearProperty(CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS);
+  }
+
+  @Test
+  public void successiveIsTrippedSharesOneSample() {
+    AtomicInteger calls = new AtomicInteger();
+    LoadAverageCircuitBreaker breaker =
+        new LoadAverageCircuitBreaker() {
+          @Override
+          protected double calculateLiveLoadAverage() {
+            calls.incrementAndGet();
+            return 1.0;
+          }
+        };
+    breaker.setThreshold(0.5);
+
+    for (int i = 0; i < 100; i++) {
+      assertTrue("breaker should be tripped (1.0 >= 0.5)", breaker.isTripped());
+    }
+    assertEquals(
+        "Underlying calculateLiveLoadAverage() must be invoked once per TTL window, not per call",
+        1,
+        calls.get());
+  }
+
+  @Test
+  public void zeroTtlDisablesCache() {
+    System.setProperty(CircuitBreakerRegistry.SYSPROP_SAMPLE_TTL_MS, "0");
+    AtomicInteger calls = new AtomicInteger();
+    LoadAverageCircuitBreaker breaker =
+        new LoadAverageCircuitBreaker() {
+          @Override
+          protected double calculateLiveLoadAverage() {
+            calls.incrementAndGet();
+            return 1.0;
+          }
+        };
+    breaker.setThreshold(0.5);
+
+    for (int i = 0; i < 5; i++) {
+      breaker.isTripped();
+    }
+    assertEquals("With zero TTL, every call re-evaluates", 5, calls.get());
+  }
+}

--- a/solr/webapp/web/WEB-INF/web.xml
+++ b/solr/webapp/web/WEB-INF/web.xml
@@ -28,6 +28,7 @@
   <filter>
     <filter-name>SolrFilter</filter-name>
     <filter-class>org.apache.solr.servlet.RequiredSolrRequestFilter</filter-class>
+    <async-supported>true</async-supported>
   </filter>
   <filter-mapping>
     <filter-name>SolrFilter</filter-name>
@@ -35,17 +36,9 @@
   </filter-mapping>
 
   <filter>
-    <filter-name>RateLimitFilter</filter-name>
-    <filter-class>org.apache.solr.servlet.RateLimitFilter</filter-class>
-  </filter>
-  <filter-mapping>
-    <filter-name>RateLimitFilter</filter-name>
-    <servlet-name>SolrServlet</servlet-name>
-  </filter-mapping>
-
-  <filter>
     <filter-name>TracingFilter</filter-name>
     <filter-class>org.apache.solr.servlet.TracingFilter</filter-class>
+    <async-supported>true</async-supported>
   </filter>
   <filter-mapping>
     <filter-name>TracingFilter</filter-name>
@@ -55,15 +48,37 @@
   <filter>
     <filter-name>AuthenticationFilter</filter-name>
     <filter-class>org.apache.solr.servlet.AuthenticationFilter</filter-class>
+    <async-supported>true</async-supported>
   </filter>
   <filter-mapping>
     <filter-name>AuthenticationFilter</filter-name>
     <servlet-name>SolrServlet</servlet-name>
   </filter-mapping>
 
+  <filter>
+    <filter-name>SolrQoSFilter</filter-name>
+    <filter-class>org.apache.solr.servlet.SolrQoSFilter</filter-class>
+    <async-supported>true</async-supported>
+  </filter>
+  <filter-mapping>
+    <filter-name>SolrQoSFilter</filter-name>
+    <servlet-name>SolrServlet</servlet-name>
+  </filter-mapping>
+
+  <filter>
+    <filter-name>RateLimitFilter</filter-name>
+    <filter-class>org.apache.solr.servlet.RateLimitFilter</filter-class>
+    <async-supported>true</async-supported>
+  </filter>
+  <filter-mapping>
+    <filter-name>RateLimitFilter</filter-name>
+    <servlet-name>SolrServlet</servlet-name>
+  </filter-mapping>
+
   <servlet>
     <servlet-name>SolrServlet</servlet-name>
     <servlet-class>org.apache.solr.servlet.SolrServlet</servlet-class>
+    <async-supported>true</async-supported>
   </servlet>
   <servlet-mapping>
     <servlet-name>SolrServlet</servlet-name>


### PR DESCRIPTION
*Experimental Branch* Not for contribution review.

# Move circuit breaker enforcement into an async SolrQoSFilter

## Motivation

The previous design enforced circuit breakers synchronously inside `SearchHandler.checkCircuitBreakers` and `ContentStreamHandlerBase.checkCircuitBreakers`. When a breaker tripped, requests were immediately rejected with a 429. During transient stress events — a 1-2 second GC pause, a burst of expensive faceted queries, brief CPU saturation — every in-flight client got an error even though the underlying condition would clear in moments. Operators saw error spikes that bore no proportional relationship to actual cluster trouble.

This PR replaces that with a Jetty-`QoSFilter`-style admission control layer: when a breaker is tripped, requests are **suspended via `AsyncContext`** and held in a small priority queue until the breaker clears, at which point they're dispatched as normal. Transient pressure is just some added latency instead of a wall of 429s.

## Architectural shift

| Aspect | Before | After |
|---|---|---|
| Where breakers are checked | Inside `SearchHandler` / `ContentStreamHandlerBase` after dispatch | In `SolrQoSFilter` before dispatch |
| What a tripped breaker does | Synchronous 429 | Asynchronous suspend, dispatch when clear |
| Priority awareness | None — first-come-first-served reject | Three-lane priority queue: admin/probe > query > update |
| Sub-shard deadlock risk | Possible: a coordinator could be 429'd waiting on its own sub-shards | Mitigated: internal traffic bypasses suspension |
| Cost of breaker checks under load | Each request re-polled OS/JVM metrics | Cached scan shared across requests within an evaluation window |

## What's in this PR

### `SolrQoSFilter` (new)

- Synchronously checks `CircuitBreakerRegistry.checkTrippedAcrossCores(cc, type)` on each request.
- If tripped and queueing is enabled (the new default), suspends via `req.startAsync()` and parks the `AsyncContext` in a priority+type queue.
- If tripped and queueing is disabled, returns a synchronous 429 — preserves the legacy handler behavior for operators who deliberately want fail-fast.
- A scheduled `drainAll` (default every 100 ms) re-checks the breaker and dispatches queued requests when it clears, walking lanes in priority order (HIGH → MEDIUM → LOW) and types within each lane.
- Suspended requests get an `AsyncListener` so timeouts and client disconnects are accounted correctly (counters decremented, response written, slot freed).
- Internal intra-cluster traffic — detected via `Solr-Request-Context: SERVER` header or the `isShard=true` / `distrib.from=` query params — bypasses both the breaker check and the suspension queue to avoid the obvious distributed-deadlock failure mode (parent request waits for sub-shard, sub-shard is queued waiting for parent's breaker to clear).

### Priority lanes

Requests are sorted into three lanes:

| Lane | Default population |
|---|---|
| HIGH | `/admin/ping`, `/admin/info` |
| MEDIUM | User queries |
| LOW | Updates |

Clients can override via the new **`Solr-Request-Priority`** request header (`HIGH` / `MEDIUM` / `LOW`, case-insensitive). Unknown values fall through to the path/type heuristic. SolrJ already populates `Solr-Request-Type`; the priority hint is opt-in for code paths that want explicit control without parsing the request body.

### Per-priority admission caps

The big bug class the lanes are meant to insulate against — a flood of LOW-priority bulk updates filling the suspension queue and locking out HIGH-priority admin/health probes — would have remained open with a single global counter. Each lane therefore has its **own admission cap**, partitioned out of `maxSuspendedRequests` via configurable shares:

```
solr.circuitbreaker.qos.priority.high.share    (default 0.10)
solr.circuitbreaker.qos.priority.medium.share  (default 0.60)
# LOW takes the remainder
```

At the default `maxSuspendedRequests=1024`: HIGH=102, MEDIUM=614, LOW=308. A saturated LOW lane refuses further LOW requests but leaves HIGH and MEDIUM headroom intact.

### Priority-scaled drain budget

`drainBudget` (the number of requests dispatched per lane per drain tick) is scaled by priority:

```
HIGH:   drainBudget × 4.0   (configurable: qos.drainBudget.highMultiplier)
MEDIUM: drainBudget × 1.0
LOW:    drainBudget × 0.5   (configurable: qos.drainBudget.lowMultiplier)
```

So HIGH clears in essentially one tick, MEDIUM clears at the baseline rate, and LOW yields capacity back to MEDIUM after a breaker recovery.

### Auto-scaled `drainBudget`

The base `drainBudget` defaults to `max(200, 2 × maxSuspendedRequests × checkIntervalMs / suspendTimeoutMs)`. The formula ensures a fully-saturated queue can drain *twice* within the suspension timeout window, so requests don't expire before they're resumed. Floors at the static default so small/default deployments are unchanged; large deployments (`maxSuspendedRequests=100000`) get the budget they actually need without manual tuning. Explicit `qos.drainBudget` overrides win.

### Cached breaker scan

`SolrQoSFilter` caches `CircuitBreakerRegistry.checkTrippedAcrossCores` per request type for `evaluationIntervalMs` (default 200ms). Concurrent admission-control callers share one underlying breaker scan rather than each re-walking the registry and re-polling OS/JVM metrics.

### `MemoryCircuitBreaker` rewrite

The old signal was a 30-second moving average of `MemoryMXBean.getHeapMemoryUsage()`. Under a generational collector, raw heap usage climbs steadily toward `max` between collections — that's the *normal* shape, not a problem. The moving average inherited that climb and tripped on healthy heaps.

The new signal reads `MemoryPoolMXBean.getCollectionUsage()` on the old/tenured pool, which reports the bytes resident immediately after the most recent collection that affected that pool. That's the only point at which "how full is the heap really?" has a defined answer. For non-generational collectors (non-generational ZGC, Shenandoah) the breaker sums `getCollectionUsage()` across every HEAP-typed pool. Threshold semantics are unchanged (percentage of max heap); the underlying signal is now meaningful.

### `GcOverheadCircuitBreaker` (new)

Trips when the JVM is spending more than a configured percentage of wall-clock time in garbage collection over a sliding window. Complementary to `MemoryCircuitBreaker`:
- `MemoryCircuitBreaker` fires when post-GC live data is exhausting the heap.
- `GcOverheadCircuitBreaker` fires when GC is keeping up (live data may be small) but consuming so much CPU that the application is starving.

Both conditions usually precede an OOM, but each catches the other's blind spot. Configurable via `solr.circuitbreaker.{update,query}.gcoverhead=<percent>` and `solr.circuitbreaker.gcoverhead.windowSeconds` (default 30).

### `TtlSampledMetric` (new)

Tiny utility wrapping `AtomicReference<Sample>` for time-bounded caching of expensive metric reads. Used by `CPUCircuitBreaker`, `LoadAverageCircuitBreaker`, `MemoryCircuitBreaker` (post-GC live-bytes lookup), and `GcOverheadCircuitBreaker` (ratio computation). Configurable globally via `solr.circuitbreaker.sampleTtlMs` (default 1000ms). Stops high-QPS admission control from hammering `OperatingSystemMXBean`, Prometheus metric scans, and `MemoryPoolMXBean` walks on every request.

### `CircuitBreakerRegistry` additions

- `checkTrippedGlobal(SolrRequestType)` — static; consults only the process-wide global map. Used by filter-tier callers that have no per-core context. Warn-only breakers excluded.
- `checkTrippedLocal(SolrRequestType)` — per-instance; consults only this registry's per-core breakers. Warn-only excluded.
- `checkTrippedAcrossCores(CoreContainer, SolrRequestType)` — combines global + every per-core registry. Used by `SolrQoSFilter`. Iterates all cores; if any core's breaker for the type is tripped, the request is treated as tripped cluster-wide (intentionally conservative — the filter doesn't yet know which core a request will resolve to).
- Recognizes a new `gcoverhead` breaker type in `parseCircuitBreakersFromProperties`.

### Handler changes

- `SearchHandler.checkCircuitBreakers` removed.
- `ContentStreamHandlerBase.checkCircuitBreakers` removed.
- Tests that previously asserted these handlers threw `SolrException` on tripped breakers now assert against the registry directly.

### `web.xml`

- New `SolrQoSFilter` mapping.
- `<async-supported>true</async-supported>` propagated to all filters in the chain ahead of `SolrServlet` (`RequiredSolrRequestFilter`, `TracingFilter`, `AuthenticationFilter`, `RateLimitFilter`) — required by the Servlet spec for `startAsync()` to work.

## Configuration reference

All new system properties:

```
# QoS filter
solr.circuitbreaker.qos.enabled                       (default true)
solr.circuitbreaker.qos.maxSuspendedRequests          (default 1024)
solr.circuitbreaker.qos.suspendTimeoutMs              (default 5000)
solr.circuitbreaker.qos.checkIntervalMs               (default 100)
solr.circuitbreaker.qos.evaluationIntervalMs          (default 200)
solr.circuitbreaker.qos.drainBudget                   (auto-scaled, floor 200)
solr.circuitbreaker.qos.priority.high.share           (default 0.10)
solr.circuitbreaker.qos.priority.medium.share         (default 0.60)
solr.circuitbreaker.qos.drainBudget.highMultiplier    (default 4.0)
solr.circuitbreaker.qos.drainBudget.lowMultiplier     (default 0.5)

# Breakers
solr.circuitbreaker.sampleTtlMs                       (default 1000)
solr.circuitbreaker.{update,query}.gcoverhead         (no default — register to enable)
solr.circuitbreaker.gcoverhead.windowSeconds          (default 30)
```

New request header:

```
Solr-Request-Priority: HIGH | MEDIUM | LOW
```

New metrics (counter unless noted):

```
qos.suspended.total
qos.suspended.current   (observable gauge)
qos.resumed.total
qos.expired.total
qos.rejected.total
```

## Behavior changes

1. **`qos.enabled` defaults to `true`.** New deployments will async-suspend tripped breakers instead of fail-fast. Operators who want the legacy synchronous 429 can set `solr.circuitbreaker.qos.enabled=false`.
2. **`MemoryCircuitBreaker` semantics changed.** Threshold is now compared against post-GC live data rather than the raw heap usage moving average. The breaker should fire *less often* on healthy generational-GC clusters; thresholds previously tuned around the noisy signal may now feel conservative and can be lowered. Tuning review recommended at upgrade.
3. **Async dispatch in the filter chain.** All filters ahead of `SolrServlet` are now declared `async-supported`. Downstream Solr filters/servlets are unchanged, but custom third-party filters injected into the chain must also declare `async-supported` or `startAsync()` will throw.