### PR TITLE
SOLR-18321: Use Configsets V2 API instead of ZooKeeper cluster-state scans in bin/solr delete

### DIFF
--- a/changelog/unreleased/SOLR-18321-delete-collection-configset-if-unused.yml
+++ b/changelog/unreleased/SOLR-18321-delete-collection-configset-if-unused.yml
@@ -1,0 +1,7 @@
+title: bin/solr delete no longer requires a direct ZooKeeper connection to safely delete a collection's configset; it now uses the Configsets V2 API, which gained an "ifUnused" flag to skip deletion (and report which collections use it) when the configset is still in use.
+type: changed
+authors:
+  - name: Eric Pugh
+links:
+  - name: SOLR-18321
+    url: https://issues.apache.org/jira/browse/SOLR-18321

--- a/solr/api/src/java/org/apache/solr/client/api/endpoint/ConfigsetsApi.java
+++ b/solr/api/src/java/org/apache/solr/client/api/endpoint/ConfigsetsApi.java
@@ -20,6 +20,7 @@ import static org.apache.solr.client.api.util.Constants.GENERIC_ENTITY_PROPERTY;
 import static org.apache.solr.client.api.util.Constants.RAW_OUTPUT_PROPERTY;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -37,6 +38,7 @@ import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.solr.client.api.model.CloneConfigsetRequestBody;
+import org.apache.solr.client.api.model.DeleteConfigSetResponse;
 import org.apache.solr.client.api.model.ListConfigsetsResponse;
 import org.apache.solr.client.api.model.SolrJerseyResponse;
 
