### PR TITLE
Tweak nightly docker image builds

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -25,13 +25,13 @@ jobs:
             version: 11.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
-            base-image: eclipse-temurin:25-jre-jammy
+            base-image: eclipse-temurin:25-jre-noble
             tag-suffix: ''
           - branch: main
             version: 11.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: slim
-            base-image: eclipse-temurin:25-jre-jammy
+            base-image: eclipse-temurin:25-jre-noble
             tag-suffix: ''
 
           # branch_10x - Gradle on JDK21, Docker images with JRE21 (default) and JRE25
@@ -39,19 +39,19 @@ jobs:
             version: 10.1.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
-            base-image: eclipse-temurin:21-jre-jammy
+            base-image: eclipse-temurin:21-jre-noble
             tag-suffix: ''
           - branch: branch_10x
             version: 10.1.0-SNAPSHOT
             gradle-jdk: 21
             dist: slim
-            base-image: eclipse-temurin:21-jre-jammy
+            base-image: eclipse-temurin:21-jre-noble
             tag-suffix: ''
           - branch: branch_10x
             version: 10.1.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
-            base-image: eclipse-temurin:25-jre-jammy
+            base-image: eclipse-temurin:25-jre-noble
             tag-suffix: '-java25'
 
           # branch_10_0 - Gradle on JDK21, Docker images with JRE21 (default) and JRE25
@@ -76,18 +76,38 @@ jobs:
 
           # branch_9x - Gradle on JDK17, Docker images with JRE17 (default) and JRE21
           - branch: branch_9x
-            version: 9.11.0-SNAPSHOT
+            version: 9.12.0-SNAPSHOT
             gradle-jdk: 17
             dist: full
             base-image: eclipse-temurin:17-jre-jammy
             tag-suffix: ''
           - branch: branch_9x
-            version: 9.11.0-SNAPSHOT
+            version: 9.12.0-SNAPSHOT
             gradle-jdk: 17
             dist: slim
             base-image: eclipse-temurin:17-jre-jammy
             tag-suffix: ''
           - branch: branch_9x
+            version: 9.12.0-SNAPSHOT
+            gradle-jdk: 17
+            dist: full
+            base-image: eclipse-temurin:21-jre-jammy
+            tag-suffix: '-java21'
+
+          # branch_9_11 - Gradle on JDK17, Docker images with JRE17 (default) and JRE21
+          - branch: branch_9_11
+            version: 9.11.0-SNAPSHOT
+            gradle-jdk: 17
+            dist: full
+            base-image: eclipse-temurin:17-jre-jammy
+            tag-suffix: ''
+          - branch: branch_9_11
+            version: 9.11.0-SNAPSHOT
+            gradle-jdk: 17
+            dist: slim
+            base-image: eclipse-temurin:17-jre-jammy
+            tag-suffix: ''
+          - branch: branch_9_11
             version: 9.11.0-SNAPSHOT
             gradle-jdk: 17
             dist: full

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -22,13 +22,11 @@ jobs:
         include:
           # main branch - Gradle on JDK21, Docker images with JRE25
           - branch: main
-            version: 11.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
             base-image: eclipse-temurin:25-jre-noble
             tag-suffix: ''
           - branch: main
-            version: 11.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: slim
             base-image: eclipse-temurin:25-jre-noble
@@ -36,19 +34,16 @@ jobs:
 
           # branch_10x - Gradle on JDK21, Docker images with JRE21 (default) and JRE25
           - branch: branch_10x
-            version: 10.1.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
             base-image: eclipse-temurin:21-jre-noble
             tag-suffix: ''
           - branch: branch_10x
-            version: 10.1.0-SNAPSHOT
             gradle-jdk: 21
             dist: slim
             base-image: eclipse-temurin:21-jre-noble
             tag-suffix: ''
           - branch: branch_10x
-            version: 10.1.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
             base-image: eclipse-temurin:25-jre-noble
@@ -56,19 +51,16 @@ jobs:
 
           # branch_10_0 - Gradle on JDK21, Docker images with JRE21 (default) and JRE25
           - branch: branch_10_0
-            version: 10.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
             base-image: eclipse-temurin:21-jre-jammy
             tag-suffix: ''
           - branch: branch_10_0
-            version: 10.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: slim
             base-image: eclipse-temurin:21-jre-jammy
             tag-suffix: ''
           - branch: branch_10_0
