### PR TITLE
SOLR-18332: Remove reliance on deprecated 'qt' param in a first batch of tests

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestCrossCoreJoin.java
+++ b/solr/core/src/test/org/apache/solr/TestCrossCoreJoin.java
@@ -186,7 +186,6 @@ public class TestCrossCoreJoin extends SolrTestCaseJ4 {
     assertQEx("schema12.xml" + " has no \"cat\" field", req("cat:*"), ErrorCode.BAD_REQUEST);
     ModifiableSolrParams solrParams = new ModifiableSolrParams();
     solrParams.set(CommonParams.Q, "cat:*");
-    solrParams.set(CommonParams.QT, "/select");
     solrParams.set(CommonParams.ROWS, 100);
     try (var req = new SolrQueryRequestBase(fromCore, solrParams)) {
       final String resp = query(fromCore, req);
@@ -196,10 +195,7 @@ public class TestCrossCoreJoin extends SolrTestCaseJ4 {
   }
 
   public String query(SolrCore core, SolrQueryRequest req) throws Exception {
-    String handler = "standard";
-    if (req.getParams().get("qt") != null) {
-      handler = req.getParams().get("qt");
-    }
+    String handler = "/select";
     if (req.getParams().get("wt") == null) {
       ModifiableSolrParams params = new ModifiableSolrParams(req.getParams());
       params.set("wt", "xml");

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -172,8 +172,6 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
         "true",
         "spellcheck.build",
         "true",
-        "qt",
-        "spellCheckCompRH",
         "df",
         "subject");
     query(
@@ -564,8 +562,6 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
         "true",
         "spellcheck.build",
         "true",
-        "qt",
-        "spellCheckCompRH",
         "df",
         "subject");
     query(

--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZk2Test.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZk2Test.java
@@ -445,7 +445,6 @@ public class BasicDistributedZk2Test extends AbstractFullDistribZkTestBase {
         getHttpSolrClient((String) shardToJetty.get(SHARD2).get(0).info.get("base_url"))) {
       final String backupName = "the_backup";
       ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set("qt", ReplicationHandler.PATH);
       params.set("command", "backup");
       params.set("name", backupName);
       final Path location = FilterPath.unwrap(createTempDir()).toRealPath();
@@ -453,7 +452,7 @@ public class BasicDistributedZk2Test extends AbstractFullDistribZkTestBase {
       jettys.forEach(j -> j.getCoreContainer().getAllowPaths().add(location));
       params.set("location", location.toString());
 
-      QueryRequest request = new QueryRequest(params);
+      QueryRequest request = new QueryRequest(ReplicationHandler.PATH, params);
       client.request(request, DEFAULT_TEST_COLLECTION_NAME);
 
       final BackupStatusChecker backupStatus =

--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
@@ -761,7 +761,7 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
     SolrQuery query = new SolrQuery("*:*");
     query.addFacetField(tsort);
     query.setFacetMissing(false);
-    QueryResponse resp = queryRandomShard(query);
+    QueryResponse resp = queryRandomShard("/select", query);
     List<FacetField> ffs = resp.getFacetFields();
     for (FacetField ff : ffs) {
       if (ff.getName().equals(tsort) == false) continue;
@@ -1665,14 +1665,15 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
   }
 
   @Override
-  protected QueryResponse queryRandomShard(ModifiableSolrParams params)
+  protected QueryResponse queryRandomShard(String requestHandler, ModifiableSolrParams params)
       throws SolrServerException, IOException {
 
-    if (r.nextBoolean()) return super.queryRandomShard(params);
+    if (r.nextBoolean()) return super.queryRandomShard(requestHandler, params);
 
     if (r.nextBoolean()) params.set("collection", DEFAULT_COLLECTION);
 
-    QueryResponse rsp = getCommonCloudSolrClient().query(params);
+    QueryResponse rsp =
+        new QueryRequest(requestHandler, params).process(getCommonCloudSolrClient());
     return rsp;
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
@@ -293,8 +293,7 @@ public class DistribDocExpirationUpdateProcessorTest extends SolrCloudTestCase {
         ModifiableSolrParams params = new ModifiableSolrParams();
         params.set("command", "indexversion");
         params.set("_trace", "getIndexVersion");
-        params.set("qt", ReplicationHandler.PATH);
-        QueryRequest req = setAuthIfNeeded(new QueryRequest(params));
+        QueryRequest req = setAuthIfNeeded(new QueryRequest(ReplicationHandler.PATH, params));
 
         NamedList<Object> res = client.request(req);
         assertNotNull("null response from server: " + coreName, res);

--- a/solr/core/src/test/org/apache/solr/cloud/TestStressInPlaceUpdates.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestStressInPlaceUpdates.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.math3.primes.Primes;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.UpdateResponse;
@@ -409,7 +410,6 @@ public class TestStressInPlaceUpdates extends AbstractFullDistribZkTestBase {
                   ModifiableSolrParams params = new ModifiableSolrParams();
                   if (realTime) {
                     params.set("wt", "json");
-                    params.set("qt", "/get");
                     params.set("ids", Integer.toString(id));
                   } else {
                     params.set("wt", "json");
@@ -420,7 +420,11 @@ public class TestStressInPlaceUpdates extends AbstractFullDistribZkTestBase {
                   int clientId = rand.nextInt(clients.size());
                   if (!realTime) clientId = clientIndexUsedForCommit;
 
-                  QueryResponse response = clients.get(clientId).query(params);
+                  SolrClient client = clients.get(clientId);
+                  QueryResponse response =
+                      realTime
+                          ? new QueryRequest("/get", params).process(client)
+                          : client.query(params);
                   if (response.getResults().size() == 0) {
                     // there's no info we can get back from a delete operation, so not much we
                     // can check

--- a/solr/core/src/test/org/apache/solr/handler/MoreLikeThisHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/MoreLikeThisHandlerTest.java
@@ -220,17 +220,17 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
     }
 
     // test that qparser plugins work w/ the MoreLikeThisHandler
-    params.set(CommonParams.QT, "/mlt");
     params.set(CommonParams.Q, "{!field f=id}44");
     try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
-      assertQ(mltreq, "//result/doc[1]/str[@name='id'][.='45']");
+      assertQ(null, "/mlt", mltreq, "//result/doc[1]/str[@name='id'][.='45']");
     }
 
     // test that debugging works (test for MoreLikeThis*Handler*)
-    params.set(CommonParams.QT, "/mlt");
     params.set(CommonParams.DEBUG_QUERY, "true");
     try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
       assertQ(
+          null,
+          "/mlt",
           mltreq,
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='debug']/lst[@name='explain']");
@@ -240,6 +240,8 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
     params.set("facet.field", "name");
     try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
       assertQ(
+          null,
+          "/mlt",
           mltreq,
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='facet_counts']/lst[@name='facet_fields']/lst[@name='name']/int[@name='George'][.='1']");
@@ -248,6 +250,8 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
     params.set("fq", "{!tag=tg}name:George");
     try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
       assertQ(
+          null,
+          "/mlt",
           mltreq,
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='facet_counts']/lst[@name='facet_fields']/lst[@name='name']/int[@name='George'][.='1']");
@@ -265,7 +269,6 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
     assertU(adoc("id", "4", "name", "        ccc", "subword", "    bbb    "));
     assertU(commit());
 
-    params.set(CommonParams.QT, "/mlt");
     params.set(MoreLikeThisParams.MLT, "true");
     params.set(MoreLikeThisParams.SIMILARITY_FIELDS, "name,subword");
     params.set(MoreLikeThisParams.INTERESTING_TERMS, "details");
@@ -280,6 +283,8 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
       // Make sure we have terms from both fields in the interestingTerms array and all documents
       // have been retrieved as matching.
       assertQ(
+          null,
+          "/mlt",
           req,
           "//lst[@name = 'interestingTerms']/float[@name = 'subword:bbb']",
           "//lst[@name = 'interestingTerms']/float[@name = 'name:bbb']",

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -735,11 +735,13 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     params.set("command", "details");
     params.set("follower", "true");
 
-    QueryResponse response = new QueryRequest("/replication", params).process(followerClient);
+    final var getDetails = new GenericSolrRequest(SolrRequest.METHOD.GET, "/replication", params);
+    getDetails.setRequiresCollection(true);
+    final var getDetailsResponse = getDetails.process(followerClient);
 
     // details/follower/timesIndexReplicated
     @SuppressWarnings({"unchecked"})
-    NamedList<Object> details = (NamedList<Object>) response.getResponse().get("details");
+    NamedList<Object> details = (NamedList<Object>) getDetailsResponse.getResponse().get("details");
     @SuppressWarnings({"unchecked"})
     NamedList<Object> follower = (NamedList<Object>) details.get("follower");
     return follower;
@@ -1480,13 +1482,11 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
 
   @Test
   public void testFileListShouldReportErrorsWhenTheyOccur() throws Exception {
-    SolrQuery q = new SolrQuery();
-    q.add("wt", "json")
-        .add("command", "filelist")
-        .add(
-            "generation",
-            "-2"); // A 'generation' value not matching any commit point should cause error.
-    QueryResponse response = new QueryRequest("/replication", q).process(followerClient);
+    // A 'generation' value not matching any commit point should cause error.
+    final var params = params("wt", "json", "command", "filelist", "generation", "-2");
+    final var filelistReq = new GenericSolrRequest(SolrRequest.METHOD.GET, "/replication", params);
+    filelistReq.setRequiresCollection(true);
+    final var response = filelistReq.process(followerClient);
     NamedList<Object> resp = response.getResponse();
     assertNotNull(resp);
     assertEquals("ERROR", resp.get("status"));

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -55,6 +55,7 @@ import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CoresApi;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.ReplicationApi;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -64,7 +65,6 @@ import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.TimeSource;
@@ -732,11 +732,10 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
 
   private NamedList<Object> getFollowerDetails() throws SolrServerException, IOException {
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set(CommonParams.QT, "/replication");
     params.set("command", "details");
     params.set("follower", "true");
 
-    QueryResponse response = followerClient.query(params);
+    QueryResponse response = new QueryRequest("/replication", params).process(followerClient);
 
     // details/follower/timesIndexReplicated
     @SuppressWarnings({"unchecked"})
@@ -1482,13 +1481,12 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   @Test
   public void testFileListShouldReportErrorsWhenTheyOccur() throws Exception {
     SolrQuery q = new SolrQuery();
-    q.add("qt", "/replication")
-        .add("wt", "json")
+    q.add("wt", "json")
         .add("command", "filelist")
         .add(
             "generation",
             "-2"); // A 'generation' value not matching any commit point should cause error.
-    QueryResponse response = followerClient.query(q);
+    QueryResponse response = new QueryRequest("/replication", q).process(followerClient);
     NamedList<Object> resp = response.getResponse();
     assertNotNull(resp);
     assertEquals("ERROR", resp.get("status"));
@@ -1500,12 +1498,11 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     int leaderPort = leaderJetty.getLocalPort();
     leaderJetty.stop();
     SolrQuery q = new SolrQuery();
-    q.add("qt", "/replication")
-        .add("wt", "json")
+    q.add("wt", "json")
         .add("wait", "true")
         .add("command", "fetchindex")
         .add("leaderUrl", buildUrl(leaderPort));
-    QueryResponse response = followerClient.query(q);
+    QueryResponse response = new QueryRequest("/replication", q).process(followerClient);
     NamedList<Object> resp = response.getResponse();
     assertNotNull(resp);
     assertEquals(
@@ -1517,12 +1514,12 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   @Test
   public void testShouldReportErrorWhenRequiredCommandArgMissing() {
     SolrQuery q = new SolrQuery();
-    q.add("qt", "/replication").add("wt", "json");
+    q.add("wt", "json");
     SolrException thrown =
         expectThrows(
             SolrException.class,
             () -> {
-              followerClient.query(q);
+              new QueryRequest("/replication", q).process(followerClient);
             });
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, thrown.code());
     assertThat(thrown.getMessage(), containsString("Missing required parameter: command"));
@@ -1531,12 +1528,12 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
   @Test
   public void testShouldReportErrorWhenDeletingBackupButNameMissing() {
     SolrQuery q = new SolrQuery();
-    q.add("qt", "/replication").add("wt", "json").add("command", "deletebackup");
+    q.add("wt", "json").add("command", "deletebackup");
     SolrException thrown =
         expectThrows(
             SolrException.class,
             () -> {
-              followerClient.query(q);
+              new QueryRequest("/replication", q).process(followerClient);
             });
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, thrown.code());
     assertThat(thrown.getMessage(), containsString("Missing required parameter: name"));

--- a/solr/core/src/test/org/apache/solr/handler/TestUserManagedReplicationWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestUserManagedReplicationWithAuth.java
@@ -231,8 +231,7 @@ public class TestUserManagedReplicationWithAuth extends SolrTestCaseJ4 {
     ModifiableSolrParams disablePollParams = new ModifiableSolrParams();
     disablePollParams.set(COMMAND, CMD_DISABLE_POLL);
     disablePollParams.set(CommonParams.WT, JAVABIN);
-    disablePollParams.set(CommonParams.QT, ReplicationHandler.PATH);
-    QueryRequest req = new QueryRequest(disablePollParams);
+    QueryRequest req = new QueryRequest(ReplicationHandler.PATH, disablePollParams);
     withBasicAuth(req);
 
     final var baseUrl = buildUrl(Jetty.getLocalPort());
@@ -252,14 +251,13 @@ public class TestUserManagedReplicationWithAuth extends SolrTestCaseJ4 {
     ModifiableSolrParams solrParams = new ModifiableSolrParams();
     solrParams.set(COMMAND, CMD_FETCH_INDEX);
     solrParams.set(CommonParams.WT, JAVABIN);
-    solrParams.set(CommonParams.QT, ReplicationHandler.PATH);
     solrParams.set("leaderUrl", srcUrl);
     solrParams.set("wait", "true");
     if (authEnabled) {
       solrParams.set("httpBasicAuthUser", user);
       solrParams.set("httpBasicAuthPassword", pass);
     }
-    QueryRequest req = new QueryRequest(solrParams);
+    QueryRequest req = new QueryRequest(ReplicationHandler.PATH, solrParams);
     return req;
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/LukeRequestHandlerDistribTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/LukeRequestHandlerDistribTest.java
@@ -46,7 +46,6 @@ public class LukeRequestHandlerDistribTest extends BaseDistributedSearchTestCase
 
   private LukeResponse requestLuke(ModifiableSolrParams extra) throws Exception {
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set("qt", "/admin/luke");
     params.set("numTerms", "0");
     params.set("shards.info", "true");
     params.add(extra);
@@ -61,7 +60,7 @@ public class LukeRequestHandlerDistribTest extends BaseDistributedSearchTestCase
     handle.put(LukeRequestHandler.KEY_DISTINCT, SKIP);
     handle.put(LukeRequestHandler.KEY_TOP_TERMS, SKIP);
     handle.put(LukeRequestHandler.KEY_HISTOGRAM, SKIP);
-    QueryResponse qr = query(params);
+    QueryResponse qr = query("/admin/luke", params);
     LukeResponse rsp = new LukeResponse();
     rsp.setResponse(qr.getResponse());
 

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
@@ -46,7 +46,7 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
 
   @Override
   public void distribSetUp() throws Exception {
-    requestHandlerName = "mltrh";
+    requestHandlerName = "/mltrh";
     super.distribSetUp();
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerAppendsCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerAppendsCloudTest.java
@@ -130,9 +130,7 @@ public class SearchHandlerAppendsCloudTest extends SolrCloudTestCase {
 
             // compose the query
             final SolrQuery solrQuery = new SolrQuery(bee_t + ":bee");
-            if (searchHandlerNames[ii] != null) {
-              solrQuery.setParam(CommonParams.QT, searchHandlerNames[ii]);
-            }
+            final String path = searchHandlerNames[ii] != null ? searchHandlerNames[ii] : "/select";
             if (searchHandlerNames[jj] != null) {
               solrQuery.setParam(ShardParams.SHARDS_QT, searchHandlerNames[jj]);
             }
@@ -144,7 +142,7 @@ public class SearchHandlerAppendsCloudTest extends SolrCloudTestCase {
 
             // make the query
             final QueryResponse queryResponse =
-                new QueryRequest(solrQuery).process(cluster.getSolrClient(), COLLECTION);
+                new QueryRequest(path, solrQuery).process(cluster.getSolrClient(), COLLECTION);
 
             // analyse the response
             final StringBuilder contextInfo = new StringBuilder();

--- a/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentDistributedTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentDistributedTest.java
@@ -131,7 +131,7 @@ public class TermVectorComponentDistributedTest extends BaseDistributedSearchTes
 
     commit();
 
-    final String tv = "tvrh";
+    final String tv = "/tvrh";
 
     for (String q : new String[] {"id:0", "id:7", "id:[3 TO 6]", "*:*"}) {
       query(

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTest.java
@@ -126,7 +126,7 @@ public class TaggerTest extends TaggerTestCase {
     String doc = "london business school"; // just one tag
     SolrQueryRequest req =
         reqDoc(doc, "indent", "on", "omitHeader", "on", "matchText", "" + matchText);
-    String rspStr = h.query(req);
+    String rspStr = h.query(HANDLER, req);
     req.close();
     return rspStr;
   }
@@ -320,7 +320,7 @@ public class TaggerTest extends TaggerTestCase {
     // SOLR-14396: Ensure tagger handler doesn't fail on empty collections
     SolrQueryRequest req =
         reqDoc("anything", "indent", "on", "omitHeader", "on", "matchText", "false");
-    String rspStr = h.query(req);
+    String rspStr = h.query(HANDLER, req);
     req.close();
 
     String expected =

--- a/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/TaggerTestCase.java
@@ -70,6 +70,8 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
 
   protected final ModifiableSolrParams baseParams = new ModifiableSolrParams();
 
+  protected static final String HANDLER = "/tag";
+
   // populated in buildNames; tested in assertTags
   protected static List<String> NAMES;
 
@@ -77,7 +79,6 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
   public void setUp() throws Exception {
     super.setUp();
     baseParams.clear();
-    baseParams.set(CommonParams.QT, "/tag");
     baseParams.set(CommonParams.WT, "xml");
   }
 
@@ -121,7 +122,7 @@ public abstract class TaggerTestCase extends SolrTestCaseJ4 {
   /** Asserts the tags. Will call req.close(). */
   protected void assertTags(SolrQueryRequest req, TestTag... eTags) throws Exception {
     try {
-      SolrQueryResponse rsp = h.queryAndResponse(req.getParams().get(CommonParams.QT), req);
+      SolrQueryResponse rsp = h.queryAndResponse(HANDLER, req);
       TestTag[] aTags = pullTagsFromResponse(req, rsp);
 
       String message;

--- a/solr/core/src/test/org/apache/solr/handler/tagger/XmlInterpolationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/XmlInterpolationTest.java
@@ -102,7 +102,7 @@ public class XmlInterpolationTest extends TaggerTestCase {
 
   protected void assertXmlTag(String docText, boolean expected) throws Exception {
     try (SolrQueryRequest req = reqDoc(docText)) {
-      final SolrQueryResponse rsp = h.queryAndResponse(req.getParams().get("qt"), req);
+      final SolrQueryResponse rsp = h.queryAndResponse(HANDLER, req);
       final TestTag[] testTags = pullTagsFromResponse(req, rsp);
       if (!expected) {
         assertEquals(0, testTags.length);

--- a/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
@@ -363,7 +363,6 @@ public class SpellCheckCollatorTest extends SolrTestCaseJ4 {
     assertNotNull("speller is null and it shouldn't be", speller);
 
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.add(CommonParams.QT, "spellCheckCompRH");
     params.add(CommonParams.Q, "lowerfilt:(+fauth +home +loane)");
     params.add(SpellingParams.SPELLCHECK_EXTENDED_RESULTS, "true");
     params.add(SpellCheckComponent.COMPONENT_NAME, "true");

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.client.solrj;
 
+import static org.apache.solr.client.solrj.SolrRequest.METHOD.GET;
 import static org.apache.solr.common.params.UpdateParams.ASSUME_CONTENT_TYPE;
 import static org.apache.solr.common.util.Utils.fromJSONString;
 import static org.apache.solr.core.CoreContainer.ALLOW_PATHS_SYSPROP;
@@ -57,6 +58,7 @@ import org.apache.solr.client.solrj.request.MultiContentWriterRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.request.StreamingUpdateRequest;
+import org.apache.solr.client.solrj.request.SystemInfoRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.FieldStatsInfo;
@@ -440,7 +442,7 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
       try (SolrClient adminClient = getHttpSolrClient(url)) {
         SolrQuery q = new SolrQuery();
 
-        QueryResponse rsp = new QueryRequest(CommonParams.SYSTEM_INFO_PATH, q).process(adminClient);
+        final var rsp = new SystemInfoRequest().process(adminClient);
         assertNotNull(rsp.getResponse().get("mode"));
         assertNotNull(rsp.getResponse().get("lucene"));
       }
@@ -697,12 +699,11 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
   public void testErrorHandling() throws Exception {
     SolrClient client = getSolrClient();
 
-    SolrQuery query = new SolrQuery();
-    query.set(AnalysisParams.FIELD_TYPE, "pint");
-    query.set(AnalysisParams.FIELD_VALUE, "ignore_exception");
-    SolrException ex =
-        expectThrows(
-            SolrException.class, () -> new QueryRequest("/analysis/field", query).process(client));
+    final var params =
+        params(AnalysisParams.FIELD_TYPE, "pint", AnalysisParams.FIELD_VALUE, "ignore_exception");
+    final var req = new GenericSolrRequest(GET, "/analysis/field", params);
+    req.setRequiresCollection(true);
+    SolrException ex = expectThrows(SolrException.class, () -> req.process(client));
     assertEquals(400, ex.code());
     assertThat(ex.getMessage(), containsString("Invalid Number: ignore_exception"));
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/SolrExampleTests.java
@@ -439,9 +439,8 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
       String url = solrTestRule.getBaseUrl();
       try (SolrClient adminClient = getHttpSolrClient(url)) {
         SolrQuery q = new SolrQuery();
-        q.set("qt", CommonParams.SYSTEM_INFO_PATH);
 
-        QueryResponse rsp = adminClient.query(q);
+        QueryResponse rsp = new QueryRequest(CommonParams.SYSTEM_INFO_PATH, q).process(adminClient);
         assertNotNull(rsp.getResponse().get("mode"));
         assertNotNull(rsp.getResponse().get("lucene"));
       }
@@ -699,10 +698,11 @@ public abstract class SolrExampleTests extends SolrExampleTestsBase {
     SolrClient client = getSolrClient();
 
     SolrQuery query = new SolrQuery();
-    query.set(CommonParams.QT, "/analysis/field");
     query.set(AnalysisParams.FIELD_TYPE, "pint");
     query.set(AnalysisParams.FIELD_VALUE, "ignore_exception");
-    SolrException ex = expectThrows(SolrException.class, () -> client.query(query));
+    SolrException ex =
+        expectThrows(
+            SolrException.class, () -> new QueryRequest("/analysis/field", query).process(client));
     assertEquals(400, ex.code());
     assertThat(ex.getMessage(), containsString("Invalid Number: ignore_exception"));
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestSpellCheckResponse.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestSpellCheckResponse.java
@@ -24,7 +24,6 @@ import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.response.SpellCheckResponse.Collation;
 import org.apache.solr.client.solrj.response.SpellCheckResponse.Correction;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SpellingParams;
 import org.apache.solr.util.EmbeddedSolrServerTestRule;
 import org.apache.solr.util.ExternalPaths;
@@ -72,10 +71,9 @@ public class TestSpellCheckResponse extends SolrTestCase {
     client.commit(true, true);
 
     SolrQuery query = new SolrQuery("*:*");
-    query.set(CommonParams.QT, "/spell");
     query.set("spellcheck", true);
     query.set(SpellingParams.SPELLCHECK_Q, "samsang");
-    QueryRequest request = new QueryRequest(query);
+    QueryRequest request = new QueryRequest("/spell", query);
     SpellCheckResponse response = request.process(client).getSpellCheckResponse();
     assertEquals("samsung", response.getFirstSuggestion("samsang"));
   }
@@ -91,11 +89,10 @@ public class TestSpellCheckResponse extends SolrTestCase {
     client.commit(true, true);
 
     SolrQuery query = new SolrQuery("*:*");
-    query.set(CommonParams.QT, "/spell");
     query.set("spellcheck", true);
     query.set(SpellingParams.SPELLCHECK_Q, "samsang");
     query.set(SpellingParams.SPELLCHECK_EXTENDED_RESULTS, true);
-    QueryRequest request = new QueryRequest(query);
+    QueryRequest request = new QueryRequest("/spell", query);
     SpellCheckResponse response = request.process(client).getSpellCheckResponse();
     assertEquals("samsung", response.getFirstSuggestion("samsang"));
 
@@ -148,11 +145,10 @@ public class TestSpellCheckResponse extends SolrTestCase {
 
     // Test Backwards Compatibility
     SolrQuery query = new SolrQuery("name:(+fauth +home +loane)");
-    query.set(CommonParams.QT, "/spell");
     query.set("spellcheck", true);
     query.set(SpellingParams.SPELLCHECK_COUNT, 10);
     query.set(SpellingParams.SPELLCHECK_COLLATE, true);
-    QueryRequest request = new QueryRequest(query);
+    QueryRequest request = new QueryRequest("/spell", query);
     SpellCheckResponse response = request.process(client).getSpellCheckResponse();
     response = request.process(client).getSpellCheckResponse();
     assertEquals("name:(+faith +hope +loaves)", response.getCollatedResult());
@@ -161,7 +157,7 @@ public class TestSpellCheckResponse extends SolrTestCase {
     query.set(SpellingParams.SPELLCHECK_COLLATE_EXTENDED_RESULTS, true);
     query.set(SpellingParams.SPELLCHECK_MAX_COLLATION_TRIES, 10);
     query.set(SpellingParams.SPELLCHECK_MAX_COLLATIONS, 2);
-    request = new QueryRequest(query);
+    request = new QueryRequest("/spell", query);
     response = request.process(client).getSpellCheckResponse();
     assertTrue(
         "name:(+faith +hope +love)".equals(response.getCollatedResult())

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestSuggesterResponse.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/response/TestSuggesterResponse.java
@@ -27,7 +27,6 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.util.ExternalPaths;
 import org.apache.solr.util.SolrJettyTestRule;
@@ -56,11 +55,10 @@ public class TestSuggesterResponse extends SolrTestCaseJ4 {
 
     try (SolrClient solrClient = createSuggestSolrClient()) {
       SolrQuery query = new SolrQuery("*:*");
-      query.set(CommonParams.QT, "/suggest");
       query.set("suggest.dictionary", "mySuggester");
       query.set("suggest.q", "Com");
       query.set("suggest.build", true);
-      QueryRequest request = new QueryRequest(query);
+      QueryRequest request = new QueryRequest("/suggest", query);
       QueryResponse queryResponse = request.process(solrClient);
       SuggesterResponse response = queryResponse.getSuggesterResponse();
       Map<String, List<Suggestion>> dictionary2suggestions = response.getSuggestions();
@@ -82,11 +80,10 @@ public class TestSuggesterResponse extends SolrTestCaseJ4 {
 
     try (SolrClient solrClient = createSuggestSolrClient()) {
       SolrQuery query = new SolrQuery("*:*");
-      query.set(CommonParams.QT, "/suggest");
       query.set("suggest.dictionary", "mySuggester");
       query.set("suggest.q", "Com");
       query.set("suggest.build", true);
-      QueryRequest request = new QueryRequest(query);
+      QueryRequest request = new QueryRequest("/suggest", query);
       QueryResponse queryResponse = request.process(solrClient);
       SuggesterResponse response = queryResponse.getSuggesterResponse();
       Map<String, List<String>> dictionary2suggestions = response.getSuggestedTerms();
@@ -104,11 +101,10 @@ public class TestSuggesterResponse extends SolrTestCaseJ4 {
 
     try (SolrClient solrClient = createSuggestSolrClient()) {
       SolrQuery query = new SolrQuery("*:*");
-      query.set(CommonParams.QT, "/suggest");
       query.set("suggest.dictionary", "mySuggester");
       query.set("suggest.q", "Empty");
       query.set("suggest.build", true);
-      QueryRequest request = new QueryRequest(query);
+      QueryRequest request = new QueryRequest("/suggest", query);
       QueryResponse queryResponse = request.process(solrClient);
       SuggesterResponse response = queryResponse.getSuggesterResponse();
       Map<String, List<String>> dictionary2suggestions = response.getSuggestedTerms();

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -51,12 +51,14 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.CollectionUtil;
@@ -598,18 +600,22 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     }
   }
 
+  protected QueryResponse queryRandomShard(ModifiableSolrParams params)
+      throws SolrServerException, IOException {
+    return queryRandomShard(params.get(CommonParams.QT, "/select"), params);
+  }
+
   /**
    * Queries a random shard; nothing more.
    *
    * <p>WARNING: tests should generally not call this as it doesn't compare to the control client
    */
-  protected QueryResponse queryRandomShard(ModifiableSolrParams params)
+  protected QueryResponse queryRandomShard(String requestHandler, ModifiableSolrParams params)
       throws SolrServerException, IOException {
     // query a random server
     int which = r.nextInt(clients.size());
     SolrClient client = clients.get(which);
-    QueryResponse rsp = client.query(params);
-    return rsp;
+    return new QueryRequest(requestHandler, params).process(client);
   }
 
   /** Sets distributed params. Returns the distributed QueryResponse */
@@ -629,13 +635,22 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     return query(setDistribParams, params);
   }
 
-  /** Returns the distributed QueryResponse */
+  protected QueryResponse query(String requestHandler, SolrParams p) throws Exception {
+    return query(requestHandler, true, p);
+  }
+
   protected QueryResponse query(boolean setDistribParams, SolrParams p) throws Exception {
+    return query(p.get(CommonParams.QT, "/select"), setDistribParams, p);
+  }
+
+  /** Returns the distributed QueryResponse */
+  protected QueryResponse query(String requestHandler, boolean setDistribParams, SolrParams p)
+      throws Exception {
     if (p.get("distrib") != null) {
       throw new IllegalArgumentException("don't pass distrib param");
     }
 
-    final QueryResponse controlRsp = controlClient.query(p);
+    final QueryResponse controlRsp = new QueryRequest(requestHandler, p).process(controlClient);
     validateControlData(controlRsp);
 
     if (shardCount == 0) { // mostly for temp debugging
@@ -645,7 +660,7 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     final ModifiableSolrParams params = new ModifiableSolrParams(p);
     if (setDistribParams) setDistributedParams(params);
 
-    QueryResponse rsp = queryRandomShard(params);
+    QueryResponse rsp = queryRandomShard(requestHandler, params);
 
     compareResponses(rsp, controlRsp);
 
@@ -660,7 +675,9 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
                     int which = r.nextInt(clients.size());
                     SolrClient client = clients.get(which);
                     try {
-                      QueryResponse rsp1 = client.query(new ModifiableSolrParams(params));
+                      QueryResponse rsp1 =
+                          new QueryRequest(requestHandler, new ModifiableSolrParams(params))
+                              .process(client);
                       if (verifyStress) {
                         compareResponses(rsp1, controlRsp);
                       }

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -848,6 +848,15 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   /** Validates a query matches some XPath test expressions and closes the query */
   public static void assertQ(String message, SolrQueryRequest req, String... tests) {
+    assertQ(message, req.getParams().get(CommonParams.QT), req, tests);
+  }
+
+  /**
+   * Validates a query against the named handler matches some XPath test expressions and closes the
+   * query
+   */
+  public static void assertQ(
+      String message, String handler, SolrQueryRequest req, String... tests) {
     try {
       String m = (null == message) ? "" : message + " "; // TODO log 'm' !!!
       // since the default (standard) response format is now JSON
@@ -857,7 +866,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       // for tests, let's turn indention off so we don't have to handle extraneous spaces
       xmlWriterTypeParams.set("indent", xmlWriterTypeParams.get("indent", "off"));
       req.setParams(xmlWriterTypeParams);
-      String response = h.query(req);
+      String response = h.query(handler, req);
 
       if (req.getParams().getBool("facet", false)) {
         // add a test to ensure that faceting did not throw an exception

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -64,6 +64,7 @@ import org.apache.solr.client.solrj.jetty.HttpJettySolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
@@ -2076,12 +2077,12 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
   }
 
   @Override
-  protected QueryResponse queryRandomShard(ModifiableSolrParams params)
+  protected QueryResponse queryRandomShard(String requestHandler, ModifiableSolrParams params)
       throws SolrServerException, IOException {
 
     if (r.nextBoolean()) params.set("collection", DEFAULT_COLLECTION);
 
-    return cloudClient.query(params);
+    return new QueryRequest(requestHandler, params).process(cloudClient);
   }
 
   abstract static class StoppableThread extends Thread {


### PR DESCRIPTION
Convert tests that set the 'qt' request parameter directly on a
SolrQuery/SolrParams object to instead select the request handler via
QueryRequest's path-based constructor or an explicit handler argument.

Involves minor method-overload changes to SolrTestCaseJ4 and
BaseDistributedSearchTestCase.