@@ -76,7 +78,15 @@ public interface ConfigsetsApi {
   interface Delete {
     @DELETE
     @Operation(summary = "Delete an existing configset.", tags = "configsets")
-    SolrJerseyResponse deleteConfigSet(@PathParam("configSetName") String configSetName)
+    DeleteConfigSetResponse deleteConfigSet(
+        @PathParam("configSetName") String configSetName,
+        @Parameter(
+                description =
+                    "If true, don't delete the configset (and report the collections using it) "
+                        + "when it's still in use by one or more collections; if false or omitted, "
+                        + "delete unconditionally.")
+            @QueryParam("ifUnused")
+            Boolean ifUnused)
         throws Exception;
   }
 

--- a/solr/api/src/java/org/apache/solr/client/api/model/DeleteConfigSetResponse.java
+++ b/solr/api/src/java/org/apache/solr/client/api/model/DeleteConfigSetResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class DeleteConfigSetResponse extends SolrJerseyResponse {
+
+  @JsonProperty public boolean deleted;
+
+  // Only populated when 'deleted' is false because 'ifUnused' was requested and the configset is
+  // still in use.
+  @JsonProperty public List<String> collectionsUsingConfigSet;
+}

--- a/solr/core/src/java/org/apache/solr/cli/DeleteTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/DeleteTool.java
@@ -17,18 +17,14 @@
 package org.apache.solr.cli;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collection;
 import java.util.Locale;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.jetty.HttpJettySolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CollectionsApi;
 import org.apache.solr.client.solrj.request.ConfigsetsApi;
 import org.apache.solr.client.solrj.request.CoresApi;
@@ -94,98 +90,68 @@ public class DeleteTool extends ToolBase {
   public void runImpl(CommandLine cli) throws Exception {
     try (var solrClient = CLIUtils.getSolrClient(cli)) {
       if (CLIUtils.isCloudMode(solrClient)) {
-        deleteCollection(cli);
+        deleteCollection(cli, solrClient);
       } else {
         deleteCore(cli, solrClient);
       }
     }
   }
 
-  protected void deleteCollection(CommandLine cli) throws Exception {
-    var builder =
-        new HttpJettySolrClient.Builder()
-            .withIdleTimeout(30, TimeUnit.SECONDS)
-            .withConnectionTimeout(15, TimeUnit.SECONDS)
-            .withKeyStoreReloadInterval(-1, TimeUnit.SECONDS)
-            .withOptionalBasicAuthCredentials(
-                cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION));
-
-    var solrConnection = CLIUtils.getSolrConnection(cli);
-    try (var cloudSolrClient = CLIUtils.getCloudSolrClient(solrConnection, builder)) {
-      echoIfVerbose("Connecting to Solr at " + solrConnection.toString());
-      deleteCollection(cloudSolrClient, cli);
-    }
-  }
-
-  protected void deleteCollection(CloudSolrClient cloudSolrClient, CommandLine cli)
-      throws Exception {
-    Set<String> liveNodes = cloudSolrClient.getClusterState().getLiveNodes();
-    if (liveNodes.isEmpty())
-      throw new IllegalStateException(
-          "No live nodes found! Cannot delete a collection until "
-              + "there is at least 1 live node in the cluster.");
-
+  protected void deleteCollection(CommandLine cli, SolrClient solrClient) throws Exception {
     String collectionName = cli.getOptionValue(COLLECTION_NAME_OPTION);
-    if (!cloudSolrClient.getClusterState().hasCollection(collectionName)) {
+    String solrUrl = CLIUtils.normalizeSolrUrl(cli);
+
+    if (!CLIUtils.safeCheckCollectionExists(
+        solrUrl, collectionName, cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION))) {
       throw new IllegalArgumentException("Collection " + collectionName + " not found!");
     }
 
-    String configName =
-        cloudSolrClient.getClusterState().getCollection(collectionName).getConfigName();
+    // Uses the V1 CLUSTERSTATUS request rather than the V2 CollectionsApi.GetCollectionStatus:
+    // the latter goes through a Jersey code path that currently throws under basic-auth-secured
+    // clusters. Still a plain HTTP admin call, not a direct ZK connection.
+    var statusReq = new CollectionAdminRequest.ClusterStatus().setCollectionName(collectionName);
+    var statusResponse = statusReq.process(solrClient);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cluster = (Map<String, Object>) statusResponse.getResponse().get("cluster");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> collections = (Map<String, Object>) cluster.get("collections");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> collectionInfo = (Map<String, Object>) collections.get(collectionName);
+    String configName = collectionInfo != null ? (String) collectionInfo.get("configName") : null;
     boolean deleteConfig = cli.hasOption(DELETE_CONFIG_OPTION);
+    boolean force = cli.hasOption(FORCE_OPTION);
 
-    if (deleteConfig && configName != null) {
-      if (cli.hasOption(FORCE_OPTION)) {
-        log.warn(
-            "Skipping safety checks, configuration directory {} will be deleted with impunity.",
-            configName);
-      } else {
-        // need to scan all Collections to see if any are using the config
-        Collection<String> collections = cloudSolrClient.getClusterState().getCollectionNames();
-
-        // give a little note to the user if there are many collections in case it takes a while
-        if (collections.size() > 50)
-          if (log.isInfoEnabled()) {
-            log.info(
-                "Scanning {} to ensure no other collections are using config {}",
-                collections.size(),
-                configName);
-          }
-
-        Optional<String> inUse =
-            collections.stream()
-                .filter(name -> !name.equals(collectionName)) // ignore this collection
-                .filter(
-                    name ->
-                        configName.equals(
-                            cloudSolrClient.getClusterState().getCollection(name).getConfigName()))
-                .findFirst();
-        if (inUse.isPresent()) {
-          deleteConfig = false;
-          log.warn(
-              "Configuration directory {} is also being used by {}{}",
-              configName,
-              inUse.get(),
-              "; configuration will not be deleted from ZooKeeper. You can pass the --force-delete-config flag to force delete.");
-        }
-      }
+    if (deleteConfig && configName != null && force) {
+      log.warn(
+          "Skipping safety checks, configuration directory {} will be deleted with impunity.",
+          configName);
     }
 
     echoIfVerbose("\nDeleting collection '" + collectionName + "' using V2 Collections API");
 
     try {
       var req = new CollectionsApi.DeleteCollection(collectionName);
-      var response = req.process(cloudSolrClient);
+      var response = req.process(solrClient);
       echoIfVerbose(response);
     } catch (SolrServerException sse) {
       throw new Exception(
           "Failed to delete collection '" + collectionName + "' due to: " + sse.getMessage());
     }
 
-    if (deleteConfig) {
+    if (deleteConfig && configName != null) {
       try {
         var req = new ConfigsetsApi.DeleteConfigSet(configName);
-        req.process(cloudSolrClient);
+        // With the collection already deleted above, the server only needs to check whether any
+        // *other* collection still uses this config.
+        req.setIfUnused(!force);
+        var response = req.process(solrClient);
+        if (!response.deleted) {
+          log.warn(
+              "Configuration directory {} is also being used by {}; configuration will not be"
+                  + " deleted. You can pass the --force flag to force delete.",
+              configName,
+              response.collectionsUsingConfigSet);
+        }
       } catch (Exception exc) {
         echo(
             "\nWARNING: Failed to delete configSet "

--- a/solr/core/src/java/org/apache/solr/handler/admin/ConfigSetsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ConfigSetsHandler.java
@@ -88,7 +88,7 @@ public class ConfigSetsHandler extends RequestHandlerBase implements PermissionN
       case DELETE:
         final DeleteConfigSet deleteConfigSetAPI = new DeleteConfigSet(coreContainer, req, rsp);
         final var deleteResponse =
-            deleteConfigSetAPI.deleteConfigSet(req.getParams().required().get(NAME));
+            deleteConfigSetAPI.deleteConfigSet(req.getParams().required().get(NAME), null);
         V2ApiUtils.squashIntoSolrResponseWithoutHeader(rsp, deleteResponse);
         break;
       case UPLOAD:

--- a/solr/core/src/java/org/apache/solr/handler/configsets/DeleteConfigSet.java
+++ b/solr/core/src/java/org/apache/solr/handler/configsets/DeleteConfigSet.java
@@ -21,10 +21,13 @@ import static org.apache.solr.security.PermissionNameProvider.Name.CONFIG_EDIT_P
 
 import jakarta.inject.Inject;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.solr.client.api.endpoint.ConfigsetsApi;
-import org.apache.solr.client.api.model.SolrJerseyResponse;
+import org.apache.solr.client.api.model.DeleteConfigSetResponse;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.params.ConfigSetParams;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.CoreContainer;
@@ -49,17 +52,36 @@ public class DeleteConfigSet extends ConfigSetAPIBase implements ConfigsetsApi.D
 
   @Override
   @PermissionName(CONFIG_EDIT_PERM)
-  public SolrJerseyResponse deleteConfigSet(String configSetName) throws Exception {
-    final var response = instantiateJerseyResponse(SolrJerseyResponse.class);
+  public DeleteConfigSetResponse deleteConfigSet(String configSetName, Boolean ifUnused)
+      throws Exception {
+    final var response = instantiateJerseyResponse(DeleteConfigSetResponse.class);
     if (StrUtils.isNullOrEmpty(configSetName) || StrUtils.isBlank(configSetName)) {
       throw new SolrException(
           SolrException.ErrorCode.BAD_REQUEST, "No configset name provided to delete");
     }
+
+    if (Boolean.TRUE.equals(ifUnused) && coreContainer.isZooKeeperAware()) {
+      List<String> collectionsUsingConfigSet =
+          coreContainer
+              .getZkController()
+              .getClusterState()
+              .collectionStream()
+              .filter(collection -> configSetName.equals(collection.getConfigName()))
+              .map(DocCollection::getName)
+              .collect(Collectors.toList());
+      if (!collectionsUsingConfigSet.isEmpty()) {
+        response.deleted = false;
+        response.collectionsUsingConfigSet = collectionsUsingConfigSet;
+        return response;
+      }
+    }
+
     final Map<String, Object> configsetCommandMsg = new HashMap<>();
     configsetCommandMsg.put(NAME, configSetName);
 
     runConfigSetCommand(
         solrQueryResponse, ConfigSetParams.ConfigSetAction.DELETE, configsetCommandMsg);
+    response.deleted = true;
     return response;
   }
 }

--- a/solr/core/src/test/org/apache/solr/cli/DeleteToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/DeleteToolTest.java
@@ -116,4 +116,63 @@ public class DeleteToolTest extends SolrCloudTestCase {
     };
     assertEquals(1, CLITestHelper.runTool(args, DeleteTool.class));
   }
+
+  @Test
+  public void testDeleteCollectionSkipsConfigDeleteWhileStillInUse() throws Exception {
+    String sharedConfigName = "testDeleteCollectionSkipsConfigDeleteWhileStillInUse-config";
+    cluster.uploadConfigSet(configset("cloud-minimal"), sharedConfigName);
+
+    withBasicAuth(
+            CollectionAdminRequest.createCollection(
+                "testDeleteConfigInUseA", sharedConfigName, 1, 1))
+        .processAndWait(cluster.getSolrClient(), 10);
+    withBasicAuth(
+            CollectionAdminRequest.createCollection(
+                "testDeleteConfigInUseB", sharedConfigName, 1, 1))
+        .processAndWait(cluster.getSolrClient(), 10);
+    waitForState(
+        "Expected collection to be created with 1 shard and 1 replicas",
+        "testDeleteConfigInUseA",
+        clusterShape(1, 1));
+    waitForState(
+        "Expected collection to be created with 1 shard and 1 replicas",
+        "testDeleteConfigInUseB",
+        clusterShape(1, 1));
+
+    String[] deleteFirstArgs = {
+      "delete",
+      "-c",
+      "testDeleteConfigInUseA",
+      "--delete-config",
+      "-z",
+      cluster.getZkClient().getZkServerAddress(),
+      "--credentials",
+      SecurityJson.USER_PASS,
+      "--verbose"
+    };
+    assertEquals(0, CLITestHelper.runTool(deleteFirstArgs, DeleteTool.class));
+
+    // still used by testDeleteConfigInUseB, so it should have been left alone
+    assertTrue(
+        "configset should still exist since it's still used by testDeleteConfigInUseB",
+        cluster.getZkClient().exists("/configs/" + sharedConfigName));
+
+    String[] deleteSecondArgs = {
+      "delete",
+      "-c",
+      "testDeleteConfigInUseB",
+      "--delete-config",
+      "-z",
+      cluster.getZkClient().getZkServerAddress(),
+      "--credentials",
+      SecurityJson.USER_PASS,
+      "--verbose"
+    };
+    assertEquals(0, CLITestHelper.runTool(deleteSecondArgs, DeleteTool.class));
+
+    // no longer used by any collection, so it should now be gone
+    assertFalse(
+        "configset should have been deleted since no collection uses it anymore",
+        cluster.getZkClient().exists("/configs/" + sharedConfigName));
+  }
 }

--- a/solr/core/src/test/org/apache/solr/handler/configsets/DeleteConfigSetAPITest.java
+++ b/solr/core/src/test/org/apache/solr/handler/configsets/DeleteConfigSetAPITest.java
@@ -50,7 +50,7 @@ public class DeleteConfigSetAPITest extends SolrTestCase {
   @Test
   public void testNullConfigSetNameThrowsBadRequest() {
     final var api = new DeleteConfigSet(mockCoreContainer, null, null);
-    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet(null));
+    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet(null, null));
 
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ex.code());
     assertTrue(
@@ -61,7 +61,7 @@ public class DeleteConfigSetAPITest extends SolrTestCase {
   @Test
   public void testEmptyConfigSetNameThrowsBadRequest() {
     final var api = new DeleteConfigSet(mockCoreContainer, null, null);
-    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet(""));
+    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet("", null));
 
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ex.code());
     assertTrue(
@@ -72,7 +72,7 @@ public class DeleteConfigSetAPITest extends SolrTestCase {
   @Test
   public void testWhitespaceOnlyConfigSetNameThrowsBadRequest() {
     final var api = new DeleteConfigSet(mockCoreContainer, null, null);
-    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet("   "));
+    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet("   ", null));
 
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ex.code());
     assertTrue(
@@ -83,7 +83,7 @@ public class DeleteConfigSetAPITest extends SolrTestCase {
   @Test
   public void testTabOnlyConfigSetNameThrowsBadRequest() {
     final var api = new DeleteConfigSet(mockCoreContainer, null, null);
-    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet("\t"));
+    final var ex = assertThrows(SolrException.class, () -> api.deleteConfigSet("\t", null));
 
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ex.code());
     assertTrue(


### PR DESCRIPTION
## Summary
- Added an opt-in `ifUnused` query param to `DELETE /api/configsets/{configSetName}`: when true, the server checks (using its own cached cluster state, not a client-side scan) whether any collection still references the configset, and if so skips deletion and reports which collections are using it, instead of deleting unconditionally. Default behavior (param omitted) is unchanged — fully backward compatible for existing callers.
- New `DeleteConfigSetResponse` (`deleted: boolean`, `collectionsUsingConfigSet: List<String>`) so callers get a structured answer instead of having to infer outcome from an exception.
- `bin/solr delete`'s `deleteCollection`/`deleteCore` now just take a `SolrClient` rather than building their own `CloudSolrClient` from a ZooKeeper connection string — the collection-delete flow no longer needs direct ZK cluster-state access; it now:
  - checks collection existence via `CLIUtils.safeCheckCollectionExists` (V2 `CollectionsApi.ListCollections`)
  - looks up the collection's configName via the V1 `CLUSTERSTATUS` request (see note below)
  - deletes the collection via `CollectionsApi.DeleteCollection` (V2, unchanged)
  - deletes the configset via the new `ifUnused`-aware `ConfigsetsApi.DeleteConfigSet` (V2), letting the server do the "is this still used elsewhere" check with its cached state instead of the CLI doing N sequential HTTP calls (one per collection) to scan for it.

### Note on the configName lookup
While implementing this, `CollectionsApi.GetCollectionStatus` (V2, `GET /api/collections/{name}`) turned out to throw under basic-auth-secured clusters — reproducibly, and independent of this change (confirmed by testing the same call against a non-secured cluster, where it works fine). The failure is a `java.lang.AssertionError` in `RTimer.stop()` surfacing through Jersey's exception-mapping/metrics-filter chain, seemingly unrelated to configset/collection logic. Rather than build on a broken endpoint, `DeleteTool` uses the classic V1 `CollectionAdminRequest.ClusterStatus` request instead — still a plain HTTP admin call (no direct ZK connection), just not the newest V2 endpoint.  This spawned https://github.com/apache/solr/pull/4676
