### PR TITLE
SolrRequest.getPath setPath documentation

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -172,11 +172,20 @@ public abstract class SolrRequest<T> implements Serializable {
     this.method = method;
   }
 
+  /**
+   * The URI path to a "request handler", such as "/select". Must start with a "/". For
+   * collection/core requests, this is appended to the core/collection path; otherwise it's a node
+   * level request and thus is relative to the solr root.
+   */
   public String getPath() {
     return path;
   }
 
   public void setPath(String path) {
+    if (path == null || !path.startsWith("/")) {
+      throw new IllegalArgumentException("Must start with a '/': " + path);
+    }
+
     this.path = path;
   }
 


### PR DESCRIPTION
and enforce need to start with a '/'; not null.

In particular I was motivated by not seeing the words "request handler".  Users shifting away from deprecated get/set RequestHandler on SolrQuery don't see an obvious substitute here.

While I was at it, let's enforce some basics on the setter.