### PR TITLE
SOLR-17697: Implement picocli for auth command / AuthTool

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/AuthTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/AuthTool.java
@@ -32,11 +32,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.lucene.util.Constants;
+import org.apache.solr.client.solrj.impl.SolrZkClientTimeout;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.core.SolrCore;
@@ -103,6 +105,22 @@ public class AuthTool extends ToolBase {
               "This is where any authentication related configuration files, if any, would be placed.  Defaults to $SOLR_HOME.")
           .get();
 
+  /**
+   * Parameters for the auth sub-commands, independent of the command line parser.
+   *
+   * @param zkHost resolved ZooKeeper connection string, or null if {@code updateIncludeFileOnly} is
+   *     set or the connection string could not be resolved
+   */
+  record AuthParams(
+      boolean prompt,
+      String credentials,
+      String blockUnknown,
+      boolean updateIncludeFileOnly,
+      String solrIncludeFile,
+      String authConfDir,
+      boolean zkHostSpecified,
+      String zkHost) {}
+
   public AuthTool(ToolRuntime runtime) {
     super(runtime);
   }
@@ -147,201 +165,178 @@ public class AuthTool extends ToolBase {
         .addOptionGroup(getConnectionOptions());
   }
 
-  private void ensureArgumentIsValidBooleanIfPresent(CommandLine cli, Option option) {
-    if (cli.hasOption(option)) {
-      final String value = cli.getOptionValue(option);
-      if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
-        echo(
-            "Argument ["
-                + option.getLongOpt()
-                + "] must be either true or false, but was ["
-                + value
-                + "]");
+  private void ensureArgumentIsValidBooleanIfPresent(String optionName, String value) {
+    if (value != null && !"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+      echo("Argument [" + optionName + "] must be either true or false, but was [" + value + "]");
+      runtime.exit(1);
+    }
+  }
+
+  private void handleCommand(String cmd, AuthParams params) throws Exception {
+    switch (cmd) {
+      case "enable" -> enableBasicAuth(params);
+      case "disable" -> disableBasicAuth(params);
+      default -> {
+        CLIO.out("Valid auth commands are: enable, disable.");
         runtime.exit(1);
       }
     }
   }
 
-  private void handleBasicAuth(CommandLine cli) throws Exception {
-    String cmd = cli.getArgs()[0];
-    boolean prompt = Boolean.parseBoolean(cli.getOptionValue(PROMPT_OPTION, "false"));
-    boolean updateIncludeFileOnly =
-        Boolean.parseBoolean(cli.getOptionValue(UPDATE_INCLUDE_FILE_OPTION, "false"));
-    switch (cmd) {
-      case "enable":
-        {
-          if (!prompt && !cli.hasOption(CommonCLIOptions.CREDENTIALS_OPTION)) {
-            CLIO.out("Option --credentials or --prompt is required with enable.");
-            runtime.exit(1);
-          } else if (!prompt
-              && (cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION) == null
-                  || !cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION).contains(":"))) {
-            CLIO.out("Option --credentials is not in correct format.");
-            runtime.exit(1);
-          }
-
-          String zkHost = null;
-
-          if (!updateIncludeFileOnly) {
-            try {
-              zkHost = CLIUtils.getZkHost(cli);
-            } catch (Exception ex) {
-              if (cli.hasOption(CommonCLIOptions.ZK_HOST_OPTION)) {
-                CLIO.out(
-                    "Couldn't get ZooKeeper host. Please make sure that ZooKeeper is running and the correct zk-host has been passed in.");
-              } else {
-                CLIO.out(
-                    "Couldn't get ZooKeeper host. Please make sure Solr is running in cloud mode, or a zk-host has been passed in.");
-              }
-              runtime.exit(1);
-            }
-            if (zkHost == null) {
-              if (cli.hasOption(CommonCLIOptions.ZK_HOST_OPTION)) {
-                CLIO.out(
-                    "Couldn't get ZooKeeper host. Please make sure that ZooKeeper is running and the correct zk-host has been passed in.");
-              } else {
-                CLIO.out(
-                    "Couldn't get ZooKeeper host. Please make sure Solr is running in cloud mode, or a zk-host has been passed in.");
-              }
-              runtime.exit(1);
-            }
-
-            // check if security is already enabled or not
-            try (SolrZkClient zkClient = CLIUtils.getSolrZkClient(cli, zkHost)) {
-              checkSecurityJsonExists(zkClient);
-            }
-          }
-
-          String username, password;
-          if (cli.hasOption(CommonCLIOptions.CREDENTIALS_OPTION)) {
-            String credentials = cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION);
-            username = credentials.split(":")[0];
-            password = credentials.split(":")[1];
-          } else {
-            Console console = System.console();
-            // keep prompting until they've entered a non-empty username & password
-            do {
-              username = console.readLine("Enter username: ");
-            } while (username == null || username.trim().isEmpty());
-            username = username.trim();
-
-            do {
-              password = new String(console.readPassword("Enter password: "));
-            } while (password.isEmpty());
-          }
-
-          if (username.equals(password)
-              && !EnvUtils.getPropertyAsBool(
-                  Sha256AuthenticationProvider.ALLOW_USER_AS_PASSWORD_PROP, false)) {
-            CLIO.err(
-                "Error: username and password must not be identical."
-                    + " This credential would never authenticate.");
-            runtime.exit(1);
-          }
-
-          String resourceName = "security.json";
-          final URL resource = SolrCore.class.getClassLoader().getResource(resourceName);
-          if (null == resource) {
-            throw new IllegalArgumentException("invalid resource name: " + resourceName);
-          }
-
-          ObjectMapper mapper = new ObjectMapper();
-          JsonNode securityJson1 = mapper.readTree(resource.openStream());
-          // Only override blockUnknown if explicitly passed; otherwise let the template decide
-          if (cli.hasOption(BLOCK_UNKNOWN_OPTION)) {
-            boolean blockUnknown = Boolean.parseBoolean(cli.getOptionValue(BLOCK_UNKNOWN_OPTION));
-            ((ObjectNode) securityJson1.get("authentication")).put("blockUnknown", blockUnknown);
-          }
-          JsonNode credentialsNode = securityJson1.get("authentication").get("credentials");
-          ((ObjectNode) credentialsNode)
-              .put(username, Sha256AuthenticationProvider.getSaltedHashedValue(password));
-          JsonNode userRoleNode = securityJson1.get("authorization").get("user-role");
-          String[] predefinedRoles = {"superadmin", "admin", "search", "index"};
-          ArrayNode rolesNode = mapper.createArrayNode();
-          for (String role : predefinedRoles) {
-            rolesNode.add(role);
-          }
-          ((ObjectNode) userRoleNode).set(username, rolesNode);
-          String securityJson = securityJson1.toPrettyString();
-
-          if (!updateIncludeFileOnly) {
-            echoIfVerbose("Uploading following security.json: " + securityJson);
-            try (SolrZkClient zkClient = CLIUtils.getSolrZkClient(cli, zkHost)) {
-              zkClient.makePath(
-                  "/security.json", securityJson.getBytes(StandardCharsets.UTF_8), false);
-            }
-          }
-
-          String solrIncludeFilename = cli.getOptionValue(SOLR_INCLUDE_FILE_OPTION);
-          Path includeFile = Path.of(solrIncludeFilename);
-          if (Files.notExists(includeFile) || !Files.isWritable(includeFile)) {
-            CLIO.out(
-                "Solr include file " + solrIncludeFilename + " doesn't exist or is not writeable.");
-            printAuthEnablingInstructions(username, password);
-            runtime.exit(0);
-          }
-          String authConfDir = cli.getOptionValue(AUTH_CONF_DIR_OPTION);
-          Path basicAuthConfFile = Path.of(authConfDir, "basicAuth.conf");
-
-          if (!Files.isWritable(basicAuthConfFile.getParent())) {
-            CLIO.out("Cannot write to file: " + basicAuthConfFile.toAbsolutePath());
-            printAuthEnablingInstructions(username, password);
-            runtime.exit(0);
-          }
-
-          Files.writeString(
-              basicAuthConfFile,
-              "httpBasicAuthUser=" + username + "\nhttpBasicAuthPassword=" + password,
-              StandardCharsets.UTF_8);
-
-          // update the solr.in.sh file to contain the necessary authentication lines
-          updateIncludeFileEnableAuth(includeFile, basicAuthConfFile);
-          final String successMessage =
-              String.format(
-                  Locale.ROOT,
-                  "Successfully enabled basic auth with username [%s] assigned to all roles (superadmin, admin, index, search).",
-                  username);
-          echo(successMessage);
-          if (!updateIncludeFileOnly) {
-            Map<String, String> templateUsers = new LinkedHashMap<>();
-            templateUsers.put("admin", "admin, index, search");
-            templateUsers.put("index", "index, search");
-            templateUsers.put("search", "search");
-            templateUsers.remove(username);
-            CLIO.out(
-                "\nIMPORTANT: The following template users have been created with NO password set"
-                    + " and cannot log in until passwords are assigned:");
-            templateUsers.forEach((u, roles) -> CLIO.out("  - " + u + "  (roles: " + roles + ")"));
-            CLIO.out(
-                "Set their passwords using the Admin UI Security page or the authentication API.");
-          }
-          return;
-        }
-      case "disable":
-        {
-          clearSecurityJson(cli, updateIncludeFileOnly);
-
-          String solrIncludeFilename = cli.getOptionValue(SOLR_INCLUDE_FILE_OPTION);
-          Path includeFile = Path.of(solrIncludeFilename);
-          if (Files.notExists(includeFile) || !Files.isWritable(includeFile)) {
-            CLIO.out(
-                "Solr include file " + solrIncludeFilename + " doesn't exist or is not writeable.");
-            CLIO.out(
-                "Security has been disabled. Please remove any SOLR_AUTH_TYPE or SOLR_AUTHENTICATION_OPTS configuration from solr.in.sh/solr.in.cmd.\n");
-            runtime.exit(0);
-          }
-
-          // update the solr.in.sh file to comment out the necessary authentication lines
-          updateIncludeFileDisableAuth(includeFile);
-          return;
-        }
-      default:
-        CLIO.out("Valid auth commands are: enable, disable.");
-        runtime.exit(1);
+  private void enableBasicAuth(AuthParams params) throws Exception {
+    if (!params.prompt() && params.credentials() == null) {
+      CLIO.out("Option --credentials or --prompt is required with enable.");
+      runtime.exit(1);
+    } else if (!params.prompt() && !params.credentials().contains(":")) {
+      CLIO.out("Option --credentials is not in correct format.");
+      runtime.exit(1);
     }
 
-    CLIO.out("Options not understood.");
-    runtime.exit(1);
+    String zkHost = params.zkHost();
+
+    if (!params.updateIncludeFileOnly()) {
+      if (zkHost == null) {
+        printZkHostError(params.zkHostSpecified());
+        runtime.exit(1);
+      }
+
+      // check if security is already enabled or not
+      try (SolrZkClient zkClient = zkClient(zkHost)) {
+        checkSecurityJsonExists(zkClient);
+      }
+    }
+
+    String username, password;
+    if (params.credentials() != null) {
+      username = params.credentials().split(":")[0];
+      password = params.credentials().split(":")[1];
+    } else {
+      Console console = System.console();
+      // keep prompting until they've entered a non-empty username & password
+      do {
+        username = console.readLine("Enter username: ");
+      } while (username == null || username.trim().isEmpty());
+      username = username.trim();
+
+      do {
+        password = new String(console.readPassword("Enter password: "));
+      } while (password.isEmpty());
+    }
+
+    if (username.equals(password)
+        && !EnvUtils.getPropertyAsBool(
+            Sha256AuthenticationProvider.ALLOW_USER_AS_PASSWORD_PROP, false)) {
+      CLIO.err(
+          "Error: username and password must not be identical."
+              + " This credential would never authenticate.");
+      runtime.exit(1);
+    }
+
+    String resourceName = "security.json";
+    final URL resource = SolrCore.class.getClassLoader().getResource(resourceName);
+    if (null == resource) {
+      throw new IllegalArgumentException("invalid resource name: " + resourceName);
+    }
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode securityJson1 = mapper.readTree(resource.openStream());
+    // Only override blockUnknown if explicitly passed; otherwise let the template decide
+    if (params.blockUnknown() != null) {
+      boolean blockUnknown = Boolean.parseBoolean(params.blockUnknown());
+      ((ObjectNode) securityJson1.get("authentication")).put("blockUnknown", blockUnknown);
+    }
+    JsonNode credentialsNode = securityJson1.get("authentication").get("credentials");
+    ((ObjectNode) credentialsNode)
+        .put(username, Sha256AuthenticationProvider.getSaltedHashedValue(password));
+    JsonNode userRoleNode = securityJson1.get("authorization").get("user-role");
+    String[] predefinedRoles = {"superadmin", "admin", "search", "index"};
+    ArrayNode rolesNode = mapper.createArrayNode();
+    for (String role : predefinedRoles) {
+      rolesNode.add(role);
+    }
+    ((ObjectNode) userRoleNode).set(username, rolesNode);
+    String securityJson = securityJson1.toPrettyString();
+
+    if (!params.updateIncludeFileOnly()) {
+      echoIfVerbose("Uploading following security.json: " + securityJson);
+      try (SolrZkClient zkClient = zkClient(zkHost)) {
+        zkClient.makePath("/security.json", securityJson.getBytes(StandardCharsets.UTF_8), false);
+      }
+    }
+
+    Path includeFile = Path.of(params.solrIncludeFile());
+    if (Files.notExists(includeFile) || !Files.isWritable(includeFile)) {
+      CLIO.out(
+          "Solr include file " + params.solrIncludeFile() + " doesn't exist or is not writeable.");
+      printAuthEnablingInstructions(username, password);
+      runtime.exit(0);
+    }
+    Path basicAuthConfFile = Path.of(params.authConfDir(), "basicAuth.conf");
+
+    if (!Files.isWritable(basicAuthConfFile.getParent())) {
+      CLIO.out("Cannot write to file: " + basicAuthConfFile.toAbsolutePath());
+      printAuthEnablingInstructions(username, password);
+      runtime.exit(0);
+    }
+
+    Files.writeString(
+        basicAuthConfFile,
+        "httpBasicAuthUser=" + username + "\nhttpBasicAuthPassword=" + password,
+        StandardCharsets.UTF_8);
+
+    // update the solr.in.sh file to contain the necessary authentication lines
+    updateIncludeFileEnableAuth(includeFile, basicAuthConfFile);
+    final String successMessage =
+        String.format(
+            Locale.ROOT,
+            "Successfully enabled basic auth with username [%s] assigned to all roles (superadmin, admin, index, search).",
+            username);
+    echo(successMessage);
+    if (!params.updateIncludeFileOnly()) {
+      Map<String, String> templateUsers = new LinkedHashMap<>();
+      templateUsers.put("admin", "admin, index, search");
+      templateUsers.put("index", "index, search");
+      templateUsers.put("search", "search");
+      templateUsers.remove(username);
+      CLIO.out(
+          "\nIMPORTANT: The following template users have been created with NO password set"
+              + " and cannot log in until passwords are assigned:");
+      templateUsers.forEach((u, roles) -> CLIO.out("  - " + u + "  (roles: " + roles + ")"));
+      CLIO.out("Set their passwords using the Admin UI Security page or the authentication API.");
+    }
+  }
+
+  private void disableBasicAuth(AuthParams params) throws Exception {
+    clearSecurityJson(params);
+
+    Path includeFile = Path.of(params.solrIncludeFile());
+    if (Files.notExists(includeFile) || !Files.isWritable(includeFile)) {
+      CLIO.out(
+          "Solr include file " + params.solrIncludeFile() + " doesn't exist or is not writeable.");
+      CLIO.out(
+          "Security has been disabled. Please remove any SOLR_AUTH_TYPE or SOLR_AUTHENTICATION_OPTS configuration from solr.in.sh/solr.in.cmd.\n");
+      runtime.exit(0);
+    }
+
+    // update the solr.in.sh file to comment out the necessary authentication lines
+    updateIncludeFileDisableAuth(includeFile);
+  }
+
+  private void printZkHostError(boolean zkHostSpecified) {
+    if (zkHostSpecified) {
+      CLIO.out(
+          "Couldn't get ZooKeeper host. Please make sure that ZooKeeper is running and the correct zk-host has been passed in.");
+    } else {
+      CLIO.out(
+          "Couldn't get ZooKeeper host. Please make sure Solr is running in cloud mode, or a zk-host has been passed in.");
+    }
+  }
+
+  private static SolrZkClient zkClient(String zkHost) {
+    return new SolrZkClient.Builder()
+        .withUrl(zkHost)
+        .withTimeout(SolrZkClientTimeout.DEFAULT_ZK_CLIENT_TIMEOUT, TimeUnit.MILLISECONDS)
+        .build();
   }
 
   private void checkSecurityJsonExists(SolrZkClient zkClient)
@@ -357,10 +352,9 @@ public class AuthTool extends ToolBase {
     }
   }
 
