### PR TITLE
Propose better Renovatebot grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,11 @@
       "versioning": "regex:^(?<major>\\d{1,4})\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
     },
     {
+      "description": "Byte Buddy publishes a -jdk5 backport variant alongside each release (e.g. 1.18.10-jdk5). Ignore those so we track the mainline versions (e.g. 1.18.10).",
+      "matchPackagePrefixes": ["net.bytebuddy"],
+      "allowedVersions": "!/-jdk5$/"
+    },
+    {
       "description": "CATCH-ALL: bundle all remaining minor/patch bumps of otherwise-ungrouped libraries into one PR to cut churn. Major bumps are intentionally NOT grouped here - they stay as individual PRs. The test bucket and the logical groups below override this for their packages.",
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,45 +28,126 @@
       "versioning": "regex:^(?<major>\\d{1,4})\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
     },
     {
-      "description": "Group these calcite dependency upgrades together in same PR",
-      "matchPackagePrefixes": ["org.apache.calcite"],
-      "groupName": "org.apache.calcite"
+      "description": "CATCH-ALL: bundle all remaining minor/patch bumps of otherwise-ungrouped libraries into one PR to cut churn. Major bumps are intentionally NOT grouped here - they stay as individual PRs. The test bucket and the logical groups below override this for their packages.",
+      "matchManagers": ["gradle"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies"
     },
     {
-      "description": "Group these httpcomponents dependency upgrades together in same PR",
-      "matchPackagePrefixes": ["org.apache.httpcomponents"],
-      "groupName": "org.apache.httpcomponents"
-    },
-    {
-      "description": "Test-dependencies are checked less often than the shipped deps",
+      "description": "CATCH-ALL for test-only deps: bundle their minor/patch bumps separately from shipped deps. Major bumps stay individual.",
+      "matchManagers": ["gradle"],
       "matchDepTypes": ["test"],
-      "schedule": ["before 9am on the first day of the month"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major test dependencies"
     },
     {
-      "description": "AWS SDK packages checked less often",
+      "description": "Admin UI (Kotlin Multiplatform / Compose stack in solr/ui) - compose, androidx, kotlin(x), decompose/essenty/mvikotlin, ktor and kotlin-logging all move together. The Compose compiler plugin is version-locked to the Kotlin release.",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin",
+        "org.jetbrains.compose",
+        "org.jetbrains.androidx",
+        "com.arkivanov",
+        "io.ktor",
+        "io.github.oshai"
+      ],
+      "groupName": "Admin UI"
+    },
+    {
+      "description": "Web/server stack - Jetty servlet container, the Jakarta EE APIs, and the Jersey (JAX-RS) impl with its HK2 DI. solr/core wires jersey-container-jetty-http + jersey-inject-hk2 + jakarta APIs onto Jetty, so they must stay compatible.",
+      "matchPackagePrefixes": [
+        "org.eclipse.jetty",
+        "jakarta.",
+        "org.glassfish.jersey",
+        "org.glassfish.hk2"
+      ],
+      "groupName": "Web server stack"
+    },
+    {
+      "description": "gRPC / Netty / protobuf transport stack - grpc-netty uses Netty as its transport and grpc-protobuf uses protobuf. Shared by both the OpenTelemetry OTLP exporter and the GCS client, so it is its own group rather than owned by either.",
+      "matchPackagePrefixes": [
+        "io.grpc",
+        "io.netty",
+        "com.google.protobuf"
+      ],
+      "groupName": "gRPC and Netty"
+    },
+    {
+      "description": "Telemetry - OpenTelemetry API/SDK/exporters/instrumentation plus the Prometheus metrics libraries it exports to (solr/core uses otel-exporter-prometheus with prometheus-metrics-*).",
+      "matchPackagePrefixes": [
+        "io.opentelemetry",
+        "io.prometheus"
+      ],
+      "groupName": "Telemetry (OpenTelemetry & Prometheus)"
+    },
+    {
+      "description": "Google Cloud client stack used by the GCS repository - cloud client, api and auth libraries plus the BOM. Kept separate from the gRPC transport it consumes and from general com.google.* utility libs (guava, gson, errorprone).",
+      "matchPackagePrefixes": [
+        "com.google.cloud",
+        "com.google.api",
+        "com.google.auth"
+      ],
+      "groupName": "Google Cloud"
+    },
+    {
+      "description": "FasterXML Jackson and the Woodstox XML stack - jackson-bom family, plus woodstox-core (com.fasterxml.woodstox) and its required stax2-api (org.codehaus.woodstox), which are used together in solr/core.",
+      "matchPackagePrefixes": [
+        "com.fasterxml.jackson",
+        "com.fasterxml.woodstox",
+        "org.codehaus.woodstox"
+      ],
+      "groupName": "Jackson & Woodstox"
+    },
+    {
+      "description": "Logging stack - Log4j, SLF4J (the log4j-slf4j2-impl bridge and jul/jcl bridges tie them together) and LMAX Disruptor, which is only present for Log4j2 async logging.",
+      "matchPackagePrefixes": [
+        "org.apache.logging.log4j",
+        "org.slf4j",
+        "com.lmax"
+      ],
+      "groupName": "Logging"
+    },
+    {
+      "description": "ZooKeeper and Curator - Curator is a ZooKeeper client library and must stay compatible with the ZooKeeper version.",
+      "matchPackagePrefixes": [
+        "org.apache.zookeeper",
+        "org.apache.curator"
+      ],
+      "groupName": "ZooKeeper & Curator"
+    },
+    {
+      "description": "Calcite (calcite-core/linq4j + avatica) must move together",
+      "matchPackagePrefixes": ["org.apache.calcite"],
+      "groupName": "Calcite"
+    },
+    {
+      "description": "Apache HttpComponents (httpclient/httpcore/httpmime) must move together",
+      "matchPackagePrefixes": ["org.apache.httpcomponents"],
+      "groupName": "Apache HttpComponents"
+    },
+    {
+      "description": "AWS SDK - single BOM-aligned version across ~11 artifacts",
       "matchPackagePrefixes": ["software.amazon.awssdk"],
-      "groupName": "AWS SDK",
-      "schedule": ["before 9am on the first day of the month"]
+      "groupName": "AWS SDK"
     },
     {
-      "description": "Google Cloud BOM checked less often to avoid spam",
-      "matchPackageNames": ["com.google.cloud:google-cloud-bom"],
-      "schedule": ["before 9am on the first day of the month"]
+      "description": "OkHttp and Okio - okhttp depends on a compatible okio",
+      "matchPackagePrefixes": ["com.squareup.okhttp3", "com.squareup.okio"],
+      "groupName": "OkHttp & Okio"
     },
     {
-      "description": "Workaround for https://github.com/renovatebot/renovate/issues/19226",
-      "matchPackageNames": ["solr:modules", "HH:mm"],
+      "description": "Skip major jetty upgrades - must be done manually (overrides the Web server stack group above for jetty majors only)",
+      "matchPackagePrefixes": ["org.eclipse.jetty"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
-      "description": "Lucene dependencies should be skipped",
+      "description": "Lucene dependencies should be skipped (upgraded together with the Lucene release)",
       "matchPackagePrefixes": ["org.apache.lucene"],
       "enabled": false
     },
     {
-      "description": "Skip major jetty upgrades - must be done manually",
-      "matchPackagePrefixes": ["org.eclipse.jetty"],
-      "matchUpdateTypes": ["major"],
+      "description": "Workaround for https://github.com/renovatebot/renovate/issues/19226",
+      "matchPackageNames": ["solr:modules", "HH:mm"],
       "enabled": false
     },
     {
@@ -96,18 +177,12 @@
       "changelogUrl": "https://commons.apache.org/proper/commons-configuration/changes-report.html"
     },
     {
-      "description": "Group these UI dependency upgrades together in same PR",
-      "matchPackagePrefixes": ["com.arkivanov", "org.jetbrains.compose"],
-      "groupName": "Admin UI libraries"
-    },
-    {
-      "description": "Group all GitHub Actions upgrades together in same PR, checked once per month",
+      "description": "Group all GitHub Actions upgrades together in same PR",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "schedule": ["before 9am on the first day of the month"]
+      "groupName": "GitHub Actions"
     }
   ],
-  "schedule": ["* * * * 0"],
+  "schedule": ["before 9am on the first day of the month"],
   "prConcurrentLimit": 300,
   "prHourlyLimit": 20,
   "minimumReleaseAge": "5 days"

--- a/dev-docs/dependency-upgrades.adoc
+++ b/dev-docs/dependency-upgrades.adoc
@@ -76,25 +76,11 @@ every couple of months, a monthly cadence keeps the number of open dependency PR
 wants to be on the very latest right before a release can temporarily switch to a more frequent schedule (e.g.
 `["* * * * 0"]` for weekly) by editing `renovate.json`.
 
-To further cut down on the number of tiny PRs, upgrades are *grouped*. The groups are derived from how the libraries
-are actually wired together in the build (shared BOMs, shared version keys, and functional coupling between modules),
-so that artifacts which must stay version-compatible always land in the same PR:
-
-* *Admin UI* - the Kotlin-Multiplatform / Compose stack in `solr/ui` (compose, androidx, kotlin(x), decompose,
-  essenty, mvikotlin, ktor, kotlin-logging); the Compose compiler plugin is version-locked to the Kotlin release.
-* *Web server stack* - Jetty, the Jakarta EE APIs, and Jersey (JAX-RS) with its HK2 DI, wired together via
-  `jersey-container-jetty-http` in `solr/core`.
-* *gRPC and Netty* - gRPC with Netty (its transport) and protobuf; shared by both the OTel OTLP exporter and the GCS client.
-* *Telemetry* - OpenTelemetry plus the Prometheus metrics libraries it exports to.
-* *Google Cloud* - the GCS client stack (cloud/api/auth + BOM), kept separate from the gRPC transport it consumes.
-* *Jackson & Woodstox*, *Logging* (Log4j + SLF4J + Disruptor), *ZooKeeper & Curator*, *Calcite*,
-  *Apache HttpComponents*, *AWS SDK*, *OkHttp & Okio*, and *GitHub Actions*.
-* Everything else that does not belong to a family has its *minor and patch* bumps bundled into two catch-all PRs:
-  "all non-major dependencies" and "all non-major test dependencies". This is the bulk of the churn reduction.
-* *Major* version bumps are never grouped into the catch-all buckets - each major update gets its own PR so it can
-  be reviewed and merged (or skipped) individually, since majors tend to conflict and need more scrutiny. Renovate
-  also splits a major bump of any grouped family into its own "... (major)" PR.
-* Lucene follows the Lucene release and jetty *major* bumps are done manually, so both are left out of the bot.
+To further cut down on the number of tiny PRs, upgrades are *grouped*. There are a handful of logical groups for
+libraries that must stay version-compatible (e.g. Admin UI, Web server stack, Logging), and then two large
+catch-all groups - "all non-major dependencies" and "all non-major test dependencies" - that bundle the *minor and
+patch* bumps of everything else. *Major* bumps are never grouped; each gets its own PR for individual review. See
+`renovate.json` for the exact group definitions.
 
 If an upgrade is decided, simply merge (and backport) the PR. To skip an upgrade, close the PR. If a PR is left open,
 it will be re-used and auto updated whenever a newer patch- or minor version gets available. Thus, one can reduce

--- a/dev-docs/dependency-upgrades.adoc
+++ b/dev-docs/dependency-upgrades.adoc
@@ -70,14 +70,39 @@ changes resulting from the gradle tasks `resolveAndLockAll` and `updateLicenses`
 Community members and committers can then review, and if manual changes are needed, help bring the PR to completion.
 For many dependencies, a changelog is included in the PR text, which may help guide the upgrade decision.
 
-The scans are run on a schedule. New PRs are filed every Sunday, and only dependency versions that are at least
-5 days old are suggested, to guard against bad apples. If a new *major* version of a dependency is available,
-that will get its own separate Pull Request, so you can choose.
+The scans are run on a schedule. New PRs are filed once a month (before 9am on the first day of the month), and only
+dependency versions that are at least 5 days old are suggested, to guard against bad apples. Since Solr only releases
+every couple of months, a monthly cadence keeps the number of open dependency PRs manageable. A Release Manager who
+wants to be on the very latest right before a release can temporarily switch to a more frequent schedule (e.g.
+`["* * * * 0"]` for weekly) by editing `renovate.json`.
+
+To further cut down on the number of tiny PRs, upgrades are *grouped*. The groups are derived from how the libraries
+are actually wired together in the build (shared BOMs, shared version keys, and functional coupling between modules),
+so that artifacts which must stay version-compatible always land in the same PR:
+
+* *Admin UI* - the Kotlin-Multiplatform / Compose stack in `solr/ui` (compose, androidx, kotlin(x), decompose,
+  essenty, mvikotlin, ktor, kotlin-logging); the Compose compiler plugin is version-locked to the Kotlin release.
+* *Web server stack* - Jetty, the Jakarta EE APIs, and Jersey (JAX-RS) with its HK2 DI, wired together via
+  `jersey-container-jetty-http` in `solr/core`.
+* *gRPC and Netty* - gRPC with Netty (its transport) and protobuf; shared by both the OTel OTLP exporter and the GCS client.
+* *Telemetry* - OpenTelemetry plus the Prometheus metrics libraries it exports to.
+* *Google Cloud* - the GCS client stack (cloud/api/auth + BOM), kept separate from the gRPC transport it consumes.
+* *Jackson & Woodstox*, *Logging* (Log4j + SLF4J + Disruptor), *ZooKeeper & Curator*, *Calcite*,
+  *Apache HttpComponents*, *AWS SDK*, *OkHttp & Okio*, and *GitHub Actions*.
+* Everything else that does not belong to a family has its *minor and patch* bumps bundled into two catch-all PRs:
+  "all non-major dependencies" and "all non-major test dependencies". This is the bulk of the churn reduction.
+* *Major* version bumps are never grouped into the catch-all buckets - each major update gets its own PR so it can
+  be reviewed and merged (or skipped) individually, since majors tend to conflict and need more scrutiny. Renovate
+  also splits a major bump of any grouped family into its own "... (major)" PR.
+* Lucene follows the Lucene release and jetty *major* bumps are done manually, so both are left out of the bot.
 
 If an upgrade is decided, simply merge (and backport) the PR. To skip an upgrade, close the PR. If a PR is left open,
 it will be re-used and auto updated whenever a newer patch- or minor version gets available. Thus, one can reduce
 churn from frequently-updated dependencies by delaying merge until a few weeks before a new release. One can also
 choose to change to a less frequent schedule or disable the bot, by editing `renovate.json`.
+
+The `branch_9x` branch has its own `renovate.json` that layers on top of (and inherits from) this one, overriding only
+the schedule and the lockfile/license commands. Grouping rules defined here therefore apply to `branch_9x` too.
 
 Please note that Solr version prior to 10.X use a versions resolution plugin that uses `versions.lock` instead of
 `libs.version.toml`. Therefore, changes cannot be backported via cherry-pick.


### PR DESCRIPTION
Renovate currently files dependency PRs **every Sunday**, producing more than a hundred tiny individual PRs that are a lot of work to review and merge. Since Solr only releases every couple of months, this cadence and granularity is more than we need.

We have had some success with grouping dep upgrades on the solr-orbit sub project and also github-actions grouping here seems to work well. So proposing a BIG change here that will cap the max open solrbot PRs to about 14 plus individual major-version PRs. Plus the same for branch_9x. This is better than 200+

Even if the "catch-all" groups will have a higher chance of conflict, those can now be resolved as a group instead of in many individual PRs. And flaky crave.io tests will bite fewer times, and we'll need to run the entire test suite less often.

This PR reworks `.github/renovate.json` to cut that churn.

### Changes

- **Schedule: weekly → monthly** (`before 9am on the first day of the month`). An RM can
  temporarily switch back to weekly a few weeks before a release. Redundant per-group
  monthly schedules were removed.
- **Two catch-all buckets** collapse the long tail of unrelated libraries: minor/patch bumps
  land in `all non-major dependencies` / `all non-major test dependencies`. **Major bumps are
  never bundled** — each still gets its own PR for individual review.
- **12 logical groups** derived from how libraries are actually wired in the build (shared
  BOMs / version keys / cross-module coupling), so version-compatible artifacts always move together:
  - **Admin UI** — the `solr/ui` KMP/Compose stack (compose, androidx, kotlin(x), decompose,
    essenty, mvikotlin, ktor, kotlin-logging)
  - **Web server stack** — Jetty + Jakarta EE + Jersey + HK2 (`jersey-container-jetty-http`)
  - **gRPC and Netty** — gRPC + Netty (its transport) + protobuf; shared by OTel and GCS
  - **Telemetry** — OpenTelemetry + the Prometheus libs it exports to
  - **Google Cloud** — cloud/api/auth client stack (kept apart from the gRPC transport it consumes)
  - **Jackson & Woodstox**, **Logging** (Log4j + SLF4J + Disruptor), **ZooKeeper & Curator**,
    **Calcite**, **Apache HttpComponents**, **AWS SDK**, **OkHttp & Okio**, **GitHub Actions**
- Lucene (follows the Lucene release) and **jetty major** bumps (done manually) remain excluded.
- `dev-docs/dependency-upgrades.adoc` updated to document the new cadence and grouping.

Rule ordering: catch-alls → logical groups override → `enabled:false` skips win last.