### PR TITLE
Ref Guide - Add the Solr Operator

### DIFF
--- a/solr/solr-ref-guide/antora.template.yml
+++ b/solr/solr-ref-guide/antora.template.yml
@@ -23,7 +23,7 @@ version: '${solr_version_major}_${solr_version_minor}'
 display_version: '${displayVersion}'
 # Marking a version as 'prerelease: false' is only needed for published branches (minor version branches, branch_x_y, that have had a release)
 prerelease: ${prerelease}
-title: Solr Reference Guide
+title: Apache Solr
 nav:
 - modules/getting-started/getting-started-nav.adoc
 - modules/deployment-guide/deployment-nav.adoc

--- a/solr/solr-ref-guide/antora.yml
+++ b/solr/solr-ref-guide/antora.yml
@@ -23,7 +23,7 @@ version: '11_0'
 display_version: '11.0-alpha'
 # Marking a version as 'prerelease: false' is only needed for published branches (minor version branches, branch_x_y, that have had a release)
 prerelease: -alpha
-title: Solr Reference Guide
+title: Apache Solr
 nav:
 - modules/getting-started/getting-started-nav.adoc
 - modules/deployment-guide/deployment-nav.adoc

--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -167,7 +167,10 @@ task buildLocalAntoraPlaybookYaml(type: Copy) {
       // The Solr Operator is only aggregated into the official multi-version
       // site. Local builds render just the ref guide; operator contributors
       // preview their component from the apache/solr-operator repo (make docs).
-      'additional_sources': "",
+      'additional_sources': """
+  - url: "https://github.com/apache/solr-operator.git"
+    branches: \"release-*\"
+    start_path: docs""",
   ]
 
   expand(escapeYamlSingleQuotesString(props))
@@ -185,7 +188,7 @@ task buildOfficialAntoraPlaybookYaml(type: Copy) {
   }
   into project.ext.playbooksDir
 
