### PR TITLE
Extract CLIUtils.solrUrlFromConnection() from normalizeSolrUrl(CommandLine)

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/CLIUtils.java
+++ b/solr/core/src/java/org/apache/solr/cli/CLIUtils.java
@@ -233,32 +233,40 @@ public final class CLIUtils {
             "Neither --solr-connection, --zk-host or --solr-url parameters, nor SOLR_CONNECTION, ZK_HOST env var provided, so assuming solr url is "
                 + solrUrl
                 + ".");
-      } else if (!solrConnection.isZookeeper()) {
-        // HTTP form (e.g. `-s http://host:port`): the connection string already names a Solr URL,
-        // so use it directly without spinning up a CloudSolrClient.
-        solrUrl = normalizeSolrUrl(solrConnection.quorumItems().get(0), false);
       } else {
-        var builder =
-            new HttpJettySolrClient.Builder()
-                .withOptionalBasicAuthCredentials(
-                    cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION));
-        try (CloudSolrClient cloudSolrClient = getCloudSolrClient(solrConnection, builder)) {
-          Set<String> liveNodes = cloudSolrClient.getClusterState().getLiveNodes();
-          if (liveNodes.isEmpty())
-            throw new IllegalStateException(
-                "No live nodes found! Cannot determine 'solrUrl' from SolrCloud: "
-                    + solrConnection);
-
-          String firstLiveNode = liveNodes.iterator().next();
-          String urlScheme =
-              cloudSolrClient.getClusterStateProvider().getClusterProperty("urlScheme", "http");
-          solrUrl = URLUtil.getBaseUrlForNodeName(firstLiveNode, urlScheme, false);
-          solrUrl = normalizeSolrUrl(solrUrl, false);
-        }
+        solrUrl =
+            solrUrlFromConnection(
+                solrConnection, cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION));
       }
     }
     solrUrl = normalizeSolrUrl(solrUrl);
     return solrUrl;
+  }
+
+  /**
+   * Resolves a base Solr URL from a parsed connection. The HTTP form (e.g. {@code -s
+   * http://host:port}) already names a Solr URL, so it is used directly without spinning up a
+   * CloudSolrClient; the ZooKeeper form queries the cluster for a live node's base URL.
+   */
+  public static String solrUrlFromConnection(
+      CloudSolrClient.CloudSolrClientConnection solrConnection, String credentials)
+      throws Exception {
+    if (!solrConnection.isZookeeper()) {
+      return normalizeSolrUrl(solrConnection.quorumItems().get(0), false);
+    }
+    var builder = new HttpJettySolrClient.Builder().withOptionalBasicAuthCredentials(credentials);
+    try (CloudSolrClient cloudSolrClient = getCloudSolrClient(solrConnection, builder)) {
+      Set<String> liveNodes = cloudSolrClient.getClusterState().getLiveNodes();
+      if (liveNodes.isEmpty())
+        throw new IllegalStateException(
+            "No live nodes found! Cannot determine 'solrUrl' from SolrCloud: " + solrConnection);
+
+      String firstLiveNode = liveNodes.iterator().next();
+      String urlScheme =
+          cloudSolrClient.getClusterStateProvider().getClusterProperty("urlScheme", "http");
+      return normalizeSolrUrl(
+          URLUtil.getBaseUrlForNodeName(firstLiveNode, urlScheme, false), false);
+    }
   }
 
   /**


### PR DESCRIPTION
Extracts the connection-string-to-Solr-URL resolution logic added in SOLR-18130 (HTTP form used directly; ZooKeeper form queried for a live node's base URL) out of the commons-cli-coupled `normalizeSolrUrl(CommandLine)` into a reusable public helper `solrUrlFromConnection(CloudSolrClientConnection, credentials)`. The commons-cli path delegates to it, so there is no behavior change.

This makes the resolution reusable outside commons-cli contexts — e.g. the picocli migration branch (#3254) needs it — and landing it on main independently keeps non-picocli drift off that long-running branch.