### PR TITLE
Flaky test TestDistributedGrouping timeAllowed

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -1300,7 +1300,7 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
                 "cache",
                 "false",
                 "timeAllowed",
-                "200",
+                "10000", // generous; queries must complete fully even on slow CI
                 "sleep",
                 "10");
         assertFalse(

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -481,7 +481,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
             "group.query",
             "id:2",
             "timeAllowed",
-            "200"),
+            "10000"), // generous; must complete fully even on slow CI
         "/grouped/id:1/matches==5",
         "/grouped/id:2/matches==5");
   }

--- a/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
+++ b/solr/core/src/test/org/apache/solr/search/TestQueryLimits.java
@@ -114,7 +114,7 @@ public class TestQueryLimits extends SolrCloudTestCase {
   @Test
   public void testAdjustShardRequestLimits() throws Exception {
     SolrClient solrClient = cluster.getSolrClient();
-    String timeAllowed = "1000"; // ms - increased from 500 to avoid flakiness with grouped queries
+    String timeAllowed = "10000"; // ms - generous; must complete fully even on slow CI
     ModifiableSolrParams params =
         params(
             "q",


### PR DESCRIPTION
Need higher timeout; 200 isn't enough.  10_000 is plenty; doesn't slow down tests.

Failed in CI like 0.5% of the time according to Develocity & Fucit

Claude expanded to do a couple other tests that would seem to benefit similarly.