### PR TITLE
SOLR-18329: DenseVectorField support existence queries

### DIFF
--- a/changelog/unreleased/SOLR-18329-densevector-existence-queries.yml
+++ b/changelog/unreleased/SOLR-18329-densevector-existence-queries.yml
@@ -1,0 +1,8 @@
+title: DenseVectorField now supports existence queries (field:* / [* TO *])
+type: changed
+authors:
+  - name: Li Enlai
+    nick: linslee75
+links:
+  - name: SOLR-18329
+    url: https://issues.apache.org/jira/browse/SOLR-18329

--- a/changelog/unreleased/SOLR-18329-densevector-existence-queries.yml
+++ b/changelog/unreleased/SOLR-18329-densevector-existence-queries.yml
@@ -1,5 +1,5 @@
 title: DenseVectorField now supports existence queries (field:* / [* TO *])
-type: changed
+type: added
 authors:
   - name: Li Enlai
     nick: linslee75

--- a/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
+++ b/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.valuesource.ByteKnnVectorFieldSource;
 import org.apache.lucene.queries.function.valuesource.FloatKnnVectorFieldSource;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.PatienceKnnVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SeededKnnVectorQuery;
@@ -573,6 +574,15 @@ public class DenseVectorField extends FloatPointField {
   }
 
   /**
+   * Dense vector fields index neither docValues nor norms usable for existence checks, but Lucene
+   * exposes docs that contain a vector via {@link FieldExistsQuery}.
+   */
+  @Override
+  public Query getExistenceQuery(QParser parser, SchemaField field) {
+    return new FieldExistsQuery(field.getName());
+  }
+
+  /**
    * Not Supported. Please use the {!knn} query parser to run K nearest neighbors search queries.
    */
   @Override
@@ -582,7 +592,10 @@ public class DenseVectorField extends FloatPointField {
         "Field Queries are not supported for Dense Vector fields. Please use the {!knn} query parser to run K nearest neighbors search queries.");
   }
 
