### PR TITLE
Fix reference-equality comparison bugs found by Error Prone 2.50.0

### DIFF
--- a/changelog/unreleased/PR#4605-reference-equality-fixes.yml
+++ b/changelog/unreleased/PR#4605-reference-equality-fixes.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Fix reference-equality comparison bugs in ZkMaintenanceUtils single-file upload and HttpShardHandler onlyNrt detection
+type: fixed
+authors:
+  - name: Jan Høydahl
+links:
+- name: PR#4605
+  url: https://github.com/apache/solr/pull/4605

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -496,7 +496,7 @@ public class HttpShardHandler extends ShardHandler {
 
     ReplicaSource replicaSource;
     if (zkController != null) {
-      boolean onlyNrt = Boolean.TRUE == req.getContext().get(ONLY_NRT_REPLICAS);
+      boolean onlyNrt = Boolean.TRUE.equals(req.getContext().get(ONLY_NRT_REPLICAS));
 
       replicaSource =
           new CloudReplicaSource.Builder()

--- a/solr/core/src/test/org/apache/solr/cloud/ZkShardTermsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkShardTermsTest.java
@@ -380,7 +380,7 @@ public class ZkShardTermsTest extends SolrCloudTestCase {
   private <T> void waitFor(T expected, Supplier<T> supplier) throws InterruptedException {
     TimeOut timeOut = new TimeOut(10, TimeUnit.SECONDS, new TimeSource.CurrentTimeSource());
     while (!timeOut.hasTimedOut()) {
-      if (expected == supplier.get()) return;
+      if (Objects.equals(expected, supplier.get())) return;
       Thread.sleep(100);
     }
     assertEquals(expected, supplier.get());

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkMaintenanceUtils.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkMaintenanceUtils.java
@@ -349,7 +349,7 @@ public class ZkMaintenanceUtils {
               if (file.getFileName().toString().equals(ZKNODE_DATA_FILE)
                   && zkClient.exists(zkNode)) {
                 zkClient.setData(zkNode, file);
-              } else if (file == rootPath) {
+              } else if (file.equals(rootPath)) {
                 // We are only uploading a single file, preVisitDirectory was never called
                 if (zkClient.exists(zkPath)) {
                   zkClient.setData(zkPath, file);

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -905,6 +905,8 @@ public class Utils {
       Class<? extends Annotation> catchAllAnnotation,
       Function<Field, String> fieldNamer)
       throws IllegalAccessException {
+    // ClassLoader identity (not equals) determines whether it is safe to cache reflective metadata.
+    @SuppressWarnings("ReferenceEquality")
     boolean sameClassLoader = c.getClassLoader() == Utils.class.getClassLoader();
     // we should not cache the class references of objects loaded from packages because they will
     // not get garbage collected


### PR DESCRIPTION
Three latent bugs surfaced by the Error Prone 2.50.0 upgrade in #4604, split out into their own PR per review feedback there:

- **ZkMaintenanceUtils**: compared `Path` objects with `==` in the single-file-upload case, so the intended branch was never guaranteed to be taken.
- **HttpShardHandler**: compared a request-context `Boolean` with `==`; now `Boolean.TRUE.equals(...)` so any `true` value enables `onlyNrt`.
- **ZkShardTermsTest.waitFor**: compared boxed values by reference, always burning the 10s timeout for values outside the `Integer` cache.

Also documents (with a `@SuppressWarnings("ReferenceEquality")`) that the ClassLoader cache guard in `Utils` intentionally uses identity comparison.

#4604 will suppress these findings with TODO comments pointing here; once this merges, that branch drops the TODOs on rebase.