### PR TITLE
used EnvUtils for system properties in core

### DIFF
--- a/changelog/unreleased/PR#4629-envutils-core-properties.yml
+++ b/changelog/unreleased/PR#4629-envutils-core-properties.yml
@@ -1,5 +1,5 @@
-title: Core system properties can now be set via environment variables using EnvUtils
-type: feature
+title: Core system properties can now also be configured via environment variables
+type: changed
 authors:
   - name: Prithvi S
 links:

--- a/changelog/unreleased/PR#4629-envutils-core-properties.yml
+++ b/changelog/unreleased/PR#4629-envutils-core-properties.yml
@@ -1,0 +1,7 @@
+title: Core system properties can now be set via environment variables using EnvUtils
+type: feature
+authors:
+  - name: Prithvi S
+links:
+  - name: PR#4629
+    url: https://github.com/apache/solr/pull/4629

--- a/solr/core/src/java/org/apache/solr/cli/ConfigSetUploadTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ConfigSetUploadTool.java
@@ -23,6 +23,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkMaintenanceUtils;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.core.ConfigSetService;
 import org.apache.solr.util.FileTypeMagicUtil;
 import org.slf4j.Logger;
@@ -77,7 +78,7 @@ public class ConfigSetUploadTool extends ToolBase {
   public void runImpl(CommandLine cli) throws Exception {
     String zkHost = CLIUtils.getZkHost(cli);
 
-    final String solrInstallDir = System.getProperty("solr.install.dir");
+    final String solrInstallDir = EnvUtils.getProperty("solr.install.dir");
     Path solrInstallDirPath = Path.of(solrInstallDir);
 
     String confName = cli.getOptionValue(CONF_NAME_OPTION);

--- a/solr/core/src/java/org/apache/solr/cli/CreateTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/CreateTool.java
@@ -38,6 +38,7 @@ import org.apache.solr.client.solrj.request.SystemInfoRequest;
 import org.apache.solr.client.solrj.response.SystemInfoResponse;
 import org.apache.solr.cloud.ZkConfigSetService;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.core.ConfigSetService;
 
 /** Supports create command in the bin/solr script. */
@@ -135,7 +136,7 @@ public class CreateTool extends ToolBase {
     String coreName = cli.getOptionValue(COLLECTION_NAME_OPTION);
     String solrUrl = CLIUtils.normalizeSolrUrl(cli);
 
-    final String solrInstallDir = System.getProperty("solr.install.dir");
+    final String solrInstallDir = EnvUtils.getProperty("solr.install.dir");
     final String confDirName =
         cli.getOptionValue(CONF_DIR_OPTION, DefaultValues.DEFAULT_CONFIG_SET);
 
@@ -217,7 +218,7 @@ public class CreateTool extends ToolBase {
       throws Exception {
 
     String collectionName = cli.getOptionValue(COLLECTION_NAME_OPTION);
-    final String solrInstallDir = System.getProperty("solr.install.dir");
+    final String solrInstallDir = EnvUtils.getProperty("solr.install.dir");
     String confName = cli.getOptionValue(CONF_NAME_OPTION);
     String confDir = cli.getOptionValue(CONF_DIR_OPTION, DefaultValues.DEFAULT_CONFIG_SET);
     Path solrInstallDirPath = Path.of(solrInstallDir);

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -45,6 +45,7 @@ import org.apache.commons.cli.help.TextHelpAppendable;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest;
 import org.apache.solr.common.util.ContentStreamBase;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.util.configuration.SSLConfigurationsFactory;
@@ -143,7 +144,7 @@ public class SolrCLI implements CLIO {
     argList.addAll(dashDList);
 
     // for SSL support, try to accommodate relative paths set for SSL store props
-    String solrInstallDir = System.getProperty("solr.install.dir");
+    String solrInstallDir = EnvUtils.getProperty("solr.install.dir");
     if (solrInstallDir != null) {
       checkSslStoreSysProp(solrInstallDir, "keyStore");
       checkSslStoreSysProp(solrInstallDir, "trustStore");
@@ -154,7 +155,7 @@ public class SolrCLI implements CLIO {
 
   protected static void checkSslStoreSysProp(String solrInstallDir, String key) {
     String sysProp = "javax.net.ssl." + key;
-    String keyStore = System.getProperty(sysProp);
+    String keyStore = EnvUtils.getProperty(sysProp);
     if (keyStore == null) return;
 
     Path keyStoreFile = Path.of(keyStore);

--- a/solr/core/src/java/org/apache/solr/cli/ZkCpTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ZkCpTool.java
@@ -31,6 +31,7 @@ import org.apache.solr.client.solrj.impl.SolrZkClientTimeout;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.util.Compressor;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.ZLibCompressor;
 import org.apache.solr.core.NodeConfig;
@@ -154,7 +155,7 @@ public class ZkCpTool extends ToolBase {
     if (dstIsZk) {
       String solrHome = cli.getOptionValue(SOLR_HOME_OPTION);
       if (StrUtils.isNullOrEmpty(solrHome)) {
-        solrHome = System.getProperty("solr.home");
+        solrHome = EnvUtils.getProperty("solr.home", EnvUtils.getProperty("solr.solr.home"));
       }
 
       if (solrHome != null) {

--- a/solr/core/src/java/org/apache/solr/cli/ZkCpTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/ZkCpTool.java
@@ -155,7 +155,7 @@ public class ZkCpTool extends ToolBase {
     if (dstIsZk) {
       String solrHome = cli.getOptionValue(SOLR_HOME_OPTION);
       if (StrUtils.isNullOrEmpty(solrHome)) {
-        solrHome = EnvUtils.getProperty("solr.home", EnvUtils.getProperty("solr.solr.home"));
+        solrHome = EnvUtils.getProperty("solr.home");
       }
 
       if (solrHome != null) {

--- a/solr/core/src/java/org/apache/solr/cloud/SolrZkServer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/SolrZkServer.java
@@ -104,7 +104,7 @@ public class SolrZkServer {
     var zooCfgPath = Path.of(confHome).resolve("zoo.cfg");
     if (!Files.exists(zooCfgPath)) {
       log.info("Zookeeper configuration not found in {}, using built-in default", confHome);
-      String solrInstallDir = System.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
+      String solrInstallDir = EnvUtils.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
       if (solrInstallDir == null) {
         throw new SolrException(
             SolrException.ErrorCode.SERVER_ERROR,
@@ -142,7 +142,7 @@ public class SolrZkServer {
     }
 
     ensureZkMaxCnxnsConfigured();
-    if (System.getProperty(ZK_WHITELIST_PROPERTY) == null) {
+    if (EnvUtils.getProperty(ZK_WHITELIST_PROPERTY) == null) {
       System.setProperty(ZK_WHITELIST_PROPERTY, "ruok, mntr, conf");
     }
     AtomicReference<Exception> zkException = new AtomicReference<>();

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/PlacementPluginFactoryLoader.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/PlacementPluginFactoryLoader.java
@@ -29,6 +29,7 @@ import org.apache.solr.cluster.placement.plugins.MinimizeCoresPlacementFactory;
 import org.apache.solr.cluster.placement.plugins.RandomPlacementFactory;
 import org.apache.solr.cluster.placement.plugins.SimplePlacementFactory;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.EnvUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class PlacementPluginFactoryLoader {
   /** Returns the default {@link PlacementPluginFactory} */
   public static PlacementPluginFactory<?> getDefaultPlacementPluginFactory() {
     // Use the default provided by system properties.
-    String defaultPluginId = System.getProperty(PLACEMENTPLUGIN_DEFAULT_SYSPROP);
+    String defaultPluginId = EnvUtils.getProperty(PLACEMENTPLUGIN_DEFAULT_SYSPROP);
     if (defaultPluginId != null) {
       log.info(
           "Default replica placement plugin set in {} to {}",

--- a/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
@@ -137,7 +137,7 @@ public abstract class ConfigSetService {
         log.warn(
             "The _default configset could not be uploaded. Please provide 'solr.configset.default.confdir' parameter that points to a configset {} {}",
             "intended to be the default. Current 'solr.configset.default.confdir' value:",
-            System.getProperty(SOLR_CONFIGSET_DEFAULT_CONFDIR));
+            EnvUtils.getProperty(SOLR_CONFIGSET_DEFAULT_CONFDIR));
       } else {
         this.uploadConfig(ConfigSetsHandler.DEFAULT_CONFIGSET_NAME, configDirPath);
       }
@@ -165,7 +165,7 @@ public abstract class ConfigSetService {
    * @see ConfigSetService#SOLR_CONFIGSET_DEFAULT_CONFDIR
    */
   public static Path getDefaultConfigDirPath() {
-    String confDir = System.getProperty(SOLR_CONFIGSET_DEFAULT_CONFDIR);
+    String confDir = EnvUtils.getProperty(SOLR_CONFIGSET_DEFAULT_CONFDIR);
     if (confDir != null) {
       Path path = Path.of(confDir);
       if (Files.exists(path)) {
@@ -173,7 +173,7 @@ public abstract class ConfigSetService {
       }
     }
 
-    String installDir = System.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
+    String installDir = EnvUtils.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
     if (installDir != null) {
       Path subPath = Path.of("server", "solr", "configsets", "_default", "conf");
       Path path = Path.of(installDir).resolve(subPath);

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -290,7 +290,7 @@ public class CoreContainer {
 
   private final ObjectCache objectCache = new ObjectCache();
 
-  public final NodeRoles nodeRoles = new NodeRoles(System.getProperty(NodeRoles.NODE_ROLES_PROP));
+  public final NodeRoles nodeRoles = new NodeRoles(EnvUtils.getProperty(NodeRoles.NODE_ROLES_PROP));
 
   private final ExecutorService indexSearcherExecutor;
 
@@ -556,14 +556,17 @@ public class CoreContainer {
 
     if (pluginClassName != null) {
       log.debug("Authentication plugin class obtained from security.json: {}", pluginClassName);
-    } else if (System.getProperty(AUTHENTICATION_PLUGIN_PROP) != null) {
-      pluginClassName = System.getProperty(AUTHENTICATION_PLUGIN_PROP);
-      log.debug(
-          "Authentication plugin class obtained from system property '{}': {}",
-          AUTHENTICATION_PLUGIN_PROP,
-          pluginClassName);
     } else {
-      log.debug("No authentication plugin used.");
+      String authPluginProp = EnvUtils.getProperty(AUTHENTICATION_PLUGIN_PROP);
+      if (authPluginProp != null) {
+        pluginClassName = authPluginProp;
+        log.debug(
+            "Authentication plugin class obtained from system property '{}': {}",
+            AUTHENTICATION_PLUGIN_PROP,
+            pluginClassName);
+      } else {
+        log.debug("No authentication plugin used.");
+      }
     }
     SecurityPluginHolder<AuthenticationPlugin> old = authenticationPlugin;
     SecurityPluginHolder<AuthenticationPlugin> authenticationPlugin = null;
@@ -1141,7 +1144,7 @@ public class CoreContainer {
     }
 
     if (authenticationPlugin != null
-        && StrUtils.isNullOrEmpty(System.getProperty("solr.jetty.https.port"))) {
+        && StrUtils.isNullOrEmpty(EnvUtils.getProperty("solr.jetty.https.port"))) {
       log.warn(
           "Solr authentication is enabled, but SSL is off.  Consider enabling SSL to protect user credentials and data with encryption.");
     }
@@ -1768,7 +1771,7 @@ public class CoreContainer {
 
     CoreInitFailedAction action =
         CoreInitFailedAction.valueOf(
-            System.getProperty(CoreInitFailedAction.class.getSimpleName(), "none"));
+            EnvUtils.getProperty(CoreInitFailedAction.class.getSimpleName(), "none"));
     log.debug("CorruptIndexException while creating core, will attempt to repair via {}", action);
 
     switch (action) {
@@ -2500,7 +2503,7 @@ public class CoreContainer {
   }
 
   public static void setWeakStringInterner() {
-    boolean enable = "true".equals(System.getProperty("solr.use.str.intern", "true"));
+    boolean enable = "true".equals(EnvUtils.getProperty("solr.use.str.intern", "true"));
     if (!enable) return;
     Interner<String> interner = Interner.newWeakInterner();
     ClusterState.setStrInternerParser(

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -294,7 +294,7 @@ public class NodeConfig {
    * @return path to install dir or null if solr.install.dir not set.
    */
   public static Path getSolrInstallDir() {
-    String prop = System.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
+    String prop = EnvUtils.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
     if (prop == null || prop.isBlank()) {
       log.debug("solr.install.dir property not initialized.");
       return null;
@@ -644,7 +644,7 @@ public class NodeConfig {
       this.solrHome = solrHome.toAbsolutePath();
       this.coreRootDirectory = solrHome;
       // always init from sysprop because <solrDataHome> config element may be missing
-      setSolrDataHome(System.getProperty(SolrXmlConfig.SOLR_DATA_HOME));
+      setSolrDataHome(EnvUtils.getProperty(SolrXmlConfig.SOLR_DATA_HOME));
       setConfigSetBaseDirectory("configsets");
       this.metricsConfig = new MetricsConfig.MetricsConfigBuilder().build();
     }

--- a/solr/core/src/java/org/apache/solr/core/OpenTelemetryConfigurator.java
+++ b/solr/core/src/java/org/apache/solr/core/OpenTelemetryConfigurator.java
@@ -160,7 +160,7 @@ public abstract class OpenTelemetryConfigurator implements NamedListInitializedP
    */
   protected static String getConfig(String envName, Map<String, String> env) {
     String sysName = envNameToSyspropName(envName);
-    String sysValue = System.getProperty(sysName);
+    String sysValue = EnvUtils.getProperty(sysName);
     String envValue = env.get(envName);
     return sysValue != null ? sysValue : envValue;
   }

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -87,7 +87,7 @@ public class SolrXmlConfig {
     }
     // we always wrap if we might set a property -- never mutate the original props
     final Properties results = (null == props ? new Properties() : new Properties(props));
-    final String sysprop = System.getProperty(ZK_HOST);
+    final String sysprop = EnvUtils.getProperty(ZK_HOST);
     if (StrUtils.isNotNullOrEmpty(sysprop)) {
       results.setProperty(ZK_HOST, sysprop);
     }
@@ -179,7 +179,7 @@ public class SolrXmlConfig {
             "solr.xml does not exist in " + configFile.getParent() + " cannot start Solr");
       }
       log.info("solr.xml not found in SOLR_HOME, using built-in default");
-      String solrInstallDir = System.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
+      String solrInstallDir = EnvUtils.getProperty(CoreContainerProvider.SOLR_INSTALL_DIR);
       if (solrInstallDir == null) {
         throw new SolrException(
             SolrException.ErrorCode.SERVER_ERROR,

--- a/solr/core/src/java/org/apache/solr/core/ZkContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/ZkContainer.java
@@ -134,7 +134,7 @@ public class ZkContainer {
             new ZkController(cc, zookeeperHost, zkClientConnectTimeout, config);
 
         if (zkRun) {
-          if (StrUtils.isNotNullOrEmpty(System.getProperty(HTTPS_PORT_PROP))) {
+          if (StrUtils.isNotNullOrEmpty(EnvUtils.getProperty(HTTPS_PORT_PROP))) {
             // Embedded ZK and probably running with SSL
             new ClusterProperties(zkController.getZkClient())
                 .setClusterProperty(ZkStateReader.URL_SCHEME, HTTPS);

--- a/solr/core/src/java/org/apache/solr/handler/admin/SolrEnvironment.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SolrEnvironment.java
@@ -21,6 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.EnvUtils;
 
 /**
  * It is possible to define an environment code when starting Solr, through
@@ -87,8 +88,8 @@ public class SolrEnvironment {
    */
   public static SolrEnvironment getFromSyspropOrClusterprop(ZkStateReader zkStateReader) {
     String env = "unknown";
-    if (System.getProperty("solr.environment") != null) {
-      env = System.getProperty("solr.environment");
+    if (EnvUtils.getProperty("solr.environment") != null) {
+      env = EnvUtils.getProperty("solr.environment");
     } else if (zkStateReader != null) {
       env = zkStateReader.getClusterProperty("environment", "unknown");
     }

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -445,7 +445,8 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
     if (isSolrSslEnabled != null) {
       return isSolrSslEnabled ? "https" : "http";
     }
-    String urlScheme = getParameter(args, INIT_URL_SCHEME, System.getProperty(INIT_URL_SCHEME), sb);
+    String urlScheme =
+        getParameter(args, INIT_URL_SCHEME, EnvUtils.getProperty(INIT_URL_SCHEME), sb);
     if (urlScheme != null && urlScheme.endsWith("://")) {
       urlScheme = urlScheme.replace("://", "");
     }

--- a/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
@@ -153,13 +153,13 @@ public class CoreContainerProvider implements ServletContextListener {
 
       logWelcomeBanner(extraProperties);
 
-      String muteConsole = System.getProperty(SOLR_LOG_MUTECONSOLE);
+      String muteConsole = EnvUtils.getProperty(SOLR_LOG_MUTECONSOLE);
       if (muteConsole != null
           && !Arrays.asList("false", "0", "off", "no")
               .contains(muteConsole.toLowerCase(Locale.ROOT))) {
         StartupLoggingUtils.muteConsole();
       }
-      String logLevel = System.getProperty(SOLR_LOG_LEVEL);
+      String logLevel = EnvUtils.getProperty(SOLR_LOG_LEVEL);
       if (logLevel != null) {
         log.info("Log level override, property solr.log.level={}", logLevel);
         StartupLoggingUtils.changeLogLevel(logLevel);
@@ -208,7 +208,7 @@ public class CoreContainerProvider implements ServletContextListener {
           getSolrPort());
     }
     if (log.isInfoEnabled()) {
-      log.info("\\__ \\/ _ \\ | '_|  Install dir: {}", System.getProperty(SOLR_INSTALL_DIR));
+      log.info("\\__ \\/ _ \\ | '_|  Install dir: {}", EnvUtils.getProperty(SOLR_INSTALL_DIR));
     }
     if (log.isInfoEnabled()) {
       log.info("|___/\\___/_|_|    Start time: {}", Instant.now());
@@ -241,7 +241,7 @@ public class CoreContainerProvider implements ServletContextListener {
               "Solr typically starts with \"-XX:+CrashOnOutOfMemoryError\" that will crash on any OutOfMemoryError exception. "
                   + "Unable to get the specific file due to an exception."
                   + "The cause of the OOME will be logged in a crash file in the logs directory: %s",
-              System.getProperty("solr.logs.dir"));
+              EnvUtils.getProperty("solr.logs.dir"));
       log.info(logMessage, e);
     }
   }
@@ -316,7 +316,7 @@ public class CoreContainerProvider implements ServletContextListener {
       // Now try system property
       final String prop = "solr.solr.home";
       source = "system property: " + prop;
-      home = System.getProperty(prop);
+      home = EnvUtils.getProperty(prop);
     }
 
     if (null == home) {

--- a/solr/core/src/java/org/apache/solr/servlet/LoadAdminUiServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/LoadAdminUiServlet.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.core.SolrCore;
 
 /**
@@ -40,8 +41,7 @@ import org.apache.solr.core.SolrCore;
 public final class LoadAdminUiServlet extends HttpServlet {
 
   // check system properties for whether the admin UI is disabled, default is false
-  private static final boolean uiEnabled =
-      Boolean.parseBoolean(System.getProperty("solr.ui.enabled", "true"));
+  private static final boolean uiEnabled = EnvUtils.getPropertyAsBool("solr.ui.enabled", true);
   // list of comma separated URLs to inject into the CSP connect-src directive
   public static final String SYSPROP_CSP_CONNECT_SRC_URLS = "solr.ui.headers.csp.connect-src.urls";
 
@@ -107,7 +107,7 @@ public final class LoadAdminUiServlet extends HttpServlet {
    * concatenate them into a space-separated string that can be used in CSP connect-src directive
    */
   private String generateCspConnectSrc() {
-    String cspURLs = System.getProperty(SYSPROP_CSP_CONNECT_SRC_URLS, "");
+    String cspURLs = EnvUtils.getProperty(SYSPROP_CSP_CONNECT_SRC_URLS, "");
     List<String> props = new ArrayList<>(Arrays.asList(cspURLs.split(",")));
     props.add("'self'");
     return String.join(" ", props);

--- a/solr/core/src/java/org/apache/solr/util/FileTypeMagicUtil.java
+++ b/solr/core/src/java/org/apache/solr/util/FileTypeMagicUtil.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.EnvUtils;
 
 /** Utility class to guess the mime type of file based on its magic number. */
 public class FileTypeMagicUtil implements ContentInfoUtil.ErrorCallBack {
@@ -194,7 +195,7 @@ public class FileTypeMagicUtil implements ContentInfoUtil.ErrorCallBack {
   private static final Set<String> forbiddenTypes =
       new HashSet<>(
           Arrays.asList(
-              System.getProperty(
+              EnvUtils.getProperty(
                       "solr.configset.upload.mimetypes.forbidden",
                       "application/x-java-applet,application/zip,application/x-tar,text/x-shellscript")
                   .split(",")));

--- a/solr/core/src/java/org/apache/solr/util/StartupLoggingUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/StartupLoggingUtils.java
@@ -210,9 +210,11 @@ public final class StartupLoggingUtils {
    * "solr.logs.requestlog.enabled is set in solr/server/etc/jetty-requestlog.xml
    */
   public static void checkRequestLogging() {
-    // EnvUtils doesn't work here.
+    // Note: "solr.logs.requestlog.enabled" is deliberately excluded from EnvUtils
+    // env var mapping (see EnvToSyspropMappings.properties), so Boolean.getBoolean
+    // is the correct way to read it (it only looks at system properties).
     boolean requestLogEnabled = Boolean.getBoolean("solr.logs.requestlog.enabled");
-    String retainDays = System.getProperty("solr.logs.requestlog.retain.days");
+    String retainDays = EnvUtils.getProperty("solr.logs.requestlog.retain.days");
     if (requestLogEnabled) {
       if (retainDays == null) {
         log.warn(

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -83,7 +83,7 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   private static SolrException.ErrorCode resolveExceptionErrorCode() {
     int intCode = SolrException.ErrorCode.TOO_MANY_REQUESTS.code;
-    String strCode = System.getProperty(SYSPROP_SOLR_CIRCUITBREAKER_ERRORCODE);
+    String strCode = EnvUtils.getProperty(SYSPROP_SOLR_CIRCUITBREAKER_ERRORCODE);
     if (strCode != null) {
       try {
         intCode = Integer.parseInt(strCode);

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -128,7 +128,7 @@ public class CircuitBreakerRegistry implements Closeable {
 
   private static String buildCircuitBreakerKey(String metricType, String thresholdProp) {
     final var warnOnly = EnvUtils.getProperty(thresholdProp + SYSPROP_WARN_ONLY_SUFFIX, "false");
-    return metricType + ":" + System.getProperty(thresholdProp) + ":" + warnOnly;
+    return metricType + ":" + EnvUtils.getProperty(thresholdProp) + ":" + warnOnly;
   }
 
   private static synchronized void initGlobal(CoreContainer coreContainer) {

--- a/solr/core/src/java/org/apache/solr/util/configuration/SSLConfigurations.java
+++ b/solr/core/src/java/org/apache/solr/util/configuration/SSLConfigurations.java
@@ -19,6 +19,7 @@ package org.apache.solr.util.configuration;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.StrUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,7 @@ public class SSLConfigurations {
     String clientTruststorePassword = getClientTrustStorePassword();
     String truststorePassword = getTrustStorePassword();
 
-    if (StrUtils.isNullOrEmpty(System.getProperty(SysProps.SSL_CLIENT_KEY_STORE_PASSWORD))
+    if (StrUtils.isNullOrEmpty(EnvUtils.getProperty(SysProps.SSL_CLIENT_KEY_STORE_PASSWORD))
         && !(StrUtils.isNullOrEmpty(clientKeystorePassword)
             && StrUtils.isNullOrEmpty(keystorePassword))) {
       log.info("Setting {}", SysProps.SSL_CLIENT_KEY_STORE_PASSWORD);
@@ -68,7 +69,7 @@ public class SSLConfigurations {
           SysProps.SSL_CLIENT_KEY_STORE_PASSWORD,
           clientKeystorePassword != null ? clientKeystorePassword : keystorePassword);
     }
-    if (StrUtils.isNullOrEmpty(System.getProperty(SysProps.SSL_CLIENT_TRUST_STORE_PASSWORD))
+    if (StrUtils.isNullOrEmpty(EnvUtils.getProperty(SysProps.SSL_CLIENT_TRUST_STORE_PASSWORD))
         && !(StrUtils.isNullOrEmpty(clientTruststorePassword)
             && StrUtils.isNullOrEmpty(truststorePassword))) {
       log.info("Setting {}", SysProps.SSL_CLIENT_TRUST_STORE_PASSWORD);

--- a/solr/core/src/java/org/apache/solr/util/configuration/SSLCredentialProviderFactory.java
+++ b/solr/core/src/java/org/apache/solr/util/configuration/SSLCredentialProviderFactory.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.util.configuration.providers.EnvSSLCredentialProvider;
 import org.apache.solr.util.configuration.providers.SysPropSSLCredentialProvider;
 import org.slf4j.Logger;
@@ -42,7 +43,7 @@ public class SSLCredentialProviderFactory {
   private String providerChain;
 
   public SSLCredentialProviderFactory() {
-    this.providerChain = System.getProperty(PROVIDER_CHAIN_KEY, DEFAULT_PROVIDER_CHAIN);
+    this.providerChain = EnvUtils.getProperty(PROVIDER_CHAIN_KEY, DEFAULT_PROVIDER_CHAIN);
   }
 
   public SSLCredentialProviderFactory(String providerChain) {

--- a/solr/core/src/java/org/apache/solr/util/configuration/providers/SysPropSSLCredentialProvider.java
+++ b/solr/core/src/java/org/apache/solr/util/configuration/providers/SysPropSSLCredentialProvider.java
@@ -18,6 +18,7 @@
 package org.apache.solr.util.configuration.providers;
 
 import java.util.EnumMap;
+import org.apache.solr.common.util.EnvUtils;
 
 /** System property based SSL configuration provider */
 public class SysPropSSLCredentialProvider extends AbstractSSLCredentialProvider {
@@ -28,10 +29,7 @@ public class SysPropSSLCredentialProvider extends AbstractSSLCredentialProvider 
 
   @Override
   protected String getCredential(String syspropKey) {
-    if (System.getProperty(syspropKey) != null) {
-      return System.getProperty(syspropKey);
-    } else {
-      return null;
-    }
+    String value = EnvUtils.getProperty(syspropKey);
+    return (value != null) ? value : null;
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/configuration/providers/SysPropSSLCredentialProvider.java
+++ b/solr/core/src/java/org/apache/solr/util/configuration/providers/SysPropSSLCredentialProvider.java
@@ -29,7 +29,6 @@ public class SysPropSSLCredentialProvider extends AbstractSSLCredentialProvider 
 
   @Override
   protected String getCredential(String syspropKey) {
-    String value = EnvUtils.getProperty(syspropKey);
-    return (value != null) ? value : null;
+    return EnvUtils.getProperty(syspropKey);
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/tracing/SimplePropagator.java
+++ b/solr/core/src/java/org/apache/solr/util/tracing/SimplePropagator.java
@@ -25,6 +25,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.logging.MDCLoggingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,11 +42,11 @@ public class SimplePropagator implements TextMapPropagator {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String TRACE_HOST_NAME =
-      System.getProperty("solr.traceHostName", System.getProperty("host"));
+      EnvUtils.getProperty("solr.traceHostName", EnvUtils.getProperty("host"));
   private static final TextMapPropagator INSTANCE = new SimplePropagator();
   private static final ContextKey<String> TRACE_ID_KEY = ContextKey.named("trace_id");
 
-  static final String TRACE_ID = System.getProperty("solr.traceIdHeader", "X-Trace-Id");
+  static final String TRACE_ID = EnvUtils.getProperty("solr.traceIdHeader", "X-Trace-Id");
   private static final List<String> FIELDS = List.of(TRACE_ID);
 
   private static final AtomicLong traceCounter = new AtomicLong(0);


### PR DESCRIPTION
replaced direct `System.getProperty(...)` / `System.getenv` calls for Solr configuration properties with `EnvUtils` equivalents throughout the core module. this provides consistent support for `SOLR_*` environment variables (and the automatic `SOLR_FOO_BAR` → `solr.foo.bar` conversion) in all core startup and configuration paths.