-  /** Not Supported */
+  /**
+   * Unbounded ranges ({@code [* TO *]}) are treated as existence queries. Bounded range queries are
+   * not supported.
+   */
   @Override
   public Query getRangeQuery(
       QParser parser,
@@ -591,6 +604,9 @@ public class DenseVectorField extends FloatPointField {
       String part2,
       boolean minInclusive,
       boolean maxInclusive) {
+    if (part1 == null && part2 == null) {
+      return getExistenceQuery(parser, field);
+    }
     throw new SolrException(
         SolrException.ErrorCode.BAD_REQUEST,
         "Range Queries are not supported for Dense Vector fields. Please use the {!knn} query parser to run K nearest neighbors search queries.");

--- a/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
+++ b/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
@@ -573,10 +573,6 @@ public class DenseVectorField extends FloatPointField {
     return baseQuery;
   }
 
-  /**
-   * Dense vector fields index neither docValues nor norms usable for existence checks, but Lucene
-   * exposes docs that contain a vector via {@link FieldExistsQuery}.
-   */
   @Override
   public Query getExistenceQuery(QParser parser, SchemaField field) {
     return new FieldExistsQuery(field.getName());

--- a/solr/core/src/test/org/apache/solr/schema/DenseVectorFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DenseVectorFieldTest.java
@@ -563,7 +563,7 @@ public class DenseVectorFieldTest extends AbstractBadConfigTestBase {
 
       SolrInputDocument doc1 = new SolrInputDocument();
       doc1.addField("id", "1");
-      doc1.addField("vector", Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f));
+      doc1.addField("vector", List.of(1.0f, 2.0f, 3.0f, 4.0f));
       assertU(adoc(doc1));
 
       SolrInputDocument doc2 = new SolrInputDocument();

--- a/solr/core/src/test/org/apache/solr/schema/DenseVectorFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DenseVectorFieldTest.java
@@ -556,18 +556,36 @@ public class DenseVectorFieldTest extends AbstractBadConfigTestBase {
     }
   }
 
-  /** Not Supported */
   @Test
-  public void query_existenceSearch_shouldThrowException() throws Exception {
+  public void query_existenceSearch_shouldMatchDocumentsWithVector() throws Exception {
     try {
       initCore("solrconfig-basic.xml", "schema-densevector.xml");
 
-      assertQEx(
-          "Running Existence queries on a dense vector field should raise an Exception",
-          "Range Queries are not supported for Dense Vector fields."
-              + " Please use the {!knn} query parser to run K nearest neighbors search queries.",
-          req("q", "vector:[* TO *]", "fl", "vector"),
-          SolrException.ErrorCode.BAD_REQUEST);
+      SolrInputDocument doc1 = new SolrInputDocument();
+      doc1.addField("id", "1");
+      doc1.addField("vector", Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f));
+      assertU(adoc(doc1));
+
+      SolrInputDocument doc2 = new SolrInputDocument();
+      doc2.addField("id", "2");
+      assertU(adoc(doc2));
+
+      assertU(commit());
+
+      assertJQ(
+          req("q", "vector:[* TO *]", "fl", "id", "sort", "id asc"),
+          "/response/numFound==1",
+          "/response/docs/[0]/id=='1'");
+
+      assertJQ(
+          req("q", "vector:*", "fl", "id", "sort", "id asc"),
+          "/response/numFound==1",
+          "/response/docs/[0]/id=='1'");
+
+      assertJQ(
+          req("q", "-vector:*", "fl", "id", "sort", "id asc"),
+          "/response/numFound==1",
+          "/response/docs/[0]/id=='2'");
     } finally {
       deleteCore();
     }

--- a/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
+++ b/solr/solr-ref-guide/modules/query-guide/pages/dense-vector-search.adoc
@@ -355,6 +355,8 @@ Apache Solr provides three query parsers that work with the `DenseVectorField` f
 
 All parsers return scores for retrieved documents that are the approximate distance to the target vector (defined by the similarityFunction configured at indexing time) and both support "Pre-Filtering" the document graph to reduce the number of candidate vectors evaluated (without needing to compute their vector similarity distances).
 
+While field queries and bounded range queries are not supported on `DenseVectorField`, existence queries such as `vector:*` (or the equivalent `vector:[* TO *]`) can be used to match documents that have a value for the vector field.
+
 Common parameters for all query parsers are:
 
 `f`::


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18329

# Description
DenseVectorField currently rejects existence queries with BAD_REQUEST.
Lucene has supported vector-field existence checks since 9.1 via
FieldExistsQuery, so Solr should allow the usual existence syntax on
dense vector fields.

Discuss:
- https://lists.apache.org/thread/5rgllrwmxr99k3wwrssbwy0p8nlh3rmx
- https://lists.apache.org/thread/x0x61yh07zzqo73cbct2hdzkybrlgr3m

# Solution
- Override DenseVectorField.getExistenceQuery() to return FieldExistsQuery
- Treat unbounded ranges (`[* TO *]`) as existence queries
- Keep rejecting bounded range queries
- Document existence query support in the dense vector search ref guide
- Add changelog entry

AI coding assistants were used while preparing this change.

# Tests
- Updated DenseVectorFieldTest to verify:
  - `vector:*`
  - `-vector:*`
  - `vector:[* TO *]`
- Confirmed bounded range queries still return BAD_REQUEST
- Ran:
  - `./gradlew :solr:core:test --tests org.apache.solr.schema.DenseVectorFieldTest.query_existenceSearch_shouldMatchDocumentsWithVector --tests org.apache.solr.schema.DenseVectorFieldTest.query_rangeSearch_shouldThrowException`
  - `./gradlew :solr:core:check -x test`

# Checklist
Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://solr.apache.org/guide/solr/latest/deployment-guide/how-to-contribute.html) and this [code review
  sheet](https://cwiki.apache.org/confluence/display/solr/Code+Review+Checklist)
- [x] I have created a Jira issue and added the issue ID to this pull request title
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch
  (optional but recommended)
- [x] I have developed this patch against the `main` branch
- [ ] I have run `./gradlew check`
- [x] I have added tests for my changes
- [x] I have added documentation for the [Reference Guide](https://solr.apache.org/guide/solr/latest/deployment-guide/how-to-contribute.html#reference-guide)
- [x] I have added a `changelog` entry
