### PR TITLE
.editorconfig: /ui is 4-space for kotlin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -157,7 +157,7 @@ ij_java_generate_final_locals = false
 ij_java_generate_final_parameters = false
 ij_java_generate_use_type_annotation_before_type = true
 ij_java_if_brace_force = never
-ij_java_imports_layout = @*,$*,|,*
+ij_java_imports_layout = @*, $*, |, *
 ij_java_indent_case_from_switch = true
 ij_java_insert_inner_class_imports = false
 ij_java_insert_override_annotation = true
@@ -349,7 +349,6 @@ ij_java_wrap_long_lines = true
 ij_java_wrap_semicolon_after_call_chain = false
 
 [{*.kt,*.kts}]
-indent_size = 4
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 
 #  Disable wildcard imports entirely
@@ -360,7 +359,7 @@ ij_kotlin_packages_to_use_import_on_demand = unset
 ktlint_code_style = intellij_idea
 ktlint_function_naming_ignore_when_annotated_with = Composable
 compose_allowed_composition_locals = LocalExtendedColorScheme, LocalExtendedTypography
-ij_kotlin_imports_layout=*,^
+ij_kotlin_imports_layout = *, ^
 
 [*.adoc]
 indent_size = 4
@@ -473,7 +472,7 @@ ij_groovy_ginq_on_wrap_policy = 1
 ij_groovy_ginq_space_after_keyword = true
 ij_groovy_if_brace_force = never
 ij_groovy_import_annotation_wrap = 2
-ij_groovy_imports_layout = @*,$*,|,*
+ij_groovy_imports_layout = @*, $*, |, *
 ij_groovy_indent_case_from_switch = true
 ij_groovy_indent_label_blocks = true
 ij_groovy_insert_inner_class_imports = false

--- a/solr/ui/.editorconfig
+++ b/solr/ui/.editorconfig
@@ -1,0 +1,2 @@
+[{*.kt,*.kts}]
+indent_size = 4


### PR DESCRIPTION
But other places (root or other modules) retain project default of 2-space).  Thus new build.gradle.kts somewhere else uses 4-space