### PR TITLE
JavaBinCodec: fix self-suppression risk

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
@@ -1481,7 +1481,10 @@ public class JavaBinCodec implements PushWriter {
 
   @Override
   public void close() throws IOException {
-    if (daos != null) {
+    // marshal() already flushes in its own finally block, so skip the redundant flush.
+    // Flushing again after a marshal failure would re-throw the same exception from the broken
+    // stream, causing "Self-suppression not permitted" in the caller's try-with-resources.
+    if (daos != null && !alreadyMarshalled) {
       daos.flushBuffer();
     }
   }


### PR DESCRIPTION
While working on the Jetty HttpClient test conversion, and troubleshooting a flaky nightly test failure, Claude caught this issue.

Not thinking a changelog as it seems obscure / infrequent but I want this on its own commit, unbundled from a big PR.  I'll add one if asked!

Will merge in 48 hours if no feedback.