-            version: 10.0.0-SNAPSHOT
             gradle-jdk: 21
             dist: full
             base-image: eclipse-temurin:25-jre-jammy
@@ -76,19 +68,16 @@ jobs:
 
           # branch_9x - Gradle on JDK17, Docker images with JRE17 (default) and JRE21
           - branch: branch_9x
-            version: 9.12.0-SNAPSHOT
             gradle-jdk: 17
             dist: full
             base-image: eclipse-temurin:17-jre-jammy
             tag-suffix: ''
           - branch: branch_9x
-            version: 9.12.0-SNAPSHOT
             gradle-jdk: 17
             dist: slim
             base-image: eclipse-temurin:17-jre-jammy
             tag-suffix: ''
           - branch: branch_9x
-            version: 9.12.0-SNAPSHOT
             gradle-jdk: 17
             dist: full
             base-image: eclipse-temurin:21-jre-jammy
@@ -96,19 +85,16 @@ jobs:
 
           # branch_9_11 - Gradle on JDK17, Docker images with JRE17 (default) and JRE21
           - branch: branch_9_11
-            version: 9.11.0-SNAPSHOT
             gradle-jdk: 17
             dist: full
             base-image: eclipse-temurin:17-jre-jammy
             tag-suffix: ''
           - branch: branch_9_11
-            version: 9.11.0-SNAPSHOT
             gradle-jdk: 17
             dist: slim
             base-image: eclipse-temurin:17-jre-jammy
             tag-suffix: ''
           - branch: branch_9_11
-            version: 9.11.0-SNAPSHOT
             gradle-jdk: 17
             dist: full
             base-image: eclipse-temurin:21-jre-jammy
@@ -175,20 +161,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Docker tag name
-        id: tag
-        run: |
-          if [ "${{ matrix.dist }}" = "slim" ]; then
-            echo "tag=${{ matrix.version }}-slim${{ matrix.tag-suffix }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${{ matrix.version }}${{ matrix.tag-suffix }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Test and publish Docker image
         run: |
+          TAG_ARGS=""
+          if [ -n "${{ matrix.version }}" ]; then
+            if [ "${{ matrix.dist }}" = "slim" ]; then
+              TAG_ARGS="-Psolr.docker.imageTag=${{ matrix.version }}-slim${{ matrix.tag-suffix }}"
+            else
+              TAG_ARGS="-Psolr.docker.imageTag=${{ matrix.version }}${{ matrix.tag-suffix }}"
+            fi
+          elif [ -n "${{ matrix.tag-suffix }}" ]; then
+            TAG_ARGS="-Psolr.docker.imageTagSuffix=${{ matrix.tag-suffix }}"
+          fi
           ./gradlew testDocker dockerPush \
             -Psolr.docker.imageRepo=apache/solr-nightly \
-            -Psolr.docker.imageTag=${{ steps.tag.outputs.tag }} \
+            $TAG_ARGS \
             -Psolr.docker.dist=${{ matrix.dist }} \
             -Psolr.docker.platform=linux/arm64,linux/amd64 \
             -Psolr.docker.baseImage=${{ matrix.base-image }}

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -49,23 +49,6 @@ jobs:
             base-image: eclipse-temurin:25-jre-noble
             tag-suffix: '-java25'
 
-          # branch_10_0 - Gradle on JDK21, Docker images with JRE21 (default) and JRE25
-          - branch: branch_10_0
-            gradle-jdk: 21
-            dist: full
-            base-image: eclipse-temurin:21-jre-jammy
-            tag-suffix: ''
-          - branch: branch_10_0
-            gradle-jdk: 21
-            dist: slim
-            base-image: eclipse-temurin:21-jre-jammy
-            tag-suffix: ''
-          - branch: branch_10_0
-            gradle-jdk: 21
-            dist: full
-            base-image: eclipse-temurin:25-jre-jammy
-            tag-suffix: '-java25'
-
           # branch_9x - Gradle on JDK17, Docker images with JRE17 (default) and JRE21
           - branch: branch_9x
             gradle-jdk: 17


### PR DESCRIPTION
* All 10.x and main use Ubuntu **noble**, as is default
* Remove explicit `version` from matrix and fall back to branch defaults
* Add builds for `branch_9_11` (remove again after release)
* Remove `branch_10_0` as there won't be a 10.0.1 release...