### PR TITLE
Logging: ZkStateReader.getLeaderRetry to TRACE

### DIFF
--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -849,6 +849,7 @@ public class ZkStateReader implements SolrCloseable {
   }
 
   public void registerClusterPropertiesListener(ClusterPropertiesListener listener) {
+    log.debug("registerClusterPropertiesListener");
     // fire it once with current properties
     if (listener.onChange(getClusterProperties())) {
       removeClusterPropertiesListener(listener);
@@ -862,6 +863,7 @@ public class ZkStateReader implements SolrCloseable {
   }
 
   public void registerLiveNodesListener(LiveNodesListener listener) {
+    log.debug("registerLiveNodesListener");
     // fire it once with current live nodes
     if (listener.onChange(
         new TreeSet<>(getClusterState().getLiveNodes()),
@@ -1003,7 +1005,7 @@ public class ZkStateReader implements SolrCloseable {
             if (c == null) return false;
             Replica l = getLeader(n, c, shard);
             if (l != null) {
-              log.debug("leader found for {}/{} to be {}", collection, shard, l);
+              log.trace("leader found for {}/{} to be {}", collection, shard, l);
               leader.set(l);
               return true;
             }
@@ -1608,6 +1610,7 @@ public class ZkStateReader implements SolrCloseable {
    */
   public void registerDocCollectionWatcher(
       String collection, DocCollectionWatcher docCollectionWatcher) {
+    log.debug("registerDocCollectionWatcher collection={}", collection);
     AtomicReference<StateWatcher> newWatcherRef = new AtomicReference<>();
     collectionWatches.compute(
         collection,
@@ -1664,7 +1667,7 @@ public class ZkStateReader implements SolrCloseable {
       DocCollection docCollection = clusterState.getCollectionOrNull(collection);
       if (liveNodes != null && docCollection != null) {
         if (predicate.matches(liveNodes, docCollection)) {
-          log.debug("Found {} directly in clusterState", predicate);
+          log.trace("waitForState collection={}: cache hit in clusterState", collection);
           return;
         }
       }
@@ -1746,11 +1749,13 @@ public class ZkStateReader implements SolrCloseable {
       DocCollection docCollection = clusterState.getCollectionOrNull(collection);
       if (docCollection != null) {
         if (predicate.test(docCollection)) {
-          log.debug("Found {} directly in clusterState", predicate);
+          log.trace("waitForState collection={}: cache hit in clusterState", collection);
           return docCollection;
         }
       }
     }
+
+    log.debug("waitForState collection={}: not in cached state; add watcher", collection);
 
     final CountDownLatch latch = new CountDownLatch(1);
     waitLatches.add(latch);

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1755,8 +1755,6 @@ public class ZkStateReader implements SolrCloseable {
       }
     }
 
-    log.debug("waitForState collection={}: not in cached state; add watcher", collection);
-
     final CountDownLatch latch = new CountDownLatch(1);
     waitLatches.add(latch);
     AtomicReference<DocCollection> docCollectionReference = new AtomicReference<>();


### PR DESCRIPTION
from DEBUG.

But if there's a cache miss, other ZkStateReader watcher registrations newly added will now log at DEBUG.

Inspired to do this change from logging at DEBUG level of ZkStateReader on a cluster with all TLOG replica types.  It seems getLeaderRetry is invoked often, albeit I expect the value to be in the cache.