### PR TITLE
SOLR-18098: force an FS directory factory in IndexFetcherPacketProtocolTest

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/IndexFetcherPacketProtocolTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/IndexFetcherPacketProtocolTest.java
@@ -72,6 +72,7 @@ public class IndexFetcherPacketProtocolTest extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    useFactory(null); // force an FS factory; replication reads real files from the index dir
     System.setProperty("solr.security.allow.urls.enabled", "false");
     initCore("solrconfig.xml", "schema.xml");
   }
@@ -79,6 +80,7 @@ public class IndexFetcherPacketProtocolTest extends SolrTestCaseJ4 {
   @AfterClass
   public static void afterClass() throws Exception {
     System.clearProperty("solr.security.allow.urls.enabled");
+    resetFactory();
   }
 
   // Tests for files that are exact multiples of PACKET_SZ


### PR DESCRIPTION
IndexFetcherPacketProtocolTest fails deterministically on main with seed `6FA33BD8BF6D0D4C`:

```
IndexFetcherPacketProtocolTest > testSingleByte FAILED
    java.lang.AssertionError: fetchPackets return code mismatch expected:<0> but was:<1>
```

The test stages a file into the index directory and reads it back through the replication fetch path. When the randomized directory factory is an ephemeral (RAM) one like ByteBuffersDirectory, the staged file is not visible to the fetch path, so the server side throws `NoSuchFileException`, no bytes are sent, and fetchPackets returns a non-zero code. With an FS-backed factory (the default random pick most of the time) it passes, which is why it looks flaky.

This is the same reason `TestReplicationHandler` forces an FS factory via `useFactory(null)` in its tests — replication reads real files from the index dir. The SOLR-18098 test just didn't do the same.

Fix: call `useFactory(null)` in `@BeforeClass` (and `resetFactory()` in `@AfterClass`).

Verified: the previously failing seed `6FA33BD8BF6D0D4C` now passes, along with several other random seeds.