### PR TITLE
HttpJettySolrClient: don't throw IllegalStateException if connection lost

### DIFF
--- a/changelog/unreleased/PR#4490-HttpJettySolrClient-IllegalStateException.yml
+++ b/changelog/unreleased/PR#4490-HttpJettySolrClient-IllegalStateException.yml
@@ -1,0 +1,33 @@
+# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
+
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+
+# If the change is minor, don't bother adding a changelog entry.
+# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
+
+# title:
+#  * The audience is end-users and administrators, not committers.
+#  * Be short and focused on the user impact.  Multiple sentences is fine!
+#  * For technical/geeky details, prefer the commit message instead of changelog.
+#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
+
+# type:
+#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
+#  `changed` for improvements; not opt-in
+#  `fixed` for improvements that are deemed to have fixed buggy behavior
+#  `deprecated` for marking things deprecated
+#  `removed` for code removed
+#  `dependency_update` for updates to dependencies
+#  `other` for anything else, like large/significant refactorings, build changes,
+#    test infrastructure, or documentation.
+#    Most such changes are too small/minor to bother with a changelog entry.
+
+title: >
+  HttpJettySolrClient could throw IllegalStateException on connection lost,
+  which foiled LBSolrClient's attempts to classify a request as retry-able.
+type: fixed
+authors:
+  - name: David Smiley
+links:
+  - name: PR#4490
+    url: https://github.com/apache/solr/pull/4490

--- a/changelog/unreleased/PR#4490-HttpJettySolrClient-IllegalStateException.yml
+++ b/changelog/unreleased/PR#4490-HttpJettySolrClient-IllegalStateException.yml
@@ -1,27 +1,3 @@
-# (DELETE ALL COMMENTS UP HERE AFTER FILLING THIS IN
-
-# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-
-# If the change is minor, don't bother adding a changelog entry.
-# For `other` type entries, the threshold to bother with a changelog entry should be even higher.
-
-# title:
-#  * The audience is end-users and administrators, not committers.
-#  * Be short and focused on the user impact.  Multiple sentences is fine!
-#  * For technical/geeky details, prefer the commit message instead of changelog.
-#  * Reference JIRA issues like `SOLR-12345`, or if no JIRA but have a GitHub PR then `PR#12345`.
-
-# type:
-#  `added` for new features/improvements, opt-in by the user typically documented in the ref guide
-#  `changed` for improvements; not opt-in
-#  `fixed` for improvements that are deemed to have fixed buggy behavior
-#  `deprecated` for marking things deprecated
-#  `removed` for code removed
-#  `dependency_update` for updates to dependencies
-#  `other` for anything else, like large/significant refactorings, build changes,
-#    test infrastructure, or documentation.
-#    Most such changes are too small/minor to bother with a changelog entry.
-
 title: >
   HttpJettySolrClient could throw IllegalStateException on connection lost,
   which foiled LBSolrClient's attempts to classify a request as retry-able.

--- a/solr/solrj-jetty/src/java/org/apache/solr/client/solrj/jetty/HttpJettySolrClient.java
+++ b/solr/solrj-jetty/src/java/org/apache/solr/client/solrj/jetty/HttpJettySolrClient.java
@@ -507,6 +507,10 @@ public class HttpJettySolrClient extends HttpSolrClient {
             "IOException occurred when talking to server at: " + url, cause);
       }
       throw new SolrServerException(cause.getMessage(), cause);
+    } catch (IllegalStateException e) {
+      // Jetty HTTP/2 throws IllegalStateException ("session closed") when the connection is lost.
+      abortCause = e;
+      throw new SolrServerException("Connection lost at: " + url, new IOException(e));
     } catch (SolrServerException | RuntimeException sse) {
       abortCause = sse;
       throw sse;


### PR DESCRIPTION
Fix ensures that LBSolrClient treats it as a retry-able connection failure.

Found this with Claude while converting tests to HttpJettySolrClient from Apache HttpClient based -- SOLR-18188 but deserves its own commit/changelog

Will merge in 48 hours without feedback.