### PR TITLE
Speed up TestOnReconnectListenerSupport by porting to SolrCloudTestCase

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/TestOnReconnectListenerSupport.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestOnReconnectListenerSupport.java
@@ -17,63 +17,42 @@
 
 package org.apache.solr.cloud;
 
-import static org.apache.solr.common.cloud.ZkStateReader.CORE_NAME_PROP;
-
-import java.lang.invoke.MethodHandles;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.cloud.OnReconnect;
 import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.schema.ZkIndexSchemaReader;
+import org.apache.solr.util.TimeOut;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
-public class TestOnReconnectListenerSupport extends AbstractFullDistribZkTestBase {
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  public TestOnReconnectListenerSupport() {
-    super();
-    sliceCount = 2;
-    fixShardCount(3);
-  }
+public class TestOnReconnectListenerSupport extends SolrCloudTestCase {
 
   @BeforeClass
-  public static void initSysProperties() {
+  public static void setupCluster() throws Exception {
     System.setProperty("managed.schema.mutable", "false");
-    System.setProperty("solr.index.updatelog.enabled", "true");
-  }
-
-  @Override
-  protected String getCloudSolrConfig() {
-    return "solrconfig-managed-schema.xml";
+    configureCluster(1).addConfig("conf1", configset("cloud-managed")).configure();
   }
 
   @Test
   public void test() throws Exception {
-    waitForThingsToLevelOut(30, TimeUnit.SECONDS);
-
     String testCollectionName = "c8n_onreconnect_1x1";
-    String shardId = "shard1";
-    createCollectionRetry(testCollectionName, "conf1", 1, 1);
+    CollectionAdminRequest.createCollection(testCollectionName, "conf1", 1, 1)
+        .process(cluster.getSolrClient());
+    cluster.waitForActiveCollection(testCollectionName, 1, 1);
 
-    Replica leader = getShardLeader(testCollectionName, shardId, 30 /* timeout secs */);
-    JettySolrRunner leaderJetty = getJettyOnPort(getReplicaPort(leader));
-
-    // get the ZkController for the node hosting the leader
-    CoreContainer cores = leaderJetty.getCoreContainer();
+    Replica leader = getCollectionState(testCollectionName).getReplicas().get(0);
+    CoreContainer cores = cluster.getJettySolrRunner(0).getCoreContainer();
     ZkController zkController = cores.getZkController();
     assertNotNull("ZkController is null", zkController);
 
-    String leaderCoreName = leader.getStr(CORE_NAME_PROP);
+    String leaderCoreName = leader.getCoreName();
     String leaderCoreId;
     try (SolrCore leaderCore = cores.getCore(leaderCoreName)) {
       assertNotNull("SolrCore for " + leaderCoreName + " not found!", leaderCore);
@@ -81,33 +60,16 @@ public class TestOnReconnectListenerSupport extends AbstractFullDistribZkTestBas
     }
 
     // verify the ZkIndexSchemaReader is a registered OnReconnect listener
-    Set<OnReconnect> listeners = zkController.getCurrentOnReconnectListeners();
-    assertNotNull("ZkController returned null OnReconnect listeners", listeners);
-    ZkIndexSchemaReader expectedListener = null;
-    for (OnReconnect listener : listeners) {
-      if (listener instanceof ZkIndexSchemaReader reader) {
-        if (leaderCoreId.equals(reader.getUniqueCoreId())) {
-          expectedListener = reader;
-          break;
-        }
-      }
-    }
     assertNotNull(
         "ZkIndexSchemaReader for core "
             + leaderCoreName
             + " not registered as an OnReconnect listener and should be",
-        expectedListener);
+        findSchemaReaderListener(zkController, leaderCoreId));
 
-    // reload the collection
-    boolean wasReloaded = reloadCollection(leader, testCollectionName);
-    assertTrue(
-        "Collection '"
-            + testCollectionName
-            + "' failed to reload within a reasonable amount of time!",
-        wasReloaded);
+    // reload the collection; the reloaded core should be registered as an OnReconnect listener
+    // and the old core should not be
+    CollectionAdminRequest.reloadCollection(testCollectionName).process(cluster.getSolrClient());
 
-    // after reload, the new core should be registered as an OnReconnect listener and the old should
-    // not be
     String reloadedLeaderCoreId;
     try (SolrCore leaderCore = cores.getCore(leaderCoreName)) {
       reloadedLeaderCoreId = leaderCore.getName() + ":" + leaderCore.getStartNanoTime();
@@ -116,51 +78,40 @@ public class TestOnReconnectListenerSupport extends AbstractFullDistribZkTestBas
     // they shouldn't be equal after reload
     assertNotEquals(leaderCoreId, reloadedLeaderCoreId);
 
-    listeners = zkController.getCurrentOnReconnectListeners();
-    assertNotNull("ZkController returned null OnReconnect listeners", listeners);
-
-    expectedListener = null; // reset
-    for (OnReconnect listener : listeners) {
-      if (listener instanceof ZkIndexSchemaReader reader) {
-        if (leaderCoreId.equals(reader.getUniqueCoreId())) {
-          fail(
-              "Previous core "
-                  + leaderCoreId
-                  + " should no longer be a registered OnReconnect listener! Current listeners: "
-                  + listeners);
-        } else if (reloadedLeaderCoreId.equals(reader.getUniqueCoreId())) {
-          expectedListener = reader;
-          break;
-        }
-      }
-    }
-
+    assertNull(
+        "Previous core "
+            + leaderCoreId
+            + " should no longer be a registered OnReconnect listener! Current listeners: "
+            + zkController.getCurrentOnReconnectListeners(),
+        findSchemaReaderListener(zkController, leaderCoreId));
     assertNotNull(
         "ZkIndexSchemaReader for core "
             + reloadedLeaderCoreId
             + " not registered as an OnReconnect listener and should be",
-        expectedListener);
+        findSchemaReaderListener(zkController, reloadedLeaderCoreId));
 
-    // try to clean up
-    try {
-      CollectionAdminRequest.deleteCollection(testCollectionName).process(cloudClient);
-    } catch (Exception e) {
-      // don't fail the test
-      log.warn("Could not delete collection {} after test completed", testCollectionName);
-    }
+    // deleting the collection should unregister the listener once the core closes
+    CollectionAdminRequest.deleteCollection(testCollectionName).process(cluster.getSolrClient());
 
-    listeners = zkController.getCurrentOnReconnectListeners();
+    TimeOut timeOut = new TimeOut(30, TimeUnit.SECONDS, TimeSource.NANO_TIME);
+    timeOut.waitFor(
+        "Core "
+            + reloadedLeaderCoreId
+            + " should no longer be a registered OnReconnect listener after collection delete!",
+        () -> findSchemaReaderListener(zkController, reloadedLeaderCoreId) == null);
+  }
+
+  /** Returns the registered {@link ZkIndexSchemaReader} listener for the given core id, if any. */
+  private static ZkIndexSchemaReader findSchemaReaderListener(
+      ZkController zkController, String coreId) {
+    Set<OnReconnect> listeners = zkController.getCurrentOnReconnectListeners();
+    assertNotNull("ZkController returned null OnReconnect listeners", listeners);
     for (OnReconnect listener : listeners) {
-      if (listener instanceof ZkIndexSchemaReader reader) {
-        if (reloadedLeaderCoreId.equals(reader.getUniqueCoreId())) {
-          fail(
-              "Previous core "
-                  + reloadedLeaderCoreId
-                  + " should no longer be a registered OnReconnect listener after collection delete!");
-        }
+      if (listener instanceof ZkIndexSchemaReader reader
+          && coreId.equals(reader.getUniqueCoreId())) {
+        return reader;
       }
     }
-
-    log.info("TestOnReconnectListenerSupport succeeded ... shutting down now!");
+    return null;
   }
 }


### PR DESCRIPTION
The test spun up **4 Jetty nodes** (1 control + 3 cloud, `sliceCount=2`/`fixShardCount(3)`) via the legacy `AbstractFullDistribZkTestBase`, plus a control collection — yet only ever creates and inspects a **1-shard/1-replica** collection.

Rewritten on `SolrCloudTestCase` with a single node, using the `cloud-managed` configset (`ManagedIndexSchemaFactory`, which is what registers `ZkIndexSchemaReader` as an `OnReconnect` listener — the behavior under test). All assertions are preserved:

* `ZkIndexSchemaReader` registered as an `OnReconnect` listener for the core
* after collection RELOAD, the old core's listener is unregistered and the new core's is registered
* after collection DELETE, the listener is unregistered (now with an explicit wait instead of a one-shot check)

Measured locally: suite time drops from **~14s to ~3s** (test method 13.6s → 0.7s). Also one fewer test on the legacy `AbstractFullDistribZkTestBase`.

Test-only change, no changelog entry.

### Why and how
Crave is shutting down. We need to speed up our tests. I asked claude to pick 50 solr-core tests at random and look for speed improvements. It picked this first and improved it from 13 to 1 seconds.