### PR TITLE
SOLR-17697: visually flag required options

### DIFF
--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -592,6 +592,42 @@ String cliFileNameToNavLabel(String baseName) {
   return baseName.split('-').last()
 }
 
+// Repeatedly strip "[...]" (optional groups) and "(...)" (required groups whose
+// members aren't *individually* required) from a synopsis line. What remains are
+// the tokens that the user must always provide.
+String stripSynopsisGroups(String text) {
+  String s = text
+  String prev = null
+  while (s != prev) {
+    prev = s
+    s = s.replaceAll(/\[[^\[\]]*\]/, '')
+    s = s.replaceAll(/\([^()]*\)/, '')
+  }
+  return s
+}
+
+// Extract option names (e.g. "-d", "--name") that appear unbracketed in the
+// synopsis. Picocli's ManPageGenerator doesn't emit a per-option required marker,
+// but the synopsis bracket convention does encode it — we use that as the source
+// of truth so we don't have to reach into the CommandSpec.
+Set<String> extractRequiredOptionNames(String synopsis) {
+  def stripped = stripSynopsisGroups(synopsis)
+  def result = new LinkedHashSet<String>()
+  def m = stripped =~ /(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)/
+  while (m.find()) { result.add(m.group(1)) }
+  return result
+}
+
+// Extract positional argument names (e.g. "<src>") that appear unbracketed in the
+// synopsis — same approach as required options.
+Set<String> extractRequiredPositionalNames(String synopsis) {
+  def stripped = stripSynopsisGroups(synopsis)
+  def result = new LinkedHashSet<String>()
+  def m = stripped =~ /(<[^<>\s]+>)/
+  while (m.find()) { result.add(m.group(1)) }
+  return result
+}
+
 // Post-process a raw ManPageGenerator AsciiDoc file for Antora compatibility.
 // The title lives inside the man-section-header block, so we replace the whole
 // header block with an Antora-compatible page title + attributes.
@@ -629,6 +665,45 @@ String postProcessCliManPage(File rawFile, String asfHeader, String doNotEditNot
       .replaceAll(/(?m)^solr /, 'bin/solr ')  // qualified name "solr start" → "bin/solr start"
       .replaceAll(/(?m)^( +)/, '    $1')     // re-align wrapped lines: add 4 spaces ("bin/" length)
     "${m[1]}....\n${synopsis}\n....${m[3]}"
+  }
+
+  // Mark required options and positional arguments in the Options/Arguments sections.
+  // Picocli's ManPageGenerator doesn't emit a per-option required marker, so we parse
+  // the synopsis (where required tokens are unbracketed) and prepend "*(required)*" to
+  // the matching description lines.
+  def synopsisMatch = content =~ /(?s)== Synopsis\n\n\.{4}\n(.*?)\n\.{4}/
+  if (synopsisMatch.find()) {
+    def synopsisText = synopsisMatch.group(1).replaceAll(/\s+/, ' ')
+    def requiredOpts = extractRequiredOptionNames(synopsisText)
+    def requiredArgs = extractRequiredPositionalNames(synopsisText)
+
+    // Option labels look like "*-d*, *--conf-dir*=_DIR_::" or "*-rf, --replication-factor*=_<x>_::"
+    // or "*--all*::". We strip the asciidoc marks, look at the part before '=', and pull
+    // every -x / --xx token so we match against the required set regardless of label shape.
+    if (!requiredOpts.isEmpty()) {
+      content = content.replaceAll(/(?m)^(\*-[^\n]+::)\n( +)([^\n]+)/) { List<String> m ->
+        def label = m[1]
+        def indent = m[2]
+        def descLine = m[3]
+        def beforeEq = label.replaceAll(/[*_]/, '').split('=', 2)[0]
+        def names = []
+        def nm = beforeEq =~ /(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)/
+        while (nm.find()) { names << nm.group(1) }
+        names.any { requiredOpts.contains(it) } ?
+          "${label}\n${indent}*(required)* ${descLine}" : m[0]
+      }
+    }
+
+    // Positional arg labels look like "_<src>_::".
+    if (!requiredArgs.isEmpty()) {
+      content = content.replaceAll(/(?m)^_(<[^<>\n]+>)_::\n( +)([^\n]+)/) { List<String> m ->
+        def name = m[1]
+        def indent = m[2]
+        def descLine = m[3]
+        requiredArgs.contains(name) ?
+          "_${name}_::\n${indent}*(required)* ${descLine}" : m[0]
+      }
+    }
   }
 
   // Strip the outer full-manpage tag wrappers

