### PR TITLE
SOLR-18233 Fix test failure in AuthToolTest

### DIFF
--- a/solr/core/src/test/org/apache/solr/cli/AuthToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/AuthToolTest.java
@@ -67,7 +67,7 @@ public class AuthToolTest extends SolrCloudTestCase {
       "--solr-include-file",
       solrIncludeFile.toAbsolutePath().toString(),
       "--credentials",
-      "solr:solr",
+      "solr:solrRocks",
       "--block-unknown",
       "true"
     };

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
@@ -66,15 +66,23 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   private static String solrUrl = null;
 
   /**
+   * Helper: every user's password is derived from their username via this method. The password must
+   * differ from the username (Solr's Basic Auth policy rejects passwords equal to the username).
+   */
+  private static String passwordFor(final String user) {
+    return user + "_password";
+  }
+
+  /**
    * Helper that returns the original {@link SolrRequest} <em>with its original type</em> so it can
-   * be chained. This method knows that for the purpose of this test, every username is its own
-   * password
+   * be chained. This method knows that for the purpose of this test, every user's password is
+   * derived from their username via {@link #passwordFor}.
    *
    * @see SolrRequest#setBasicAuthCredentials
    */
   private static <T extends SolrRequest<?>> T setBasicAuthCredentials(T req, String user) {
     assertNotNull(user);
-    req.setBasicAuthCredentials(user, user);
+    req.setBasicAuthCredentials(user, passwordFor(user));
     return req;
   }
 
@@ -82,9 +90,11 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public static void setupCluster() throws Exception {
     final List<String> users =
         Arrays.asList(READ_ONLY_USER, WRITE_X_USER, WRITE_Y_USER, ADMIN_USER);
-    // For simplicity: every user uses a password the same as their name...
+    // For simplicity: every user's password is derived from their name via passwordFor()...
     final Map<String, String> credentials =
-        users.stream().collect(Collectors.toMap(Function.identity(), s -> getSaltedHashedValue(s)));
+        users.stream()
+            .collect(
+                Collectors.toMap(Function.identity(), s -> getSaltedHashedValue(passwordFor(s))));
 
     // For simplicity: Every user is their own role...
     final Map<String, String> roles =
@@ -123,7 +133,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
     for (String collection : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
       CollectionAdminRequest.createCollection(collection, "_default", 2, 2)
-          .setBasicAuthCredentials(ADMIN_USER, ADMIN_USER)
+          .setBasicAuthCredentials(ADMIN_USER, passwordFor(ADMIN_USER))
           .process(cluster.getSolrClient());
     }
 
@@ -246,7 +256,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
             params(
                 "qt", "/stream",
                 "expr", "echo(hello world)"));
-    solrStream.setCredentials(READ_ONLY_USER, READ_ONLY_USER);
+    solrStream.setCredentials(READ_ONLY_USER, passwordFor(READ_ONLY_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
     assertEquals("hello world", tuples.get(0).get("echo"));
@@ -295,7 +305,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                 "/stream",
                 "expr",
                 "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
-    solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+    solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
     assertEquals(1L, tuples.get(0).get("totalIndexed"));
@@ -338,7 +348,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
 
-      solrStream.setCredentials(user, user);
+      solrStream.setCredentials(user, passwordFor(user));
 
       // NOTE: Can't make any assertions about Exception: SOLR-14226
       expectThrows(
@@ -361,7 +371,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "/stream",
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
       assertEquals(1L, tuples.get(0).get("totalIndexed"));
@@ -390,7 +400,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
           new SolrStream(
               solrUrl + "/" + COLLECTION_Y, // NOTE: Y route
               params("qt", "/stream", "expr", expr));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
       assertEquals(10L, tuples.get(0).get("batchIndexed"));
@@ -410,7 +420,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
           new SolrStream(
               solrUrl + "/" + COLLECTION_X, // NOTE: X route
               params("qt", "/stream", "expr", expr));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(3, tuples.size());
 
@@ -439,7 +449,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "/stream",
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
-      solrStream.setCredentials(WRITE_Y_USER, WRITE_Y_USER);
+      solrStream.setCredentials(WRITE_Y_USER, passwordFor(WRITE_Y_USER));
 
       // NOTE: Can't make any assertions about Exception: SOLR-14226
       expectThrows(
@@ -459,7 +469,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
             + ", batchSize=5, tuple(id=42,a_i=1,b_i=5))\"))";
     final SolrStream solrStream =
         new SolrStream(solrUrl + "/" + COLLECTION_X, params("qt", "/stream", "expr", expr));
-    solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+    solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(0, tuples.size());
 
@@ -486,7 +496,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
             new SolrStream(
                 solrUrl + "/" + path,
                 params("qt", "/stream", "_trace", "executor_via_" + trace, "expr", expr));
-        solrStream.setCredentials(user, user);
+        solrStream.setCredentials(user, passwordFor(user));
 
         // NOTE: Because of the background threads, no failures will to be returned to client...
         final List<Tuple> tuples = getTuples(solrStream);
@@ -518,7 +528,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
               + ",tuple(id=42,a_i=1,b_i=5)))";
       final SolrStream solrStream =
           new SolrStream(daemonUrl, params("qt", "/stream", "expr", expr));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size()); // daemon starting status
     }
@@ -533,7 +543,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                 params(
                     "qt", "/stream",
                     "action", "list"));
-        daemonCheck.setCredentials(WRITE_X_USER, WRITE_X_USER);
+        daemonCheck.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
         final List<Tuple> tuples = getTuples(daemonCheck);
         assertEquals(1, tuples.size()); // our daemon;
         iterations = tuples.get(0).getLong("iterations");
@@ -555,7 +565,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "qt", "/stream",
                   "action", "kill",
                   "id", "daemonId"));
