### PR TITLE
SOLR-18246: Support multiple facet.field parameters in Admin UI query screen

### DIFF
--- a/changelog/unreleased/SOLR-18246.yml
+++ b/changelog/unreleased/SOLR-18246.yml
@@ -1,4 +1,4 @@
-title: Solr Admin UI does not support multiple facet.field parameters correctly
+title: Solr Admin UI properly supports multiple facet.field parameters
 type: fixed
 authors:
   - name: Umut Saribiyik

--- a/changelog/unreleased/SOLR-18246.yml
+++ b/changelog/unreleased/SOLR-18246.yml
@@ -1,0 +1,7 @@
+title: Solr Admin UI does not support multiple facet.field parameters correctly
+type: fixed
+authors:
+  - name: Umut Saribiyik
+links:
+  - name: SOLR-18246
+    url: https://issues.apache.org/jira/browse/SOLR-18246

--- a/solr/webapp/web/js/angular/controllers/query.js
+++ b/solr/webapp/web/js/angular/controllers/query.js
@@ -21,6 +21,7 @@ solrAdminApp.controller('QueryController',
 
     $scope._models = [];
     $scope.filters = [{fq:""}];
+    $scope.facetFields = [{value:""}];
     $scope.rawParams = [{rawParam:""}];
     $scope.val = {};
     $scope.val['q'] = "*:*";
@@ -72,6 +73,8 @@ solrAdminApp.controller('QueryController',
         // filters and rawParams are handled specially because of possible multiple values
         if( p === "fq" ) {
             addFilters(urlParams[p]);
+        } else if( p === "facet.field" ) {
+            addFacetFields(urlParams[p]);
         } else {
             setParam(p, urlParams[p]);
         }
@@ -125,6 +128,18 @@ solrAdminApp.controller('QueryController',
             }
           } else {
             $scope.filters.push({fq: argObject});
+          }
+      }
+    }
+    function addFacetFields(argObject){
+      if( argObject ){
+        $scope.facetFields = [];
+          if( Array.isArray(argObject) ){
+            for( var i = 0, iLen = argObject.length; i<iLen; i++ ){
+              $scope.facetFields.push({value: argObject[i]});
+            }
+          } else {
+            $scope.facetFields.push({value: argObject});
           }
       }
     }
@@ -187,6 +202,12 @@ solrAdminApp.controller('QueryController',
 
       for (var filter in $scope.filters) {
         copy(params, $scope.filters[filter]);
+      }
+
+      for (var fi in $scope.facetFields) {
+        if ($scope.facetFields[fi].value) {
+          set("facet.field", $scope.facetFields[fi].value);
+        }
       }
 
       for (var rawIndex in $scope.rawParams) {
@@ -293,6 +314,16 @@ solrAdminApp.controller('QueryController',
     };
     $scope.addFilter = function(index) {
       $scope.filters.splice(index+1, 0, {fq:""});
+    };
+    $scope.removeFacetField = function(index) {
+      if ($scope.facetFields.length === 1) {
+        $scope.facetFields = [{value: ""}];
+      } else {
+        $scope.facetFields.splice(index, 1);
+      }
+    };
+    $scope.addFacetField = function(index) {
+      $scope.facetFields.splice(index+1, 0, {value:""});
     };
     $scope.removeRawParam = function (index) {
       if ($scope.rawParams.length === 1) {

--- a/solr/webapp/web/partials/query.html
+++ b/solr/webapp/web/partials/query.html
@@ -433,7 +433,15 @@ limitations under the License.
           <textarea ng-model="val['facet.query']" name="facet.query" id="facet_query"></textarea>
 
           <label for="facet_field">facet.field</label>
-          <input type="text" ng-model="val['facet.field']" name="facet.field" id="facet_field">
+          <div class="multiple" id="facet_field">
+            <div class="row clearfix" ng-repeat="facetField in facetFields">
+              <input type="text" ng-model="facetField.value" name="facet.field" title="Facet field.">
+              <div class="buttons">
+                <a class="rem" ng-click="removeFacetField($index)"><span></span></a>
+                <a class="add" ng-click="addFacetField($index)"><span></span></a>
+              </div>
+            </div>
+          </div>
 
           <label for="facet_prefix">facet.prefix</label>
           <input type="text" ng-model="val['facet.prefix']" name="facet.prefix" id="facet_prefix">


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18246

# Description

This PR fixes handling of multiple `facet.field` parameters in the Solr Admin UI query screen.

Previously, the UI only provided a single `facet.field` input. When multiple facet fields were entered, the generated request could contain them as a single comma-separated parameter value, for example:

```text
facet.field=foo,bar
```

Solr treats this as one facet field value instead of two separate `facet.field` parameters.

The expected request format is:

```text
facet.field=foo&facet.field=bar
```

The same problem can also occur when using the raw parameters area: multiple `facet.field` values can be entered there, but the resulting facet parameters are still built incorrectly. In addition, the dedicated `facet.field` input should support multiple facet fields directly, without requiring users to rely on raw parameters for this common use case.

# Solution

This PR updates the Admin UI query screen to handle multiple `facet.field` values explicitly.

The changes include:

- Adding a `facetFields` model and initializing it with a default entry
- Parsing `facet.field` from the URL, supporting both array and scalar values
- Rendering repeatable `facet.field` inputs with add/remove controls
- Including all configured `facet.field` values when building the query parameters

This ensures that multiple facet fields are sent as repeated `facet.field` parameters instead of a single comma-separated value.

# Tests

I manually tested the Admin UI query screen with faceting enabled.

Tested scenarios:

- Querying with a single `facet.field`
- Querying with multiple `facet.field` values
- Adding and removing `facet.field` inputs in the UI
- Loading existing query URLs containing one or more `facet.field` parameters
- Verifying that the generated request contains repeated `facet.field` parameters, for example:

```text
facet.field=foo&facet.field=bar
```

and not:

```text
facet.field=foo,bar
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change