### PR TITLE
SOLR-17170: Support block/nested docs with index sorting

### DIFF
--- a/changelog/unreleased/SOLR-17170-indexSortBlocks.yml
+++ b/changelog/unreleased/SOLR-17170-indexSortBlocks.yml
@@ -1,0 +1,8 @@
+title: >
+  Support block / nested-docs with index sorting
+type: added
+authors:
+  - name: David Smiley
+links:
+  - name: SOLR-17170
+    url: https://issues.apache.org/jira/browse/SOLR-17170

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
@@ -104,6 +104,7 @@ public class IndexSchema {
   public static final String NEST_PARENT_FIELD_NAME = "_nest_parent_";
   public static final String NEST_PATH_FIELD_NAME = "_nest_path_";
   public static final String NESTED_VECTORS_PSEUDO_FIELD_NAME = "_nested_vectors_";
+  public static final String IS_ROOT_FIELD_NAME = "_is_root_";
   public static final String REQUIRED = "required";
   public static final String SCHEMA = "schema";
   public static final String SIMILARITY = "similarity";

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergeScheduler;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.Version;
 import org.apache.solr.common.ConfigNode;
 import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.util.NamedList;
@@ -261,7 +262,11 @@ public class SolrIndexConfig implements MapWriter {
       iwc.setIndexSort(indexSort);
     }
 
-    if (iwc.getIndexSort() != null && schema.isUsableForChildDocs()) {
+    if (iwc.getIndexSort() != null
+        && schema.isUsableForChildDocs()
+        && core.getSolrConfig().luceneMatchVersion.onOrAfter(Version.LUCENE_10_4_0)) {
+      // Solr 10 shipped with Lucene 10.3.x, and Solr <=10 didn't set the parent field.
+      // This version check allows an upgrading user to continue to do index sorting.
       iwc.setParentField(IndexSchema.IS_ROOT_FIELD_NAME);
     }
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -261,6 +261,10 @@ public class SolrIndexConfig implements MapWriter {
       iwc.setIndexSort(indexSort);
     }
 
+    if (iwc.getIndexSort() != null && schema.isUsableForChildDocs()) {
+      iwc.setParentField(IndexSchema.IS_ROOT_FIELD_NAME);
+    }
+
     iwc.setUseCompoundFile(useCompoundFile);
 
     if (mergedSegmentWarmerInfo != null) {

--- a/solr/core/src/test/org/apache/solr/cloud/TestSegmentSorting.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestSegmentSorting.java
@@ -25,7 +25,6 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest.Field;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.common.SolrDocumentList;
-import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreDescriptor;
 import org.junit.After;
 import org.junit.Before;
@@ -94,6 +93,21 @@ public class TestSegmentSorting extends SolrCloudTestCase {
 
     // add some documents, then optimize to get merged-sorted segments
     tstes.addDocuments(collectionName, cloudSolrClient, 10, 10, true);
+
+    // add some block docs (parent + child) to exercise index sort with document blocks
+    for (int i = 0; i < 5; i++) {
+      int ts = random().nextInt(60);
+      cloudSolrClient.add(
+          collectionName,
+          sdoc(
+              "id",
+              10000 + i,
+              "timestamp_i_dvo",
+              ts,
+              "children",
+              sdocs(sdoc("id", 10100 + i, "timestamp_i_dvo", ts))));
+    }
+    cloudSolrClient.commit(collectionName);
 
     // CommonParams.SEGMENT_TERMINATE_EARLY parameter intentionally absent
     tstes.queryTimestampDescending(collectionName, cloudSolrClient);
@@ -216,27 +230,5 @@ public class TestSegmentSorting extends SolrCloudTestCase {
       }
     }
     assertTrue(oldDocId != newDocId);
-  }
-
-  @Test
-  public void testBlockDocsWithIndexSort() throws Exception {
-    final var client = cluster.getSolrClient();
-
-    SolrInputDocument doc =
-        sdoc(
-            "id",
-            "1",
-            "timestamp_i_dvo",
-            100,
-            "children",
-            sdocs(
-                sdoc("id", "2", "timestamp_i_dvo", 100), sdoc("id", "3", "timestamp_i_dvo", 100)));
-
-    client.add(collectionName, doc);
-    client.commit(collectionName);
-
-    assertEquals(3, client.query(collectionName, params("q", "*:*")).getResults().getNumFound());
-    assertEquals(
-        3, client.query(collectionName, params("q", "_root_:1")).getResults().getNumFound());
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestSegmentSorting.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestSegmentSorting.java
@@ -94,20 +94,32 @@ public class TestSegmentSorting extends SolrCloudTestCase {
     // add some documents, then optimize to get merged-sorted segments
     tstes.addDocuments(collectionName, cloudSolrClient, 10, 10, true);
 
-    // add some block docs (parent + child) to exercise index sort with document blocks
+    // add block docs with children having different sort values than parent;
+    // Lucene sorts by parent values only, so block integrity must be preserved
     for (int i = 0; i < 5; i++) {
-      int ts = random().nextInt(60);
+      int parentTs = random().nextInt(60);
+      int childTs = random().nextInt(60);
       cloudSolrClient.add(
           collectionName,
           sdoc(
               "id",
               10000 + i,
               "timestamp_i_dvo",
-              ts,
+              parentTs,
               "children",
-              sdocs(sdoc("id", 10100 + i, "timestamp_i_dvo", ts))));
+              sdocs(sdoc("id", 10100 + i, "timestamp_i_dvo", childTs))));
     }
     cloudSolrClient.commit(collectionName);
+    cloudSolrClient.optimize(collectionName);
+    // verify block integrity: each child still belongs to its parent after merge-sorting
+    for (int i = 0; i < 5; i++) {
+      assertEquals(
+          2,
+          cloudSolrClient
+              .query(collectionName, params("q", "_root_:" + (10000 + i)))
+              .getResults()
+              .getNumFound());
+    }
 
     // CommonParams.SEGMENT_TERMINATE_EARLY parameter intentionally absent
     tstes.queryTimestampDescending(collectionName, cloudSolrClient);

--- a/solr/core/src/test/org/apache/solr/cloud/TestSegmentSorting.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestSegmentSorting.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest.Field;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreDescriptor;
 import org.junit.After;
 import org.junit.Before;
@@ -215,5 +216,27 @@ public class TestSegmentSorting extends SolrCloudTestCase {
       }
     }
     assertTrue(oldDocId != newDocId);
+  }
+
+  @Test
+  public void testBlockDocsWithIndexSort() throws Exception {
+    final var client = cluster.getSolrClient();
+
+    SolrInputDocument doc =
+        sdoc(
+            "id",
+            "1",
+            "timestamp_i_dvo",
+            100,
+            "children",
+            sdocs(
+                sdoc("id", "2", "timestamp_i_dvo", 100), sdoc("id", "3", "timestamp_i_dvo", 100)));
+
+    client.add(collectionName, doc);
+    client.commit(collectionName);
+
+    assertEquals(3, client.query(collectionName, params("q", "*:*")).getResults().getNumFound());
+    assertEquals(
+        3, client.query(collectionName, params("q", "_root_:1")).getResults().getNumFound());
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -113,6 +113,7 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
     assertEquals("ms.maxMergeCount", 987, ms.getMaxMergeCount());
     assertEquals("ms.maxThreadCount", 42, ms.getMaxThreadCount());
     assertFalse("ms.isAutoIOThrottle", ms.getAutoIOThrottle());
+    assertNull("parentField should not be set without index sort", iwc.getParentField());
   }
 
   @Test
