### PR TITLE
SOLR-18314: Correct pf boost handling for single-term and clause-less queries

### DIFF
--- a/changelog/unreleased/SOLR-18314-empty-phrase-boost-matchalldocs.yml
+++ b/changelog/unreleased/SOLR-18314-empty-phrase-boost-matchalldocs.yml
@@ -1,0 +1,11 @@
+title: Fix the eDisMax parser adding an empty phrase (pf) boost clause for clause-less queries such
+  as q=*:* (distinct from single-term queries). The empty SHOULD clause defeated the single-clause
+  MatchAllDocsQuery optimization; it is now omitted, so these queries again reduce to a
+  MatchAllDocsQuery.
+type: fixed
+authors:
+  - name: Ian Springer
+    nick: ianspringer
+links:
+  - name: SOLR-18314
+    url: https://issues.apache.org/jira/browse/SOLR-18314

--- a/changelog/unreleased/SOLR-18314-skip-phrase-analysis-single-term.yml
+++ b/changelog/unreleased/SOLR-18314-skip-phrase-analysis-single-term.yml
@@ -1,0 +1,8 @@
+title: Skip phrase field (pf) boost analysis for single-term queries in DisMax and eDisMax parsers
+type: changed
+authors:
+  - name: Ian Springer
+    nick: ianspringer
+links:
+  - name: SOLR-18314
+    url: https://issues.apache.org/jira/browse/SOLR-18314

--- a/changelog/unreleased/SOLR-18314-skip-phrase-analysis-single-term.yml
+++ b/changelog/unreleased/SOLR-18314-skip-phrase-analysis-single-term.yml
@@ -1,4 +1,7 @@
-title: Skip phrase field (pf) boost analysis for single-term queries in DisMax and eDisMax parsers
+title: Skip phrase field (pf) boost analysis for single-term queries in DisMax and eDisMax parsers.
+  This may affect relevancy scores for single-term queries if pf fields differ from qf fields or use
+  different boost weights, since the single-term phrase boost (effectively a redundant term boost) is
+  no longer applied.
 type: changed
 authors:
   - name: Ian Springer

