### PR TITLE
jgit 7.x supports git worktrees

### DIFF
--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -50,11 +50,6 @@ Set<String> loadGitTrackedFiles() {
   rootProject.ext.ratGitTrackedFiles = null
 
   def dotGit = new File(rootProject.projectDir, ".git")
-  if (dotGit.isFile()) {
-    // git worktrees use a .git file — jgit does not fully support them
-    logger.warn("WARNING: git worktrees are not supported by jgit — RAT git-tracking filter disabled.")
-    return null
-  }
   if (!dotGit.isDirectory()) {
     return null // not a git repository
   }


### PR DESCRIPTION
jgit 7.x supports git worktrees:
https://github.com/eclipse-jgit/jgit/issues/264#issuecomment-4381182663

And I've seen it work myself.  I've been a long-time user of worktrees.  The recent change to RAT to depend on jgit means that it's quite important for jgit to support worktrees.  Unfortunately 7.x requires JDK 17 so this can't come to branch_9x unless we require JDK 17 for building.