### PR TITLE
SOLR-18243: Refactor solrj-streaming to reuse shared CloudHttp2SolrClient engine

### DIFF
--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/SolrClientCache.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/SolrClientCache.java
@@ -31,6 +31,7 @@ import org.apache.solr.client.solrj.impl.SolrHttpConstants;
 import org.apache.solr.common.AlreadyClosedException;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.URLUtil;
+import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 
 /** The SolrClientCache caches SolrClients, so they can be reused by different TupleStreams. */
 public class SolrClientCache implements Closeable {
@@ -136,7 +137,22 @@ public class SolrClientCache implements Closeable {
     ensureOpen();
     Objects.requireNonNull(baseUrl, "Url cannot be null!");
     return httpSolrClients.computeIfAbsent(
-        baseUrl, url -> newHttpSolrClientBuilder(url, httpSolrClient).build());
+        baseUrl,
+        url -> {
+          // Find an existing Cloud Client connection
+          HttpSolrClient sharedEngine = this.httpSolrClient;
+
+          if (sharedEngine == null && !cloudSolClients.isEmpty()) {
+            // Get first available active Cloud client connection
+            CloudSolrClient firstCloudClient = cloudSolClients.values().iterator().next();
+            if (firstCloudClient instanceof CloudHttp2SolrClient) {
+              sharedEngine = ((CloudHttp2SolrClient) firstCloudClient).getHttpClient();
+            }
+          }
+
+          // Build the client using the shared engine if found one
+          return newHttpSolrClientBuilder(url, sharedEngine).build();
+        });
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
Modifies SolrClientCache.java to extract the underlying, shared HTTP client engine from an active CloudHttp2SolrClient connection pool when provisioning stream target connections. This eliminates the creation of isolated, duplicate legacy HttpSolrClient instances across cluster node lookups in solrj-streaming. Verified via StreamExpressionTest debugging sessions.