-      daemonKiller.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      daemonKiller.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(daemonKiller);
       assertEquals(1, tuples.size()); // daemon death status
     }
@@ -582,7 +592,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
         final SolrStream solrStream =
             new SolrStream(
                 daemonUrl, params("qt", "/stream", "_trace", "start_" + daemonId, "expr", expr));
-        solrStream.setCredentials(user, user);
+        solrStream.setCredentials(user, passwordFor(user));
         final List<Tuple> tuples = getTuples(solrStream);
         assertEquals(1, tuples.size()); // daemon starting status
       }
@@ -598,7 +608,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                       "qt", "/stream",
                       "_trace", "check_" + daemonId,
                       "action", "list"));
-          daemonCheck.setCredentials(user, user);
+          daemonCheck.setCredentials(user, passwordFor(user));
           final List<Tuple> tuples = getTuples(daemonCheck);
           assertEquals(1, tuples.size()); // our daemon;
           if (log.isInfoEnabled()) {
@@ -631,7 +641,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                     "kill",
                     "id",
                     daemonId));
-        daemonKiller.setCredentials(user, user);
+        daemonKiller.setCredentials(user, passwordFor(user));
         final List<Tuple> tuples = getTuples(daemonKiller);
         assertEquals(1, tuples.size()); // daemon death status
       }
@@ -663,7 +673,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                 "/stream",
                 "expr",
                 "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
-    solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+    solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
     assertEquals(1L, tuples.get(0).get("totalIndexed"));
@@ -697,7 +707,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(solrUrl + "/" + COLLECTION_X, params("qt", "/stream", "expr", expr));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
       assertEquals(5L, tuples.get(0).get("totalIndexed"));
@@ -758,7 +768,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
 
-      solrStream.setCredentials(user, user);
+      solrStream.setCredentials(user, passwordFor(user));
 
       // NOTE: Can't make any assertions about Exception: SOLR-14226
       expectThrows(
@@ -801,7 +811,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "/stream",
                   "expr",
                   "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42z))"));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
       assertEquals(1L, tuples.get(0).get("totalIndexed"));
@@ -825,7 +835,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
           new SolrStream(
               solrUrl + "/" + COLLECTION_Y, // NOTE: Y route
               params("qt", "/stream", "expr", expr));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
       assertEquals(10L, tuples.get(0).get("batchIndexed"));
@@ -849,7 +859,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
           new SolrStream(
               solrUrl + "/" + COLLECTION_X, // NOTE: X route
               params("qt", "/stream", "expr", expr));
-      solrStream.setCredentials(WRITE_X_USER, WRITE_X_USER);
+      solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(3, tuples.size());
 
@@ -888,7 +898,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                   "/stream",
                   "expr",
                   "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
-      solrStream.setCredentials(WRITE_Y_USER, WRITE_Y_USER);
+      solrStream.setCredentials(WRITE_Y_USER, passwordFor(WRITE_Y_USER));
 
       // NOTE: Can't make any assertions about Exception: SOLR-14226
       expectThrows(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18233

Fix silly test failure not caught in the first merge. Since username==password is no longer accepted, the test using `solr:solr` now fails.