### PR TITLE
SOLR-18281 Make PackageManager testable by printing to console through ToolRuntime

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/CLIUtils.java
+++ b/solr/core/src/java/org/apache/solr/cli/CLIUtils.java
@@ -58,6 +58,8 @@ public final class CLIUtils {
 
   public static String YELLOW = "\u001B[33m";
 
+  public static String RESET = "\u001B[0m";
+
   private static final long MAX_WAIT_FOR_CORE_LOAD_NANOS =
       TimeUnit.NANOSECONDS.convert(1, TimeUnit.MINUTES);
 

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -480,10 +480,8 @@ public class SolrCLI implements CLIO {
   }
 
   public static void print(String color, Object message) {
-    String RESET = "\u001B[0m";
-
     if (color != null) {
-      CLIO.out(color + message + RESET);
+      CLIO.out(color + message + CLIUtils.RESET);
     } else {
       CLIO.out(String.valueOf(message));
     }

--- a/solr/core/src/java/org/apache/solr/cli/ToolRuntime.java
+++ b/solr/core/src/java/org/apache/solr/cli/ToolRuntime.java
@@ -30,6 +30,16 @@ public abstract class ToolRuntime {
 
   public abstract void println(String message);
 
+  /** Print an error message, highlighted in red on terminals. */
+  public void printError(String message) {
+    println(CLIUtils.RED + message + CLIUtils.RESET);
+  }
+
+  /** Print a success message, highlighted in green on terminals. */
+  public void printSuccess(String message) {
+    println(CLIUtils.GREEN + message + CLIUtils.RESET);
+  }
+
   /** Invokes {@link System#exit(int)} to force the JVM to immediately quit. */
   @SuppressForbidden(reason = "That's the only method in CLI code where we allow to exit the JVM")
   public void exit(int status) {

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -17,8 +17,6 @@
 
 package org.apache.solr.packagemanager;
 
-import static org.apache.solr.cli.SolrCLI.printGreen;
-import static org.apache.solr.cli.SolrCLI.printRed;
 import static org.apache.solr.packagemanager.PackageUtils.getMapper;
 
 import com.jayway.jsonpath.InvalidPathException;
@@ -108,7 +106,7 @@ public class PackageManager implements Closeable {
       throws IOException, SolrServerException {
     SolrPackageInstance packageInstance = getPackageInstance(packageName, version);
     if (packageInstance == null) {
-      printRed(
+      runtime.printError(
           "Package "
               + packageName
               + ":"
@@ -121,7 +119,7 @@ public class PackageManager implements Closeable {
     Map<String, String> collectionsDeployedOn = getDeployedCollections(packageName);
     for (String collection : collectionsDeployedOn.keySet()) {
       if (version.equals(collectionsDeployedOn.get(collection))) {
-        printRed(
+        runtime.printError(
             "Package "
                 + packageName
                 + " is currently deployed on collection: "
@@ -138,7 +136,7 @@ public class PackageManager implements Closeable {
       SolrPackageInstance clusterPackageInstance = clusterPackages.get(clusterPackageName);
       if (packageName.equals(clusterPackageName)
           && version.equals(clusterPackageInstance.version)) {
-        printRed(
+        runtime.printError(
             "Package "
                 + packageName
                 + "is currently deployed as a cluster-level plugin ("
@@ -150,7 +148,7 @@ public class PackageManager implements Closeable {
 
     // Delete the package by calling the Package API and remove the Jar
 
-    printGreen("Executing Package API to remove this package...");
+    runtime.printSuccess("Executing Package API to remove this package...");
     PackagePayload.DelVersion del = new PackagePayload.DelVersion();
     del.version = version;
     del.pkg = packageName;
@@ -164,12 +162,13 @@ public class PackageManager implements Closeable {
 
     try {
       V2Response resp = req.process(solrClient);
-      printGreen("Response: " + resp.jsonStr());
+      runtime.printSuccess("Response: " + resp.jsonStr());
     } catch (SolrServerException | IOException e) {
       throw new SolrException(ErrorCode.BAD_REQUEST, e);
     }
 
-    printGreen("Executing Package Store API to remove the " + packageName + " package...");
+    runtime.printSuccess(
+        "Executing Package Store API to remove the " + packageName + " package...");
 
     List<String> filesToDelete = new ArrayList<>(packageInstance.files);
     filesToDelete.add(
@@ -177,11 +176,11 @@ public class PackageManager implements Closeable {
     for (String filePath : filesToDelete) {
       DistribFileStore.deleteZKFileEntry(zkClient, filePath);
       String path = "/api/cluster/filestore/files" + filePath;
-      printGreen("Deleting " + path);
+      runtime.printSuccess("Deleting " + path);
       solrClient.request(new GenericSolrRequest(SolrRequest.METHOD.DELETE, path));
     }
 
-    printGreen("Package uninstalled: " + packageName + ":" + version + ":-)");
+    runtime.printSuccess("Package uninstalled: " + packageName + ":" + version + ":-)");
   }
 
   public List<SolrPackageInstance> fetchInstalledPackageInstances() throws SolrException {
@@ -369,7 +368,7 @@ public class PackageManager implements Closeable {
     boolean verifySuccess =
         verify(packageInstance, deployedCollections, shouldDeployClusterPlugins, overrides);
     if (verifySuccess) {
-      printGreen(
+      runtime.printSuccess(
           "Deployed on "
               + deployedCollections
               + " and verified package: "
@@ -398,13 +397,13 @@ public class PackageManager implements Closeable {
           getPackagesDeployed(collection).get(packageInstance.name);
       if (packageInstance.equals(deployedPackage)) {
         if (!pegToLatest) {
-          printRed("Package " + packageInstance + " already deployed on " + collection);
+          runtime.printError("Package " + packageInstance + " already deployed on " + collection);
           previouslyDeployed.add(collection);
           continue;
         }
       } else {
         if (deployedPackage != null && !isUpdate) {
-          printRed(
+          runtime.printError(
               "Package "
                   + deployedPackage
                   + " already deployed on "
@@ -503,7 +502,7 @@ public class PackageManager implements Closeable {
                         packageInstance.parameterDefaults,
                         collectionParameterOverrides,
                         systemParams);
-                printGreen("Executing " + payload + " for path:" + path);
+                runtime.printSuccess("Executing " + payload + " for path:" + path);
                 boolean shouldExecute = prompt(noprompt);
                 if (shouldExecute) {
                   SolrCLI.postJsonToSolr(solrClient, path, payload);
@@ -516,7 +515,7 @@ public class PackageManager implements Closeable {
                   ErrorCode.BAD_REQUEST, "Non-POST method not supported for setup commands");
             }
           } else {
-            printRed("There is no setup command to execute for plugin: " + plugin.name);
+            runtime.printError("There is no setup command to execute for plugin: " + plugin.name);
           }
         }
       }
@@ -537,7 +536,7 @@ public class PackageManager implements Closeable {
     }
 
     if (!previouslyDeployed.isEmpty()) {
-      printRed(
+      runtime.printError(
           "Already Deployed on "
               + previouslyDeployed
               + ", package: "
@@ -565,7 +564,7 @@ public class PackageManager implements Closeable {
         SolrPackageInstance deployedPackage =
             getPackagesDeployedAsClusterLevelPlugins().get(packageInstance.name);
         if (deployedPackage == null) {
-          printRed(
+          runtime.printError(
               "Cluster level plugin "
                   + plugin.name
                   + " from package "
@@ -575,12 +574,13 @@ public class PackageManager implements Closeable {
           continue;
         }
         for (PluginMeta pluginMeta : (List<PluginMeta>) deployedPackage.getCustomData()) {
-          printGreen("Updating this plugin: " + pluginMeta);
+          runtime.printSuccess("Updating this plugin: " + pluginMeta);
           try {
             // just update the version, let the other metadata same
             pluginMeta.version = packageInstance.version;
             String postBody = "{\"update\": " + Utils.toJSONString(pluginMeta) + "}";
-            printGreen("Posting " + postBody + " to " + PackageUtils.CLUSTER_PLUGINS_PATH);
+            runtime.printSuccess(
+                "Posting " + postBody + " to " + PackageUtils.CLUSTER_PLUGINS_PATH);
             SolrCLI.postJsonToSolr(solrClient, PackageUtils.CLUSTER_PLUGINS_PATH, postBody);
           } catch (Exception e) {
             throw new SolrException(ErrorCode.SERVER_ERROR, e);
@@ -589,9 +589,9 @@ public class PackageManager implements Closeable {
         numberOfClusterPluginsDeployed++;
       }
       if (numberOfClusterPluginsDeployed > 0) {
-        printGreen(numberOfClusterPluginsDeployed + " cluster level plugins updated.");
+        runtime.printSuccess(numberOfClusterPluginsDeployed + " cluster level plugins updated.");
       } else {
-        printRed("No cluster level plugin updated.");
+        runtime.printError("No cluster level plugin updated.");
         clusterPluginFailed = true;
       }
     } else {
@@ -614,7 +614,7 @@ public class PackageManager implements Closeable {
                 ((Map<String, Object>) clusterprops.getOrDefault("plugin", Map.of()))
                     .get(packageInstance.name + ":" + plugin.name);
             if (pkg != null) {
-              printRed(
+              runtime.printError(
                   "Cluster level plugin "
                       + plugin.name
                       + " from package "
@@ -651,7 +651,7 @@ public class PackageManager implements Closeable {
               String path =
                   PackageUtils.resolve(
                       cmd.path, packageInstance.parameterDefaults, overridesMap, systemParams);
-              printGreen("Executing " + payload + " for path:" + path);
+              runtime.printSuccess("Executing " + payload + " for path:" + path);
               boolean shouldExecute = prompt(noprompt);
               if (shouldExecute) {
                 SolrCLI.postJsonToSolr(solrClient, path, payload);
@@ -665,13 +665,13 @@ public class PackageManager implements Closeable {
                 ErrorCode.BAD_REQUEST, "Non-POST method not supported for setup commands");
           }
         } else {
-          printRed("There is no setup command to execute for plugin: " + plugin.name);
+          runtime.printError("There is no setup command to execute for plugin: " + plugin.name);
         }
       }
       if (numberOfClusterPluginsDeployed > 0) {
-        printGreen(numberOfClusterPluginsDeployed + " cluster level plugins setup.");
+        runtime.printSuccess(numberOfClusterPluginsDeployed + " cluster level plugins setup.");
       } else {
-        printRed("No cluster level plugin setup.");
+        runtime.printError("No cluster level plugin setup.");
         clusterPluginFailed = true;
       }
     }
@@ -688,7 +688,7 @@ public class PackageManager implements Closeable {
         String userInput = scanner.next();
         if ("no".trim().equalsIgnoreCase(userInput) || "n".trim().equalsIgnoreCase(userInput)) {
           shouldExecute = false;
-          printRed(
+          runtime.printError(
               "Skipping setup command for deploying (deployment verification may fail)."
                   + " Please run this step manually or refer to package documentation.");
         }
@@ -771,13 +771,13 @@ public class PackageManager implements Closeable {
                   plugin.name);
           String path =
               PackageUtils.resolve(cmd.path, pkg.parameterDefaults, overridesMap, systemParams);
-          printGreen("Executing " + solrUrl + path + " for cluster level plugin");
+          runtime.printSuccess("Executing " + solrUrl + path + " for cluster level plugin");
 
           if ("GET".equalsIgnoreCase(cmd.method)) {
             String response =
                 PackageUtils.getJsonStringFromNonCollectionApi(
                     solrClient, path, new ModifiableSolrParams());
-            printGreen(response);
+            runtime.printSuccess(response);
             String actualValue = null;
             try {
               String jsonPath =
@@ -785,16 +785,16 @@ public class PackageManager implements Closeable {
                       cmd.condition, pkg.parameterDefaults, overridesMap, systemParams);
               actualValue = jsonPathRead(response, jsonPath);
             } catch (PathNotFoundException ex) {
-              printRed("Failed to deploy plugin: " + plugin.name);
+              runtime.printError("Failed to deploy plugin: " + plugin.name);
               success = false;
             }
             if (actualValue != null) {
               String expectedValue =
                   PackageUtils.resolve(
                       cmd.expected, pkg.parameterDefaults, overridesMap, systemParams);
-              printGreen("Actual: " + actualValue + ", expected: " + expectedValue);
+              runtime.printSuccess("Actual: " + actualValue + ", expected: " + expectedValue);
               if (!expectedValue.equals(actualValue)) {
-                printRed("Failed to deploy plugin: " + plugin.name);
+                runtime.printError("Failed to deploy plugin: " + plugin.name);
                 success = false;
               }
             }
@@ -821,13 +821,13 @@ public class PackageManager implements Closeable {
             String path =
                 PackageUtils.resolve(
                     cmd.path, pkg.parameterDefaults, collectionParameterOverrides, systemParams);
-            printGreen("Executing " + solrUrl + path + " for collection:" + collection);
+            runtime.printSuccess("Executing " + solrUrl + path + " for collection:" + collection);
 
             if ("GET".equalsIgnoreCase(cmd.method)) {
               String response =
                   PackageUtils.getJsonStringFromCollectionApi(
                       solrClient, path, new ModifiableSolrParams());
-              printGreen(response);
+              runtime.printSuccess(response);
               String actualValue = null;
               try {
                 String jsonPath =
@@ -838,7 +838,7 @@ public class PackageManager implements Closeable {
                         systemParams);
                 actualValue = jsonPathRead(response, jsonPath);
               } catch (PathNotFoundException ex) {
-                printRed("Failed to deploy plugin: " + plugin.name);
+                runtime.printError("Failed to deploy plugin: " + plugin.name);
                 success = false;
               }
               if (actualValue != null) {
@@ -848,9 +848,9 @@ public class PackageManager implements Closeable {
                         pkg.parameterDefaults,
                         collectionParameterOverrides,
                         systemParams);
-                printGreen("Actual: " + actualValue + ", expected: " + expectedValue);
+                runtime.printSuccess("Actual: " + actualValue + ", expected: " + expectedValue);
                 if (!expectedValue.equals(actualValue)) {
-                  printRed("Failed to deploy plugin: " + plugin.name);
+                  runtime.printError("Failed to deploy plugin: " + plugin.name);
                   success = false;
                 }
               }
@@ -929,7 +929,7 @@ public class PackageManager implements Closeable {
     boolean pegToLatest = PackageUtils.LATEST.equals(version);
     SolrPackageInstance packageInstance = getPackageInstance(packageName, version);
     if (packageInstance == null) {
-      printRed(
+      runtime.printError(
           "Package instance doesn't exist: "
               + packageName
               + ":"
@@ -940,7 +940,7 @@ public class PackageManager implements Closeable {
 
     Manifest manifest = packageInstance.manifest;
     if (!SolrVersion.LATEST.satisfies(manifest.versionConstraint)) {
-      printRed(
+      runtime.printError(
           "Version incompatible! Solr version: "
               + SolrVersion.LATEST
               + ", package version constraint: "
@@ -972,7 +972,7 @@ public class PackageManager implements Closeable {
       SolrPackageInstance deployedPackage =
           getPackagesDeployedAsClusterLevelPlugins().get(packageName);
       if (deployedPackage == null) {
-        printRed("Cluster level plugins from package " + packageName + " not deployed.");
+        runtime.printError("Cluster level plugins from package " + packageName + " not deployed.");
       } else {
         for (Plugin plugin : deployedPackage.plugins) {
           if (!shouldUndeployClusterPlugins || !"cluster".equalsIgnoreCase(plugin.type)) continue;
@@ -998,7 +998,7 @@ public class PackageManager implements Closeable {
                 String path =
                     PackageUtils.resolve(
                         cmd.path, deployedPackage.parameterDefaults, Map.of(), systemParams);
-                printGreen("Executing " + payload + " for path:" + path);
+                runtime.printSuccess("Executing " + payload + " for path:" + path);
                 SolrCLI.postJsonToSolr(solrClient, path, payload);
               } catch (Exception ex) {
                 throw new SolrException(ErrorCode.SERVER_ERROR, ex);
@@ -1008,7 +1008,8 @@ public class PackageManager implements Closeable {
                   ErrorCode.BAD_REQUEST, "Non-POST method not supported for uninstall commands");
             }
           } else {
-            printRed("There is no uninstall command to execute for plugin: " + plugin.name);
+            runtime.printError(
+                "There is no uninstall command to execute for plugin: " + plugin.name);
           }
         }
       }
@@ -1017,7 +1018,7 @@ public class PackageManager implements Closeable {
     for (String collection : collections) {
       SolrPackageInstance deployedPackage = getPackagesDeployed(collection).get(packageName);
       if (deployedPackage == null) {
-        printRed("Package " + packageName + " not deployed on collection " + collection);
+        runtime.printError("Package " + packageName + " not deployed on collection " + collection);
         continue;
       }
       Map<String, String> collectionParameterOverrides = getPackageParams(packageName, collection);
@@ -1054,7 +1055,7 @@ public class PackageManager implements Closeable {
                       deployedPackage.parameterDefaults,
                       collectionParameterOverrides,
                       systemParams);
-              printGreen("Executing " + payload + " for path:" + path);
+              runtime.printSuccess("Executing " + payload + " for path:" + path);
               SolrCLI.postJsonToSolr(solrClient, path, payload);
             } catch (Exception ex) {
               throw new SolrException(ErrorCode.SERVER_ERROR, ex);
@@ -1064,7 +1065,7 @@ public class PackageManager implements Closeable {
                 ErrorCode.BAD_REQUEST, "Non-POST method not supported for uninstall commands");
           }
         } else {
-          printRed("There is no uninstall command to execute for plugin: " + plugin.name);
+          runtime.printError("There is no uninstall command to execute for plugin: " + plugin.name);
         }
       }
 

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageManager.java
@@ -681,9 +681,10 @@ public class PackageManager implements Closeable {
   private boolean prompt(boolean noprompt) {
     boolean shouldExecute = true;
     if (!noprompt) { // show a prompt asking user to execute the setup command for the plugin
-      PackageUtils.print(
-          CLIUtils.YELLOW,
-          "Execute this command. (If you choose no, you can manually deploy/undeploy this plugin later) (y/n): ");
+      runtime.print(
+          CLIUtils.YELLOW
+              + "Execute this command. (If you choose no, you can manually deploy/undeploy this plugin later) (y/n): "
+              + CLIUtils.RESET);
       try (Scanner scanner = new Scanner(System.in, StandardCharsets.UTF_8)) {
         String userInput = scanner.next();
         if ("no".trim().equalsIgnoreCase(userInput) || "n".trim().equalsIgnoreCase(userInput)) {
@@ -957,8 +958,11 @@ public class PackageManager implements Closeable {
             Arrays.asList(collections),
             shouldInstallClusterPlugins,
             parameters);
-    PackageUtils.print(
-        res ? CLIUtils.GREEN : CLIUtils.RED, res ? "Deployment successful" : "Deployment failed");
+    if (res) {
+      runtime.printSuccess("Deployment successful");
+    } else {
+      runtime.printError("Deployment failed");
+    }
   }
 
   /** Undeploys a package from given collections. */

--- a/solr/core/src/java/org/apache/solr/packagemanager/PackageUtils.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/PackageUtils.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.IOUtils;
-import org.apache.lucene.util.SuppressForbidden;
 import org.apache.solr.cli.CLIUtils;
 import org.apache.solr.client.api.model.UploadToFileStoreResponse;
 import org.apache.solr.client.solrj.SolrClient;
@@ -246,23 +245,9 @@ public class PackageUtils {
     format(sb, null, message);
   }
 
-  @SuppressForbidden(
-      reason = "Need to use System.out.println() instead of log4j/slf4j for cleaner output")
-  public static void print(String color, Object message) {
-    String RESET = "\u001B[0m";
-
-    if (color != null) {
-      System.out.println(color + String.valueOf(message) + RESET);
-    } else {
-      System.out.println(message);
-    }
-  }
-
   public static void format(StringBuilder sb, String color, Object message) {
-    String RESET = "\u001B[0m";
-
     if (color != null) {
-      sb.append(color + String.valueOf(message) + RESET + "\n");
+      sb.append(color + String.valueOf(message) + CLIUtils.RESET + "\n");
     } else {
       sb.append(message + "\n");
     }

--- a/solr/core/src/java/org/apache/solr/packagemanager/RepositoryManager.java
+++ b/solr/core/src/java/org/apache/solr/packagemanager/RepositoryManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.packagemanager;
 
-import static org.apache.solr.cli.SolrCLI.printGreen;
 import static org.apache.solr.packagemanager.PackageUtils.getMapper;
 
 import java.io.IOException;
@@ -37,7 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.solr.cli.SolrCLI;
+import org.apache.solr.cli.ToolRuntime;
 import org.apache.solr.client.api.util.SolrVersion;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -69,11 +68,13 @@ public class RepositoryManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final PackageManager packageManager;
+  private final ToolRuntime runtime;
 
   final SolrClient solrClient;
 
   public RepositoryManager(SolrClient solrClient, PackageManager packageManager) {
     this.packageManager = packageManager;
+    this.runtime = packageManager.runtime;
     this.solrClient = solrClient;
   }
 
@@ -181,7 +182,7 @@ public class RepositoryManager {
 
     try {
       // post the manifest
-      printGreen("Posting manifest...");
+      runtime.printSuccess("Posting manifest...");
 
       if (release.manifest == null) {
         String manifestJson = PackageUtils.getFileFromJarsAsString(downloaded, "manifest.json");
@@ -202,7 +203,7 @@ public class RepositoryManager {
           null);
 
       // post the artifacts
-      printGreen("Posting artifacts...");
+      runtime.printSuccess("Posting artifacts...");
       for (int i = 0; i < release.artifacts.size(); i++) {
         PackageUtils.postFile(
             solrClient,
@@ -217,7 +218,7 @@ public class RepositoryManager {
       }
 
       // Call Package API to add this version of the package
-      printGreen("Executing Package API to register this package...");
+      runtime.printSuccess("Executing Package API to register this package...");
       PackagePayload.AddVersion add = new PackagePayload.AddVersion();
       add.version = version;
       add.pkg = packageName;
@@ -245,7 +246,7 @@ public class RepositoryManager {
           };
       try {
         NamedList<Object> resp = solrClient.request(request);
-        printGreen("Response: " + resp.jsonStr());
+        runtime.printSuccess("Response: " + resp.jsonStr());
       } catch (SolrServerException | IOException e) {
         throw new SolrException(ErrorCode.BAD_REQUEST, e);
       }
@@ -343,7 +344,7 @@ public class RepositoryManager {
   public boolean install(String packageName, String version) throws SolrException {
     SolrPackageRelease pkg = getLastPackageRelease(packageName);
     if (pkg == null) {
-      SolrCLI.printRed(
+      runtime.printError(
           "Package "
               + packageName
               + " not found in any repository. Check list of available packages via \"solr package list-available\".");
@@ -359,7 +360,7 @@ public class RepositoryManager {
                     collectionsDeployedIn.get(collection).equals(SolrPackageLoader.LATEST))
             .collect(Collectors.toList());
     if (!collectionsPeggedToLatest.isEmpty()) {
-      printGreen(
+      runtime.printSuccess(
           "Collections that will be affected (since they are configured to use $LATEST): "
               + collectionsPeggedToLatest);
     }
@@ -380,7 +381,7 @@ public class RepositoryManager {
               false,
               new String
                   [] {}); // Cluster level plugins don't work with peggedToLatest functionality
-      printGreen(
+      runtime.printSuccess(
           "Verifying version "
               + updatedPackage.version
               + " on "
@@ -388,7 +389,7 @@ public class RepositoryManager {
               + ", result: "
               + res);
       if (!res) {
-        SolrCLI.printRed("Failed verification after deployment");
+        runtime.printError("Failed verification after deployment");
         return false;
       }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18281

* Adds `printSuccess()` and `printError()` to ToolRuntime (which prints green/red ANSI text)
* Replace Pkgmgr `printGreen()`  with `runtime.printSuccess()` and `printRed()` with `runtime.printError()`

This insulates the PackageManager from raw console output by using the `ToolRuntime` properly.

And this makes the new `PackateToolTest.testDeployValidationMessages()` assert tool output as designed.