### PR TITLE
PKIAuthenticationPlugin: handle non-base64 SolrAuthV2 signature

### DIFF
--- a/changelog/unreleased/PR#4553-pki-v2-header-base64-fix.yml
+++ b/changelog/unreleased/PR#4553-pki-v2-header-base64-fix.yml
@@ -2,3 +2,6 @@ title: PKIAuthenticationPlugin now rejects a SolrAuthV2 header with a malformed 
 type: fixed
 authors:
   - name: Jan Høydahl
+links:
+  - name: PR#4553
+    url: https://github.com/apache/solr/pull/4553

--- a/changelog/unreleased/pki-v2-header-base64-fix.yml
+++ b/changelog/unreleased/pki-v2-header-base64-fix.yml
@@ -1,0 +1,4 @@
+title: PKIAuthenticationPlugin now rejects a SolrAuthV2 header with a malformed signature using a 401 response, instead of returning a 500
+type: fixed
+authors:
+  - name: Jan Høydahl

--- a/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/PKIAuthenticationPlugin.java
@@ -209,7 +209,13 @@ public class PKIAuthenticationPlugin extends AuthenticationPlugin
     int sigStart = header.lastIndexOf(' ');
 
     String data = header.substring(0, sigStart);
-    byte[] sig = Base64.getDecoder().decode(header.substring(sigStart + 1));
+    byte[] sig;
+    try {
+      sig = Base64.getDecoder().decode(header.substring(sigStart + 1));
+    } catch (IllegalArgumentException e) {
+      log.warn("Could not parse signature in SolrAuthV2 header as base64");
+      return null;
+    }
     PKIHeaderData rv = validateSignature(data, sig, key, false);
     if (rv == null) {
       log.warn("Failed to verify signature, trying after refreshing the key ");

--- a/solr/core/src/test/org/apache/solr/security/TestPKIAuthenticationPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/TestPKIAuthenticationPlugin.java
@@ -207,6 +207,23 @@ public class TestPKIAuthenticationPlugin extends SolrTestCaseJ4 {
         "Should not have proceeded after authentication failure", wrappedRequestByFilter.get());
   }
 
+  @Test
+  public void testMalformedV2HeaderSignatureRejected() throws Exception {
+    headerValue.set(nodeName + " someuser 1234567890 not_base64!!!");
+
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    assertFalse(
+        "Should have rejected request with a non-base64 signature",
+        mock.authenticate(mockReq, response, filterChain));
+
+    verify(response)
+        .setHeader(HttpHeader.WWW_AUTHENTICATE.asString(), PKIAuthenticationPlugin.HEADER_V2);
+    verify(response).sendError(ArgumentMatchers.eq(401), anyString());
+
+    assertNull(
+        "Should not have proceeded after authentication failure", wrappedRequestByFilter.get());
+  }
+
   private HttpServletRequest createMockRequest(final AtomicReference<String> headerValue) {
     HttpServletRequest mockReq = mock(HttpServletRequest.class);
     when(mockReq.getHeader(any(String.class)))


### PR DESCRIPTION
Wrap the base64 decode of the signature token in decipherHeaderV2 in a try/catch so a malformed (non-base64) value returns null and results in a generic 401, instead of propagating an IllegalArgumentException that surfaces as a 500.
