### PR TITLE
solrj-streaming FacetStream: remove weird lb.proxy param

### DIFF
--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/FacetStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/FacetStream.java
@@ -673,9 +673,6 @@ public class FacetStream extends TupleStream implements Expressible, ParallelMet
     paramsLoc.set("rows", "0");
 
     QueryRequest request = new QueryRequest(paramsLoc, SolrRequest.METHOD.POST);
-    if (paramsLoc.get("lb.proxy") != null) {
-      request.setPath("/" + collection + "/select");
-    }
 
     try {
       NamedList<?> response = cloudSolrClient.request(request, collection);


### PR DESCRIPTION
Inexplicable purpose

Added in https://github.com/apache/lucene-solr/pull/2132/changes#r3692647469 by @thelabdude 
Using git pick-axe, I see no prior existence of "lb.proxy".