### PR TITLE
SOLR-18270 CertAuthPlugin : update the lookup attribute (without parametrization)

### DIFF
--- a/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
+++ b/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
@@ -2,7 +2,7 @@ title: Update looked up attribute for SSL authentication
 type: fixed
 authors:
   - name: Jean-Marie HEITZ
-    nich: heitzjm
+    nick: heitzjm
 links:
   - name: SOLR-18270
     url: https://issues.apache.org/jira/projects/SOLR/issues/SOLR-18270

--- a/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
+++ b/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
@@ -1,0 +1,8 @@
+title: Update looked up attribute for SSL authentication
+type: fixed
+authors:
+  - name: Jean-Marie HEITZ
+    nich: heitzjm
+links:
+  - name: SOLR-18270
+    url: https://issues.apache.org/jira/projects/SOLR/issues/SOLR-18270

--- a/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
+++ b/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
@@ -5,4 +5,4 @@ authors:
     nick: heitzjm
 links:
   - name: SOLR-18270
-    url: https://issues.apache.org/jira/projects/SOLR/issues/SOLR-18270
+    url: https://issues.apache.org/jira/browse/SOLR-18270

--- a/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
+++ b/changelog/unreleased/SOLR-18270-easy-fix-without-parametrization.yml
@@ -1,4 +1,4 @@
-title: Update looked up attribute for SSL authentication
+title: CertAuthPlugin now uses correct Jetty attribute for certificate lookup for SSL authentication
 type: fixed
 authors:
   - name: Jean-Marie HEITZ

