### PR TITLE
Simplify SolrRequest path usage: prefer ctor not setPath

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
@@ -43,12 +43,15 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.AbstractUpdateRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest.Create;
 import org.apache.solr.client.solrj.request.CoreAdminRequest.Unload;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.MetricsRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
@@ -1143,8 +1146,8 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
     }
     params.set("name", collectionName);
     params.set("collection.configName", configSetName);
-    QueryRequest request = new QueryRequest(params);
-    request.setPath("/admin/collections");
+    var request =
+        new GenericSolrRequest(METHOD.POST, "/admin/collections", SolrRequestType.ADMIN, params);
 
     CollectionAdminResponse res = new CollectionAdminResponse();
     if (client == null) {

--- a/solr/core/src/test/org/apache/solr/cloud/MultiThreadedOCPTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MultiThreadedOCPTest.java
@@ -23,11 +23,13 @@ import java.lang.invoke.MethodHandles;
 import java.util.Random;
 import org.apache.solr.client.solrj.RemoteSolrException;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.Create;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.SplitShard;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -322,8 +324,8 @@ public class MultiThreadedOCPTest extends AbstractFullDistribZkTestBase {
       ModifiableSolrParams params = new ModifiableSolrParams();
       params.set("action", CollectionParams.CollectionAction.CLUSTERSTATUS.toString());
       params.set("collection", "collection1");
-      QueryRequest request = new QueryRequest(params);
-      request.setPath("/admin/collections");
+      var request =
+          new GenericSolrRequest(METHOD.GET, "/admin/collections", SolrRequestType.ADMIN, params);
 
       client.request(request);
 

--- a/solr/core/src/test/org/apache/solr/cloud/SSLMigrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SSLMigrationTest.java
@@ -23,9 +23,11 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.impl.LBSolrClient;
 import org.apache.solr.client.solrj.jetty.LBJettySolrClient;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
@@ -116,8 +118,8 @@ public class SSLMigrationTest extends AbstractFullDistribZkTestBase {
             "val",
             value);
     SolrParams params = new MapSolrParams(m);
-    QueryRequest request = new QueryRequest(params);
-    request.setPath("/admin/collections");
+    var request =
+        new GenericSolrRequest(METHOD.POST, "/admin/collections", SolrRequestType.ADMIN, params);
 
     LBSolrClient.Endpoint[] urls =
         getReplicas().stream()

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPhrasesIdentificationComponent.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPhrasesIdentificationComponent.java
@@ -133,8 +133,7 @@ public class TestCloudPhrasesIdentificationComponent extends SolrCloudTestCase {
               params("q", input, "phrases", "true"),
               params("q", "*:*", "phrases.q", input, "phrases", "true"),
               params("q", "-*:*", "phrases.q", input, "phrases", "true"))) {
-        final QueryRequest req = new QueryRequest(p);
-        req.setPath(path);
+        final QueryRequest req = new QueryRequest(path, p);
         final QueryResponse rsp = req.process(getRandClient(random()));
         try {
           @SuppressWarnings({"unchecked"})
@@ -169,8 +168,7 @@ public class TestCloudPhrasesIdentificationComponent extends SolrCloudTestCase {
           Arrays.asList(
               params("q", "*:*", "phrases.q", input, "phrases", "true"),
               params("q", "-*:*", "phrases.q", input, "phrases", "true"))) {
-        final QueryRequest req = new QueryRequest(p);
-        req.setPath("/phrases");
+        final QueryRequest req = new QueryRequest("/phrases", p);
         final QueryResponse rsp = req.process(getRandClient(random()));
         try {
           @SuppressWarnings({"unchecked"})

--- a/solr/core/src/test/org/apache/solr/cloud/TestGracefulJettyShutdown.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestGracefulJettyShutdown.java
@@ -85,8 +85,7 @@ public class TestGracefulJettyShutdown extends SolrTestCaseJ4 {
       final List<Future<QueryResponse>> results = new ArrayList<>(13);
 
       try (SolrClient jettyClient = nodeToStop.newClient()) {
-        final QueryRequest req = new QueryRequest(params("q", "foo_s:aaa"));
-        req.setPath(handler);
+        final QueryRequest req = new QueryRequest(handler, params("q", "foo_s:aaa"));
 
         // check inflight requests using both clients...
         for (SolrClient client : Arrays.asList(cloudClient, jettyClient)) {

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -39,10 +39,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.solr.client.solrj.RemoteSolrException;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -1269,8 +1271,8 @@ public class ShardSplitTest extends BasicDistributedZkTest {
     if (splitKey != null) {
       params.set("split.key", splitKey);
     }
-    QueryRequest request = new QueryRequest(params);
-    request.setPath("/admin/collections");
+    var request =
+        new GenericSolrRequest(METHOD.POST, "/admin/collections", SolrRequestType.ADMIN, params);
 
     JettySolrRunner jetty = shardToJetty.get(SHARD1).getFirst().jetty;
     try (SolrClient baseServer = jetty.newClient(30_000, 300_000)) {

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestRequestStatusCollectionAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestRequestStatusCollectionAPI.java
@@ -24,8 +24,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.solr.client.solrj.RemoteSolrException;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.cloud.BasicDistributedZkTest;
 import org.apache.solr.common.params.CollectionParams;
@@ -225,8 +227,8 @@ public class TestRequestStatusCollectionAPI extends BasicDistributedZkTest {
 
   protected NamedList<Object> sendRequest(ModifiableSolrParams params)
       throws SolrServerException, IOException {
-    QueryRequest request = new QueryRequest(params);
-    request.setPath("/admin/collections");
+    var request =
+        new GenericSolrRequest(METHOD.GET, "/admin/collections", SolrRequestType.ADMIN, params);
 
     return shardToJetty.get(SHARD1).getFirst().jetty.getSolrClient().request(request);
   }

--- a/solr/core/src/test/org/apache/solr/response/TestErrorResponseStackTrace.java
+++ b/solr/core/src/test/org/apache/solr/response/TestErrorResponseStackTrace.java
@@ -99,8 +99,8 @@ public class TestErrorResponseStackTrace extends SolrTestCaseJ4 {
   public void testRemoteSolrException() {
     var client = solrTestRule.getSolrClient("collection1");
     QueryRequest queryRequest =
-        new QueryRequest(new ModifiableSolrParams().set("q", "*:*").set("wt", "json"));
-    queryRequest.setPath("/withError");
+        new QueryRequest(
+            "/withError", new ModifiableSolrParams().set("q", "*:*").set("wt", "json"));
     RemoteSolrException exception =
         expectThrows(RemoteSolrException.class, () -> queryRequest.process(client, "collection1"));
     assertTrue(exception.getRemoteErrorObject() instanceof NamedList);

--- a/solr/core/src/test/org/apache/solr/schema/TestCloudManagedSchema.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestCloudManagedSchema.java
@@ -22,7 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.api.model.CoreStatusResponse;
-import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.json.JacksonContentWriter;
 import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -54,8 +56,7 @@ public class TestCloudManagedSchema extends AbstractFullDistribZkTestBase {
   public void test() throws Exception {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set(CoreAdminParams.ACTION, CoreAdminParams.CoreAdminAction.STATUS.toString());
-    QueryRequest request = new QueryRequest(params);
-    request.setPath("/admin/cores");
+    var request = new GenericSolrRequest(METHOD.GET, "/admin/cores", SolrRequestType.ADMIN, params);
     int which = r.nextInt(clients.size());
 
     // use a client that does not have the /collection1 as part of the URL.

--- a/solr/core/src/test/org/apache/solr/search/TestSmileRequest.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSmileRequest.java
@@ -74,10 +74,6 @@ public class TestSmileRequest extends SolrTestCaseJ4 {
               throws Exception {
             QueryRequest query = new QueryRequest(args);
             query.setResponseParser(new SmileResponseParser());
-            String path = args.get("qt");
-            if (path != null) {
-              query.setPath(path);
-            }
             NamedList<Object> rsp = client.request(query);
             @SuppressWarnings({"rawtypes"})
             Map m = rsp.asMap(5);

--- a/solr/core/src/test/org/apache/solr/update/UuidAtomicUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/UuidAtomicUpdateTest.java
@@ -126,8 +126,7 @@ public class UuidAtomicUpdateTest extends SolrCloudTestCase {
       final ModifiableSolrParams solrParams = new ModifiableSolrParams();
       solrParams.set("id", identifyingDocId);
       solrParams.set("shards.preference", "replica.leader:" + tf);
-      QueryRequest request = new QueryRequest(solrParams);
-      request.setPath("/get");
+      QueryRequest request = new QueryRequest("/get", solrParams);
       final QueryResponse response = request.process(cluster.getSolrClient(), COLLECTION);
 
       final NamedList<Object> rawResponse = response.getResponse();

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJavabinTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdateJavabinTest.java
@@ -419,8 +419,7 @@ public class AtomicUpdateJavabinTest extends SolrCloudTestCase {
       String identifyingDocId, String fieldName, Object... expectedValues) throws Exception {
     final ModifiableSolrParams solrParams = new ModifiableSolrParams();
     solrParams.set("id", identifyingDocId);
-    QueryRequest request = new QueryRequest(solrParams);
-    request.setPath("/get");
+    QueryRequest request = new QueryRequest("/get", solrParams);
     final QueryResponse response = request.process(cluster.getSolrClient(), COLLECTION);
 
     final NamedList<Object> rawResponse = response.getResponse();

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankCutoffOnSolrCloud.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankCutoffOnSolrCloud.java
@@ -46,8 +46,7 @@ public class TestLTRReRankCutoffOnSolrCloud extends AbstractLTRSolrCloudTestBase
     final SolrQuery query = newBaseRerankQuery();
     query.add("rq", "{!ltr model=powpularityS-model reRankDocs=3 echoReRankCutoff=true}");
 
-    final QueryRequest queryRequest = new QueryRequest(query);
-    queryRequest.setPath("/query");
+    final QueryRequest queryRequest = new QueryRequest("/query", query);
     final QueryResponse queryResponse =
         queryRequest.process(solrCluster.getSolrClient(), COLLECTION);
 
@@ -72,8 +71,7 @@ public class TestLTRReRankCutoffOnSolrCloud extends AbstractLTRSolrCloudTestBase
     final SolrQuery query = newBaseRerankQuery();
     query.add("rq", "{!ltr model=powpularityS-model reRankDocs=3}");
 
-    final QueryRequest queryRequest = new QueryRequest(query);
-    queryRequest.setPath("/query");
+    final QueryRequest queryRequest = new QueryRequest("/query", query);
     final QueryResponse queryResponse =
         queryRequest.process(solrCluster.getSolrClient(), COLLECTION);
     assertNull(
@@ -87,8 +85,7 @@ public class TestLTRReRankCutoffOnSolrCloud extends AbstractLTRSolrCloudTestBase
     final SolrQuery query = newBaseRerankQuery();
     query.add("rq", "{!ltr model=powpularityS-model reRankDocs=3 echoReRankCutoff=false}");
 
-    final QueryRequest queryRequest = new QueryRequest(query);
-    queryRequest.setPath("/query");
+    final QueryRequest queryRequest = new QueryRequest("/query", query);
     final QueryResponse queryResponse =
         queryRequest.process(solrCluster.getSolrClient(), COLLECTION);
     assertNull(

--- a/solr/solr-ref-guide/modules/query-guide/examples/TermComponentRefGuideExamplesTest.java
+++ b/solr/solr-ref-guide/modules/query-guide/examples/TermComponentRefGuideExamplesTest.java
@@ -87,8 +87,7 @@ public class TermComponentRefGuideExamplesTest extends SolrCloudTestCase {
     termsQuery.addTermsField("name");
     termsQuery.setTermsMinCount(1);
 
-    final QueryRequest request = new QueryRequest(termsQuery);
-    request.setPath("/terms");
+    final QueryRequest request = new QueryRequest("/terms", termsQuery);
     final List<Term> terms =
         request
             .process(cluster.getSolrClient(), COLLECTION_NAME)

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/JSONTupleStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/JSONTupleStream.java
@@ -28,7 +28,6 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.InputStreamResponseParser;
-import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.noggit.JSONParser;
@@ -53,16 +52,8 @@ public class JSONTupleStream implements TupleStreamParser {
   // temporary...
   public static JSONTupleStream create(SolrClient server, SolrParams requestParams)
       throws IOException, SolrServerException {
-    String p = requestParams.get("qt");
-    if (p != null) {
-      ModifiableSolrParams modifiableSolrParams = (ModifiableSolrParams) requestParams;
-      modifiableSolrParams.remove("qt");
-    }
-
-    QueryRequest query = new QueryRequest(requestParams);
-    query.setPath(p);
+    QueryRequest query = new QueryRequest(requestParams, SolrRequest.METHOD.POST);
     query.setResponseParser(new InputStreamResponseParser("json"));
-    query.setMethod(SolrRequest.METHOD.POST);
     NamedList<Object> genericResponse = server.request(query);
     InputStream stream = (InputStream) genericResponse.get(InputStreamResponseParser.STREAM_KEY);
     InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -270,34 +270,19 @@ public class SolrStream extends TupleStream {
 
   private TupleStreamParser constructParser(SolrParams requestParams)
       throws IOException, SolrServerException {
-    String p = requestParams.get("qt");
-    if (p != null) {
-      ModifiableSolrParams modifiableSolrParams = (ModifiableSolrParams) requestParams;
-      modifiableSolrParams.remove("qt");
-      // performance optimization - remove extra whitespace by default when streaming
-      modifiableSolrParams.set("indent", modifiableSolrParams.get("indent", "off"));
-    }
+    // performance optimization - remove extra whitespace when streaming
+    requestParams = SolrParams.wrapDefaults(requestParams, SolrParams.of("indent", "off"));
 
+    QueryRequest query = new QueryRequest(requestParams, SolrRequest.METHOD.POST);
     String wt = requestParams.get(CommonParams.WT, "json");
-    QueryRequest query = new QueryRequest(requestParams);
-
-    // in order to reuse HttpSolrClient objects per node, we need to cache them without the core
-    // name in the URL
-    if (core != null) {
-      query.setPath("/" + core + (p != null ? p : "/select"));
-    } else {
-      query.setPath(p);
-    }
-
     query.setResponseParser(new InputStreamResponseParser(wt));
-    query.setMethod(SolrRequest.METHOD.POST);
 
     if (user != null && password != null) {
       query.setBasicAuthCredentials(user, password);
     }
 
     var client = clientCache.getHttpSolrClient(baseUrl);
-    NamedList<Object> genericResponse = client.request(query);
+    NamedList<Object> genericResponse = client.request(query, core);
     InputStream stream = (InputStream) genericResponse.get(InputStreamResponseParser.STREAM_KEY);
     // since 9.4 the updated format has a dedicated status field
     final Integer statusCode = (Integer) genericResponse.get("responseStatus");

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/graph/GraphExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/graph/GraphExpressionTest.java
@@ -1244,8 +1244,7 @@ public class GraphExpressionTest extends SolrCloudTestCase {
             + "gather=\"to_s\"))";
 
     params.add("expr", expr);
-    QueryRequest query = new QueryRequest(params);
-    query.setPath("/collection1/graph");
+    QueryRequest query = new QueryRequest("/collection1/graph", params);
 
     query.setResponseParser(new InputStreamResponseParser("xml"));
     query.setMethod(SolrRequest.METHOD.POST);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
@@ -63,8 +63,8 @@ public class UpdateRequest extends AbstractUpdateRequest {
     super(METHOD.POST, "/update");
   }
 
-  public UpdateRequest(String url) {
-    super(METHOD.POST, url);
+  public UpdateRequest(String path) {
+    super(METHOD.POST, path);
   }
 
   /** clear the pending documents and delete commands */
@@ -250,11 +250,10 @@ public class UpdateRequest extends AbstractUpdateRequest {
         String leaderUrl = urls.get(0);
         LBSolrClient.Req request = routes.get(leaderUrl);
         if (request == null) {
-          UpdateRequest updateRequest = new UpdateRequest();
+          UpdateRequest updateRequest = new UpdateRequest(getPath());
           updateRequest.setMethod(getMethod());
           updateRequest.setCommitWithin(getCommitWithin());
           updateRequest.setParams(params);
-          updateRequest.setPath(getPath());
           updateRequest.setBasicAuthCredentials(getBasicAuthUser(), getBasicAuthPassword());
           updateRequest.setResponseParser(getResponseParser());
           updateRequest.addHeaders(getHeaders());

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
@@ -2337,8 +2337,7 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
     q.set("fl", "id,name,aaa:[value v=aaa]");
 
     // First Try with the BinaryResponseParser
-    QueryRequest req = new QueryRequest(q);
-    req.setPath("/get");
+    QueryRequest req = new QueryRequest("/get", q);
     req.setResponseParser(new JavaBinResponseParser());
     QueryResponse rsp = req.process(client);
     SolrDocument out = (SolrDocument) rsp.getResponse().get("doc");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCoreAdmin.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCoreAdmin.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
+import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.embedded.AbstractEmbeddedSolrServerTestCase;
 import org.apache.solr.client.solrj.request.CoreAdminRequest.Create;
 import org.apache.solr.client.solrj.request.CoreAdminRequest.RequestRecovery;
@@ -110,8 +112,8 @@ public class TestCoreAdmin extends AbstractEmbeddedSolrServerTestCase {
     params.set("action", "BADACTION");
     String collectionName = "badactioncollection";
     params.set("name", collectionName);
-    QueryRequest request = new QueryRequest(params);
-    request.setPath("/admin/cores");
+    var request =
+        new GenericSolrRequest(METHOD.POST, "/admin/cores", SolrRequestType.ADMIN, params);
     expectThrows(SolrException.class, () -> getSolrAdmin().request(request));
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseHS.java
@@ -163,14 +163,9 @@ public class SolrTestCaseHS extends SolrTestCaseJ4 {
     }
     ModifiableSolrParams p = new ModifiableSolrParams(params);
     p.set("wt", wt);
-    String path = p.get("qt");
-    p.remove("qt");
     p.set("indent", "true");
 
     QueryRequest query = new QueryRequest(p);
-    if (path != null) {
-      query.setPath(path);
-    }
 
     if ("json".equals(wt)) {
       query.setResponseParser(new JsonMapResponseParser());

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -2837,7 +2837,6 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
       params.set("name", testCollectionName);
       var request =
           new GenericSolrRequest(METHOD.GET, "/admin/collections", SolrRequestType.ADMIN, params);
-      request.setPath("/admin/collections");
       client.request(request);
       Thread.sleep(2000); // reload can take a short while
 


### PR DESCRIPTION
Simplify qt/path handling in QueryRequest callers

QueryRequest's constructors already resolve the "qt" param into the
request path, so callers no longer need to manually extract/remove
qt and call setPath themselves.

Tests: SolrRequest path usage: prefer ctor not setPath

And don't use QueryRequest for non-SearchHandler.