@@ -163,6 +164,11 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
     }
     final Sort actual = sortingMergePolicy.getSort();
     assertEquals("SortingMergePolicy.getSort", expected, actual);
+    assertEquals("indexSort on IWC", expected, iwc.getIndexSort());
+    assertEquals(
+        "parentField should be set when indexSort is configured",
+        IndexSchema.IS_ROOT_FIELD_NAME,
+        iwc.getParentField());
   }
 
   public void testMergeOnFlushMPSolrIndexConfigCreation() throws Exception {

--- a/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
+++ b/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-10.adoc
@@ -36,9 +36,15 @@ Solr 10.0 requires at least Java 21, while SolrJ 10.0 requires at least Java 17.
 
 == Solr 10.1
 
+=== Misc
+
 For SSL (https), it's no longer necessary to set the "urlScheme" cluster property since the `SOLR_SSL_ENABLED` env var (or `solr.ssl.enabled` sys-prop) suffices.
 These are now honored by CloudSolrClient, as well as scheme detection from the connection string / hosts.
 The "urlScheme" cluster property and httpShardHandlerFactory configuration is likely to be deprecated; feedback welcome.
+
+If you use xref:configuration-guide:index-segments-merging.adoc#customizing-merge-policies[`SortingMergePolicyFactory`] for index sorting and your schema declares `\_root_`, Solr configures a new mechanism in Lucene that affects the index to support nested/block documents with sorted indexes.
+This requires a fresh Solr 10.1 index.
+To retain compatibility with existing sorted indexes, deferring a reindex, keep `luceneMatchVersion` at 10.3.1 or earlier in solrconfig.xml.
 
 === Universal connection string support
 


### PR DESCRIPTION
Set IndexWriterConfig.setParentField() when index sort is configured, enabling Lucene to treat document blocks as atomic units during index-level sorting and merging. Without this, Lucene 10 throws IllegalArgumentException when indexing nested docs with a SortingMergePolicyFactory.

https://issues.apache.org/jira/browse/SOLR-17170