### PR TITLE
SOLR-18188: httpClient is left open causing flaky nightly o.a.s.cloud.ChaosMonkeyNothingIsSafeTest

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/cloud/FullThrottleStoppableIndexingThread.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/FullThrottleStoppableIndexingThread.java
@@ -31,6 +31,7 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.jetty.ConcurrentUpdateJettySolrClient;
 import org.apache.solr.client.solrj.jetty.HttpJettySolrClient;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,6 +146,7 @@ class FullThrottleStoppableIndexingThread extends StoppableIndexingThread {
       log.warn("Exception waiting for the indexing client to finish", e);
     } finally {
       cusc.shutdownNow();
+      IOUtils.closeQuietly(httpClient);
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18188


# Description

I noticed that the nightly main builds on jenkins have been failing for a bit: https://ci-builds.apache.org/job/Solr/job/Solr-NightlyTests-main/1878/

I looked and saw two tests.  I asked Claude to dig in, and it came back the work in SOLR-18188 as the probably cause.   Did some testing, and here is what makes a reproducible failure on main, and a fix on this branch:

./gradlew :solr:core:test --tests "org.apache.solr.cloud.ChaosMonkeyNothingIsSafeTest" \
    -Ptests.nightly=true -Ptests.seed=DEAD00000000004 --rerun-tasks

`-Ptests.seed=DEAD00000000004` and `DEAD00000000005` are seeds that draw `runFullThrottle=true` and reliably reproduce the `HttpJettySolrClient` leak without the fix. With the fix applied, both pass. Seeds that draw `runFullThrottle=false` (e.g. `DEAD00000000001`) pass either way, so use one of the two seeds above to exercise the affected path.
# Solution

Claude and I looked and he recommended this `IOUtils.closeQuietly`.


# Tests

Ran the failing test on branch, it passes, on main, it fails.
