### PR TITLE
SOLR-18313: Prep for Lucene 11: switch two call sites to the newer Lucene API forms

### DIFF
--- a/changelog/unreleased/SOLR-18313-prep-for-lucene-11.yml
+++ b/changelog/unreleased/SOLR-18313-prep-for-lucene-11.yml
@@ -1,0 +1,10 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: >
+  Prep for Lucene 11: switch two internal call sites (sort missing-value handling and automaton
+  concatenation) to the newer Lucene API forms that already exist in Lucene 10.4. No behavior change.
+type: changed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18313
+    url: https://issues.apache.org/jira/browse/SOLR-18313

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -1296,14 +1296,15 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
           WildcardQuery.toAutomaton(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
       // TODO: we should likely use the automaton to calculate shouldReverse, too.
       if (factory.shouldReverse(termStr)) {
-        automaton = Operations.concatenate(automaton, Automata.makeChar(factory.getMarkerChar()));
+        automaton =
+            Operations.concatenate(List.of(automaton, Automata.makeChar(factory.getMarkerChar())));
         automaton = Operations.reverse(automaton);
       } else {
         // reverse wildcardfilter is active: remove false positives
         // fsa representing false positives (markerChar*)
         Automaton falsePositives =
             Operations.concatenate(
-                Automata.makeChar(factory.getMarkerChar()), Automata.makeAnyString());
+                List.of(Automata.makeChar(factory.getMarkerChar()), Automata.makeAnyString()));
         // subtract these away
         automaton =
             Operations.minus(automaton, falsePositives, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);

--- a/solr/core/src/java/org/apache/solr/schema/EnumFieldType.java
+++ b/solr/core/src/java/org/apache/solr/schema/EnumFieldType.java
@@ -41,6 +41,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
+import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -452,7 +453,16 @@ public class EnumFieldType extends PrimitiveFieldType {
     final SortField result = getNumericSort(field, NumberType.INTEGER, top);
     if (null == result.getMissingValue()) {
       // special case 'enum' default behavior: assume missing values are "below" all enum values
-      result.setMissingValue(Integer.MIN_VALUE);
+      if (result instanceof SortedNumericSortField snsf) {
+        return new SortedNumericSortField(
+            snsf.getField(),
+            snsf.getNumericType(),
+            snsf.getReverse(),
+            snsf.getSelector(),
+            Integer.MIN_VALUE);
+      }
+      return new SortField(
+          result.getField(), result.getType(), result.getReverse(), Integer.MIN_VALUE);
     }
     return result;
   }

--- a/solr/core/src/java/org/apache/solr/schema/FieldType.java
+++ b/solr/core/src/java/org/apache/solr/schema/FieldType.java
@@ -778,10 +778,8 @@ public abstract class FieldType extends FieldProperties {
       Object missingHigh) {
     field.checkSortability();
 
-    SortField sf = new SortField(field.getName(), sortType, reverse);
-    applySetMissingValue(field, sf, missingLow, missingHigh);
-
-    return sf;
+    return new SortField(
+        field.getName(), sortType, reverse, missingValue(field, reverse, missingLow, missingHigh));
   }
 
   /** Same as {@link #getSortField} but using {@link SortedSetSortField} */
@@ -793,10 +791,8 @@ public abstract class FieldType extends FieldProperties {
       Object missingHigh) {
 
     field.checkSortability();
-    SortField sf = new SortedSetSortField(field.getName(), reverse, selector);
-    applySetMissingValue(field, sf, missingLow, missingHigh);
-
-    return sf;
+    return new SortedSetSortField(
+        field.getName(), reverse, selector, missingValue(field, reverse, missingLow, missingHigh));
   }
 
   /** Same as {@link #getSortField} but using {@link SortedNumericSortField}. */
@@ -809,25 +805,30 @@ public abstract class FieldType extends FieldProperties {
       Object missingHigh) {
 
     field.checkSortability();
-    SortField sf = new SortedNumericSortField(field.getName(), sortType, reverse, selector);
-    applySetMissingValue(field, sf, missingLow, missingHigh);
-
-    return sf;
+    return new SortedNumericSortField(
+        field.getName(),
+        sortType,
+        reverse,
+        selector,
+        missingValue(field, reverse, missingLow, missingHigh));
   }
 
   /**
+   * Computes the sort {@code missingValue} to pass to a {@link SortField} constructor based on the
+   * field's {@code sortMissingFirst}/{@code sortMissingLast} properties and the sort direction.
+   * Returns {@code null} when neither property is set.
+   *
    * @see #getSortField
    * @see #getSortedSetSortField
    */
-  private static void applySetMissingValue(
-      SchemaField field, SortField sortField, Object missingLow, Object missingHigh) {
-    final boolean reverse = sortField.getReverse();
-
+  private static Object missingValue(
+      SchemaField field, boolean reverse, Object missingLow, Object missingHigh) {
     if (field.sortMissingLast()) {
-      sortField.setMissingValue(reverse ? missingLow : missingHigh);
+      return reverse ? missingLow : missingHigh;
     } else if (field.sortMissingFirst()) {
-      sortField.setMissingValue(reverse ? missingHigh : missingLow);
+      return reverse ? missingHigh : missingLow;
     }
+    return null;
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18313

# Description

Lucene 11 removes two old API forms that Solr currently uses. Both have a replacement that already exists in the Lucene we're on today (10.4), so we can switch now with no behavior change, which shrinks the eventual Lucene 11 upgrade. Discussed on dev@ ("[EXPERIMENT] Upgrading Solr against Lucene main (the future 11.0)").

1. **Sort "missing value"** (where docs without a value in the sort field are placed). Lucene 11 removes `SortField.setMissingValue(...)`; the value must be passed to the `SortField` constructor instead. `FieldType` and `EnumFieldType` now compute the missing value and pass it into the constructor rather than setting it after construction. Missing values sort in the same place as before.
2. **Automaton concatenation** in the reverse-wildcard query path. Lucene 11 removes `Operations.concatenate(a, b)` in favor of `Operations.concatenate(List.of(a, b))`. `SolrQueryParserBase` now uses the `List` form.

No functional change and nothing to reindex. The broader Lucene 11 port and the Java 25 baseline bump are deferred until Lucene 11 is released.

# Solution

Replaced the two call sites with the Lucene 10.4 equivalents:
- `FieldType`: extracted the missing-value computation into a small `missingValue(...)` helper and passed its result into the `SortField` / `SortedSetSortField` / `SortedNumericSortField` constructors (was: construct, then `setMissingValue`). `EnumFieldType.getSortField` rebuilds via the constructor when it needs its `Integer.MIN_VALUE` default.
- `SolrQueryParserBase`: `Operations.concatenate(a, b)` → `Operations.concatenate(List.of(a, b))`.

AI assistant disclosure: I used an AI coding assistant to help scope which Lucene 11 changes are already adoptable on 10.4 and to draft this change; I reviewed and verified all of it.

# Tests

No new tests — this is a no-behavior-change refactor covered by existing tests. Ran `./gradlew check` on current main (Lucene 10.4), plus the affected suites: `TestFieldCacheSort`, `TestSort`, `EnumFieldTest`, `TestReversedWildcardFilterFactory`, `SolrIndexConfigTest` — all green.

