### PR TITLE
SOLR-18174 Ignore flaky test testSemaphoreLeakOnLBRetry

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/component/AsyncTrackerSemaphoreLeakTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/AsyncTrackerSemaphoreLeakTest.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -116,11 +117,12 @@ public class AsyncTrackerSemaphoreLeakTest extends SolrCloudTestCase {
    * org.apache.solr.client.solrj.jetty.LBJettySolrClient} retrying a request synchronously inside a
    * {@link CompletableFuture#whenComplete} callback that runs on the Jetty IO selector thread.
    *
-   * <p>This test <b>passes</b> with the {@code failureDispatchExecutor} fix in this branch. Without
-   * the fix, the IO thread would block forever in {@code semaphore.acquire()} and this test would
-   * time out.
+   * <p>Without the {@code failureDispatchExecutor} fix (SOLR-18174), the IO thread would block
+   * forever in {@code semaphore.acquire()} and this test would time out.
    */
   @Test
+  @Ignore(
+      "SOLR-18174: Flaky due to timing-sensitive TCP RST simulation; kept for regression testing")
   public void testSemaphoreLeakOnLBRetry() throws Exception {
     // Dedicated client so that permanently deadlocked IO threads don't affect the cluster's client.
     HttpJettySolrClient testClient =
@@ -312,7 +314,7 @@ public class AsyncTrackerSemaphoreLeakTest extends SolrCloudTestCase {
           permitsAfter);
 
     } finally {
-      // Force-terminate the Phaser as a safety net; without the fix the phaser would be unbalanced.
+      // Force-terminate the Phaser as a safety net in case the phaser is unbalanced.
       try {
         Field phaserField = asyncTrackerClass.getDeclaredField("phaser");
         phaserField.setAccessible(true);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18174

See https://develocity.apache.org/s/grk56hejnipui/tests/task/:solr:core:test/details/org.apache.solr.handler.component.AsyncTrackerSemaphoreLeakTest/testSemaphoreLeakOnLBRetry?top-execution=1