### PR TITLE
build: fetch BATS test libs via HTTP instead of npm/node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform) apply false
   alias(libs.plugins.littlerobots.versioncatalogupdate) apply false
   alias(libs.plugins.thetaphi.forbiddenapis) apply false
-  alias(libs.plugins.undercouch.download) apply false
   alias(libs.plugins.ltgt.errorprone) apply false
   alias(libs.plugins.diffplug.spotless) apply false
   alias(libs.plugins.nodegradle.node) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,12 +52,14 @@ asciidoctor-mathjax = "0.0.9"
 # @keep Asciidoctor tabs version used in ref-guide
 asciidoctor-tabs = "1.0.0-beta.6"
 azagniotov-langdetect = "12.5.2"
-# @keep bats-assert (node) version used in packaging
+# @keep bats-assert version used in packaging
 bats-assert = "2.0.0"
-# @keep bats-core (node) version used in packaging
+# @keep bats-core version used in packaging
 bats-core = "1.8.2"
-# @keep bats-file (node) version used in packaging
+# @keep bats-file version used in packaging
 bats-file = "0.3.0"
+# @keep bats-support version used in packaging
+bats-support = "0.2.0"
 bc-jose4j = "0.9.6"
 benmanes-caffeine = "3.2.3"
 benmanes-versions = "0.53.0"
@@ -196,7 +198,6 @@ tdunning-tdigest = "3.3"
 testcontainers = "2.0.5"
 thetaphi-forbiddenapis = "3.10"
 threeten-bp = "1.7.3"
-undercouch-download = "5.7.0"
 xerial-snappy = "1.1.10.8"
 
 [plugins]
@@ -215,7 +216,6 @@ openapi-generator = { id = "org.openapi.generator", version.ref = "openapi" }
 owasp-dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "owasp-dependencycheck" }
 swagger3-core = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref = "swagger3" }
 thetaphi-forbiddenapis = { id = "de.thetaphi.forbiddenapis", version.ref = "thetaphi-forbiddenapis" }
-undercouch-download = { id = "de.undercouch.download", version.ref = "undercouch-download" }
 
 [libraries]
 adobe-testing-s3mock-junit4 = { module = "com.adobe.testing:s3mock-junit4", version.ref = "adobe-testing-s3mock" }

--- a/gradle/node.gradle
+++ b/gradle/node.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-configure([project(":solr:packaging"), project(":solr:solr-ref-guide"), project(":solr:webapp")]) {
+configure([project(":solr:solr-ref-guide"), project(":solr:webapp")]) {
   apply plugin: libs.plugins.nodegradle.node.get().pluginId
 
   def npmRegistry = "${-> propertyOrEnvOrDefault("solr.npm.registry", "SOLR_NPM_REGISTRY", '')}"

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -32,6 +32,7 @@ ext {
   slimDistDir = file("$buildDir/solr-${version}-slim")
   devDir = file("$buildDir/dev")
   slimDevDir = file("$buildDir/dev-slim")
+  batsLibsDir = file("$buildDir/bats-libs")
 }
 
 configurations {
@@ -249,18 +250,39 @@ tasks.register('runDev', JavaExec) {
   args((project.findProperty('args') ?: '--module=http').split())
 }
 
-task downloadBats(type: NpmTask) {
+tasks.register('downloadBats') {
   group = 'Build Dependency Download'
-  args = ["install", "https://github.com/bats-core/bats-core#v${libs.versions.bats.core.get()}",
-      "https://github.com/bats-core/bats-assert#v${libs.versions.bats.assert.get()}",
-      "https://github.com/bats-core/bats-file#v${libs.versions.bats.file.get()}",
-  ]
+  description =
+      'Downloads BATS and its helper libraries (bats-support, bats-assert, bats-file) used by integrationTests'
 
-  inputs.files("${project.ext.nodeProjectDir}/package.json")
-  outputs.dir("${project.ext.nodeProjectDir}/node_modules/bats")
-  outputs.dir("${project.ext.nodeProjectDir}/node_modules/bats-support")
-  outputs.dir("${project.ext.nodeProjectDir}/node_modules/bats-assert")
-  outputs.dir("${project.ext.nodeProjectDir}/node_modules/bats-file")
+  def batsLibs = [
+      [org: 'bats-core', repo: 'bats-core', version: libs.versions.bats.core.get()],
+      [org: 'ztombol', repo: 'bats-support', version: libs.versions.bats.support.get()],
+      [org: 'bats-core', repo: 'bats-assert', version: libs.versions.bats.assert.get()],
+      [org: 'bats-core', repo: 'bats-file', version: libs.versions.bats.file.get()],
+  ]
+  def downloadDir = file("$buildDir/bats-downloads")
+
+  inputs.property('batsLibs', batsLibs)
+  outputs.dir(batsLibsDir)
+
+  doLast {
+    delete batsLibsDir
+    mkdir downloadDir
+    batsLibs.each {lib ->
+      def archiveUrl = "https://github.com/${lib.org}/${lib.repo}/archive/refs/tags/v${lib.version}.tar.gz"
+      def archiveFile = new File(downloadDir, "${lib.repo}-${lib.version}.tar.gz")
+      ant.get(src: archiveUrl, dest: archiveFile, skipexisting: true)
+      copy {
+        from(tarTree(resources.gzip(archiveFile))) {
+          // Strip the leading "<repo>-<version>/" directory that GitHub's archive adds.
+          eachFile {details -> details.path = details.path.substring(details.path.indexOf('/') + 1)}
+          includeEmptyDirs = false
+        }
+        into "$batsLibsDir/${lib.repo}"
+      }
+    }
+  }
 }
 
 task integrationTests(type: BatsTask) {
@@ -312,7 +334,7 @@ task integrationTests(type: BatsTask) {
   environment SOLR_LOGS_DIR: "$solrHome/logs"
   environment TEST_OUTPUT_DIR: integrationTestOutput
   environment TEST_FAILURE_DIR: solrTestFailuresDir
-  environment BATS_LIB_PREFIX: "$nodeProjectDir/node_modules"
+  environment BATS_LIB_PREFIX: batsLibsDir
 }
 
 abstract class BatsTask extends Exec {
@@ -337,7 +359,7 @@ abstract class BatsTask extends Exec {
   @Override
   @TaskAction
   protected void exec() {
-    executable "$project.ext.nodeProjectDir/node_modules/bats/bin/bats"
+    executable "$project.ext.batsLibsDir/bats-core/bin/bats"
 
     def batsArgs = []
     if (logger.isInfoEnabled()) {


### PR DESCRIPTION
The packaging module pulled in the node-gradle plugin solely to run `npm install <github-url>#<tag>` for bats-core/bats-assert/bats-file (npm was just being used as a git-URL fetcher here, nothing JS-related). Replace downloadBats with a plain Gradle task that fetches GitHub tag archives over HTTP and extracts them with tarTree, removing node/npm from :solr:packaging entirely and simplifying the proxy story to standard Gradle systemProp.http(s).proxyHost/Port config.

Also pin bats-support (previously an undeclared transitive dependency pulled in via bats-assert's package.json) explicitly in the version catalog.  Remove undercounch.download plugin (unused).