### PR TITLE
SOLR-18334: PRS collection creation returns too early

### DIFF
--- a/changelog/unreleased/SOLR-18334-prs-creation-waitForState.yml
+++ b/changelog/unreleased/SOLR-18334-prs-creation-waitForState.yml
@@ -1,0 +1,8 @@
+title: >
+  PRS based collection creation returns too early; can cause restore failure.
+type: fixed
+authors:
+  - name: David Smiley
+links:
+  - name: SOLR-18334
+    url: https://issues.apache.org/jira/browse/SOLR-18334

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -204,6 +204,17 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
         clusterState = clusterState.copyWith(collectionName, command.collection);
         newColl = command.collection;
         ccc.submitIntraProcessMessage(new RefreshCollectionMessage(collectionName));
+
+        // ensure the local ZkStateReader sees the collection before returning, so callers get the
+        // same "collection exists" guarantee as the non-PRS path
+        try {
+          zkStateReader.waitForState(collectionName, 30, TimeUnit.SECONDS, Objects::nonNull);
+        } catch (TimeoutException e) {
+          throw new SolrException(
+              SolrException.ErrorCode.SERVER_ERROR,
+              "Could not fully create collection: " + collectionName,
+              e);
+        }
       } else {
         if (ccc.getDistributedClusterStateUpdater().isDistributedStateUpdate()) {
           // The message has been crafted by CollectionsHandler.CollectionOperation.CREATE_OP and


### PR DESCRIPTION
--can cause restore failure.
As seen by some flaky tests.

https://issues.apache.org/jira/browse/SOLR-18334

See the detailed JIRA description.