### PR TITLE
Skip changelog entry for upgrades of github workflows

### DIFF
--- a/.github/workflows/renovate-changelog-prepare.yml
+++ b/.github/workflows/renovate-changelog-prepare.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - main
       - 'branch_*'
+    paths-ignore:
+      - '.github/**'
 
 concurrency:
   group: renovate-changelog-prepare-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Not very useful to see in solr changelog that the `actions/labeler` github action was upgraded