### PR TITLE
SOLR-18296: Upgrade google-java-format to 1.35.0 (JDK 24/25 fix)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -35,3 +35,6 @@ c99af207c761ec34812ef1cc3054eb2804b7448b
 
 # Gradle reformat PR #4037
 92792f735615c1f628da6cf7fa408f29ca1f7485
+
+# SOLR-18296 [google java formatter applied]
+71bb2cd3f8404460d09d2de449fdff2cc24266c1

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -35,6 +35,3 @@ c99af207c761ec34812ef1cc3054eb2804b7448b
 
 # Gradle reformat PR #4037
 92792f735615c1f628da6cf7fa408f29ca1f7485
-
-# SOLR-18296 [google java formatter applied]
-71bb2cd3f8404460d09d2de449fdff2cc24266c1

--- a/build-tools/missing-doclet/src/main/java/org/apache/lucene/missingdoclet/MissingDoclet.java
+++ b/build-tools/missing-doclet/src/main/java/org/apache/lucene/missingdoclet/MissingDoclet.java
@@ -230,8 +230,8 @@ public class MissingDoclet extends StandardDoclet {
       case PACKAGE:
         checkComment(element);
         break;
-        // class-like elements, check them, then recursively check their children (fields and
-        // methods)
+      // class-like elements, check them, then recursively check their children (fields and
+      // methods)
       case CLASS:
       case INTERFACE:
       case ENUM:
@@ -251,7 +251,7 @@ public class MissingDoclet extends StandardDoclet {
           }
         }
         break;
-        // method-like elements, check them if we are configured to do so
+      // method-like elements, check them if we are configured to do so
       case METHOD:
       case CONSTRUCTOR:
       case FIELD:

--- a/changelog/unreleased/gjf-SOLR-18296.yml
+++ b/changelog/unreleased/gjf-SOLR-18296.yml
@@ -1,0 +1,7 @@
+title: Upgrade google-java-format to 1.35.0 (fixes JDK 24/25 build break)
+type: dependency_update
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+- name: SOLR-18296
+  url: https://issues.apache.org/jira/browse/SOLR-18296

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,7 @@ google-guava = "33.6.0-jre"
 # @keep for version alignment
 google-j2objc = "3.1"
 # @keep This is GJF version for spotless/ tidy.
-google-javaformat = "1.18.1"
+google-javaformat = "1.35.0"
 # @keep for version alignment
 google-protobuf = "4.35.1"
 # @keep Gradle version to run the build

