### PR TITLE
changes2html.py didn't recognize github handles with hyphens

### DIFF
--- a/gradle/documentation/changes-to-html/changes2html.py
+++ b/gradle/documentation/changes-to-html/changes2html.py
@@ -213,7 +213,7 @@ class HTMLGenerator:
         # Extract markdown link: [text](url)
         markdown_link_match = re.search(r'\[([^\]]+)\]\(([^)]+)\)', author_text)
         # Extract GitHub handle: @username
-        github_match = re.search(r'@(\w+)', author_text)
+        github_match = re.search(r'@([\w-]+)', author_text)
 
         if markdown_link_match:
             # Has markdown link


### PR DESCRIPTION
Me/copilot checked that this simple change recognize all github handle patterns.  It'll match illegal handles as well (e.g. underscores can't be in a handle) but its simplicity is nice/fine.

Note I tested this by actually regenerating the Changes.html for v9.10.1 in order to update our website in svn, which is now fixed.