### PR TITLE
SOLR-18269: Restore -c as a no-op function for bin/solr start

### DIFF
--- a/changelog/unreleased/SOLR-18269.yml
+++ b/changelog/unreleased/SOLR-18269.yml
@@ -1,27 +1,3 @@
-# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
-
-# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-
-# If the change is minor, don't bother adding a changelog entry.
-# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
-
-# title:
-#  * The audience is end-users and administrators, not committers.
-#  * Be short and focused on the user impact.  Multiple sentences is fine!
-#  * For technical/geeky details, prefer the commit message instead of changelog.
-#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
-
-# type:
-#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
-#  `changed` for improvements; not opt-in
-#  `fixed` for improvements that are deemed to have fixed buggy behavior
-#  `deprecated` for marking things deprecated
-#  `removed` for code removed
-#  `dependency_update` for updates to dependencies
-#  `other` for anything else, like large/significant refactorings, build changes,
-#    test infrastructure, or documentation.
-#    Most such changes are too small/minor to bother with a changelog entry.
-
 title: Restore -c option as a no-op to bin/solr start script to simplify scripts that interact with both Solr 10 and previous versions of Solr.
 type: changed
 authors:

--- a/changelog/unreleased/SOLR-18269.yml
+++ b/changelog/unreleased/SOLR-18269.yml
@@ -1,0 +1,31 @@
+# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
+
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+
+# If the change is minor, don't bother adding a changelog entry.
+# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
+
+# title:
+#  * The audience is end-users and administrators, not committers.
+#  * Be short and focused on the user impact.  Multiple sentences is fine!
+#  * For technical/geeky details, prefer the commit message instead of changelog.
+#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
+
+# type:
+#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
+#  `changed` for improvements; not opt-in
+#  `fixed` for improvements that are deemed to have fixed buggy behavior
+#  `deprecated` for marking things deprecated
+#  `removed` for code removed
+#  `dependency_update` for updates to dependencies
+#  `other` for anything else, like large/significant refactorings, build changes,
+#    test infrastructure, or documentation.
+#    Most such changes are too small/minor to bother with a changelog entry.
+
+title: Restore -c option as a no-op to bin/solr start script to simplify scripts that interact with both Solr 10 and previous versions of Solr.
+type: changed
+authors:
+  - name: Eric Pugh
+links:
+  - name: SOLR-18269
+    url: https://issues.apache.org/jira/browse/SOLR-18269

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -371,13 +371,10 @@ function print_usage() {
 
   if [[ "$CMD" == "start" || "$CMD" == "restart" ]]; then
     echo ""
-    echo "Usage: solr $CMD [-f] [-c] [--user-managed] [--host host] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts \"jvm-opts\"] [--verbose]"
+    echo "Usage: solr $CMD [-f] [--user-managed] [--host host] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts \"jvm-opts\"] [--verbose]"
     echo ""
     echo "  -f/--foreground       Start Solr in foreground; default starts Solr in the background"
     echo "                          and sends stdout / stderr to solr-PORT-console.log"
-    echo ""
-    echo "  -c or --cloud         No-op. Solr starts in cloud mode by default; this flag is accepted for"
-    echo "                          compatibility with previous Solr scripts. Cannot be combined with --user-managed."
     echo ""
     echo "  --user-managed        Start Solr in user managed aka standalone mode"
     echo "                          See the Ref Guide for more details: https://solr.apache.org/guide/solr/latest/deployment-guide/cluster-types.html"

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -371,10 +371,13 @@ function print_usage() {
 
   if [[ "$CMD" == "start" || "$CMD" == "restart" ]]; then
     echo ""
-    echo "Usage: solr $CMD [-f] [--user-managed] [--host host] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts \"jvm-opts\"] [--verbose]"
+    echo "Usage: solr $CMD [-f] [-c] [--user-managed] [--host host] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts \"jvm-opts\"] [--verbose]"
     echo ""
     echo "  -f/--foreground       Start Solr in foreground; default starts Solr in the background"
     echo "                          and sends stdout / stderr to solr-PORT-console.log"
+    echo ""
+    echo "  -c or --cloud         No-op. Solr starts in cloud mode by default; this flag is accepted for"
+    echo "                          compatibility with previous Solr scripts. Cannot be combined with --user-managed."
     echo ""
     echo "  --user-managed        Start Solr in user managed aka standalone mode"
     echo "                          See the Ref Guide for more details: https://solr.apache.org/guide/solr/latest/deployment-guide/cluster-types.html"
@@ -682,11 +685,27 @@ SOLR_OPTS=(${SOLR_OPTS:-})
 SCRIPT_SOLR_OPTS=()
 PASS_TO_RUN_EXAMPLE=()
 SOLR_MODE="solrcloud"
+CLOUD_FLAG_SET=false
+USER_MANAGED_FLAG_SET=false
 
 if [ $# -gt 0 ]; then
   while true; do
     case "${1:-}" in
+        -c|--cloud|-cloud)
+            if [[ "$USER_MANAGED_FLAG_SET" == "true" ]]; then
+              print_usage "$SCRIPT_CMD" "Cannot combine -c/--cloud with --user-managed; choose one."
+              exit 1
+            fi
+            echo "WARNING: -c/--cloud is a no-op. Solr starts in cloud mode by default."
+            CLOUD_FLAG_SET=true
+            shift
+        ;;
         --user-managed)
+            if [[ "$CLOUD_FLAG_SET" == "true" ]]; then
+              print_usage "$SCRIPT_CMD" "Cannot combine -c/--cloud with --user-managed; choose one."
+              exit 1
+            fi
+            USER_MANAGED_FLAG_SET=true
             SOLR_MODE="user-managed"
             PASS_TO_RUN_EXAMPLE+=("--user-managed")
             shift

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -289,13 +289,10 @@ goto err
 
 :start_usage
 @echo.
-@echo Usage: solr %SCRIPT_CMD% [-f] [-c] [--user-managed] [--host hostname] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts "jvm-opts"] [--verbose]
+@echo Usage: solr %SCRIPT_CMD% [-f] [--user-managed] [--host hostname] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts "jvm-opts"] [--verbose]
 @echo.
 @echo   -f/--foreground Start Solr in foreground; default starts Solr in the background
 @echo                   and sends stdout / stderr to solr-PORT-console.log