-  private void clearSecurityJson(CommandLine cli, boolean updateIncludeFileOnly) throws Exception {
-    String zkHost;
-    if (!updateIncludeFileOnly) {
-      zkHost = CLIUtils.getZkHost(cli);
+  private void clearSecurityJson(AuthParams params) throws Exception {
+    if (!params.updateIncludeFileOnly()) {
+      String zkHost = params.zkHost();
       if (zkHost == null) {
         runtime.print("ZK Host not found. Solr should be running in cloud mode.");
         runtime.exit(1);
@@ -368,7 +362,7 @@ public class AuthTool extends ToolBase {
 
       echoIfVerbose("Uploading following security.json: {}");
 
-      try (SolrZkClient zkClient = CLIUtils.getSolrZkClient(cli, zkHost)) {
+      try (SolrZkClient zkClient = zkClient(zkHost)) {
         zkClient.makePath("/security.json", "{}".getBytes(StandardCharsets.UTF_8), false);
       }
     }
@@ -470,13 +464,35 @@ public class AuthTool extends ToolBase {
 
   @Override
   public void runImpl(CommandLine cli) throws Exception {
-    ensureArgumentIsValidBooleanIfPresent(cli, BLOCK_UNKNOWN_OPTION);
-    ensureArgumentIsValidBooleanIfPresent(cli, UPDATE_INCLUDE_FILE_OPTION);
+    ensureArgumentIsValidBooleanIfPresent(
+        BLOCK_UNKNOWN_OPTION.getLongOpt(), cli.getOptionValue(BLOCK_UNKNOWN_OPTION));
+    ensureArgumentIsValidBooleanIfPresent(
+        UPDATE_INCLUDE_FILE_OPTION.getLongOpt(), cli.getOptionValue(UPDATE_INCLUDE_FILE_OPTION));
 
     String type = cli.getOptionValue(TYPE_OPTION, "basicAuth");
     // switch structure is here to support future auth options like oAuth
     if (type.equals("basicAuth")) {
-      handleBasicAuth(cli);
+      boolean updateIncludeFileOnly =
+          Boolean.parseBoolean(cli.getOptionValue(UPDATE_INCLUDE_FILE_OPTION, "false"));
+      String zkHost = null;
+      if (!updateIncludeFileOnly) {
+        try {
+          zkHost = CLIUtils.getZkHost(cli);
+        } catch (Exception e) {
+          echoIfVerbose("Could not resolve ZooKeeper host: " + e.getMessage());
+        }
+      }
+      AuthParams params =
+          new AuthParams(
+              Boolean.parseBoolean(cli.getOptionValue(PROMPT_OPTION, "false")),
+              cli.getOptionValue(CommonCLIOptions.CREDENTIALS_OPTION),
+              cli.getOptionValue(BLOCK_UNKNOWN_OPTION),
+              updateIncludeFileOnly,
+              cli.getOptionValue(SOLR_INCLUDE_FILE_OPTION),
+              cli.getOptionValue(AUTH_CONF_DIR_OPTION),
+              cli.hasOption(CommonCLIOptions.ZK_HOST_OPTION),
+              zkHost);
+      handleCommand(cli.getArgs()[0], params);
     } else {
       throw new IllegalStateException("Only type=basicAuth supported at the moment.");
     }

--- a/solr/core/src/java/org/apache/solr/cli/AuthTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/AuthTool.java
@@ -46,6 +46,27 @@ import org.apache.solr.security.Sha256AuthenticationProvider;
 import org.apache.zookeeper.KeeperException;
 
 /** Supports auth command in the bin/solr script. */
+@SuppressWarnings("UnnecessarilyFullyQualified")
+@picocli.CommandLine.Command(
+    name = "auth",
+    description =
+        "Updates or enables/disables authentication. Must be run on the Solr server itself.",
+    exitCodeListHeading = "%nExit Codes:%n",
+    exitCodeList = {
+      "0:Authentication was enabled or disabled successfully.",
+      "1:Failed to enable or disable authentication; check output for details."
+    },
+    footerHeading = "%nExamples:%n",
+    footer = {
+      "  # Enable basic authentication with the given credentials",
+      "  bin/solr auth enable --type basicAuth --credentials solr:SolrRocks",
+      "",
+      "  # Enable basic authentication, prompting for credentials",
+      "  bin/solr auth enable --type basicAuth --prompt true",
+      "",
+      "  # Disable authentication",
+      "  bin/solr auth disable"
+    })
 public class AuthTool extends ToolBase {
 
   private static final Option TYPE_OPTION =
@@ -120,6 +141,67 @@ public class AuthTool extends ToolBase {
       String authConfDir,
       boolean zkHostSpecified,
       String zkHost) {}
+
+  // --- picocli fields ---
+
+  @picocli.CommandLine.Parameters(
+      index = "0",
+      arity = "1",
+      paramLabel = "enable|disable",
+      description = "Whether to enable or disable authentication.")
+  private String authCommand;
+
+  @picocli.CommandLine.Option(
+      names = {"--type"},
+      paramLabel = "TYPE",
+      defaultValue = "basicAuth",
+      description =
+          "The authentication mechanism to enable (currently only basicAuth). Defaults to 'basicAuth'.")
+  private String type;
+
+  @picocli.CommandLine.Option(
+      names = {"--prompt"},
+      paramLabel = "true|false",
+      description =
+          "Prompts the user to provide the credentials. Use either --credentials or --prompt, not both.")
+  private String promptOption;
+
+  @picocli.CommandLine.Option(
+      names = {"--block-unknown"},
+      paramLabel = "true|false",
+      description =
+          "Blocks all access for unknown users (requires authentication for all endpoints).")
+  private String blockUnknown;
+
+  @picocli.CommandLine.Option(
+      names = {"--solr-include-file"},
+      paramLabel = "FILE",
+      required = true,
+      description =
+          "The Solr include file which contains overridable environment variables for configuring Solr configurations. Defaults to solr.in.sh or solr.in.cmd.")
+  private String solrIncludeFile;
+
+  @picocli.CommandLine.Option(
+      names = {"--update-include-file-only"},
+      paramLabel = "true|false",
+      description =
+          "Only update the solr.in.sh or solr.in.cmd file, and skip actual enabling/disabling"
+              + " authentication (i.e. don't update security.json).")
+  private String updateIncludeFileOnly;
+
+  @picocli.CommandLine.Option(
+      names = {"--auth-conf-dir"},
+      paramLabel = "DIR",
+      required = true,
+      description =
+          "This is where any authentication related configuration files, if any, would be placed. Defaults to $SOLR_HOME.")
+  private String authConfDir;
+
+  @picocli.CommandLine.Mixin ZkConnectionOptions zkOpts;
+
+  public AuthTool() {
+    this(new DefaultToolRuntime());
+  }
 
   public AuthTool(ToolRuntime runtime) {
     super(runtime);
@@ -500,6 +582,35 @@ public class AuthTool extends ToolBase {
 
   @Override
   public int callTool() throws Exception {
-    throw new UnsupportedOperationException("This tool does not yet support PicoCli");
+    ensureArgumentIsValidBooleanIfPresent(BLOCK_UNKNOWN_OPTION.getLongOpt(), blockUnknown);
+    ensureArgumentIsValidBooleanIfPresent(
+        UPDATE_INCLUDE_FILE_OPTION.getLongOpt(), updateIncludeFileOnly);
+
+    // switch structure is here to support future auth options like oAuth
+    if (!"basicAuth".equals(type)) {
+      throw new IllegalStateException("Only type=basicAuth supported at the moment.");
+    }
+
+    boolean updateIncludeFileOnlyBool = Boolean.parseBoolean(updateIncludeFileOnly);
+    String zkHost = null;
+    if (!updateIncludeFileOnlyBool) {
+      try {
+        zkHost = zkOpts.resolveZkHost();
+      } catch (Exception e) {
+        echoIfVerbose("Could not resolve ZooKeeper host: " + e.getMessage());
+      }
+    }
+    AuthParams params =
+        new AuthParams(
+            Boolean.parseBoolean(promptOption),
+            zkOpts.credentials,
+            blockUnknown,
+            updateIncludeFileOnlyBool,
+            solrIncludeFile,
+            authConfDir,
+            zkOpts.zkHost != null || zkOpts.solrConnection != null,
+            zkHost);
+    handleCommand(authCommand, params);
+    return 0;
   }
 }

--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
       StatusTool.class,
       VersionTool.class,
       ZkTool.class,
+      AuthTool.class,
       CreateTool.class,
       DeleteTool.class
     })

--- a/solr/core/src/test/org/apache/solr/cli/AuthToolPicocliTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/AuthToolPicocliTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.cli;
+
+import java.util.Arrays;
+import picocli.CommandLine;
+
+/**
+ * Runs all {@link AuthToolTest} tests through the picocli invocation path.
+ *
+ * <p>All {@code @Test} methods are inherited from {@link AuthToolTest}. Only the tool invocation
+ * strategy is overridden here to use {@code picocli.CommandLine.execute()} instead of the
+ * commons-cli path.
+ */
+public class AuthToolPicocliTest extends AuthToolTest {
+
+  @Override
+  protected int runTool(String[] args, Class<? extends ToolBase> clazz) throws Exception {
+    // args[0] is the tool name used by commons-cli dispatch; strip it for picocli.
+    String[] toolArgs = Arrays.copyOfRange(args, 1, args.length);
+    // Use a TestingRuntime so runtime.exit() cannot terminate the test JVM
+    ToolRuntime runtime = new CLITestHelper.TestingRuntime(false);
+    ToolBase tool = clazz.getDeclaredConstructor(ToolRuntime.class).newInstance(runtime);
+    return new CommandLine(tool)
+        .setDefaultValueProvider(new CliDefaultValueProvider())
+        .execute(toolArgs);
+  }
+}

--- a/solr/core/src/test/org/apache/solr/cli/AuthToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/AuthToolTest.java
@@ -60,6 +60,10 @@ public class AuthToolTest extends SolrCloudTestCase {
     }
   }
 
+  protected int runTool(String[] args, Class<? extends ToolBase> clazz) throws Exception {
+    return CLITestHelper.runTool(args, clazz);
+  }
+
   @Test
   public void testEnableAuth() throws Exception {
     Path solrIncludeFile = Files.createFile(dir.resolve("solrIncludeFile.txt"));
@@ -77,7 +81,7 @@ public class AuthToolTest extends SolrCloudTestCase {
       "--block-unknown",
       "true"
     };
-    assertEquals(0, CLITestHelper.runTool(args, AuthTool.class));
+    assertEquals(0, runTool(args, AuthTool.class));
   }
 
   @Test
@@ -95,7 +99,7 @@ public class AuthToolTest extends SolrCloudTestCase {
       "--credentials",
       "solr:solr"
     };
-    assertNotEquals(0, CLITestHelper.runTool(args, AuthTool.class));
+    assertNotEquals(0, runTool(args, AuthTool.class));
   }
 
   @Test
@@ -115,7 +119,7 @@ public class AuthToolTest extends SolrCloudTestCase {
         "--credentials",
         "solr:solr"
       };
-      assertEquals(0, CLITestHelper.runTool(args, AuthTool.class));
+      assertEquals(0, runTool(args, AuthTool.class));
     } finally {
       System.clearProperty(Sha256AuthenticationProvider.ALLOW_USER_AS_PASSWORD_PROP);
     }

--- a/solr/solr-ref-guide/modules/deployment-guide/deployment-nav.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/deployment-nav.adoc
@@ -19,6 +19,7 @@
 
 // CLI-DOCS-START
 * xref:solr-control-script-reference.adoc[]
+** xref:cli/solr-auth.adoc[auth]
 ** xref:cli/solr-create.adoc[create]
 ** xref:cli/solr-delete.adoc[delete]
 ** xref:cli/solr-start.adoc[start]

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-auth.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/cli/solr-auth.adoc
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// DO NOT EDIT -- this page is auto-generated from picocli annotations.
+// To update: modify the @Command/@Option annotations in the Java source, then run:
+//   ./gradlew :solr:solr-ref-guide:generateCliDocs
+
+= bin/solr auth
+:page-toclevels: 2
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+bin/solr auth - Updates or enables/disables authentication. Must be run on the Solr server itself.
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+....
+bin/solr auth [-v] --auth-conf-dir=DIR [--block-unknown=true|false]
+              [--prompt=true|false] [-s=<solrConnection>] --solr-include-file=FILE
+              [--solr-url=<solrUrl>] [--type=TYPE] [-u=<credentials>]
+              [--update-include-file-only=true|false] [-z=<zkHost>] enable|disable
+....
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Updates or enables/disables authentication. Must be run on the Solr server itself.
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*--auth-conf-dir*=_DIR_::
+  *(required)* This is where any authentication related configuration files, if any, would be placed. Defaults to $SOLR_HOME.
+
+*--block-unknown*=_true|false_::
+  Blocks all access for unknown users (requires authentication for all endpoints).
+
+*--prompt*=_true|false_::
+  Prompts the user to provide the credentials. Use either --credentials or --prompt, not both.
+
+*-s*, *--solr-connection*=_<solrConnection>_::
+  Zookeeper or HTTP(s) connection string; unnecessary if SOLR_CONNECTION is defined in solr.in.sh; otherwise, defaults to localhost:9983.
+
+*--solr-include-file*=_FILE_::
+  *(required)* The Solr include file which contains overridable environment variables for configuring Solr configurations. Defaults to solr.in.sh or solr.in.cmd.
+
+*--solr-url*=_<solrUrl>_::
+  Base Solr URL, which can be used to determine the zk-host if --zk-host is not known
+
+*--type*=_TYPE_::
+  The authentication mechanism to enable (currently only basicAuth). Defaults to 'basicAuth'.
+
+*-u*, *--credentials*=_<credentials>_::
+  Credentials in the format username:password. Example: --credentials solr:SolrRocks
+
+*--update-include-file-only*=_true|false_::
+  Only update the solr.in.sh or solr.in.cmd file, and skip actual enabling/disabling authentication (i.e. don't update security.json).
+
+*-v*, *--verbose*::
+  Enable verbose mode.
+
+*-z*, *--zk-host*=_<zkHost>_::
+  Zookeeper connection string; unnecessary if ZK_HOST is defined in solr.in.sh; otherwise, defaults to localhost:9983.
+
+// end::picocli-generated-man-section-options[]
+
+// tag::picocli-generated-man-section-arguments[]
+== Arguments
+
+_enable|disable_::
+  Whether to enable or disable authentication.
+
+// end::picocli-generated-man-section-arguments[]
+
+// tag::picocli-generated-man-section-commands[]
+// end::picocli-generated-man-section-commands[]
+
+// tag::picocli-generated-man-section-exit-status[]
+==  Exit Codes:
+
+*0*::
+  Authentication was enabled or disabled successfully.
+
+*1*::
+  Failed to enable or disable authentication; check output for details.
+
+// end::picocli-generated-man-section-exit-status[]
+
+// tag::picocli-generated-man-section-footer[]
+==  Examples:
+
+[%hardbreaks]
+  # Enable basic authentication with the given credentials
+  bin/solr auth enable --type basicAuth --credentials solr:SolrRocks
+
+[%hardbreaks]
+  # Enable basic authentication, prompting for credentials
+  bin/solr auth enable --type basicAuth --prompt true
+
+[%hardbreaks]
+  # Disable authentication
+  bin/solr auth disable
+
+// end::picocli-generated-man-section-footer[]


### PR DESCRIPTION
Adds picocli support to `AuthTool` following the established dual-path pattern:

- Business logic extracted from the commons-cli-coupled `handleBasicAuth(CommandLine)` into `enableBasicAuth`/`disableBasicAuth` operating on a shared `AuthParams` record plus a pluggable zk-host resolver, so both parsing paths run identical code.
- `@Command` annotation with examples and exit codes; `enable|disable` as a positional parameter; options mirror the commons-cli definitions, with connection/credentials options provided by the `ZkConnectionOptions` mixin (includes the new `-s/--solr-connection`).
- `AuthTool` registered as a `SolrCLI` subcommand; generated `solr-auth.adoc` ref-guide page included.
- `AuthToolPicocliTest` runs the whole existing `AuthToolTest` suite through `picocli.CommandLine.execute()`.

Boolean-ish options (`--block-unknown` etc.) stay string-typed so both paths emit the same validation message asserted by `test_auth.bats`. Connection parsing remains string-only; no I/O happens during argument parsing.

Verified: `AuthToolTest` + `AuthToolPicocliTest` green, `test_auth.bats` green on the commons-cli path and the picocli path (`SOLR_PICOCLI=true`), `check -x test` with Error Prone.