### PR TITLE
CloudSolrClient.getHttpClient

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.solr.client.solrj.cloud.DistribStateManager;
 import org.apache.solr.client.solrj.cloud.SolrCloudManager;
 import org.apache.solr.client.solrj.cloud.VersionedData;
-import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.NodeValueFetcher;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.request.MetricsRequest;
@@ -879,7 +878,7 @@ public class SplitShardCmd implements CollApiCmds.CollectionApiCommand {
     var req = new MetricsRequest(params);
     req.setResponseParser(new InputStreamResponseParser("prometheus"));
 
-    var cloudClient = (CloudHttp2SolrClient) cloudManager.getSolrClient();
+    var cloudClient = cloudManager.getSolrClient();
     var httpClient = cloudClient.getHttpClient();
 
     NamedList<Object> resp =

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -41,7 +41,6 @@ import org.apache.solr.client.solrj.RemoteSolrException;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.jetty.CloudJettySolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
@@ -157,7 +156,7 @@ public class ShardSplitTest extends BasicDistributedZkTest {
         builder
             .withDefaultCollection(collectionName)
             .sendUpdatesOnlyToShardLeaders()
-            .withHttpClient(((CloudJettySolrClient) cloudClient).getHttpClient())
+            .withHttpClient(cloudClient.getHttpClient())
             .build()) {
       StoppableIndexingThread thread =
           new StoppableIndexingThread(controlClient, client, "i1", true);

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/solrj.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/solrj.adoc
@@ -183,8 +183,8 @@ processing time of the largest update request.
 
 === Cloud Request Routing
 
-The SolrJ `CloudSolrClient` implementations (`CloudSolrClient` and `CloudHttp2SolrClient`) respect the xref:solrcloud-distributed-requests.adoc#shards-preference-parameter[shards.preference parameter].
-Therefore requests sent to single-sharded collections, using either of the above clients, will route requests the same way that distributed requests are routed to individual shards.
+SolrJ `CloudSolrClient` respects the xref:solrcloud-distributed-requests.adoc#shards-preference-parameter[shards.preference parameter].
+Therefore requests sent to single-sharded collections will route requests the same way that distributed requests are routed to individual shards.
 If no `shards.preference` parameter is provided, the clients will default to sorting replicas randomly.
 
 For update requests, while the replicas are sorted in the order defined by the request, leader replicas will always be sorted first.

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientNodeStateProvider.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/SolrClientNodeStateProvider.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final CloudHttp2SolrClient solrClient;
+  private final CloudSolrClient solrClient;
   protected final Map<String, Map<String, Map<String, List<Replica>>>>
       nodeVsCollectionVsShardVsReplicaInfo = new HashMap<>();
 
@@ -61,11 +61,7 @@ public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter
   private Map<String, Map> nodeVsTags = new HashMap<>();
 
   public SolrClientNodeStateProvider(CloudSolrClient solrClient) {
-    if (!(solrClient instanceof CloudHttp2SolrClient)) {
-      throw new IllegalArgumentException(
-          "The passed-in CloudSolrClient must be a " + CloudHttp2SolrClient.class);
-    }
-    this.solrClient = (CloudHttp2SolrClient) solrClient;
+    this.solrClient = solrClient;
     try {
       readReplicaDetails();
     } catch (IOException e) {
@@ -242,7 +238,7 @@ public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter
   static class RemoteCallCtx {
 
     ZkClientClusterStateProvider zkClientClusterStateProvider;
-    CloudHttp2SolrClient cloudSolrClient;
+    CloudSolrClient cloudSolrClient;
     public final Map<String, Object> tags = new HashMap<>();
     private final String node;
     public Map<String, Object> session;
@@ -254,7 +250,7 @@ public class SolrClientNodeStateProvider implements NodeStateProvider, MapWriter
       return true;
     }
 
-    public RemoteCallCtx(String node, CloudHttp2SolrClient cloudSolrClient) {
+    public RemoteCallCtx(String node, CloudSolrClient cloudSolrClient) {
       this.node = node;
       this.cloudSolrClient = cloudSolrClient;
       this.zkClientClusterStateProvider =

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -102,6 +102,7 @@ public class CloudHttp2SolrClient extends CloudSolrClient {
     return stateProvider;
   }
 
+  @Override
   public HttpSolrClient getHttpClient() {
     return myClient;
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -639,6 +639,9 @@ public abstract class CloudSolrClient extends SolrClient {
     }
   }
 
+  /** The HttpSolrClient that underlies this one. It has no baseUrl or default collection. */
+  public abstract HttpSolrClient getHttpClient();
+
   public ResponseParser getParser() {
     return getLbClient().getParser();
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientCacheTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientCacheTest.java
@@ -424,6 +424,11 @@ public class CloudSolrClientCacheTest extends SolrTestCaseJ4 {
       return provider;
     }
 
+    @Override
+    public HttpSolrClient getHttpClient() {
+      throw new UnsupportedOperationException();
+    }
+
     @FunctionalInterface
     interface Invocation {
       NamedList<Object> invoke(SolrRequest<?> request, List<String> inputCollections)

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractCloudBackupRestoreTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractCloudBackupRestoreTestCase.java
@@ -32,7 +32,6 @@ import java.util.UUID;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.jetty.CloudJettySolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.ClusterProp;
 import org.apache.solr.client.solrj.request.QueryRequest;
@@ -467,12 +466,13 @@ public abstract class AbstractCloudBackupRestoreTestCase extends SolrCloudTestCa
   public static Map<String, Integer> getShardToDocCountMap(
       CloudSolrClient client, DocCollection docCollection) throws SolrServerException, IOException {
     Map<String, Integer> shardToDocCount = new TreeMap<>();
-    var jettySolrClient = ((CloudJettySolrClient) client).getHttpClient();
     for (Slice slice : docCollection.getActiveSlices()) {
       long docsInShard =
           new QueryRequest("/select", params("q", "*:*", "distrib", "false"))
               .processWithBaseUrl(
-                  jettySolrClient, slice.getLeader().getBaseUrl(), slice.getLeader().getCoreName())
+                  client.getHttpClient(),
+                  slice.getLeader().getBaseUrl(),
+                  slice.getLeader().getCoreName())
               .getResults()
               .getNumFound();
       shardToDocCount.put(slice.getName(), (int) docsInShard);


### PR DESCRIPTION
Now that CloudLegacySolrClient is gone, we're unblocked from doing this.

And reduce references to CloudHttp2SolrClient.  Ideally `org.apache.solr.client.solrj.impl.CloudSolrClient.Builder#build`'s return type would be coarsened to simply `CloudSolrClient` but I suppose that ship has sailed with 10.0.