### PR TITLE
tests-via-crave: limit paths

### DIFF
--- a/.github/workflows/tests-via-crave.yml
+++ b/.github/workflows/tests-via-crave.yml
@@ -1,9 +1,12 @@
-name: Solr Tests
+name: Solr Tests via Crave
 
 on:
   pull_request:
     branches:
       - '*'
+    paths:
+      - 'solr/**/src/**'
+      - 'gradle/libs.versions.toml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Don't want to run Crave for PRs that merely touch the changelog or for some other things.