--- a/solr/core/src/java/org/apache/solr/blockcache/BlockDirectory.java
+++ b/solr/core/src/java/org/apache/solr/blockcache/BlockDirectory.java
@@ -323,21 +323,21 @@ public class BlockDirectory extends FilterDirectory implements ShutdownAwareDire
       return false;
     }
     switch (context.context()) {
-        // depending on params, we don't cache on merges or when only reading once
+      // depending on params, we don't cache on merges or when only reading once
       case MERGE:
         {
           return cacheMerges;
         }
-        /* TODO
-        case READ:
-          {
-            if (context.readOnce) {
-              return cacheReadOnce;
-            } else {
-              return true;
-            }
+      /* TODO
+      case READ:
+        {
+          if (context.readOnce) {
+            return cacheReadOnce;
+          } else {
+            return true;
           }
-          */
+        }
+        */
       default:
         {
           return true;

--- a/solr/core/src/java/org/apache/solr/handler/DocumentAnalysisRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/DocumentAnalysisRequestHandler.java
@@ -279,7 +279,7 @@ public class DocumentAnalysisRequestHandler extends AnalysisRequestHandlerBase {
     while (true) {
       int event = reader.next();
       switch (event) {
-          // Add everything to the text
+        // Add everything to the text
         case XMLStreamConstants.SPACE:
         case XMLStreamConstants.CDATA:
         case XMLStreamConstants.CHARACTERS:

--- a/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
+++ b/solr/core/src/java/org/apache/solr/handler/IncrementalShardBackup.java
@@ -275,8 +275,9 @@ public class IncrementalShardBackup {
         case Error err -> throw err;
         case IOException ioe -> throw ioe;
         case RuntimeException re -> throw re;
-        default -> throw new SolrException(
-            SolrException.ErrorCode.UNKNOWN, "Error during parallel backup upload", cause);
+        default ->
+            throw new SolrException(
+                SolrException.ErrorCode.UNKNOWN, "Error during parallel backup upload", cause);
       }
     } catch (InterruptedException e) {
       uploadFutures.forEach(f -> f.cancel(true));

--- a/solr/core/src/java/org/apache/solr/handler/RestoreCore.java
+++ b/solr/core/src/java/org/apache/solr/handler/RestoreCore.java
@@ -195,8 +195,9 @@ public class RestoreCore implements Callable<Boolean> {
           case Error err -> throw err;
           case IOException ioe -> throw ioe;
           case RuntimeException re -> throw re;
-          default -> throw new SolrException(
-              SolrException.ErrorCode.UNKNOWN, "Error during parallel restore download", cause);
+          default ->
+              throw new SolrException(
+                  SolrException.ErrorCode.UNKNOWN, "Error during parallel restore download", cause);
         }
       } catch (InterruptedException e) {
         downloadFutures.forEach(f -> f.cancel(true));

--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
@@ -461,9 +461,10 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
         case "none" -> FilterType.none;
         case "name" -> FilterType.name;
         case "status" -> FilterType.status;
-        default -> throw new SolrException(
-            ErrorCode.BAD_REQUEST,
-            "Invalid filterType '" + filterType + "'. Allowed values are: none, name, status");
+        default ->
+            throw new SolrException(
+                ErrorCode.BAD_REQUEST,
+                "Invalid filterType '" + filterType + "'. Allowed values are: none, name, status");
       };
     }
     return FilterType.none;

--- a/solr/core/src/java/org/apache/solr/handler/component/PivotFacetValue.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/PivotFacetValue.java
@@ -145,8 +145,9 @@ public class PivotFacetValue {
         case STATS -> statsValues = (NamedList<NamedList<NamedList<?>>>) value;
         case QUERIES -> queryCounts = (NamedList<Number>) value;
         case RANGES -> ranges = (SimpleOrderedMap<SimpleOrderedMap<Object>>) value;
-        default -> throw new RuntimeException(
-            "PivotListEntry contains unaccounted for item: " + pivotEntry);
+        default ->
+            throw new RuntimeException(
+                "PivotListEntry contains unaccounted for item: " + pivotEntry);
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -768,7 +768,7 @@ public class SearchHandler extends RequestHandlerBase
         return "EXECUTE_QUERY";
       case STAGE_GET_FIELDS:
         return "GET_FIELDS";
-        // nobody wants to think it was DONE and canceled after it completed...
+      // nobody wants to think it was DONE and canceled after it completed...
       case STAGE_DONE:
         return "FINISHING";
       default:

--- a/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/JsonLoader.java
@@ -215,7 +215,7 @@ public class JsonLoader extends ContentStreamLoader {
               }
               break;
             }
-            // fall through
+          // fall through
 
           case JSONParser.LONG:
           case JSONParser.NUMBER:

--- a/solr/core/src/java/org/apache/solr/handler/loader/XMLLoader.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/XMLLoader.java
@@ -300,7 +300,7 @@ public class XMLLoader extends ContentStreamLoader {
           deleteCmd.clear();
           break;
 
-          // Add everything to the text
+        // Add everything to the text
         case XMLStreamConstants.SPACE:
         case XMLStreamConstants.CDATA:
         case XMLStreamConstants.CHARACTERS:
@@ -356,7 +356,7 @@ public class XMLLoader extends ContentStreamLoader {
     while (!complete) {
       int event = parser.next();
       switch (event) {
-          // Add everything to the text
+        // Add everything to the text
         case XMLStreamConstants.SPACE:
         case XMLStreamConstants.CDATA:
         case XMLStreamConstants.CHARACTERS:

--- a/solr/core/src/java/org/apache/solr/handler/tagger/TermPrefixCursor.java
+++ b/solr/core/src/java/org/apache/solr/handler/tagger/TermPrefixCursor.java
@@ -128,7 +128,7 @@ class TermPrefixCursor {
         if (termsEnum.next() == null) { // case END
           return false;
         }
-        // fall through to NOT_FOUND
+      // fall through to NOT_FOUND
 
       case NOT_FOUND:
         // termsEnum must start with prefixBuf to continue

--- a/solr/core/src/java/org/apache/solr/internal/csv/CSVPrinter.java
+++ b/solr/core/src/java/org/apache/solr/internal/csv/CSVPrinter.java
@@ -97,7 +97,7 @@ public class CSVPrinter {
           if (i + 1 < comment.length() && comment.charAt(i + 1) == '\n') {
             i++;
           }
-          // break intentionally excluded.
+        // break intentionally excluded.
         case '\n':
           println();
           out.write(this.strategy.getCommentStart());

--- a/solr/core/src/java/org/apache/solr/response/SchemaXmlWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/SchemaXmlWriter.java
@@ -159,16 +159,16 @@ public class SchemaXmlWriter extends TextResponseWriter {
         Object fieldTypePropValue = fieldTypeProperty.getValue();
 
         switch (fieldTypePropName) {
-          case FieldType.ANALYZER -> analyzerProperties =
-              (SimpleOrderedMap<Object>) fieldTypePropValue;
-          case FieldType.INDEX_ANALYZER -> indexAnalyzerProperties =
-              (SimpleOrderedMap<Object>) fieldTypePropValue;
-          case FieldType.QUERY_ANALYZER -> queryAnalyzerProperties =
-              (SimpleOrderedMap<Object>) fieldTypePropValue;
-          case FieldType.MULTI_TERM_ANALYZER -> multiTermAnalyzerProperties =
-              (SimpleOrderedMap<Object>) fieldTypePropValue;
-          case FieldType.SIMILARITY -> perFieldSimilarityProperties =
-              (SimpleOrderedMap<Object>) fieldTypePropValue;
+          case FieldType.ANALYZER ->
+              analyzerProperties = (SimpleOrderedMap<Object>) fieldTypePropValue;
+          case FieldType.INDEX_ANALYZER ->
+              indexAnalyzerProperties = (SimpleOrderedMap<Object>) fieldTypePropValue;
+          case FieldType.QUERY_ANALYZER ->
+              queryAnalyzerProperties = (SimpleOrderedMap<Object>) fieldTypePropValue;
+          case FieldType.MULTI_TERM_ANALYZER ->
+              multiTermAnalyzerProperties = (SimpleOrderedMap<Object>) fieldTypePropValue;
+          case FieldType.SIMILARITY ->
+              perFieldSimilarityProperties = (SimpleOrderedMap<Object>) fieldTypePropValue;
           default -> writeAttr(fieldTypePropName, fieldTypePropValue.toString());
         }
       }
@@ -229,8 +229,8 @@ public class SchemaXmlWriter extends TextResponseWriter {
       String name = analyzerProperty.getKey();
       Object value = analyzerProperty.getValue();
       switch (name) {
-        case FieldType.CHAR_FILTERS -> charFilterPropertiesList =
-            (List<SimpleOrderedMap<Object>>) value;
+        case FieldType.CHAR_FILTERS ->
+            charFilterPropertiesList = (List<SimpleOrderedMap<Object>>) value;
         case FieldType.TOKENIZER -> tokenizerProperties = (SimpleOrderedMap<Object>) value;
         case FieldType.FILTERS -> filterPropertiesList = (List<SimpleOrderedMap<Object>>) value;
         case FieldType.CLASS_NAME -> {

--- a/solr/core/src/java/org/apache/solr/schema/BBoxField.java
+++ b/solr/core/src/java/org/apache/solr/schema/BBoxField.java
@@ -170,7 +170,7 @@ public class BBoxField extends AbstractSpatialFieldType<BBoxStrategy> implements
     }
 
     switch (scoreParam) {
-        // TODO move these to superclass after LUCENE-5804 ?
+      // TODO move these to superclass after LUCENE-5804 ?
       case OVERLAP_RATIO:
         double queryTargetProportion = 0.25; // Suggested default; weights towards target area
 

--- a/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
+++ b/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
@@ -592,12 +592,13 @@ public class DenseVectorField extends FloatPointField {
 
   private Query getSeededQuery(Query knnQuery, Query seed) {
     return switch (knnQuery) {
-      case SolrKnnFloatVectorQuery knnFloatQuery -> SeededKnnVectorQuery.fromFloatQuery(
-          knnFloatQuery, seed);
-      case SolrKnnByteVectorQuery knnByteQuery -> SeededKnnVectorQuery.fromByteQuery(
-          knnByteQuery, seed);
-      default -> throw new SolrException(
-          SolrException.ErrorCode.SERVER_ERROR, "Invalid type of knn query");
+      case SolrKnnFloatVectorQuery knnFloatQuery ->
+          SeededKnnVectorQuery.fromFloatQuery(knnFloatQuery, seed);
+      case SolrKnnByteVectorQuery knnByteQuery ->
+          SeededKnnVectorQuery.fromByteQuery(knnByteQuery, seed);
+      default ->
+          throw new SolrException(
+              SolrException.ErrorCode.SERVER_ERROR, "Invalid type of knn query");
     };
   }
 
@@ -606,24 +607,30 @@ public class DenseVectorField extends FloatPointField {
         (earlyTermination.getSaturationThreshold() != null
             && earlyTermination.getPatience() != null);
     return switch (knnQuery) {
-      case SolrKnnFloatVectorQuery knnFloatQuery -> useExplicitParams
-          ? PatienceKnnVectorQuery.fromFloatQuery(
-              knnFloatQuery,
-              earlyTermination.getSaturationThreshold(),
-              earlyTermination.getPatience())
-          : PatienceKnnVectorQuery.fromFloatQuery(knnFloatQuery);
-      case SolrKnnByteVectorQuery knnByteQuery -> useExplicitParams
-          ? PatienceKnnVectorQuery.fromByteQuery(
-              knnByteQuery,
-              earlyTermination.getSaturationThreshold(),
-              earlyTermination.getPatience())
-          : PatienceKnnVectorQuery.fromByteQuery(knnByteQuery);
-      case SeededKnnVectorQuery seedQuery -> useExplicitParams
-          ? PatienceKnnVectorQuery.fromSeededQuery(
-              seedQuery, earlyTermination.getSaturationThreshold(), earlyTermination.getPatience())
-          : PatienceKnnVectorQuery.fromSeededQuery(seedQuery);
-      default -> throw new SolrException(
-          SolrException.ErrorCode.SERVER_ERROR, "Invalid type of knn query");
+      case SolrKnnFloatVectorQuery knnFloatQuery ->
+          useExplicitParams
+              ? PatienceKnnVectorQuery.fromFloatQuery(
+                  knnFloatQuery,
+                  earlyTermination.getSaturationThreshold(),
+                  earlyTermination.getPatience())
+              : PatienceKnnVectorQuery.fromFloatQuery(knnFloatQuery);
+      case SolrKnnByteVectorQuery knnByteQuery ->
+          useExplicitParams
+              ? PatienceKnnVectorQuery.fromByteQuery(
+                  knnByteQuery,
+                  earlyTermination.getSaturationThreshold(),
+                  earlyTermination.getPatience())
+              : PatienceKnnVectorQuery.fromByteQuery(knnByteQuery);
+      case SeededKnnVectorQuery seedQuery ->
+          useExplicitParams
+              ? PatienceKnnVectorQuery.fromSeededQuery(
+                  seedQuery,
+                  earlyTermination.getSaturationThreshold(),
+                  earlyTermination.getPatience())
+              : PatienceKnnVectorQuery.fromSeededQuery(seedQuery);
+      default ->
+          throw new SolrException(
+              SolrException.ErrorCode.SERVER_ERROR, "Invalid type of knn query");
     };
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/QParser.java
+++ b/solr/core/src/java/org/apache/solr/search/QParser.java
@@ -349,8 +349,8 @@ public abstract class QParser {
     return switch (q) {
       case null -> new LongConstValueSource(0);
       case FunctionQuery functionQuery -> functionQuery.getValueSource();
-      case FunctionScoreQuery functionQuery -> ValueSource.fromDoubleValuesSource(
-          functionQuery.getSource());
+      case FunctionScoreQuery functionQuery ->
+          ValueSource.fromDoubleValuesSource(functionQuery.getSource());
       default -> new QueryValueSource(q, 0.0f);
     };
   }

--- a/solr/core/src/java/org/apache/solr/search/ReRankQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankQParserPlugin.java
@@ -81,10 +81,12 @@ public class ReRankQParserPlugin extends QParserPlugin {
       final Query reRankQuery, final double reRankWeight, final ReRankOperator reRankOperator) {
     assert null != reRankQuery;
     return switch (reRankQuery) {
-      case FunctionQuery functionQuery -> new ReRankDoubleValuesSourceRescorer(
-          functionQuery.getValueSource().asDoubleValuesSource(), reRankWeight, reRankOperator);
-      case FunctionScoreQuery functionQuery -> new ReRankDoubleValuesSourceRescorer(
-          functionQuery.getSource(), reRankWeight, reRankOperator);
+      case FunctionQuery functionQuery ->
+          new ReRankDoubleValuesSourceRescorer(
+              functionQuery.getValueSource().asDoubleValuesSource(), reRankWeight, reRankOperator);
+      case FunctionScoreQuery functionQuery ->
+          new ReRankDoubleValuesSourceRescorer(
+              functionQuery.getSource(), reRankWeight, reRankOperator);
       default -> new ReRankQueryRescorer(reRankQuery, reRankWeight, reRankOperator);
     };
   }

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetHeatmap.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetHeatmap.java
@@ -324,11 +324,11 @@ public class FacetHeatmap extends FacetRequest {
         // A PNG graphic; compressed. Good for large & dense heatmaps; hard to consume.
         return asPngBytes(columns, rows, counts, debugInfo);
 
-        // TODO case UTFGRID  https://github.com/mapbox/utfgrid-spec
-        // TODO case skipList: //A sequence of values; negative values are actually how many 0's to
-        // insert. Good for small or large but sparse heatmaps.
-        // TODO auto choose png or skipList; use skipList when < ~25% full or <= ~512 cells remember
-        // to augment error list below when we add more formats.
+      // TODO case UTFGRID  https://github.com/mapbox/utfgrid-spec
+      // TODO case skipList: //A sequence of values; negative values are actually how many 0's to
+      // insert. Good for small or large but sparse heatmaps.
+      // TODO auto choose png or skipList; use skipList when < ~25% full or <= ~512 cells remember
+      // to augment error list below when we add more formats.
       default:
         throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Unknown format: " + format);
     }

--- a/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java
@@ -352,7 +352,7 @@ public class SolrRequestParsers {
             currentStream = valueStream;
             break;
           }
-          // fall-through
+        // fall-through
         default:
           currentStream.write(b);
       }

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -690,7 +690,7 @@ public class UpdateLog implements PluginInfoInitialized, SolrMetricProducer {
 
   private long computeBufferedOps() {
     return switch (state) {
-        // numRecords counts header as a record
+      // numRecords counts header as a record
       case BUFFERING -> (bufferTlog == null ? 0 : bufferTlog.numRecords() - 1);
       case APPLYING_BUFFERED -> {
         if (tlog == null) yield 0;

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
@@ -130,9 +130,9 @@ public class TestPullReplica extends SolrCloudTestCase {
     try {
       switch (random().nextInt(3)) {
         case 0 ->
-        // Sometimes use SolrJ
-        CollectionAdminRequest.createCollection(collectionName, "conf", 2, 1, 0, 3)
-            .process(cluster.getSolrClient());
+            // Sometimes use SolrJ
+            CollectionAdminRequest.createCollection(collectionName, "conf", 2, 1, 0, 3)
+                .process(cluster.getSolrClient());
         case 1 -> {
           // Sometimes use v1 API
           var jetty = cluster.getRandomJetty(random());

--- a/solr/core/src/test/org/apache/solr/handler/admin/api/GetMetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/api/GetMetricsTest.java
@@ -199,7 +199,8 @@ public class GetMetricsTest extends SolrTestCaseJ4 {
 
   @Test
   public void testGetMetricsCategoryParams() throws IOException {
-    String expected = """
+    String expected =
+        """
         category="QUERY"
         """;
 

--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/model/SolrTextToVectorModel.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/model/SolrTextToVectorModel.java
@@ -84,15 +84,16 @@ public class SolrTextToVectorModel extends SolrLanguageModel implements Accounta
               Duration timeOut = Duration.ofSeconds((Long) params.get(paramName));
               builder.getClass().getMethod(paramName, Duration.class).invoke(builder, timeOut);
             }
-            case MAX_SEGMENTS_PER_BATCH_PARAM, MAX_RETRIES_PARAM -> builder
-                .getClass()
-                .getMethod(paramName, Integer.class)
-                .invoke(builder, ((Long) params.get(paramName)).intValue());
+            case MAX_SEGMENTS_PER_BATCH_PARAM, MAX_RETRIES_PARAM ->
+                builder
+                    .getClass()
+                    .getMethod(paramName, Integer.class)
+                    .invoke(builder, ((Long) params.get(paramName)).intValue());
 
-              /*
-               * For primitive params if there's only one setter available, we call it.
-               * If there's choice we default to the string one
-               */
+            /*
+             * For primitive params if there's only one setter available, we call it.
+             * If there's choice we default to the string one
+             */
             default -> {
               ArrayList<Method> paramNameMatches = new ArrayList<>();
               for (var method : builder.getClass().getMethods()) {

--- a/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtlpExporterFactory.java
+++ b/solr/modules/opentelemetry/src/java/org/apache/solr/opentelemetry/OtlpExporterFactory.java
@@ -42,12 +42,14 @@ public class OtlpExporterFactory implements MetricExporterFactory {
     }
 
     return switch (OTLP_EXPORTER_PROTOCOL) {
-      case "grpc" -> OtlpGrpcMetricExporter.getDefault().toBuilder()
-          .setEndpoint(OTLP_EXPORTER_GRPC_ENDPOINT)
-          .build();
-      case "http" -> OtlpHttpMetricExporter.getDefault().toBuilder()
-          .setEndpoint(OTLP_EXPORTER_HTTP_ENDPOINT)
-          .build();
+      case "grpc" ->
+          OtlpGrpcMetricExporter.getDefault().toBuilder()
+              .setEndpoint(OTLP_EXPORTER_GRPC_ENDPOINT)
+              .build();
+      case "http" ->
+          OtlpHttpMetricExporter.getDefault().toBuilder()
+              .setEndpoint(OTLP_EXPORTER_HTTP_ENDPOINT)
+              .build();
       case "none" -> null;
       default -> {
         log.warn(

--- a/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3ReadWriteTest.java
+++ b/solr/modules/s3-repository/src/test/org/apache/solr/s3/S3ReadWriteTest.java
@@ -129,7 +129,7 @@ public class S3ReadWriteTest extends AbstractS3ClientTest {
           int numBytesToRead = random().nextInt(maxBuffer) + 1;
           // test both read() and read(buffer, off, len)
           switch (random().nextInt(3)) {
-              // read()
+            // read()
             case 0:
               {
                 for (int i = 0; i < numBytesToRead && !done; i++) {
@@ -140,7 +140,7 @@ public class S3ReadWriteTest extends AbstractS3ClientTest {
                 }
               }
               break;
-              // read(byte, off, len)
+            // read(byte, off, len)
             case 1:
               {
                 int readLen = input.read(buffer, 0, numBytesToRead);
@@ -152,7 +152,7 @@ public class S3ReadWriteTest extends AbstractS3ClientTest {
                 }
               }
               break;
-              // skip(len)
+            // skip(len)
             case 2:
               {
                 // We only want to skip 1 because

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -632,11 +632,11 @@ class SolrFilter extends Filter implements SolrRel {
           return new Pair<>(name, rightLiteral);
         case CAST:
           return translateBinary2(((RexCall) left).getOperands().get(0), right);
-          //        case OTHER_FUNCTION:
-          //          String itemName = SolrRules.isItem((RexCall) left);
-          //          if (itemName != null) {
-          //            return translateOp2(op, itemName, rightLiteral);
-          //          }
+        //        case OTHER_FUNCTION:
+        //          String itemName = SolrRules.isItem((RexCall) left);
+        //          if (itemName != null) {
+        //            return translateOp2(op, itemName, rightLiteral);
+        //          }
         default:
           return null;
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
@@ -123,8 +123,8 @@ public class QueryResponse extends SolrResponseBase {
         case "sort_values" -> _sortvalues = (NamedList<ArrayList>) val;
         case "facet_counts" -> _facetInfo = (NamedList<Object>) val;
 
-          // extractFacetInfo inspects _results, so defer calling it
-          // in case it hasn't been populated yet.
+        // extractFacetInfo inspects _results, so defer calling it
+        // in case it hasn't been populated yet.
         case "debug" -> {
           _debugInfo = (NamedList<Object>) val;
           extractDebugInfo(_debugInfo);
@@ -151,7 +151,7 @@ public class QueryResponse extends SolrResponseBase {
         }
         case "facets" -> _jsonFacetingInfo = (NamedList<Object>) val;
 
-          // Don't call extractJsonFacetingInfo(_jsonFacetingInfo) here in an effort to do it lazily
+        // Don't call extractJsonFacetingInfo(_jsonFacetingInfo) here in an effort to do it lazily
         case "suggest" -> {
           _suggestInfo = (NamedList<NamedList<Object>>) val;
           extractSuggesterInfo(_suggestInfo);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/XMLResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/XMLResponseParser.java
@@ -332,7 +332,7 @@ public class XMLResponseParser extends ResponseParser {
           break;
 
         case XMLStreamConstants.SPACE:
-          // TODO?  should this be trimmed? make sure it only gets one/two space?
+        // TODO?  should this be trimmed? make sure it only gets one/two space?
         case XMLStreamConstants.CDATA:
         case XMLStreamConstants.CHARACTERS:
           builder.append(parser.getText());
@@ -421,7 +421,7 @@ public class XMLResponseParser extends ResponseParser {
           break;
 
         case XMLStreamConstants.SPACE:
-          // TODO?  should this be trimmed? make sure it only gets one/two space?
+        // TODO?  should this be trimmed? make sure it only gets one/two space?
         case XMLStreamConstants.CDATA:
         case XMLStreamConstants.CHARACTERS:
           builder.append(parser.getText());
@@ -545,7 +545,7 @@ public class XMLResponseParser extends ResponseParser {
           break;
 
         case XMLStreamConstants.SPACE:
-          // TODO?  should this be trimmed? make sure it only gets one/two space?
+        // TODO?  should this be trimmed? make sure it only gets one/two space?
         case XMLStreamConstants.CDATA:
         case XMLStreamConstants.CHARACTERS:
           builder.append(parser.getText());

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/routing/NodePreferenceRulesComparator.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/routing/NodePreferenceRulesComparator.java
@@ -238,7 +238,7 @@ public class NodePreferenceRulesComparator {
   private Comparator<String> getPreferenceUrlComparator(PreferenceRule preferenceRule) {
     Comparator<String> comparator =
         switch (preferenceRule.name) {
-            // These preferences are not supported for URLs
+          // These preferences are not supported for URLs
           case ShardParams.SHARDS_PREFERENCE_REPLICA_TYPE:
           case ShardParams.SHARDS_PREFERENCE_REPLICA_LEADER:
           case ShardParams.SHARDS_PREFERENCE_NODE_WITH_SAME_SYSPROP:

--- a/solr/solrj/src/java/org/apache/solr/common/util/DOMUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/DOMUtil.java
@@ -249,19 +249,19 @@ public class DOMUtil {
         break;
 
       case Node.ATTRIBUTE_NODE: /* fall through */
-        /* Putting Attribute nodes in this section does not exactly
-           match the definition of how textContent should behave
-           according to the DOM Level-3 Core documentation - which
-           specifies that the Attr's children should have their
-           textContent contacted (Attr's can have a single child which
-           is either Text node or an EntityReference).  In practice,
-           DOM implementations do not seem to use child nodes of
-           Attributes, storing the "text" directly as the nodeValue.
-           Fortunately, the DOM Spec indicates that when Attr.nodeValue
-           is read, it should return the nodeValue from the child Node,
-           so this approach should work both for strict implementations,
-           and implementations actually encountered.
-        */
+      /* Putting Attribute nodes in this section does not exactly
+         match the definition of how textContent should behave
+         according to the DOM Level-3 Core documentation - which
+         specifies that the Attr's children should have their
+         textContent contacted (Attr's can have a single child which
+         is either Text node or an EntityReference).  In practice,
+         DOM implementations do not seem to use child nodes of
+         Attributes, storing the "text" directly as the nodeValue.
+         Fortunately, the DOM Spec indicates that when Attr.nodeValue
+         is read, it should return the nodeValue from the child Node,
+         so this approach should work both for strict implementations,
+         and implementations actually encountered.
+      */
       case Node.TEXT_NODE: /* fall through */
       case Node.CDATA_SECTION_NODE: /* fall through */
       case Node.COMMENT_NODE: /* fall through */

--- a/solr/solrj/src/java/org/apache/solr/common/util/Hash.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Hash.java
@@ -332,10 +332,10 @@ public class Hash {
     switch (len & 0x03) {
       case 3:
         k1 = (data[roundedEnd + 2] & 0xff) << 16;
-        // fallthrough
+      // fallthrough
       case 2:
         k1 |= (data[roundedEnd + 1] & 0xff) << 8;
-        // fallthrough
+      // fallthrough
       case 1:
         k1 |= (data[roundedEnd] & 0xff);
         k1 *= c1;

--- a/solr/solrj/src/java/org/apache/solr/common/util/JsonTextWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JsonTextWriter.java
@@ -123,7 +123,7 @@ public interface JsonTextWriter extends TextWriter {
           case '\u2029':
             unicodeEscape(getWriter(), ch);
             break;
-            // case '/':
+          // case '/':
           default:
             {
               if (ch <= 0x1F) {

--- a/solr/solrj/src/java/org/noggit/JSONParser.java
+++ b/solr/solrj/src/java/org/noggit/JSONParser.java
@@ -883,7 +883,7 @@ public class JSONParser {
     // implementation?
     for (; ; ) {
       switch (ch) {
-          // this is not the exclusive list of whitespace chars... the rest are handled in default:
+        // this is not the exclusive list of whitespace chars... the rest are handled in default:
         case ' ':
         case '\t':
         case '\r':

--- a/solr/solrj/src/java/org/noggit/JSONUtil.java
+++ b/solr/solrj/src/java/org/noggit/JSONUtil.java
@@ -126,7 +126,7 @@ public class JSONUtil {
         out.write('\\');
         out.write('f');
         break;
-        // case '/':
+      // case '/':
       case '\u2028': // valid JSON, but not valid json script
       case '\u2029':
         unicodeEscape(ch, out);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
@@ -2398,8 +2398,7 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
             concurrentClient.lastError.getMessage().contains("version conflict"));
       } else if (client
           instanceof
-          SolrExampleStreamingHttp2Test.ErrorTrackingConcurrentUpdateSolrClient
-          concurrentClient) {
+          SolrExampleStreamingHttp2Test.ErrorTrackingConcurrentUpdateSolrClient concurrentClient) {
         client.commit(); // just to be sure the client has sent the doc
         assertNotNull(
             "ConcurrentUpdateSolrClient did not report an error", concurrentClient.lastError);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18296

# Description

Bumps google-java-format from 1.18.1 to 1.35.0. Java baseline unchanged (JDK 21);
this only affects the spotless code formatter.

google-java-format 1.18.1 calls a javac internal,
`Log$DeferredDiagnosticHandler.getDiagnostics()`, whose signature changed in
JDK 24, so `gradlew tidy` / `spotlessApply` throws `NoSuchMethodError` on JDK 24+.
1.34.0+ supports the newer JDKs; 1.35.0 is the current release.

This supersedes #4573, restructured per review feedback.

# Commits

1. **Upgrade google-java-format to 1.35.0** — `gradle/libs.versions.toml` bump +
   changelog entry.
2. **Reformat with google-java-format 1.35.0** — the ~35 files reformatted by
   `gradlew tidy` under the new version. Pure mechanical formatting, no logic
   changes. Isolated in its own commit and added to `.git-blame-ignore-revs`.
3. **Add reformat commit to `.git-blame-ignore-revs`.**

The `.git-blame-ignore-revs` entry references the reformat commit's SHA, so it
relies on that commit being preserved rather than squashed.

# On splitting bump vs. reformat into separate PRs

I looked at doing the formatting as a fully separate PR, but for a pure
formatter *version* bump the two halves can't stand alone — each leaves
`spotlessJavaCheck` red:

- bump only (files not yet reformatted): files fail the format check.
- reformat only (formatter still 1.18.1): spotless crashes on JDK 25 with the
  same `NoSuchMethodError` this PR fixes.

Only the two together are green. So they're kept in one PR, with the reformat
isolated into its own commit + blame-ignore as suggested.

# Testing

`gradlew spotlessJavaCheck` passes on Eclipse Temurin 21 and JDK 25.

# AI assistance disclosure

Per AGENTS.md / how-to-contribute.adoc: prepared with the assistance of an AI
coding agent and reviewed by me for correctness, scope, and alignment with
Solr's build conventions.