--- a/changelog/unreleased/SOLR-18314-skip-phrase-analysis-single-term.yml
+++ b/changelog/unreleased/SOLR-18314-skip-phrase-analysis-single-term.yml
@@ -1,7 +1,9 @@
-title: Skip phrase field (pf) boost analysis for single-term queries in DisMax and eDisMax parsers.
-  This may affect relevancy scores for single-term queries if pf fields differ from qf fields or use
-  different boost weights, since the single-term phrase boost (effectively a redundant term boost) is
-  no longer applied.
+title: The DisMax parser no longer applies the phrase field (pf) boost to single-term queries, since
+  a one-word phrase boost is a redundant term boost. (The eDisMax parser already skipped the pf boost
+  for single-term queries.) This applies only to genuinely single-token queries, so a single input
+  term whose analysis yields multiple tokens (e.g. via CJK, ngram, WordDelimiterGraph, or multi-word
+  synonyms) is unaffected and keeps its phrase boost. This may change relevancy scores for DisMax
+  queries that previously received a single-term phrase boost.
 type: changed
 authors:
   - name: Ian Springer

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -227,6 +227,9 @@ public class DisMaxQParser extends QParser {
      * matched those phrases but do match looser phrases.
      */
     String userPhraseQuery = userQuery.replace("\"", "");
+    if (userPhraseQuery.isBlank() || userPhraseQuery.trim().indexOf(' ') < 0) {
+      return null;
+    }
     return pp.parse("\"" + userPhraseQuery + "\"");
   }
 

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -22,7 +22,11 @@ import java.util.Map;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.MultiPhraseQuery;
+import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.common.params.SolrParams;
@@ -227,11 +231,46 @@ public class DisMaxQParser extends QParser {
      * matched those phrases but do match looser phrases.
      */
     String userPhraseQuery = userQuery.replace("\"", "");
-    if (userPhraseQuery.trim().indexOf(' ') < 0) {
-      // single term - skip phrase boost
+    Query phrase = pp.parse("\"" + userPhraseQuery + "\"");
+    // A single-term phrase boost is a no-op adjacency constraint (effectively a redundant term
+    // boost), so skip it. This is decided from the analyzed query, because analyzers such as CJK,
+    // ngram, WordDelimiterGraph, and multi-word synonyms can split a single input term into several
+    // tokens that DO warrant a phrase boost. This is the DisMax-native analog of eDisMax's
+    // minClauseSize (which this parser lacks); note that DisMax counts terms after stopword
+    // removal, whereas eDisMax retains stopwords in its pf parse, so the two can differ for
+    // queries padded with stopwords.
+    if (isEffectivelySingleTerm(phrase)) {
       return null;
     }
-    return pp.parse("\"" + userPhraseQuery + "\"");
+    return phrase;
+  }
+
+  /**
+   * Returns true if the parsed phrase query boils down to a single analyzed term, in which case the
+   * phrase boost adds nothing over the term boost already applied by the main query. The parser
+   * produces a {@link DisjunctionMaxQuery} over per-field {@link BoostQuery}-wrapped term/phrase
+   * queries; we inspect the underlying query shape so that analyzers which split a single input
+   * term into multiple tokens keep their phrase boost. Unrecognized shapes conservatively return
+   * false (keep the boost).
+   */
+  private static boolean isEffectivelySingleTerm(Query query) {
+    if (query instanceof BoostQuery boostQuery) {
+      return isEffectivelySingleTerm(boostQuery.getQuery());
+    }
+    if (query instanceof DisjunctionMaxQuery dmq) {
+      // Every field's clause is a single term, so the phrase across fields is too.
+      return dmq.getDisjuncts().stream().allMatch(DisMaxQParser::isEffectivelySingleTerm);
+    }
+    if (query instanceof TermQuery) {
+      return true;
+    }
+    if (query instanceof PhraseQuery phraseQuery) {
+      return phraseQuery.getTerms().length < 2;
+    }
+    if (query instanceof MultiPhraseQuery multiPhraseQuery) {
+      return multiPhraseQuery.getTermArrays().length < 2;
+    }
+    return false;
   }
 
   protected Query getUserQuery(

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -227,7 +227,7 @@ public class DisMaxQParser extends QParser {
      * matched those phrases but do match looser phrases.
      */
     String userPhraseQuery = userQuery.replace("\"", "");
-    if (userPhraseQuery.isBlank() || userPhraseQuery.trim().indexOf(' ') < 0) {
+    if (userPhraseQuery.trim().indexOf(' ') < 0) {
       return null;
     }
     return pp.parse("\"" + userPhraseQuery + "\"");

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -203,7 +203,7 @@ public class DisMaxQParser extends QParser {
       query.add(parsedUserQuery, BooleanClause.Occur.MUST);
 
       Query phrase = getPhraseQuery(userQuery, pp);
-      if (null != phrase) {
+      if (phrase != null) {
         query.add(phrase, BooleanClause.Occur.SHOULD);
       }
     }
@@ -220,6 +220,12 @@ public class DisMaxQParser extends QParser {
     }
   }
 
+  /**
+   * Builds the phrase-boost ("pf") query: the user's terms as a contiguous phrase over the pf
+   * fields, at the pf boosts. Returns {@code null} when the phrase boils down to a single analyzed
+   * term, because a one-term phrase boost is a no-op adjacency constraint that adds nothing over
+   * the term boost already applied by the main query (see {@link #isEffectivelySingleTerm(Query)})
+   */
   protected Query getPhraseQuery(String userQuery, SolrPluginUtils.DisjunctionMaxQueryParser pp)
       throws SyntaxError {
     /* * * Add on Phrases for the Query * * */
@@ -236,10 +242,7 @@ public class DisMaxQParser extends QParser {
     // A single-term phrase boost is a no-op adjacency constraint (effectively a redundant term
     // boost), so skip it. This is decided from the analyzed query, because analyzers such as CJK,
     // ngram, WordDelimiterGraph, and multi-word synonyms can split a single input term into several
-    // tokens that DO warrant a phrase boost. This is the DisMax-native analog of eDisMax's
-    // minClauseSize (which this parser lacks); note that DisMax counts terms after stopword
-    // removal, whereas eDisMax retains stopwords in its pf parse, so the two can differ for
-    // queries padded with stopwords.
+    // tokens that DO warrant a phrase boost
     if (isEffectivelySingleTerm(phrase)) {
       return null;
     }

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -218,17 +218,19 @@ public class DisMaxQParser extends QParser {
   protected Query getPhraseQuery(String userQuery, SolrPluginUtils.DisjunctionMaxQueryParser pp)
       throws SyntaxError {
     /* * * Add on Phrases for the Query * * */
-    if (userQuery.trim().indexOf(' ') < 0) {
-      // single term - skip phrase boost
-      return null;
-    }
+
     /* build up phrase boosting queries */
+
     /* if the userQuery already has some quotes, strip them out.
      * we've already done the phrases they asked for in the main
      * part of the query, this is to boost docs that may not have
      * matched those phrases but do match looser phrases.
      */
     String userPhraseQuery = userQuery.replace("\"", "");
+    if (userPhraseQuery.trim().indexOf(' ') < 0) {
+      // single term - skip phrase boost
+      return null;
+    }
     return pp.parse("\"" + userPhraseQuery + "\"");
   }
 

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -218,18 +218,17 @@ public class DisMaxQParser extends QParser {
   protected Query getPhraseQuery(String userQuery, SolrPluginUtils.DisjunctionMaxQueryParser pp)
       throws SyntaxError {
     /* * * Add on Phrases for the Query * * */
-
+    if (userQuery.trim().indexOf(' ') < 0) {
+      // single term - skip phrase boost
+      return null;
+    }
     /* build up phrase boosting queries */
-
     /* if the userQuery already has some quotes, strip them out.
      * we've already done the phrases they asked for in the main
      * part of the query, this is to boost docs that may not have
      * matched those phrases but do match looser phrases.
      */
     String userPhraseQuery = userQuery.replace("\"", "");
-    if (userPhraseQuery.trim().indexOf(' ') < 0) {
-      return null;
-    }
     return pp.parse("\"" + userPhraseQuery + "\"");
   }
 

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.search;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -250,10 +251,11 @@ public class DisMaxQParser extends QParser {
    * phrase boost adds nothing over the term boost already applied by the main query. The parser
    * produces a {@link DisjunctionMaxQuery} over per-field {@link BoostQuery}-wrapped term/phrase
    * queries; we inspect the underlying query shape so that analyzers which split a single input
-   * term into multiple tokens keep their phrase boost. Unrecognized shapes conservatively return
-   * false (keep the boost).
+   * term into multiple tokens keep their phrase boost. Unrecognized shapes (and {@code null})
+   * conservatively return false (keep the boost).
    */
-  private static boolean isEffectivelySingleTerm(Query query) {
+  @VisibleForTesting
+  static boolean isEffectivelySingleTerm(Query query) {
     if (query instanceof BoostQuery boostQuery) {
       return isEffectivelySingleTerm(boostQuery.getQuery());
     }

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -630,6 +630,8 @@ public class ExtendedDismaxQParser extends QParser {
 
     if (0 == shingleSize) shingleSize = clauses.size();
 
+    if (shingleSize < 2) return;
+
     final int lastClauseIndex = shingleSize - 1;
 
     StringBuilder userPhraseQuery = new StringBuilder();

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -629,12 +629,7 @@ public class ExtendedDismaxQParser extends QParser {
       return;
 
     if (0 == shingleSize) shingleSize = clauses.size();
-
-    if (shingleSize < 2) {
-      // single term - skip phrase boost
-      return;
-    }
-
+    
     final int lastClauseIndex = shingleSize - 1;
 
     StringBuilder userPhraseQuery = new StringBuilder();
@@ -681,9 +676,16 @@ public class ExtendedDismaxQParser extends QParser {
     // TODO: perhaps we shouldn't use synonyms either...
 
     Query phrase = pp.parse(userPhraseQuery.toString());
-    if (phrase != null) {
+    // Skip null and *empty* boosts. A clause-less query (e.g. q=*:*) analyzes to an empty
+    // BooleanQuery rather than null; adding it as a SHOULD clause would defeat the single-clause
+    // MatchAllDocsQuery optimization applied to the main query.
+    if (phrase != null && !isEmptyBooleanQuery(phrase)) {
       mainQuery.add(phrase, BooleanClause.Occur.SHOULD);
     }
+  }
+
+  private static boolean isEmptyBooleanQuery(Query query) {
+    return query instanceof BooleanQuery && ((BooleanQuery) query).clauses().isEmpty();
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -629,7 +629,7 @@ public class ExtendedDismaxQParser extends QParser {
       return;
 
     if (0 == shingleSize) shingleSize = clauses.size();
-    
+
     final int lastClauseIndex = shingleSize - 1;
 
     StringBuilder userPhraseQuery = new StringBuilder();

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -630,7 +630,10 @@ public class ExtendedDismaxQParser extends QParser {
 
     if (0 == shingleSize) shingleSize = clauses.size();
 
-    if (shingleSize < 2) return;
+    if (shingleSize < 2) {
+      // single term - skip phrase boost
+      return;
+    }
 
     final int lastClauseIndex = shingleSize - 1;
 

--- a/solr/core/src/test-files/solr/collection1/conf/schema.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema.xml
@@ -632,6 +632,7 @@
   <field name="price" type="float" indexed="true" stored="true" multiValued="false"/>
   <field name="inStock" type="boolean" indexed="true" stored="true"/>
 
+  <field name="text_syn" type="lowerpunctfilt" indexed="true" stored="true"/>
   <field name="subword" type="subword" indexed="true" stored="true"/>
   <field name="subword_offsets" type="subword" indexed="true" stored="true" termVectors="true" termOffsets="true"/>
   <field name="numericsubword" type="numericsubword" indexed="true" stored="true"/>

--- a/solr/core/src/test-files/solr/collection1/conf/synonyms.txt
+++ b/solr/core/src/test-files/solr/collection1/conf/synonyms.txt
@@ -32,6 +32,7 @@ pixima => pixma
 # multiword synonyms
 wi fi => wifi
 crow blackbird, grackle
+usa => united states of america
 
 # Synonyms used in semantic expansion
 tabby => tabby, cat, feline, animal

--- a/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
@@ -258,9 +258,10 @@ public class DisMaxRequestHandlerTest extends SolrTestCaseJ4 {
   }
 
   // SOLR-18314: the pf phrase boost is dropped for single-term queries, decided from the analyzed
-  // query. A single input term whose analysis yields multiple tokens (here, WordDelimiter splitting
-  // "wi-fi" into "wi fi") must keep its phrase boost. Unlike eDisMax, the classic DisMax parser has
-  // no minClauseSize gate, so this is enforced by inspecting the parsed phrase query.
+  // query. A single input term whose analysis yields multiple tokens must keep its phrase boost,
+  // whether from WordDelimiter splitting "wi-fi" into "wi fi" or a multi-word synonym expanding
+  // "usa" into "united states of america". Unlike eDisMax, the classic DisMax parser has no
+  // minClauseSize gate, so this is enforced by inspecting the parsed phrase query.
   //
   // CJK is an important example of a query with no spaces that can still parse to multiple terms.
   // However, we don't add a dedicated CJK test: CJK analysis of a single input term produces the
@@ -304,5 +305,24 @@ public class DisMaxRequestHandlerTest extends SolrTestCaseJ4 {
     assertTrue(
         "multi-token query should retain its phrase boost",
         Pattern.compile("subword:\"wi fi\"").matcher(resp).find());
+
+    // A single input term expanded by a multi-word synonym ("usa" => "united states of america")
+    // likewise analyzes into multiple tokens, so its phrase boost must be retained.
+    resp =
+        h.query(
+            req(
+                "q",
+                "usa",
+                "qt",
+                "/dismax",
+                "qf",
+                "text_syn",
+                "pf",
+                "text_syn^10",
+                CommonParams.DEBUG_QUERY,
+                "true"));
+    assertTrue(
+        "multi-word synonym query should retain its phrase boost",
+        Pattern.compile("text_syn:\"united states of america\"").matcher(resp).find());
   }
 }

--- a/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/DisMaxRequestHandlerTest.java
@@ -256,4 +256,53 @@ public class DisMaxRequestHandlerTest extends SolrTestCaseJ4 {
     assertTrue(p.matcher(resp).find());
     assertTrue(p_bool.matcher(resp).find());
   }
+
+  // SOLR-18314: the pf phrase boost is dropped for single-term queries, decided from the analyzed
+  // query. A single input term whose analysis yields multiple tokens (here, WordDelimiter splitting
+  // "wi-fi" into "wi fi") must keep its phrase boost. Unlike eDisMax, the classic DisMax parser has
+  // no minClauseSize gate, so this is enforced by inspecting the parsed phrase query.
+  //
+  // CJK is an important example of a query with no spaces that can still parse to multiple terms.
+  // However, we don't add a dedicated CJK test: CJK analysis of a single input term produces the
+  // same multi-term PhraseQuery that the "wi-fi" case already exercises, so it would cover no new
+  // code path while requiring a CJK analyzer to be configured in the test schema.
+  @Test
+  public void testSingleTermPhraseBoost() throws Exception {
+    // Single analyzed token: the pf phrase boost is redundant with the qf term boost, so no phrase
+    // query should appear in the parsed query.
+    Pattern phrase = Pattern.compile("subword:\"");
+    String resp =
+        h.query(
+            req(
+                "q",
+                "wireless",
+                "qt",
+                "/dismax",
+                "qf",
+                "subword",
+                "pf",
+                "subword^10",
+                CommonParams.DEBUG_QUERY,
+                "true"));
+    assertFalse("single-term query should not produce a phrase boost", phrase.matcher(resp).find());
+
+    // Whitespace-free query that analyzes into multiple tokens: the phrase boost is meaningful and
+    // must be retained.
+    resp =
+        h.query(
+            req(
+                "q",
+                "wi-fi",
+                "qt",
+                "/dismax",
+                "qf",
+                "subword",
+                "pf",
+                "subword^10",
+                CommonParams.DEBUG_QUERY,
+                "true"));
+    assertTrue(
+        "multi-token query should retain its phrase boost",
+        Pattern.compile("subword:\"wi fi\"").matcher(resp).find());
+  }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestDisMaxQParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestDisMaxQParser.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.util.List;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MultiPhraseQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.Test;
+
+/** Unit tests for {@link DisMaxQParser} internals that do not need a running core. */
+public class TestDisMaxQParser extends SolrTestCaseJ4 {
+
+  private static TermQuery term(String field, String text) {
+    return new TermQuery(new Term(field, text));
+  }
+
+  // SOLR-18314: isEffectivelySingleTerm decides whether a parsed pf phrase query collapses to a
+  // single analyzed term (so the phrase boost is redundant and should be dropped). It must return
+  // true only when every field's clause is a single term; any clause with two or more terms means
+  // the phrase boost adds a real adjacency constraint and must be kept.
+  @Test
+  public void testIsEffectivelySingleTermIsTrueForSingleTermShapes() {
+    // A bare single term.
+    assertTrue(DisMaxQParser.isEffectivelySingleTerm(term("subject", "wireless")));
+
+    // The parser wraps each field's clause in a BoostQuery; it must be unwrapped.
+    assertTrue(
+        DisMaxQParser.isEffectivelySingleTerm(new BoostQuery(term("subject", "wireless"), 10f)));
+
+    // A one-term phrase is just a term boost in disguise.
+    assertTrue(DisMaxQParser.isEffectivelySingleTerm(new PhraseQuery("subject", "wireless")));
+
+    // A one-position MultiPhraseQuery (e.g. a single term with synonyms) is likewise single-term.
+    MultiPhraseQuery singlePosition =
+        new MultiPhraseQuery.Builder().add(new Term("subject", "wireless")).build();
+    assertTrue(DisMaxQParser.isEffectivelySingleTerm(singlePosition));
+
+    // A DisjunctionMaxQuery whose every disjunct is single-term is single-term across fields.
+    DisjunctionMaxQuery allSingle =
+        new DisjunctionMaxQuery(
+            List.of(
+                new BoostQuery(term("subject", "wireless"), 10f),
+                new BoostQuery(term("features", "wireless"), 5f)),
+            0.1f);
+    assertTrue(DisMaxQParser.isEffectivelySingleTerm(allSingle));
+  }
+
+  @Test
+  public void testIsEffectivelySingleTermIsFalseForMultiTermShapes() {
+    // A genuine two-term phrase (e.g. WordDelimiter splitting "wi-fi" into "wi fi").
+    assertFalse(DisMaxQParser.isEffectivelySingleTerm(new PhraseQuery("subject", "wi", "fi")));
+
+    // A two-position MultiPhraseQuery (e.g. a multi-word synonym expansion).
+    MultiPhraseQuery twoPositions =
+        new MultiPhraseQuery.Builder()
+            .add(new Term("subject", "wi"))
+            .add(new Term("subject", "fi"))
+            .build();
+    assertFalse(DisMaxQParser.isEffectivelySingleTerm(twoPositions));
+
+    // Any field with a multi-term clause keeps the boost, even if other fields are single-term.
+    DisjunctionMaxQuery mixed =
+        new DisjunctionMaxQuery(
+            List.of(
+                new BoostQuery(term("subject", "wireless"), 10f),
+                new BoostQuery(new PhraseQuery("features", "wi", "fi"), 5f)),
+            0.1f);
+    assertFalse(DisMaxQParser.isEffectivelySingleTerm(mixed));
+  }
+
+  @Test
+  public void testIsEffectivelySingleTermIsFalseForUnrecognizedShapes() {
+    // Unrecognized shapes conservatively keep the boost rather than silently dropping it.
+    assertFalse(DisMaxQParser.isEffectivelySingleTerm(new MatchAllDocsQuery()));
+
+    BooleanQuery booleanQuery =
+        new BooleanQuery.Builder()
+            .add(term("subject", "wireless"), BooleanClause.Occur.SHOULD)
+            .build();
+    assertFalse(DisMaxQParser.isEffectivelySingleTerm(booleanQuery));
+
+    // null is a valid input (parse() can return it) and must not throw.
+    assertFalse(DisMaxQParser.isEffectivelySingleTerm(null));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.not;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1195,6 +1196,61 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
         "//*[@numFound='2']",
         "//str[@name='id'][.='145']",
         "//str[@name='id'][.='146']");
+  }
+
+  // SOLR-18314: the single-term pf boost is dropped, but only for genuinely single-token queries.
+  // A single input term whose analysis yields multiple tokens (WordDelimiter splitting "wi-fi", or
+  // a multi-word synonym expanding "usa") must keep its phrase boost.
+  //
+  // CJK is an important example of a query with no spaces that can still parse to multiple terms.
+  // However, we don't add a dedicated CJK test: CJK analysis of a single input term produces the
+  // same multi-term PhraseQuery that the "wi-fi" and "usa" cases already exercise, so it covers no
+  // new code path while requiring a CJK analyzer to be configured in the test schema.
+  public void testSingleTermPhraseBoost() throws Exception {
+    // Plain single-token query: the pf phrase boost adds nothing over the qf term boost, so no
+    // phrase clause should be present. minClauseSize already discards it regardless of this change.
+    String singleTokenParsed =
+        getParsedQuery(
+            req(
+                "q", "wireless",
+                "qf", "subject",
+                "pf", "subject^10",
+                "defType", "edismax",
+                "debugQuery", "true"));
+    assertThat(singleTokenParsed, not(containsString("subject:\"")));
+
+    // Whitespace-free query that analyzes into multiple tokens: the phrase boost is meaningful
+    // (imposes adjacency that the qf clause does not) and must survive.
+    String multiTokenParsed =
+        getParsedQuery(
+            req(
+                "q", "wi-fi",
+                "qf", "subject",
+                "pf", "subject^10",
+                "defType", "edismax",
+                "debugQuery", "true"));
+    assertThat(multiTokenParsed, containsString("(subject:\"wi fi\")^10.0"));
+
+    // A single raw token that a multi-word synonym expands into several analyzed tokens (here
+    // "usa" => "united states of america") also warrants a real phrase boost and must be retained.
+    // This covers the same "no whitespace in, multiple tokens out" case as CJK and ngram analyzers,
+    // without needing to configure those analyzers in the test schema.
+    String synonymParsed =
+        getParsedQuery(
+            req(
+                "q", "usa",
+                "qf", "subject",
+                "pf", "subject^10",
+                "defType", "edismax",
+                "debugQuery", "true"));
+    // "of" is a stopword (the "?" gap) and Porter stemming yields unit/state/america.
+    assertThat(synonymParsed, containsString("(subject:\"unit state ? america\")^10.0"));
+
+    // A clause-less query (q=*:*) must not add an empty "" phrase clause that would defeat the
+    // MatchAllDocsQuery optimization.
+    Query matchAll =
+        QParser.getParser("*:*", "edismax", req("qf", "subject", "pf", "subject^10")).getQuery();
+    assertThat(matchAll, isA(MatchAllDocsQuery.class));
   }
 
   // test phrase fields including pf2 pf3 and phrase slop


### PR DESCRIPTION
This PR makes two related but independent changes to phrase field (`pf`) boosting in the DisMax and eDisMax query parsers.

(co-authored with Claude Code, Opus 4.8)

### 1. DisMax: skip the pf boost for single-term queries (`changed`)

The DisMax parser no longer applies the `pf` phrase boost to single-term queries, since a one-word phrase boost is a redundant term boost. (The eDisMax parser already skipped the `pf` boost for single-term queries via its `minClauseSize` gate.)

This applies only to *genuinely single-token* queries. "Single term" is decided from the **analyzed query**, not from whitespace in the raw string, so a single input term whose analysis yields multiple tokens — e.g. via CJK, ngram, WordDelimiterGraph, or multi-word synonyms — is unaffected and keeps its phrase boost.

This may change relevancy scores for DisMax queries that previously received a single-term phrase boost.

### 2. eDisMax: don't emit an empty pf clause for clause-less queries (`fixed`)

Fixes the eDisMax parser adding an empty phrase (`pf`) boost clause for clause-less queries such as `q=*:*` (distinct from single-term queries). The empty `SHOULD` clause defeated the single-clause `MatchAllDocsQuery` optimization; it is now omitted, so these queries again reduce to a `MatchAllDocsQuery`.

### Notes

- The primary value here is **correct relevancy**, not performance. An earlier approach short-circuited before parsing (a parse-time optimization), but that could not be done correctly from the raw query string without analyzing — it wrongly dropped boosts for multi-token analyses. The current approach inspects the analyzed query instead, trading away the micro-optimization for correctness.
- Tests cover: single-token dropped (`wireless`), WordDelimiter multi-token kept (`wi-fi`→`"wi fi"`), multi-word synonym kept (`usa`→`"unit state ? america"`), and `q=*:*` reducing to `MatchAllDocsQuery`. A CJK-specific test is intentionally omitted — it exercises the same multi-term `PhraseQuery` path already covered, at the cost of adding a CJK analyzer to the test schema.

# Tests

### Tests added

**`TestDisMaxQParser`** (new) — unit tests for `DisMaxQParser.isEffectivelySingleTerm` (made package-private via `@VisibleForTesting`), exercising the query-shape logic directly without a running core:
- **Single-term shapes** → boost dropped: bare `TermQuery`, `BoostQuery`-wrapped term, one-term `PhraseQuery`, one-position `MultiPhraseQuery`, and an all-single-term `DisjunctionMaxQuery`.
- **Multi-term shapes** → boost kept: two-term `PhraseQuery` (WordDelimiter-style split), two-position `MultiPhraseQuery` (synonym-style), and a mixed `DisjunctionMaxQuery` where one field is single-term and another is multi-term.
- **Unrecognized / null shapes** → conservatively kept: `MatchAllDocsQuery`, `BooleanQuery`, and `null` (must not throw).

**`DisMaxRequestHandlerTest.testSingleTermPhraseBoost`** (new) — end-to-end through the classic DisMax parser:
- `q=wireless` (single analyzed token) → no pf phrase clause emitted.
- `q=wi-fi` (WordDelimiter splits into `wi fi`) → pf phrase boost retained.
- `q=usa` (multi-word synonym → `united states of america`) → pf phrase boost retained. Added a `text_syn` field (existing synonym-enabled type) to the shared `collection1` schema to drive this. Covers the `MultiPhraseQuery` branch through the real parser pipeline.

**`TestExtendedDismaxParser.testSingleTermPhraseBoost`** (new) — end-to-end through eDisMax:
- `q=wireless` → no pf phrase boost; `q=wi-fi` and `q=usa` → boost retained (via `minClauseSize`).
- `q=*:*` → reduces to `MatchAllDocsQuery` (regression guard for the empty-phrase fix that previously defeated the single-clause optimization).

*(CJK was intentionally not given a dedicated test — a single CJK input term yields the same multi-term `PhraseQuery` the `wi-fi`/`usa` cases already exercise, so it adds no code-path coverage while requiring a CJK analyzer in the test schema. Noted in the test comments.)*

### Regression checks run

All green:
- `DisMaxRequestHandlerTest` and `TestExtendedDismaxParser` — the two suites directly touched.
- `BasicFunctionalityTest`, `org.apache.solr.schema.*`, `TestExtendedDismaxParser`, `TestDisMaxQParser` — a combined **617-test** run to confirm the additive `text_syn` field in the shared `collection1` schema (loaded by ~85 suites) broke nothing.
- `spotlessJavaCheck` — clean on all changed files.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change