-@echo.
-@echo   -c or --cloud  No-op. Solr starts in cloud mode by default; this flag is accepted for
-@echo                   compatibility with previous Solr scripts. Cannot be combined with --user-managed.
 @echo.
 @echo   --user-managed Start Solr in user managed aka standalone mode"
 @echo                   See the Ref Guide for more details: https://solr.apache.org/guide/solr/latest/deployment-guide/cluster-types.html

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -289,10 +289,13 @@ goto err
 
 :start_usage
 @echo.
-@echo Usage: solr %SCRIPT_CMD% [-f] [--user-managed] [--host hostname] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts "jvm-opts"] [--verbose]
+@echo Usage: solr %SCRIPT_CMD% [-f] [-c] [--user-managed] [--host hostname] [-p port] [--server-dir directory] [-z zkHost] [-m memory] [-e example] [--solr-home solr.solr.home] [--data-home solr.data.home] [--jvm-opts "jvm-opts"] [--verbose]
 @echo.
 @echo   -f/--foreground Start Solr in foreground; default starts Solr in the background
 @echo                   and sends stdout / stderr to solr-PORT-console.log
+@echo.
+@echo   -c or --cloud  No-op. Solr starts in cloud mode by default; this flag is accepted for
+@echo                   compatibility with previous Solr scripts. Cannot be combined with --user-managed.
 @echo.
 @echo   --user-managed Start Solr in user managed aka standalone mode"
 @echo                   See the Ref Guide for more details: https://solr.apache.org/guide/solr/latest/deployment-guide/cluster-types.html
@@ -383,6 +386,9 @@ IF "%1"=="--foreground" goto set_foreground_mode
 IF "%1"=="--verbose" goto set_verbose
 IF "%1"=="-q" goto set_warn
 IF "%1"=="--quiet" goto set_warn
+IF "%1"=="-c" goto set_cloud_mode
+IF "%1"=="-cloud" goto set_cloud_mode
+IF "%1"=="--cloud" goto set_cloud_mode
 IF "%1"=="--user-managed" goto set_user_managed_mode
 IF "%1"=="--server-dir" goto set_server_dir
 IF "%1"=="--solr-home" goto set_solr_home_dir
@@ -444,7 +450,21 @@ set SOLR_LOG_LEVEL=WARN
 SHIFT
 goto parse_args
 
+:set_cloud_mode
+IF "%SOLR_MODE%"=="user-managed" (
+  set "SCRIPT_ERROR=Cannot combine -c/--cloud with --user-managed; choose one."
+  goto invalid_cmd_line
+)
+@echo WARNING: -c/--cloud is a no-op. Solr starts in cloud mode by default.
+set CLOUD_FLAG_SET=true
+SHIFT
+goto parse_args
+
 :set_user_managed_mode
+IF "%CLOUD_FLAG_SET%"=="true" (
+  set "SCRIPT_ERROR=Cannot combine -c/--cloud with --user-managed; choose one."
+  goto invalid_cmd_line
+)
 set SOLR_MODE=user-managed
 set "PASS_TO_RUN_EXAMPLE=--user-managed !PASS_TO_RUN_EXAMPLE!"
 SHIFT

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -96,6 +96,14 @@ teardown() {
   solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
 }
 
+@test "-c flag prints no-op warning and still starts in cloud mode" {
+  run solr start -c
+  assert_output --partial 'WARNING: -c/--cloud is a no-op. Solr starts in cloud mode by default.'
+
+  solr assert --started http://localhost:${SOLR_PORT} --timeout 5000
+  solr assert --cloud http://localhost:${SOLR_PORT} --timeout 5000
+}
+
 @test "bootstrapping a configset" {
   local confdir_path="${SOLR_TIP}/server/solr/configsets/sample_techproducts_configs/conf"
   


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18269


# Description

Restore `-c` as no-op function to bin/solr start.

# Solution

Burps out a mention.  I used claude.  Added a bats test.

# Tests

bats.