-  def branches = ["branch_*", "\"!branch_9_11\""]
+  def branches = ["branch_*"]
   def operatorBranches = ["release-*"]
   if (officialSiteIncludePrerelease) {
     branches.add("main")

--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import groovy.json.JsonOutput
 import org.apache.tools.ant.util.TeeOutputStream
 
 apply plugin: 'java'
@@ -163,6 +164,10 @@ task buildLocalAntoraPlaybookYaml(type: Copy) {
       'source_branches': "HEAD",
       'start_path': project.rootDir.relativePath(file(project.ext.siteStagingDir)),
       'site_dir': "./" + file(project.ext.siteStagingDir).relativePath(file(project.ext.siteDir)),
+      // The Solr Operator is only aggregated into the official multi-version
+      // site. Local builds render just the ref guide; operator contributors
+      // preview their component from the apache/solr-operator repo (make docs).
+      'additional_sources': "",
   ]
 
   expand(escapeYamlSingleQuotesString(props))
@@ -180,12 +185,23 @@ task buildOfficialAntoraPlaybookYaml(type: Copy) {
   }
   into project.ext.playbooksDir
 
-  def branches = ["branch_*"]
+  def branches = ["branch_*", "\"!branch_9_11\""]
+  def operatorBranches = ["release-*"]
   if (officialSiteIncludePrerelease) {
     branches.add("main")
+    operatorBranches.add("main")
   } else {
     branches.add("\"!branch_*x\"")
   }
+
+  // Aggregate the Solr Operator docs as an additional component, sourced from
+  // its release-* branches (apache/solr-operator). Each such branch carries its
+  // own docs/antora.yml (component 'operator'). edit_url is overridden per
+  // source so "Edit this page" points at the operator repo rather than apache/solr.
+  def operatorSources = """
+  - url: "https://github.com/apache/solr-operator.git"
+    branches: ${JsonOutput.toJson(operatorBranches)}
+    start_path: docs"""
 
   def props = [
       'site_url': "https://solr.apache.org/guide",
@@ -194,6 +210,7 @@ task buildOfficialAntoraPlaybookYaml(type: Copy) {
       'source_branches': branches,
       'start_path': 'solr/solr-ref-guide',
       'site_dir': "./" + file(project.ext.playbooksDir).relativePath(file(project.ext.siteDir)),
+      'additional_sources': operatorSources,
   ]
 
   expand(escapeYamlSingleQuotesString(props))

--- a/solr/solr-ref-guide/playbook.template.yml
+++ b/solr/solr-ref-guide/playbook.template.yml
@@ -33,7 +33,7 @@ content:
   - url: '${source_url}'
     branches: ${source_branches}
     start_path: '${start_path}'
-
+${additional_sources}
 ui:
   bundle:
     url: 'https://nightlies.apache.org/solr/solr-reference-guide-ui-bundle/ui-bundle.zip'

--- a/solr/solr-ref-guide/ui-src/css/vars.css
+++ b/solr/solr-ref-guide/ui-src/css/vars.css
@@ -145,7 +145,9 @@
   --nav-height--desktop: var(--body-min-height);
   --nav-panel-menu-height: calc(100% - var(--drawer-height));
   --nav-panel-explore-height: calc(50% + var(--drawer-height));
-  --nav-width: calc(270 / var(--rem-base) * 1rem);
+  /* Solr Changes - Start */
+  --nav-width: calc(300 / var(--rem-base) * 1rem);
+  /* Solr Changes - End */
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);

--- a/solr/solr-ref-guide/ui-src/partials/nav-explore.hbs
+++ b/solr/solr-ref-guide/ui-src/partials/nav-explore.hbs
@@ -26,67 +26,13 @@
   <!-- Solr Additions - Start -->
   <!-- A hard-coded list of older Ref Guides, pre-Antora -->
   <ul class="components">
-    <li class="component"> <a class="title" href="https://solr.apache.org/guide">Pre-9.0 Reference Guides</a>
+    <li class="component"> <a class="title" href="https://solr.apache.org/guide">Archived Solr Reference Guides</a>
     <ul class="versions">
       <li class="version">
         <a href="https://solr.apache.org/guide/8_11">8.11</a>
       </li>
       <li class="version">
-        <a href="https://solr.apache.org/guide/8_10">8.10</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_9">8.9</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_8">8.8</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_7">8.7</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_6">8.6</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_5">8.5</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_4">8.4</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_3">8.3</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_2">8.2</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_1">8.1</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/8_0">8.0</a>
-      </li>
-      <li class="version">
         <a href="https://solr.apache.org/guide/7_7">7.7</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_6">7.6</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_5">7.5</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_4">7.4</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_3">7.3</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_2">7.2</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_1">7.1</a>
-      </li>
-      <li class="version">
-        <a href="https://solr.apache.org/guide/7_0">7.0</a>
       </li>
       <li class="version">
         <a href="https://solr.apache.org/guide/6_6">6.6</a>


### PR DESCRIPTION
Finishes up https://github.com/apache/solr-operator/issues/833

Apart from adding the Solr Operator ref guide, a few other changes:

- The "Pre-9.0 Solr Ref Guides" now reads "Archived Solr Ref Guides", and only contains 8.11, 7.7 and 6.6. The old ref guides still exist, but no reason to list them out since they are very old now. We should keep it clean and let users modify the URL if they so desire.
- In order to make the Solr ref guides to be above the Solr Operator ref guides, we need to rename the "Solr Reference Guide" component to "Apache Solr". This is also cleaner now.
### Old
<img width="370" height="381" alt="Screenshot 2026-06-10 at 10 14 42 AM" src="https://github.com/user-attachments/assets/2971cad3-1399-49cc-bb64-f0b3fd4259ff" />

### New
<img width="411" height="357" alt="Screenshot 2026-06-10 at 10 18 42 AM" src="https://github.com/user-attachments/assets/7d3588ac-933a-4d55-80a1-a862ff27a75a" />
