### PR TITLE
Redo backport of bats refactoring in PR 3706 from main to branch_10x.

### DIFF
--- a/solr/packaging/test/bats_helper.bash
+++ b/solr/packaging/test/bats_helper.bash
@@ -97,59 +97,21 @@ collection_exists() {
   return 1
 }
 
+# Utility function to retry a command until it succeeds or times out
 wait_for() {
   local timeout="${1:-30}"     # Default 30 seconds timeout
   local interval="${2:-1}"     # Default 1 second between retries
   shift 2                      # Remove timeout and interval from args
   local command=("$@")         # Remaining args are the command to execute
-
+  
   local end_time=$(($(date +%s) + timeout))
-
+  
   while [ $(date +%s) -lt $end_time ]; do
     if "${command[@]}"; then
       return 0
     fi
     sleep "$interval"
   done
-
+  
   return 1  # Timeout reached
-}
-
-# Wait for a collection to be queryable
-wait_for_collection() {
-  local collection="$1"
-  local timeout=${2:-180}
-  local start_ts
-  start_ts=$(date +%s)
-  while true; do
-    if curl -s -S -f "http://localhost:${SOLR_PORT}/solr/${collection}/select?q=*:*" | grep -q '"responseHeader"'; then
-      return 0
-    fi
-    local now
-    now=$(date +%s)
-    if [ $(( now - start_ts )) -ge ${timeout} ]; then
-      echo "Timed out waiting for collection '${collection}' to become queryable" >&2
-      return 1
-    fi
-    sleep 3
-  done
-}
-
-# Apply the ExtractingRequestHandler via Config API and print error body on failure
-apply_extract_handler() {
-  local collection="$1"
-  local json="{\"add-requesthandler\":{\"name\":\"/update/extract\",\"class\":\"org.apache.solr.handler.extraction.ExtractingRequestHandler\",\"tikaserver.url\":\"http://localhost:${TIKA_PORT}\",\"defaults\":{\"lowernames\":\"true\",\"captureAttr\":\"true\"}}}"
-  local url="http://localhost:${SOLR_PORT}/solr/${collection}/config"
-  # Capture body and status code
-  local resp code body
-  sleep 5
-  resp=$(curl -s -S -w "\n%{http_code}" -X POST -H 'Content-type:application/json' -d "$json" "$url")
-  code="${resp##*$'\n'}"
-  body="${resp%$'\n'*}"
-  if [ "$code" = "200" ]; then
-    return 0
-  else
-    echo "Config API error applying ExtractingRequestHandler to ${collection} (HTTP ${code}): ${body}" >&3
-    return 1
-  fi
 }

--- a/solr/packaging/test/bats_helper.bash
+++ b/solr/packaging/test/bats_helper.bash
@@ -97,6 +97,24 @@ collection_exists() {
   return 1
 }
 
