### PR TITLE
HttpJettySolrClient: use fewer threads

### DIFF
--- a/changelog/unreleased/PR#4668-JettyClientFewerThreads.yml
+++ b/changelog/unreleased/PR#4668-JettyClientFewerThreads.yml
@@ -1,0 +1,9 @@
+title: >
+  HttpJettySolrClient defaults would often create 32 threads, likely under-utilizing them. and it would cap threads to 256.
+  Now it does neither by default but Executor customization (and other saturation controls) remain.
+type: changed
+authors:
+  - name: David Smiley
+links:
+  - name: PR#4668
+    url: https://github.com/apache/solr/pull/4668

--- a/solr/solrj-jetty/src/java/org/apache/solr/client/solrj/jetty/HttpJettySolrClient.java
+++ b/solr/solrj-jetty/src/java/org/apache/solr/client/solrj/jetty/HttpJettySolrClient.java
@@ -83,7 +83,6 @@ import org.eclipse.jetty.http.MultiPart;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.io.ClientConnector;
-import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.ssl.KeyStoreScanner;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
@@ -220,10 +219,7 @@ public class HttpJettySolrClient extends HttpSolrClient {
   private HttpClient createHttpClient(Builder builder) {
     executor = builder.getExecutor();
     if (executor == null) {
-      BlockingArrayQueue<Runnable> queue = BlockingArrayQueue.newInstance(256, Integer.MAX_VALUE);
-      this.executor =
-          new ExecutorUtil.MDCAwareThreadPoolExecutor(
-              32, 256, 60, TimeUnit.SECONDS, queue, new SolrNamedThreadFactory("h2sc"));
+      this.executor = ExecutorUtil.newMDCAwareCachedThreadPool(new SolrNamedThreadFactory("h2sc"));
       shutdownExecutor = true;
     } else {
       shutdownExecutor = false;


### PR DESCRIPTION
A user could supply an executor with limits if they like.  Moreover, we already have `maxOutstandingRequests` so it's dubious to add yet another barrier here.

note: I have other WIP to add more javadocs to ExecutorUtil to clarify some foot-guns with how coreSize / maxSize / queue can be misused... albeit not saying that happened here in the jetty client.