### PR TITLE
Fix flaky ChaosMonkeySafeLeaderWithPullReplicasTest

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/cloud/StoppableIndexingThread.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/StoppableIndexingThread.java
@@ -25,12 +25,15 @@ import java.util.Set;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StoppableIndexingThread extends AbstractFullDistribZkTestBase.StoppableThread {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final int MAX_TRANSIENT_RETRIES = 5;
 
   static String t1 = "a_t";
   static String i1 = "a_i";
@@ -99,10 +102,12 @@ public class StoppableIndexingThread extends AbstractFullDistribZkTestBase.Stopp
             UpdateRequest req = new UpdateRequest();
             req.deleteById(deleteId);
             req.setParam("CONTROL", "TRUE");
-            req.process(controlClient);
+            processWithRetry(req, controlClient);
           }
 
-          cloudClient.deleteById(deleteId);
+          UpdateRequest cloudReq = new UpdateRequest();
+          cloudReq.deleteById(deleteId);
+          processWithRetry(cloudReq, cloudClient);
         } catch (Exception e) {
           log.error("REQUEST FAILED for id={}", deleteId, e);
           if (e instanceof SolrServerException) {
@@ -185,11 +190,45 @@ public class StoppableIndexingThread extends AbstractFullDistribZkTestBase.Stopp
       UpdateRequest req = new UpdateRequest();
       req.add(docs);
       req.setParam("CONTROL", "TRUE");
-      req.process(controlClient);
+      processWithRetry(req, controlClient);
     }
 
     UpdateRequest ureq = new UpdateRequest();
     ureq.add(docs);
-    ureq.process(cloudClient);
+    processWithRetry(ureq, cloudClient);
+  }
+
+  /**
+   * Process the request, retrying a bounded number of times when the failure is an ambiguous
+   * transport-level error (root cause is an {@link IOException}), such as a node being stopped by
+   * the chaos monkey while the request was in flight. Everything this thread sends is idempotent
+   * (adds of docs with unique ids and delete-by-id), so at-least-once delivery is safe, and
+   * retrying is what a well-behaved indexing application would do. Solr-level errors (e.g. a 4xx
+   * response) are not retried.
+   */
+  private void processWithRetry(UpdateRequest req, SolrClient client)
+      throws IOException, SolrServerException {
+    for (int attempt = 1; ; attempt++) {
+      try {
+        req.process(client);
+        return;
+      } catch (SolrServerException | IOException e) {
+        Throwable rootCause = SolrException.getRootCause(e);
+        if (attempt >= MAX_TRANSIENT_RETRIES || !(rootCause instanceof IOException)) {
+          throw e;
+        }
+        log.info(
+            "Retrying update after transient error (attempt {}/{})",
+            attempt,
+            MAX_TRANSIENT_RETRIES,
+            rootCause);
+        try {
+          Thread.sleep(250L * attempt);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw e;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

The nightly `ChaosMonkeySafeLeaderWithPullReplicasTest` (and other chaos tests) can fail with `expected:<0> but was:<1>` at `assertEquals(0, ((StoppableIndexingThread) thread).getFailCount())`. When the chaos monkey stops a node while an update is in flight, the Jetty HTTP/2 client surfaces the loss as an ambiguous `IOException` (e.g. `cancel_stream_error/input_shutdown`, `ClosedChannelException`) that `CloudSolrClient` does not retry, so the indexing thread records a failure and the test fails. Seen on Jenkins for both `main` and `branch_10x`.

# Solution

An earlier version of this PR broadened `CloudSolrClient.wasCommError()` to retry these HTTP/2 stream-failure `IOException`s. That was withdrawn: as @dsmiley pointed out, these protocol errors do **not** guarantee the server never processed the request, so retrying them for arbitrary (non-idempotent) updates risks double-processing. An audit of the Jetty 12.1.10 source confirms this — `cancel_stream_error/input_shutdown` is Jetty's *ambiguous* failure bucket; Jetty reserves `RetryableStreamException`/`RetryableRequestException` for the provably-safe subset and deliberately does not use it for this path. So a client-side classification change cannot safely fix the flake.

Instead, this PR fixes the flake where it is safe to do so: in the test framework. `StoppableIndexingThread` only sends idempotent operations — adds of documents with unique ids, and delete-by-id — so at-least-once delivery is correct, which is exactly what a well-behaved indexing application would do. It now retries the update a bounded number of times (5, with backoff) when the failure's root cause is an `IOException` (an ambiguous transport error). Solr-level errors (e.g. a 4xx/5xx response) are not retried.

No production code is changed; the fix is confined to `StoppableIndexingThread` in the test framework.

# Tests

- `ChaosMonkeySafeLeaderWithPullReplicasTest` passes with its previously-failing seed `E464797072CE8325`; a verbose rerun confirms the retry engages (`Retrying update after transient error (attempt 1/5): ClosedChannelException`).
- Fresh-seed sweep of `ChaosMonkey*`, `RestartWhileUpdatingTest`, and `TlogReplayBufferedWhileIndexingTest` is green.

> [!NOTE]
> The sweep surfaced a **separate, pre-existing** failure in the same test: the final `createCollection("testcollection")` overseer-survival check can time out (`Timeout waiting for 1 shards and 4 replicas`) when a lost response causes `LBSolrClient` to re-send the non-idempotent admin CREATE to another node. It is independent of this change and perhaps deserves its own issue...

--- 

The fix is AI assisted