### PR TITLE
SolrRequest.setPath fix; allow null

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -157,7 +157,7 @@ public abstract class SolrRequest<T> implements Serializable {
 
   public SolrRequest(METHOD m, String path, SolrRequestType requestType) {
     this.method = m;
-    this.path = path;
+    setPath(path);
     this.requestType = requestType;
   }
 
@@ -182,7 +182,7 @@ public abstract class SolrRequest<T> implements Serializable {
   }
 
   public void setPath(String path) {
-    if (path == null || !path.startsWith("/")) {
+    if (path != null && !path.startsWith("/")) {
       throw new IllegalArgumentException("Must start with a '/': " + path);
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -157,7 +157,7 @@ public abstract class SolrRequest<T> implements Serializable {
 
   public SolrRequest(METHOD m, String path, SolrRequestType requestType) {
     this.method = m;
-    setPath(path);
+    this.path = validatePath(path);
     this.requestType = requestType;
   }
 
@@ -182,11 +182,14 @@ public abstract class SolrRequest<T> implements Serializable {
   }
 
   public void setPath(String path) {
+    this.path = validatePath(path);
+  }
+
+  private static String validatePath(String path) {
     if (path != null && !path.startsWith("/")) {
       throw new IllegalArgumentException("Must start with a '/': " + path);
     }
-
-    this.path = path;
+    return path;
   }
 
   /**


### PR DESCRIPTION
and the constructor should use the same validation.
Fixes a regression in #4665 

Updated some callers of setPath that consulted "qt" to no longer do so because it is no longer necessary.  I can separate this to another PR if asked.

I held back from updating many callers of setPath to use the QueryRequest constructor, which is nicer IMO.