--- a/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
@@ -38,8 +38,10 @@ public class CertAuthPlugin extends AuthenticationPlugin {
   private static final String PARAM_PRINCIPAL_RESOLVER = "principalResolver";
   private static final String PARAM_CLASS = "class";
   private static final String PARAM_PARAMS = "params";
-  private static final String JAVAX_REQUEST_ATTRIBUTE_NAME = "javax.servlet.request.X509Certificate";
-  private static final String JAKARTA_REQUEST_ATTRIBUTE_NAME = "jakarta.servlet.request.X509Certificate";
+  private static final String JAVAX_REQUEST_ATTRIBUTE_NAME =
+      "javax.servlet.request.X509Certificate";
+  private static final String JAKARTA_REQUEST_ATTRIBUTE_NAME =
+      "jakarta.servlet.request.X509Certificate";
 
   private static final CertPrincipalResolver DEFAULT_PRINCIPAL_RESOLVER =
       certificate -> certificate.getSubjectX500Principal();

--- a/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
@@ -102,7 +102,7 @@ public class CertAuthPlugin extends AuthenticationPlugin {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws Exception {
     X509Certificate[] certs =
-        (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+        (X509Certificate[]) request.getAttribute("jakarta.servlet.request.X509Certificate");
     if (certs == null || certs.length == 0) {
       return sendError(response, "require certificate");
     }

--- a/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
@@ -38,6 +38,9 @@ public class CertAuthPlugin extends AuthenticationPlugin {
   private static final String PARAM_PRINCIPAL_RESOLVER = "principalResolver";
   private static final String PARAM_CLASS = "class";
   private static final String PARAM_PARAMS = "params";
+
+  // TODO once on/after Solr 11, discuss whether to remove the javax name or not
+
   private static final String JAVAX_REQUEST_ATTRIBUTE_NAME =
       "javax.servlet.request.X509Certificate";
   private static final String JAKARTA_REQUEST_ATTRIBUTE_NAME =

--- a/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
@@ -38,8 +38,8 @@ public class CertAuthPlugin extends AuthenticationPlugin {
   private static final String PARAM_PRINCIPAL_RESOLVER = "principalResolver";
   private static final String PARAM_CLASS = "class";
   private static final String PARAM_PARAMS = "params";
-  private static final String OLD_REQUEST_ATTRIBUTE_NAME="javax.servlet.request.X509Certificate";
-  private static final String CURRENT_REQUEST_ATTRIBUTE_NAME="jakarta.servlet.request.X509Certificate";
+  private static final String JAVAX_REQUEST_ATTRIBUTE_NAME = "javax.servlet.request.X509Certificate";
+  private static final String JAKARTA_REQUEST_ATTRIBUTE_NAME = "jakarta.servlet.request.X509Certificate";
 
   private static final CertPrincipalResolver DEFAULT_PRINCIPAL_RESOLVER =
       certificate -> certificate.getSubjectX500Principal();
@@ -104,9 +104,9 @@ public class CertAuthPlugin extends AuthenticationPlugin {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws Exception {
     X509Certificate[] certs =
-        (X509Certificate[]) request.getAttribute(CURRENT_REQUEST_ATTRIBUTE_NAME);
+        (X509Certificate[]) request.getAttribute(JAKARTA_REQUEST_ATTRIBUTE_NAME);
     if (certs == null || certs.length == 0) {
-      certs=(X509Certificate[]) request.getAttribute(OLD_REQUEST_ATTRIBUTE_NAME);
+      certs = (X509Certificate[]) request.getAttribute(JAVAX_REQUEST_ATTRIBUTE_NAME);
     }
     if (certs == null || certs.length == 0) {
       return sendError(response, "require certificate");

--- a/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
@@ -38,6 +38,8 @@ public class CertAuthPlugin extends AuthenticationPlugin {
   private static final String PARAM_PRINCIPAL_RESOLVER = "principalResolver";
   private static final String PARAM_CLASS = "class";
   private static final String PARAM_PARAMS = "params";
+  private static final String OLD_REQUEST_ATTRIBUTE_NAME="javax.servlet.request.X509Certificate";
+  private static final String CURRENT_REQUEST_ATTRIBUTE_NAME="jakarta.servlet.request.X509Certificate";
 
   private static final CertPrincipalResolver DEFAULT_PRINCIPAL_RESOLVER =
       certificate -> certificate.getSubjectX500Principal();
@@ -102,7 +104,10 @@ public class CertAuthPlugin extends AuthenticationPlugin {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws Exception {
     X509Certificate[] certs =
-        (X509Certificate[]) request.getAttribute("jakarta.servlet.request.X509Certificate");
+        (X509Certificate[]) request.getAttribute(CURRENT_REQUEST_ATTRIBUTE_NAME);
+    if (certs == null || certs.length == 0) {
+      certs=(X509Certificate[]) request.getAttribute(OLD_REQUEST_ATTRIBUTE_NAME);
+    }
     if (certs == null || certs.length == 0) {
       return sendError(response, "require certificate");
     }

--- a/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/CertAuthPlugin.java
@@ -39,10 +39,6 @@ public class CertAuthPlugin extends AuthenticationPlugin {
   private static final String PARAM_CLASS = "class";
   private static final String PARAM_PARAMS = "params";
 
-  // TODO once on/after Solr 11, discuss whether to remove the javax name or not
-
-  private static final String JAVAX_REQUEST_ATTRIBUTE_NAME =
-      "javax.servlet.request.X509Certificate";
   private static final String JAKARTA_REQUEST_ATTRIBUTE_NAME =
       "jakarta.servlet.request.X509Certificate";
 
@@ -110,9 +106,7 @@ public class CertAuthPlugin extends AuthenticationPlugin {
       throws Exception {
     X509Certificate[] certs =
         (X509Certificate[]) request.getAttribute(JAKARTA_REQUEST_ATTRIBUTE_NAME);
-    if (certs == null || certs.length == 0) {
-      certs = (X509Certificate[]) request.getAttribute(JAVAX_REQUEST_ATTRIBUTE_NAME);
-    }
+
     if (certs == null || certs.length == 0) {
       return sendError(response, "require certificate");
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18270


# Description

This PR only update the request attribute used by CertAuthPlugin to match the one filled by Jetty 12 - for SOLR 10. SOLR 9 works fine in the Official Docker Image, as it uses a lower major Jetty version.

# Solution

This PR only updates the request attribute used by CertAuthPlugin to match the one filled by Jetty 12 - for SOLR 10, and provides, after revision, as advised by @laminelam, a fallback on the old attribute.

# Tests

I checked locally by compiling SOLR from source, as well as building Docker Image from source and tested it in a K8S environment.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
5582 tests completed, 1 failed, 184 skipped
ERROR: The following test(s) have failed:
  - org.apache.solr.handler.component.AsyncTrackerSemaphoreLeakTest.testSemaphoreLeakOnLBRetry (:solr:core)
=> however, in my opinion, this test does not seem to be relevant for this PR
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change
unreleased/SOLR-18270-easy-fix-without-parametrization.yml
