### PR TITLE
Ref guide - Improve docs for Dense Vector reranking examples

### DIFF
--- a/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
@@ -814,7 +814,37 @@ Some use cases where `includeTags` and/or `excludeTags` may be more useful then 
 
 
 
-=== Usage in Re-Ranking Query
+[[vector-reranking]]
+== Usage in Re-Ranking Query
+
+Dense vector similarity scores can be used to xref:query-guide:query-re-ranking.adoc[re-rank] first pass query results.
+Possible use cases include:
+
+* Re-ranking approximate results from a quantized vector field using full fidelity float vectors.
+* Re-ranking lexical search results with dense vector similarity scores.
+
+Details about using the ReRank Query Parser can be found in the xref:query-guide:query-re-ranking.adoc[Query Re-Ranking] section.
+
+=== Re-Ranking with vectorSimilarity Function Query
+
+The xref:query-guide:function-queries.adoc#vectorsimilarity-function[vectorSimilarity()] function can be used with the `{!func}` query parser to re-rank by vector similarity.
+When used as a function query, `vectorSimilarity()` computes the exact similarity for only the candidate documents selected for re-ranking, without traversing the index graph.
+
+Here is an example of re-ranking a lexical query using a `DenseVectorField` named `vector`:
+
+[source,text]
+?q=title:phone&rq={!rerank reRankQuery=$rqq reRankDocs=100 reRankWeight=1}&rqq={!func}vectorSimilarity(vector,[1.0,2.0,3.0,4.0])
+
+NOTE: The default `reRankOperator` is `add`, which sums the first-pass score and the vector similarity score.
+Since these scores may differ in magnitude, you can adjust `reRankWeight` to control the balance between them, or use `reRankOperator=replace` to score re-ranked documents by vector similarity alone.
+
+When using a quantized vector field type (such as `ScalarQuantizedDenseVectorField`), the KNN first pass scores are computed on the quantized vectors.
+Here is an example of re-ranking those results with exact float similarity scores, where `topK` matches `reRankDocs`:
+
+[source,text]
+?q={!knn f=vector topK=100}[1.0,2.0,3.0,4.0]&rq={!rerank reRankQuery=$rqq reRankDocs=100 reRankWeight=1 reRankOperator=replace}&rqq={!func}vectorSimilarity(vector,[1.0,2.0,3.0,4.0])
+
+=== Re-Ranking with knn Query Parser
 
 Both dense vector search query parsers can be used to rerank first pass query results:
 
@@ -832,8 +862,6 @@ the k-nearest neighbors(*in the whole index*) of the target vector to search.
 This means the second pass `knn` is executed on the whole index anyway, which is a current limitation.
 
 The final ranked list of results will have the first pass score(main query `q`) added to the second pass score(the approximated similarityFunction distance to the target vector to search) multiplied by a multiplicative factor(reRankWeight).
-
-Details about using the ReRank Query Parser can be found in the xref:query-guide:query-re-ranking.adoc[Query Re-Ranking] section.
 ====
 
 

--- a/solr/solr-ref-guide/modules/query-guide/pages/query-re-ranking.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/query-re-ranking.adoc
@@ -134,6 +134,9 @@ In the example below, the scores for the top 1000 documents matching the query "
 q=phone&rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=1 reRankOperator=replace}&rqq={!func v=div(1,sum(1,price))}
 ----
 
+xref:query-guide:dense-vector-search.adoc[Dense vector fields] can also be used for re-ranking via the xref:query-guide:function-queries.adoc#vectorsimilarity-function[vectorSimilarity()] function query.
+This computes exact vector similarity only for the re-ranked candidate documents. See xref:query-guide:dense-vector-search.adoc#vector-reranking[Usage in Re-Ranking Query] for examples and details.
+
 
 === LTR Query Parser
 


### PR DESCRIPTION
# Description

The Dense Vector Search page in the Solr Ref Guide currently has a section titled `Usage in Re-Ranking Query`. However, it only contains a single example of re-ranking with the KNN query parser which has an important caveat that this initiates a second pass full KNN query. While this is true, I think it may be confusing to readers as it's not the only supported option for re-ranking documents with vectors.

This PR adds documentation for the more efficient re-ranking feature that rerank subsets of documents by direct vector comparisons with the [vectorSimilarity Function](https://solr.apache.org/guide/solr/latest/query-guide/function-queries.html#vectorsimilarity-function), with some notes about motivations and tradeoffs.

# Solution

- Moves indentation level of `Usage in Re-Ranking Query` in Dense Vector Search ref guide 
- Adds examples of how to use `{!func}vectorSimilarity` in a re-rank query
- Adds note about reranking with Dense Vector Fields in Query Re-Ranking page

## Before

<img width="1486" height="1066" alt="solr_dense_vector_ref_guide_before" src="https://github.com/user-attachments/assets/edee7996-3eac-4117-833b-23597ec468ec" />

## After

<img width="1490" height="1119" alt="solr_dense_vector_ref_guide_changes" src="https://github.com/user-attachments/assets/3284b706-272d-46cb-ad65-e3ebf00f861f" />


# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [X] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
- [ ] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change