### PR TITLE
SOLR-17600 (Part 1/4): Migrate V2 API Payloads from MapSerializable

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -51,6 +51,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.DefaultSolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.ReflectMapWriter;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.NodeRoles;
@@ -259,7 +260,7 @@ public class ClusterAPI {
     @Command(name = "add-role")
     public void addRole(PayloadObj<RoleInfo> obj) throws Exception {
       RoleInfo info = obj.get();
-      Map<String, Object> m = info.toMap(new HashMap<>());
+      Map<String, Object> m = new SimpleOrderedMap<>(info);
       m.put("action", ADDROLE.toString());
       collectionsHandler.handleRequestBody(wrapParams(obj.getRequest(), m), obj.getResponse());
     }
@@ -267,7 +268,7 @@ public class ClusterAPI {
     @Command(name = "remove-role")
     public void removeRole(PayloadObj<RoleInfo> obj) throws Exception {
       RoleInfo info = obj.get();
-      Map<String, Object> m = info.toMap(new HashMap<>());
+      Map<String, Object> m = new SimpleOrderedMap<>(info);
       m.put("action", REMOVEROLE.toString());
       collectionsHandler.handleRequestBody(wrapParams(obj.getRequest(), m), obj.getResponse());
     }

--- a/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
@@ -60,7 +60,7 @@ import org.apache.solr.client.solrj.request.CollectionRequiringSolrRequest;
 import org.apache.solr.client.solrj.response.SimpleSolrResponse;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.cloud.ZkSolrResourceLoader;
-import org.apache.solr.common.MapSerializable;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrErrorWrappingException;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterState;
@@ -75,6 +75,7 @@ import org.apache.solr.common.util.CommandOperation;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.Utils;
@@ -204,7 +205,7 @@ public class SolrConfigHandler extends RequestHandlerBase
             Map<String, Object> m = new LinkedHashMap<>();
             m.put(ZNODEVER, params.getZnodeVersion());
             if (p != null) {
-              m.put(RequestParams.NAME, Map.of(parts.get(2), p.toMap(new LinkedHashMap<>())));
+              m.put(RequestParams.NAME, Map.of(parts.get(2), new SimpleOrderedMap<>(p)));
             }
             resp.add(SolrQueryResponse.NAME, m);
           } else {
@@ -283,16 +284,16 @@ public class SolrConfigHandler extends RequestHandlerBase
               Map pluginNameVsPluginInfo = (Map) val.get(parts.get(1));
               if (pluginNameVsPluginInfo != null) {
                 Object o =
-                    pluginNameVsPluginInfo instanceof MapSerializable
+                    pluginNameVsPluginInfo instanceof MapWriter
                         ? pluginNameVsPluginInfo
                         : pluginNameVsPluginInfo.get(componentName);
                 Map<String, Object> pluginInfo =
-                    o instanceof MapSerializable
-                        ? ((MapSerializable) o).toMap(new LinkedHashMap<>())
+                    o instanceof MapWriter
+                        ? new SimpleOrderedMap<>((MapWriter) o)
                         : (Map<String, Object>) o;
                 val.put(
                     parts.get(1),
-                    pluginNameVsPluginInfo instanceof PluginInfo
+                    pluginNameVsPluginInfo instanceof MapWriter
                         ? pluginInfo
                         : Map.of(componentName, pluginInfo));
                 if (req.getParams().getBool("meta", false)) {
@@ -306,8 +307,10 @@ public class SolrConfigHandler extends RequestHandlerBase
                     if (infos == null || infos.isEmpty()) continue;
                     infos.forEach(
                         (s, mapWriter) -> {
-                          if (s.equals(pluginInfo.get("class"))) {
-                            (pluginInfo).put("_packageinfo_", mapWriter);
+                          Map<String, Object> componentInfo =
+                              getComponentInfo(pluginInfo, componentName);
+                          if (s.equals(componentInfo.get("class"))) {
+                            (componentInfo).put("_packageinfo_", mapWriter);
                           }
                         });
                   }
@@ -320,10 +323,20 @@ public class SolrConfigHandler extends RequestHandlerBase
       }
     }
 
+    @SuppressWarnings({"unchecked"})
+    private Map<String, Object> getComponentInfo(
+        Map<String, Object> pluginInfo, String componentName) {
+      if (pluginInfo.containsKey("class")) {
+        return pluginInfo;
+      }
+      return (Map<String, Object>)
+          pluginInfo.computeIfAbsent(componentName, k -> new LinkedHashMap<>());
+    }
+
     private Map<String, Object> getConfigDetails(String componentType, SolrQueryRequest req) {
       String componentName = componentType == null ? null : req.getParams().get("componentName");
       boolean showParams = req.getParams().getBool("expandParams", false);
-      Map<String, Object> map = this.req.getCore().getSolrConfig().toMap(new LinkedHashMap<>());
+      Map<String, Object> map = new SimpleOrderedMap<>(this.req.getCore().getSolrConfig());
       if (componentType != null && !SolrRequestHandler.TYPE.equals(componentType)) return map;
 
       @SuppressWarnings({"unchecked"})
@@ -356,7 +369,7 @@ public class SolrConfigHandler extends RequestHandlerBase
       if (plugin instanceof Map) {
         pluginInfo = (Map) plugin;
       } else if (plugin instanceof PluginInfo) {
-        pluginInfo = ((PluginInfo) plugin).toMap(new LinkedHashMap<>());
+        pluginInfo = new SimpleOrderedMap<>((PluginInfo) plugin);
       }
       String useParams = (String) pluginInfo.get(USEPARAM);
       String useParamsInReq = req.getOriginalParams().get(USEPARAM);
@@ -510,9 +523,7 @@ public class SolrConfigHandler extends RequestHandlerBase
           ZkController.touchConfDir(zkLoader);
         } else {
           if (log.isDebugEnabled()) {
-            log.debug(
-                "persisting params data : {}",
-                Utils.toJSONString(params.toMap(new LinkedHashMap<>())));
+            log.debug("persisting params data : {}", Utils.toJSONString(params));
           }
           int latestVersion =
               ZkController.persistConfigResourceToZooKeeper(

--- a/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java
@@ -205,7 +205,7 @@ public class SolrConfigHandler extends RequestHandlerBase
             Map<String, Object> m = new LinkedHashMap<>();
             m.put(ZNODEVER, params.getZnodeVersion());
             if (p != null) {
-              m.put(RequestParams.NAME, Map.of(parts.get(2), new SimpleOrderedMap<>(p)));
+              m.put(RequestParams.NAME, Map.of(parts.get(2), p));
             }
             resp.add(SolrQueryResponse.NAME, m);
           } else {
@@ -336,7 +336,7 @@ public class SolrConfigHandler extends RequestHandlerBase
     private Map<String, Object> getConfigDetails(String componentType, SolrQueryRequest req) {
       String componentName = componentType == null ? null : req.getParams().get("componentName");
       boolean showParams = req.getParams().getBool("expandParams", false);
-      Map<String, Object> map = new SimpleOrderedMap<>(this.req.getCore().getSolrConfig());
+      Map<String, Object> map = this.req.getCore().getSolrConfig().toMap(new LinkedHashMap<>());
       if (componentType != null && !SolrRequestHandler.TYPE.equals(componentType)) return map;
 
       @SuppressWarnings({"unchecked"})
@@ -369,7 +369,7 @@ public class SolrConfigHandler extends RequestHandlerBase
       if (plugin instanceof Map) {
         pluginInfo = (Map) plugin;
       } else if (plugin instanceof PluginInfo) {
-        pluginInfo = new SimpleOrderedMap<>((PluginInfo) plugin);
+        pluginInfo = ((PluginInfo) plugin).toMap(new LinkedHashMap<>());
       }
       String useParams = (String) pluginInfo.get(USEPARAM);
       String useParamsInReq = req.getOriginalParams().get(USEPARAM);

--- a/solr/core/src/java/org/apache/solr/handler/admin/BaseHandlerApiSupport.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/BaseHandlerApiSupport.java
@@ -21,6 +21,7 @@ import static org.apache.solr.client.solrj.SolrRequest.METHOD.POST;
 import static org.apache.solr.common.SolrException.ErrorCode.BAD_REQUEST;
 import static org.apache.solr.common.util.StrUtils.splitSmart;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -185,7 +186,7 @@ public abstract class BaseHandlerApiSupport implements ApiSupport {
           }
 
           @Override
-          public Map<String, Object> toMap(Map<String, Object> suppliedMap) {
+          public void writeMap(EntryWriter ew) throws IOException {
             for (Iterator<String> it = getParameterNamesIterator(); it.hasNext(); ) {
               final String param = it.next();
               String key = cmd.meta().getParamSubstitute(param);
@@ -195,6 +196,7 @@ public abstract class BaseHandlerApiSupport implements ApiSupport {
                       : map.get(key);
               if (o == null) o = pathValues.get(key);
               if (o == null && useRequestParams) o = origParams.getParams(key);
+              if (o == null) continue;
               // make strings out of as many things as we can now to minimize differences from
               // the standard impls that pass through a NamedList/SimpleOrderedMap...
               Class<?> oClass = o.getClass();
@@ -202,19 +204,21 @@ public abstract class BaseHandlerApiSupport implements ApiSupport {
                   || Number.class.isAssignableFrom(oClass)
                   || Character.class.isAssignableFrom(oClass)
                   || Boolean.class.isAssignableFrom(oClass)) {
-                suppliedMap.put(param, String.valueOf(o));
-              } else if (List.class.isAssignableFrom(oClass)
-                  && ((List) o).get(0) instanceof String) {
+                ew.put(param, String.valueOf(o));
+              } else if (List.class.isAssignableFrom(oClass)) {
                 @SuppressWarnings({"unchecked"})
-                List<String> l = (List<String>) o;
-                suppliedMap.put(param, l.toArray(new String[0]));
+                List<?> l = (List<?>) o;
+                if (l.isEmpty() || l.get(0) instanceof String) {
+                  ew.put(param, l.toArray(new String[0]));
+                } else {
+                  ew.put(param, o);
+                }
               } else {
                 // Lists pass through but will require special handling downstream
                 // if they contain non-string elements.
-                suppliedMap.put(param, o);
+                ew.put(param, o);
               }
             }
-            return suppliedMap;
           }
         });
   }

--- a/solr/core/src/java/org/apache/solr/handler/admin/IndexSizeEstimator.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/IndexSizeEstimator.java
@@ -59,6 +59,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.solr.common.MapWriter;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -277,12 +278,10 @@ public class IndexSizeEstimator {
     for (Map.Entry<String, Object> entry : result.entrySet()) {
       Object value = entry.getValue();
       if (value instanceof ItemPriorityQueue queue) {
-        Map<String, Object> map = new LinkedHashMap<>();
-        queue.toMap(map);
+        Map<String, Object> map = new SimpleOrderedMap<>(queue);
         entry.setValue(map);
       } else if (value instanceof MapWriterSummaryStatistics stats) {
-        Map<String, Object> map = new LinkedHashMap<>();
-        stats.toMap(map);
+        Map<String, Object> map = new SimpleOrderedMap<>(stats);
         entry.setValue(map);
       } else if (value instanceof AtomicLong) {
         entry.setValue(((AtomicLong) value).longValue());

--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
@@ -53,6 +53,7 @@ import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.SuppressForbidden;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.request.SolrQueryRequest;
@@ -758,7 +759,7 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
         for (String collection : page.selected) {
           DocCollection dc = cs.getCollectionOrNull(collection);
           if (dc != null) {
-            Map<String, Object> collectionState = dc.toMap(new LinkedHashMap<>());
+            Map<String, Object> collectionState = Utils.convertToMap(dc, new LinkedHashMap<>());
             if (applyStatusFilter) {
               // verify this collection matches the filtered state
               if (page.matchesStatusFilter(collectionState, liveNodes)) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/CreateCore.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/CreateCore.java
@@ -158,7 +158,7 @@ public class CreateCore extends CoreAdminAPIBase implements CoreApis.Create {
   }
 
   public static CreateCoreParams createRequestBodyFromV1Params(SolrParams solrParams) {
-    final var v1ParamMap = solrParams.toMap(new HashMap<>());
+    final var v1ParamMap = Utils.convertToMap(solrParams, new HashMap<>());
     v1ParamMap.remove(ACTION);
     v1ParamMap.remove(ASYNC);
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/InstallShardData.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/InstallShardData.java
@@ -32,6 +32,7 @@ import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.jersey.PermissionName;
 import org.apache.solr.request.SolrQueryRequest;
@@ -117,6 +118,6 @@ public class InstallShardData extends AdminAPIBase implements InstallShardDataAp
     }
 
     messageTyped.validate();
-    return new ZkNodeProps(messageTyped.toMap(new HashMap<>()));
+    return new ZkNodeProps(Utils.convertToMap(messageTyped, new HashMap<>()));
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/MigrateDocsAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/MigrateDocsAPI.java
@@ -29,6 +29,7 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.MigrateDocsPayload;
 import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CollectionsHandler;
 
 /**
@@ -55,7 +56,7 @@ public class MigrateDocsAPI {
   @Command(name = V2_MIGRATE_DOCS_CMD)
   public void migrateDocs(PayloadObj<MigrateDocsPayload> obj) throws Exception {
     final MigrateDocsPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, CollectionParams.CollectionAction.MIGRATE.toLower());
     v1Params.put(COLLECTION, obj.getRequest().getPathTemplateValues().get(COLLECTION));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/ModifyCollectionAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/ModifyCollectionAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.ModifyCollectionPayload;
 import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CollectionsHandler;
 
 /**
@@ -58,7 +59,7 @@ public class ModifyCollectionAPI {
   public void modifyCollection(PayloadObj<ModifyCollectionPayload> obj) throws Exception {
     final ModifyCollectionPayload v2Body = obj.get();
 
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, CollectionParams.CollectionAction.MODIFYCOLLECTION.toLower());
     v1Params.put(COLLECTION, obj.getRequest().getPathTemplateValues().get(COLLECTION));
     if (v2Body.config != null) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/MoveReplicaAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/MoveReplicaAPI.java
@@ -29,6 +29,7 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.MoveReplicaPayload;
 import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CollectionsHandler;
 
 /**
@@ -55,7 +56,7 @@ public class MoveReplicaAPI {
   @Command(name = V2_MOVE_REPLICA_CMD)
   public void moveReplica(PayloadObj<MoveReplicaPayload> obj) throws Exception {
     final MoveReplicaPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, CollectionParams.CollectionAction.MOVEREPLICA.toLower());
     v1Params.put(COLLECTION, obj.getRequest().getPathTemplateValues().get(COLLECTION));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/OverseerOperationAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/OverseerOperationAPI.java
@@ -22,7 +22,7 @@ import static org.apache.solr.common.params.CoreAdminParams.ACTION;
 import static org.apache.solr.handler.ClusterAPI.wrapParams;
 import static org.apache.solr.security.PermissionNameProvider.Name.CORE_EDIT_PERM;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.apache.solr.api.Command;
@@ -30,6 +30,7 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.OverseerOperationPayload;
 import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -59,7 +60,7 @@ public class OverseerOperationAPI {
   @Command(name = OVERSEER_OP_CMD)
   public void joinOverseerLeaderElection(PayloadObj<OverseerOperationPayload> payload)
       throws Exception {
-    final Map<String, Object> v1Params = payload.get().toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(payload.get(), new LinkedHashMap<>());
     v1Params.put(
         ACTION, CoreAdminParams.CoreAdminAction.OVERSEEROP.name().toLowerCase(Locale.ROOT));
     coreAdminHandler.handleRequestBody(

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/OverseerOperationAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/OverseerOperationAPI.java
@@ -22,7 +22,7 @@ import static org.apache.solr.common.params.CoreAdminParams.ACTION;
 import static org.apache.solr.handler.ClusterAPI.wrapParams;
 import static org.apache.solr.security.PermissionNameProvider.Name.CORE_EDIT_PERM;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.apache.solr.api.Command;
@@ -60,7 +60,7 @@ public class OverseerOperationAPI {
   @Command(name = OVERSEER_OP_CMD)
   public void joinOverseerLeaderElection(PayloadObj<OverseerOperationPayload> payload)
       throws Exception {
-    final Map<String, Object> v1Params = Utils.convertToMap(payload.get(), new LinkedHashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(payload.get(), new HashMap<>());
     v1Params.put(
         ACTION, CoreAdminParams.CoreAdminAction.OVERSEEROP.name().toLowerCase(Locale.ROOT));
     coreAdminHandler.handleRequestBody(

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/PrepareCoreRecoveryAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/PrepareCoreRecoveryAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.Command;
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.PrepareCoreRecoveryPayload;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -57,7 +58,7 @@ public class PrepareCoreRecoveryAPI {
   @Command(name = V2_PREP_RECOVERY_CMD)
   public void prepareCoreForRecovery(PayloadObj<PrepareCoreRecoveryPayload> obj) throws Exception {
     final PrepareCoreRecoveryPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, PREPRECOVERY.name().toLowerCase(Locale.ROOT));
     v1Params.put(CORE, obj.getRequest().getPathTemplateValues().get("core"));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RebalanceLeadersAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RebalanceLeadersAPI.java
@@ -29,6 +29,7 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.RebalanceLeadersPayload;
 import org.apache.solr.common.params.CollectionParams;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CollectionsHandler;
 
 /**
@@ -55,7 +56,7 @@ public class RebalanceLeadersAPI {
   @Command(name = V2_REBALANCE_LEADERS_CMD)
   public void rebalanceLeaders(PayloadObj<RebalanceLeadersPayload> obj) throws Exception {
     final RebalanceLeadersPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, CollectionParams.CollectionAction.REBALANCELEADERS.toLower());
     v1Params.put(COLLECTION, obj.getRequest().getPathTemplateValues().get(COLLECTION));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RejoinLeaderElectionAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RejoinLeaderElectionAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.Command;
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.RejoinLeaderElectionPayload;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -56,7 +57,7 @@ public class RejoinLeaderElectionAPI {
   public void rejoinLeaderElection(PayloadObj<RejoinLeaderElectionPayload> payload)
       throws Exception {
     final RejoinLeaderElectionPayload v2Body = payload.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, REJOINLEADERELECTION.name().toLowerCase(Locale.ROOT));
     if (v2Body.coreNodeName != null) {
       v1Params.remove("coreNodeName");

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RequestApplyCoreUpdatesAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RequestApplyCoreUpdatesAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.Command;
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.RequestApplyCoreUpdatesPayload;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -58,7 +59,7 @@ public class RequestApplyCoreUpdatesAPI {
   public void requestApplyCoreUpdates(PayloadObj<RequestApplyCoreUpdatesPayload> obj)
       throws Exception {
     final RequestApplyCoreUpdatesPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, REQUESTAPPLYUPDATES.name().toLowerCase(Locale.ROOT));
     v1Params.put(NAME, obj.getRequest().getPathTemplateValues().get("core"));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RequestBufferUpdatesAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RequestBufferUpdatesAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.RequestBufferUpdatesPayload;
 import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -57,7 +58,7 @@ public class RequestBufferUpdatesAPI {
   @Command(name = V2_REQUEST_BUFFER_UPDATES_CMD)
   public void requestBufferUpdates(PayloadObj<RequestBufferUpdatesPayload> obj) throws Exception {
     final RequestBufferUpdatesPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, REQUESTBUFFERUPDATES.name().toLowerCase(Locale.ROOT));
     v1Params.put(CoreAdminParams.NAME, obj.getRequest().getPathTemplateValues().get("core"));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RequestCoreRecoveryAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RequestCoreRecoveryAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.Command;
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.RequestCoreRecoveryPayload;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -57,7 +58,7 @@ public class RequestCoreRecoveryAPI {
   @Command(name = V2_REQUEST_RECOVERY_CMD)
   public void requestCoreRecovery(PayloadObj<RequestCoreRecoveryPayload> obj) throws Exception {
     final RequestCoreRecoveryPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, REQUESTRECOVERY.name().toLowerCase(Locale.ROOT));
     v1Params.put(CORE, obj.getRequest().getPathTemplateValues().get("core"));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/RequestSyncShardAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/RequestSyncShardAPI.java
@@ -31,6 +31,7 @@ import org.apache.solr.api.Command;
 import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.RequestSyncShardPayload;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -57,7 +58,7 @@ public class RequestSyncShardAPI {
   @Command(name = V2_REQUEST_SYNC_SHARD_CMD)
   public void requestSyncShard(PayloadObj<RequestSyncShardPayload> obj) throws Exception {
     final RequestSyncShardPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, REQUESTSYNCSHARD.name().toLowerCase(Locale.ROOT));
     v1Params.put(CORE, obj.getRequest().getPathTemplateValues().get("core"));
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/SplitCoreAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/SplitCoreAPI.java
@@ -34,6 +34,7 @@ import org.apache.solr.api.PayloadObj;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.util.ReflectMapWriter;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 
 /**
@@ -58,7 +59,7 @@ public class SplitCoreAPI {
   @Command(name = V2_SPLIT_CORE_CMD)
   public void splitCore(PayloadObj<SplitCorePayload> obj) throws Exception {
     final SplitCorePayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(
         CoreAdminParams.ACTION,
         CoreAdminParams.CoreAdminAction.SPLIT.name().toLowerCase(Locale.ROOT));

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/SplitShardAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/SplitShardAPI.java
@@ -34,6 +34,7 @@ import org.apache.solr.client.solrj.request.beans.SplitShardPayload;
 import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.CommonAdminParams;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.CollectionsHandler;
 
 /**
@@ -60,7 +61,7 @@ public class SplitShardAPI {
   @Command(name = V2_SPLIT_CMD)
   public void splitShard(PayloadObj<SplitShardPayload> obj) throws Exception {
     final SplitShardPayload v2Body = obj.get();
-    final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
+    final Map<String, Object> v1Params = Utils.convertToMap(v2Body, new HashMap<>());
     v1Params.put(ACTION, CollectionParams.CollectionAction.SPLITSHARD.toLower());
     v1Params.put(COLLECTION, obj.getRequest().getPathTemplateValues().get(COLLECTION));
 

--- a/solr/core/src/java/org/apache/solr/handler/designer/ManagedSchemaDiff.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/ManagedSchemaDiff.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.SuppressForbidden;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.ManagedIndexSchema;
@@ -218,8 +219,8 @@ public class ManagedSchemaDiff {
   @SuppressForbidden(reason = "Maps.difference")
   private static List<Map<String, Object>> getMapDifference(
       SimpleOrderedMap<Object> simpleOrderedMap1, SimpleOrderedMap<Object> simpleOrderedMap2) {
-    Map<String, Object> map1 = simpleOrderedMap1.toMap(new HashMap<>());
-    Map<String, Object> map2 = simpleOrderedMap2.toMap(new HashMap<>());
+    Map<String, Object> map1 = Utils.convertToMap(simpleOrderedMap1, new HashMap<>());
+    Map<String, Object> map2 = Utils.convertToMap(simpleOrderedMap2, new HashMap<>());
     Map<String, MapDifference.ValueDifference<Object>> mapDiff =
         Maps.difference(map1, map2).entriesDiffering();
     if (mapDiff.isEmpty()) {

--- a/solr/core/src/java/org/apache/solr/handler/export/ExportWriterStream.java
+++ b/solr/core/src/java/org/apache/solr/handler/export/ExportWriterStream.java
@@ -19,9 +19,7 @@ package org.apache.solr.handler.export;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.TimeoutException;
 import org.apache.solr.client.solrj.io.Tuple;
@@ -39,6 +37,7 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
 import org.apache.solr.common.IteratorWriter;
 import org.apache.solr.common.MapWriter;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +70,7 @@ public class ExportWriterStream extends TupleStream implements Expressible {
         ((IteratorWriter) v).toList(lst);
         v = lst;
       } else if (v instanceof MapWriter) {
-        Map<String, Object> map = new HashMap<>();
-        ((MapWriter) v).toMap(map);
-        v = map;
+        v = new SimpleOrderedMap<>((MapWriter) v);
       }
       tuple.put(k.toString(), v);
       return this;

--- a/solr/core/src/test/org/apache/solr/handler/designer/TestSchemaDesignerAPI.java
+++ b/solr/core/src/test/org/apache/solr/handler/designer/TestSchemaDesignerAPI.java
@@ -28,7 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -845,7 +844,7 @@ public class TestSchemaDesignerAPI extends SolrCloudTestCase implements SchemaDe
         idFieldMapUpdated.indexOf("omitTermFreqAndPositions", 0), Boolean.FALSE);
 
     SolrParams solrParams = idFieldMapUpdated.toSolrParams();
-    Map<String, Object> mapParams = solrParams.toMap(new HashMap<>());
+    Map<String, Object> mapParams = new SimpleOrderedMap<>(solrParams);
     mapParams.put("termVectors", Boolean.FALSE);
     reqParams.set(
         SCHEMA_VERSION_PARAM, rsp.getValues().toSolrParams().getInt(SCHEMA_VERSION_PARAM));


### PR DESCRIPTION
This is Part 1 of 4 to deprecate and remove the `MapSerializable` interface as part of SOLR-17600.

This PR migrates all V2 API payload and handler classes to use `MapWriter` / `Utils.convertToMap`.

**Note:** The work has been split into 4 PRs to make reviewing easier. The subsequent PRs are stacked on top of this one.