--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -618,6 +618,7 @@ Set<String> extractRequiredTokens(String synopsis, java.util.regex.Pattern patte
 // Options and Arguments sections. Picocli's ManPageGenerator doesn't emit a
 // per-option required marker, so we use the synopsis bracketing as the source of
 // truth instead of reaching into the CommandSpec.
+// See https://github.com/remkop/picocli/issues/2519.
 String markRequiredOptionsAndArgs(String content) {
   final String MARKER = '*(required)*'
   final def OPTION_NAME = ~/(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)/

--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -592,9 +592,9 @@ String cliFileNameToNavLabel(String baseName) {
   return baseName.split('-').last()
 }
 
-// Repeatedly strip "[...]" (optional groups) and "(...)" (required groups whose
-// members aren't *individually* required) from a synopsis line. What remains are
-// the tokens that the user must always provide.
+// Strip "[...]" (optional groups) and "(...)" (required groups whose members
+// aren't *individually* required), repeating until no inner groups remain.
+// Tokens left in the result are the ones the user must always provide.
 String stripSynopsisGroups(String text) {
   String s = text
   String prev = null
@@ -606,26 +606,50 @@ String stripSynopsisGroups(String text) {
   return s
 }
 
-// Extract option names (e.g. "-d", "--name") that appear unbracketed in the
-// synopsis. Picocli's ManPageGenerator doesn't emit a per-option required marker,
-// but the synopsis bracket convention does encode it — we use that as the source
-// of truth so we don't have to reach into the CommandSpec.
-Set<String> extractRequiredOptionNames(String synopsis) {
-  def stripped = stripSynopsisGroups(synopsis)
+Set<String> extractRequiredTokens(String synopsis, java.util.regex.Pattern pattern) {
   def result = new LinkedHashSet<String>()
-  def m = stripped =~ /(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)/
+  def m = stripSynopsisGroups(synopsis) =~ pattern
   while (m.find()) { result.add(m.group(1)) }
   return result
 }
 
-// Extract positional argument names (e.g. "<src>") that appear unbracketed in the
-// synopsis — same approach as required options.
-Set<String> extractRequiredPositionalNames(String synopsis) {
-  def stripped = stripSynopsisGroups(synopsis)
-  def result = new LinkedHashSet<String>()
-  def m = stripped =~ /(<[^<>\s]+>)/
-  while (m.find()) { result.add(m.group(1)) }
-  return result
+// Parse the wrapped synopsis to find required (unbracketed) options and positional
+// args, then prepend a "*(required)*" marker to their description lines in the
+// Options and Arguments sections. Picocli's ManPageGenerator doesn't emit a
+// per-option required marker, so we use the synopsis bracketing as the source of
+// truth instead of reaching into the CommandSpec.
+String markRequiredOptionsAndArgs(String content) {
+  final String MARKER = '*(required)*'
+  final def OPTION_NAME = ~/(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)/
+  final def POSITIONAL_NAME = ~/(<[^<>\s]+>)/
+
+  def synopsisMatch = content =~ /(?s)== Synopsis\n\n\.{4}\n(.*?)\n\.{4}/
+  if (!synopsisMatch.find()) return content
+
+  def synopsisText = synopsisMatch.group(1).replaceAll(/\s+/, ' ')
+  def requiredOpts = extractRequiredTokens(synopsisText, OPTION_NAME)
+  def requiredArgs = extractRequiredTokens(synopsisText, POSITIONAL_NAME)
+
+  if (!requiredOpts.isEmpty()) {
+    content = content.replaceAll(/(?m)^(\*-[^\n]+::)\n( +)([^\n]+)/) { List<String> m ->
+      def (label, indent, descLine) = [m[1], m[2], m[3]]
+      if (descLine.startsWith(MARKER)) return m[0]
+      def beforeEq = label.replaceAll(/[*_]/, '').split('=', 2)[0]
+      def names = (beforeEq =~ OPTION_NAME).collect { it[1] }
+      names.any { requiredOpts.contains(it) }
+        ? "${label}\n${indent}${MARKER} ${descLine}" : m[0]
+    }
+  }
+
+  if (!requiredArgs.isEmpty()) {
+    content = content.replaceAll(/(?m)^_(<[^<>\n]+>)_::\n( +)([^\n]+)/) { List<String> m ->
+      def (name, indent, descLine) = [m[1], m[2], m[3]]
+      if (descLine.startsWith(MARKER)) return m[0]
+      requiredArgs.contains(name)
+        ? "_${name}_::\n${indent}${MARKER} ${descLine}" : m[0]
+    }
+  }
+  return content
 }
 
 // Post-process a raw ManPageGenerator AsciiDoc file for Antora compatibility.
@@ -667,44 +691,7 @@ String postProcessCliManPage(File rawFile, String asfHeader, String doNotEditNot
     "${m[1]}....\n${synopsis}\n....${m[3]}"
   }
 
-  // Mark required options and positional arguments in the Options/Arguments sections.
-  // Picocli's ManPageGenerator doesn't emit a per-option required marker, so we parse
-  // the synopsis (where required tokens are unbracketed) and prepend "*(required)*" to
-  // the matching description lines.
-  def synopsisMatch = content =~ /(?s)== Synopsis\n\n\.{4}\n(.*?)\n\.{4}/
-  if (synopsisMatch.find()) {
-    def synopsisText = synopsisMatch.group(1).replaceAll(/\s+/, ' ')
-    def requiredOpts = extractRequiredOptionNames(synopsisText)
-    def requiredArgs = extractRequiredPositionalNames(synopsisText)
-
-    // Option labels look like "*-d*, *--conf-dir*=_DIR_::" or "*-rf, --replication-factor*=_<x>_::"
-    // or "*--all*::". We strip the asciidoc marks, look at the part before '=', and pull
-    // every -x / --xx token so we match against the required set regardless of label shape.
-    if (!requiredOpts.isEmpty()) {
-      content = content.replaceAll(/(?m)^(\*-[^\n]+::)\n( +)([^\n]+)/) { List<String> m ->
-        def label = m[1]
-        def indent = m[2]
-        def descLine = m[3]
-        def beforeEq = label.replaceAll(/[*_]/, '').split('=', 2)[0]
-        def names = []
-        def nm = beforeEq =~ /(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)/
-        while (nm.find()) { names << nm.group(1) }
-        names.any { requiredOpts.contains(it) } ?
-          "${label}\n${indent}*(required)* ${descLine}" : m[0]
-      }
-    }
-
-    // Positional arg labels look like "_<src>_::".
-    if (!requiredArgs.isEmpty()) {
-      content = content.replaceAll(/(?m)^_(<[^<>\n]+>)_::\n( +)([^\n]+)/) { List<String> m ->
-        def name = m[1]
-        def indent = m[2]
-        def descLine = m[3]
-        requiredArgs.contains(name) ?
-          "_${name}_::\n${indent}*(required)* ${descLine}" : m[0]
-      }
-    }
-  }
+  content = markRequiredOptionsAndArgs(content)
 
   // Strip the outer full-manpage tag wrappers
   content = content.replace("// tag::picocli-generated-full-manpage[]\n", '')

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-create.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-create.adoc
@@ -51,7 +51,7 @@ Creates a core or collection depending on whether Solr is running in standalone 
 == Options
 
 *-c*, *--name*=_<name>_::
-  Name of collection or core to create.
+  *(required)* Name of collection or core to create.
 
 *-d*, *--conf-dir*=_<confDir>_::
   Configuration directory to copy when creating the new collection; default is _default.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-delete.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-delete.adoc
@@ -50,7 +50,7 @@ Deletes a collection or core depending on whether Solr is running in SolrCloud o
 == Options
 
 *-c*, *--name*=_<name>_::
-  Name of the core / collection to delete.
+  *(required)* Name of the core / collection to delete.
 
 *--delete-config*::
   Flag to indicate if the underlying configuration directory for a collection should also be deleted; default is false.

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-cp.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-cp.adoc
@@ -79,10 +79,10 @@ and the last element of the <src> path will be appended unless <src> also ends i
 == Arguments
 
 _<src>_::
-  Source path: [file:][/]path/to/local/file or zk:/path/to/zk/node.
+  *(required)* Source path: [file:][/]path/to/local/file or zk:/path/to/zk/node.
 
 _<dst>_::
-  Destination path: [file:][/]path/to/local/file or zk:/path/to/zk/node.
+  *(required)* Destination path: [file:][/]path/to/local/file or zk:/path/to/zk/node.
 
 // end::picocli-generated-man-section-arguments[]
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-downconfig.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-downconfig.adoc
@@ -50,10 +50,10 @@ Download a configset from ZooKeeper to the local filesystem.
 == Options
 
 *-d*, *--conf-dir*=_DIR_::
-  Local directory with configs.
+  *(required)* Local directory with configs.
 
 *-n*, *--conf-name*=_<confName>_::
-  Configset name in ZooKeeper.
+  *(required)* Configset name in ZooKeeper.
 
 *-s*, *--solr-url*=_<solrUrl>_::
   Base Solr URL, which can be used to determine the zk-host if --zk-host is not known

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-ls.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-ls.adoc
@@ -69,7 +69,7 @@ List the contents of a ZooKeeper node.
 == Arguments
 
 _<path>_::
-  The path of the ZooKeeper znode path to list.
+  *(required)* The path of the ZooKeeper znode path to list.
 
 // end::picocli-generated-man-section-arguments[]
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-mkroot.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-mkroot.adoc
@@ -70,7 +70,7 @@ Make a znode in ZooKeeper with no data. Can be used to make a path of arbitrary 
 == Arguments
 
 _<path>_::
-  The ZooKeeper znode path to create.
+  *(required)* The ZooKeeper znode path to create.
 
 // end::picocli-generated-man-section-arguments[]
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-mv.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-mv.adoc
@@ -70,10 +70,10 @@ and the last element of the <src> path will be appended.
 == Arguments
 
 _<src>_::
-  Source ZooKeeper znode path (zk: prefix optional).
+  *(required)* Source ZooKeeper znode path (zk: prefix optional).
 
 _<dst>_::
-  Destination ZooKeeper znode path (zk: prefix optional).
+  *(required)* Destination ZooKeeper znode path (zk: prefix optional).
 
 // end::picocli-generated-man-section-arguments[]
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-rm.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-rm.adoc
@@ -69,7 +69,7 @@ Remove a znode from ZooKeeper.
 == Arguments
 
 _<path>_::
-  The ZooKeeper znode path to remove (zk: prefix optional).
+  *(required)* The ZooKeeper znode path to remove (zk: prefix optional).
 
 // end::picocli-generated-man-section-arguments[]
 

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-upconfig.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-upconfig.adoc
@@ -50,10 +50,10 @@ Upload a configset from the local filesystem to ZooKeeper.
 == Options
 
 *-d*, *--conf-dir*=_DIR_::
-  Local directory with configs.
+  *(required)* Local directory with configs.
 
 *-n*, *--conf-name*=_<confName>_::
-  Configset name in ZooKeeper.
+  *(required)* Configset name in ZooKeeper.
 
 *-s*, *--solr-url*=_<solrUrl>_::
   Base Solr URL, which can be used to determine the zk-host if --zk-host is not known

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-updateacls.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-zk-updateacls.adoc
@@ -66,7 +66,7 @@ Recursively re-applies ZooKeeper ACLs to a znode and all its descendants. The AC
 == Arguments
 
 _<path>_::
-  The ZooKeeper znode path to update ACLs for.
+  *(required)* The ZooKeeper znode path to update ACLs for.
 
 // end::picocli-generated-man-section-arguments[]
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17697

# Description

Generated Options documentation doesn't reflect if they are required or not, which is a key thing users want to know!

# Solution

Me and claude found out that there are some limitations in Picocli's Man Page Generator, and so we solved it with some more gradle code.  I opened up https://github.com/remkop/picocli/issues/2519 for a more permanent solution.

Here is a screenshot with current ref guide on left, and with this change, on the right:

<img width="1444" height="848" alt="image" src="https://github.com/user-attachments/assets/eca09519-f66f-49b3-833c-402a4189842a" />


# Tests

manual

