### PR TITLE
build: rat -- suppress noise

### DIFF
--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -248,6 +248,9 @@ allprojects {
       }
     })
     inputFileTrees.add(defaultScanFileTree)
+
+    // RAT is noisy, even when there's no problem.  So log at DEBUG
+    logging.captureStandardOutput(LogLevel.DEBUG)
   }
 }
 


### PR DESCRIPTION
Since the RAT upgrade, I saw way too much output.  This suppresses it.  We'll still see details if there's a problem.