### PR TITLE
SOLR-18306: Optimize IndexSchema.getDynamicFieldType() by checking cached fields before matching dynamic patterns.

### DIFF
--- a/changelog/unreleased/SOLR-18306-optimize-schema.yml
+++ b/changelog/unreleased/SOLR-18306-optimize-schema.yml
@@ -1,5 +1,5 @@
 title: Optimize IndexSchema.getDynamicFieldType() by checking cached fields before matching dynamic patterns.
-type: other
+type: changed
 authors:
   - name: Pierre Salagnac
 links:

--- a/changelog/unreleased/SOLR-18306-optimize-schema.yml
+++ b/changelog/unreleased/SOLR-18306-optimize-schema.yml
@@ -1,0 +1,8 @@
+title: Optimize IndexSchema.getDynamicFieldType() by checking cached fields before matching dynamic patterns.
+type: other
+authors:
+  - name: Pierre Salagnac
+links:
+  - name: SOLR-18306
+    url: https://issues.apache.org/jira/browse/SOLR-18306
+

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
@@ -1368,6 +1368,12 @@ public class IndexSchema {
       return false;
     }
 
+    // If a field with same name exists in the cache, don't match
+    // all dynamic field patterns.
+    if (dynamicFieldCache.getIfPresent(fieldName) != null) {
+      return true;
+    }
+
     for (DynamicField df : dynamicFields) {
       if (df.matches(fieldName)) return true;
     }
@@ -1477,13 +1483,24 @@ public class IndexSchema {
    * @see #getFieldTypeNoEx
    */
   public FieldType getDynamicFieldType(String fieldName) {
-    for (DynamicField df : dynamicFields) {
-      if (df.matches(fieldName)) return df.prototype.getType();
+    FieldType type = dynFieldType(fieldName);
+    if (type != null) {
+      return type;
     }
+
     throw new SolrException(ErrorCode.BAD_REQUEST, "undefined field " + fieldName);
   }
 
   private FieldType dynFieldType(String fieldName) {
+
+    // First, lookup for the field name in the dynamic field cache. In case it
+    // is available there, we save matching all the patterns by retrieving the
+    // type from it.
+    SchemaField field = dynamicFieldCache.getIfPresent(fieldName);
+    if (field != null) {
+      return field.getType();
+    }
+
     for (DynamicField df : dynamicFields) {
       if (df.matches(fieldName)) return df.prototype.getType();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18306



# Description

This fixes a CPU hotspot in `IndexSchema.getDynamicFieldType()` by using the cache of dynamic fields before matching all the patterns of dynamic field names.