### PR TITLE
Group github actions upgrades together in a renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -101,9 +101,10 @@
       "groupName": "Admin UI libraries"
     },
     {
-      "description": "Group all GitHub Actions upgrades together in same PR",
+      "description": "Group all GitHub Actions upgrades together in same PR, checked once per month",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      "schedule": ["before 9am on the first day of the month"]
     }
   ],
   "schedule": ["* * * * 0"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -99,6 +99,11 @@
       "description": "Group these UI dependency upgrades together in same PR",
       "matchPackagePrefixes": ["com.arkivanov", "org.jetbrains.compose"],
       "groupName": "Admin UI libraries"
+    },
+    {
+      "description": "Group all GitHub Actions upgrades together in same PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
     }
   ],
   "schedule": ["* * * * 0"],


### PR DESCRIPTION
This lowers the churn and lets us bulk upgrade actions (they seldom break)
We only check once a month.