+wait_for() {
+  local timeout="${1:-30}"     # Default 30 seconds timeout
+  local interval="${2:-1}"     # Default 1 second between retries
+  shift 2                      # Remove timeout and interval from args
+  local command=("$@")         # Remaining args are the command to execute
+
+  local end_time=$(($(date +%s) + timeout))
+
+  while [ $(date +%s) -lt $end_time ]; do
+    if "${command[@]}"; then
+      return 0
+    fi
+    sleep "$interval"
+  done
+
+  return 1  # Timeout reached
+}
+
 # Wait for a collection to be queryable
 wait_for_collection() {
   local collection="$1"

--- a/solr/packaging/test/test_extraction.bats
+++ b/solr/packaging/test/test_extraction.bats
@@ -18,6 +18,25 @@
 
 load bats_helper
 
+# Apply the ExtractingRequestHandler via Config API and print error body on failure
+apply_extract_handler() {
+  local collection="$1"
+  local json="{\"add-requesthandler\":{\"name\":\"/update/extract\",\"class\":\"org.apache.solr.handler.extraction.ExtractingRequestHandler\",\"tikaserver.url\":\"http://localhost:${TIKA_PORT}\",\"defaults\":{\"lowernames\":\"true\",\"captureAttr\":\"true\"}}}"
+  local url="http://localhost:${SOLR_PORT}/solr/${collection}/config"
+  # Capture body and status code
+  local resp code body
+  sleep 5
+  resp=$(curl -s -S -w "\n%{http_code}" -X POST -H 'Content-type:application/json' -d "$json" "$url")
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  if [ "$code" = "200" ]; then
+    return 0
+  else
+    echo "Config API error applying ExtractingRequestHandler to ${collection} (HTTP ${code}): ${body}" >&3
+    return 1
+  fi
+}
+
 setup_file() {
   if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
     export TIKA_PORT=$((SOLR_PORT+5))
@@ -31,7 +50,7 @@ setup_file() {
     fi
   else
     export DOCKER_UNAVAILABLE=1
-    echo "WARNING: Docker not available (CLI missing or daemon not running); Tika-dependent tests will be bypassed and marked as passed." >&3
+    echo "WARNING: Docker not available (CLI missing or daemon not running); Tika-dependent tests will be bypassed." >&3
   fi
 }
 
@@ -57,8 +76,7 @@ teardown() {
 @test "using curl to extract a single pdf file" {
 
   if [ -n "${DOCKER_UNAVAILABLE:-}" ]; then
-    echo "WARNING: Docker not available; bypassing test." >&3
-    return 0
+    skip "Docker is not available"
   fi
 
   # Disable security manager to allow extraction
@@ -67,7 +85,7 @@ teardown() {
   solr start -Dsolr.modules=extraction
 
   solr create -c gettingstarted -d _default
-  wait_for_collection gettingstarted 30
+  wait_for 30 3 curl -s -S -f "http://localhost:${SOLR_PORT}/solr/gettingstarted/select?q=*:*" -o /dev/null
   apply_extract_handler gettingstarted
 
   curl "http://localhost:${SOLR_PORT}/solr/gettingstarted/update/extract?literal.id=doc1&commit=true" -F "myfile=@${SOLR_TIP}/example/exampledocs/solr-word.pdf"
@@ -79,8 +97,7 @@ teardown() {
 @test "using the bin/solr post tool to extract content from pdf" {
 
   if [ -n "${DOCKER_UNAVAILABLE:-}" ]; then
-    echo "WARNING: Docker not available; bypassing test." >&3
-    return 0
+    skip "Docker is not available"
   fi
 
   # Disable security manager to allow extraction
@@ -89,7 +106,7 @@ teardown() {
   solr start -Dsolr.modules=extraction
 
   solr create -c content_extraction -d _default
-  wait_for_collection content_extraction 30
+  wait_for 30 3 curl -s -S -f "http://localhost:${SOLR_PORT}/solr/content_extraction/select?q=*:*" -o /dev/null
   apply_extract_handler content_extraction
 
   # We filter to pdf to invoke the Extract handler.
@@ -105,8 +122,7 @@ teardown() {
 @test "using the bin/solr post tool to crawl web site" {
 
   if [ -n "${DOCKER_UNAVAILABLE:-}" ]; then
-    echo "WARNING: Docker not available; bypassing test." >&3
-    return 0
+    skip "Docker is not available"
   fi
 
   # Disable security manager to allow extraction
@@ -115,7 +131,7 @@ teardown() {
   solr start -Dsolr.modules=extraction
 
   solr create -c website_extraction -d _default
-  wait_for_collection website_extraction 30
+  wait_for 30 3 curl -s -S -f "http://localhost:${SOLR_PORT}/solr/website_extraction/select?q=*:*" -o /dev/null
   apply_extract_handler website_extraction
 
   # Change to --recursive 1 to crawl multiple pages, but may be too slow.

--- a/solr/packaging/test/test_start_solr.bats
+++ b/solr/packaging/test/test_start_solr.bats
@@ -25,7 +25,7 @@ teardown() {
   # save a snapshot of SOLR_HOME for failed tests
   save_home_on_failure
 
-  solr stop --all >/dev/null 2>&1
+  SOLR_STOP_WAIT=30 solr stop --all >/dev/null 2>&1
 }
 
 @test "SOLR-11740 check 'solr stop' connection" {
@@ -60,6 +60,8 @@ teardown() {
   # for start/stop/restart we parse the args separate from picking the command
   # which means you don't get an error message for passing a start arg, like --jvm-opts to a stop commmand.
 
+  # Pre-check
+  timeout || skip "timeout utility is not available"
   # Set a timeout duration (in seconds)
   TIMEOUT_DURATION=2
 


### PR DESCRIPTION


# Description

Commit #0d97331eb91 was a revert that accidentally removed a method needed in bats testing that happened on the `branch_10x` only branch.   There was other work in PR 3706 that didn't make it's way to `branch_10x` either.

# Solution

Redo the backport with Mr. Claude help to sync up `main` and what is in `branch_10x`.

# Tests

Re ran the integration tests and now they pass.

