### PR TITLE
SOLR-18332:  More qt-removal from tests, rd 3

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestCrossCoreJoin.java
+++ b/solr/core/src/test/org/apache/solr/TestCrossCoreJoin.java
@@ -151,8 +151,8 @@ public class TestCrossCoreJoin extends SolrTestCaseJ4 {
         "/response=={'numFound':3,'start':0,'numFoundExact':true,'docs':[{'id':'1'},{'id':'4'},{'id':'5'}]}");
 
     assertJQ(
-        "/export",
-        req(
+        reqWithPath(
+            "/export",
             "q",
             joinPrefix + " from=dept_id_s to=dept_s fromIndex=fromCore}cat:dev",
             "fl",

--- a/solr/core/src/test/org/apache/solr/TestCrossCoreJoin.java
+++ b/solr/core/src/test/org/apache/solr/TestCrossCoreJoin.java
@@ -151,9 +151,8 @@ public class TestCrossCoreJoin extends SolrTestCaseJ4 {
         "/response=={'numFound':3,'start':0,'numFoundExact':true,'docs':[{'id':'1'},{'id':'4'},{'id':'5'}]}");
 
     assertJQ(
+        "/export",
         req(
-            "qt",
-            "/export",
             "q",
             joinPrefix + " from=dept_id_s to=dept_s fromIndex=fromCore}cat:dev",
             "fl",

--- a/solr/core/src/test/org/apache/solr/handler/MoreLikeThisHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/MoreLikeThisHandlerTest.java
@@ -221,16 +221,14 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
 
     // test that qparser plugins work w/ the MoreLikeThisHandler
     params.set(CommonParams.Q, "{!field f=id}44");
-    try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
-      assertQ(null, "/mlt", mltreq, "//result/doc[1]/str[@name='id'][.='45']");
+    try (SolrQueryRequest mltreq = withPath("/mlt", new SolrQueryRequestBase(core, params))) {
+      assertQ(mltreq, "//result/doc[1]/str[@name='id'][.='45']");
     }
 
     // test that debugging works (test for MoreLikeThis*Handler*)
     params.set(CommonParams.DEBUG_QUERY, "true");
-    try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
+    try (SolrQueryRequest mltreq = withPath("/mlt", new SolrQueryRequestBase(core, params))) {
       assertQ(
-          null,
-          "/mlt",
           mltreq,
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='debug']/lst[@name='explain']");
@@ -238,20 +236,16 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
 
     params.set(FacetComponent.COMPONENT_NAME, "true");
     params.set("facet.field", "name");
-    try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
+    try (SolrQueryRequest mltreq = withPath("/mlt", new SolrQueryRequestBase(core, params))) {
       assertQ(
-          null,
-          "/mlt",
           mltreq,
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='facet_counts']/lst[@name='facet_fields']/lst[@name='name']/int[@name='George'][.='1']");
     }
     params.set("facet.field", "{!ex=tg}name");
     params.set("fq", "{!tag=tg}name:George");
-    try (SolrQueryRequest mltreq = new SolrQueryRequestBase(core, params)) {
+    try (SolrQueryRequest mltreq = withPath("/mlt", new SolrQueryRequestBase(core, params))) {
       assertQ(
-          null,
-          "/mlt",
           mltreq,
           "//result/doc[1]/str[@name='id'][.='45']",
           "//lst[@name='facet_counts']/lst[@name='facet_fields']/lst[@name='name']/int[@name='George'][.='1']");
@@ -279,12 +273,11 @@ public class MoreLikeThisHandlerTest extends SolrTestCaseJ4 {
 
     try (SolrQueryRequestBase req = new SolrQueryRequestBase(core, params) {}) {
       req.setContentStreams(List.of(new ContentStreamBase.StringStream("bbb", "zzz")));
+      req.getContext().put(CommonParams.PATH, "/mlt");
 
       // Make sure we have terms from both fields in the interestingTerms array and all documents
       // have been retrieved as matching.
       assertQ(
-          null,
-          "/mlt",
           req,
           "//lst[@name = 'interestingTerms']/float[@name = 'subword:bbb']",
           "//lst[@name = 'interestingTerms']/float[@name = 'name:bbb']",

--- a/solr/core/src/test/org/apache/solr/handler/component/QueryElevationComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/QueryElevationComponentTest.java
@@ -118,13 +118,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AAAA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[2]/str[@name='id'][.='9']",
@@ -156,9 +151,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // elevated docs 1, 2, and 3 are returned even though our query "ZZZZ" doesn't match them
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
@@ -172,9 +167,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // exclude docs 1 and 3 even though those docs are elevated
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "str_s:b"),
           "//*[@numFound='1']",
@@ -186,9 +181,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // docs
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1,test2}str_s:b",
               QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test3"),
@@ -200,9 +195,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // behavior as above; the filter still takes effect on the elevated docs
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1,test2}str_s:b",
               QueryElevationParams.ELEVATE_EXCLUDE_TAGS, ","),
@@ -215,9 +210,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // the original filter
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1,test2}str_s:b",
               QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test0,test2,test4"),
@@ -233,9 +228,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // this case, the main query); nor does including empty values in the list of tags to exclude
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "{!tag=test0}ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1,test1,test2,test2}str_s:b",
               QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test0,test0,test2,test2,test4,test4,,,"),
@@ -250,9 +245,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // we can exclude some filters while leaving others in place
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1}id:10",
               CommonParams.FQ, "{!tag=test2}str_s:b",
@@ -265,9 +260,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // when filters are marked as cache=false, tag exclusion works the same as before
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1 cache=false}id:10",
               CommonParams.FQ, "{!tag=test2 cache=false}str_s:b",
@@ -280,9 +275,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // we can apply the same tag to two different filters
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1}id:10",
               CommonParams.FQ, "{!tag=test2}str_s:b",
@@ -295,9 +290,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // we can use filter() syntax inside fq's that are tagged for exclusion
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1}+filter(id:10) +filter(id:11)",
               CommonParams.FQ, "{!tag=test2}filter(str_s:b)",
@@ -310,9 +305,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // if we search for MMMM we should get one match; no documents are elevated for this query
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "MMMM",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='4']",
@@ -321,9 +316,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // if we add fq=str_s:b, our one document that matches MMMM will be filtered out
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "MMMM",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "str_s:b"),
           "//*[@numFound='0']");
@@ -333,9 +328,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // subject to the filter
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "MMMM",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!tag=test1}str_s:b",
               QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1"),
@@ -345,9 +340,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // excluded; first, confirm that when collapsing, all elevated docs are visible by default
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!collapse field=str_s sort='score desc'}"),
           "//*[@numFound='3']",
@@ -361,9 +356,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // when collapsing, an added filter has the expected effect
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!collapse field=str_s sort='score desc'}",
               CommonParams.FQ, "str_s:b"),
@@ -375,9 +370,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // elevated documents
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!collapse field=str_s sort='score desc'}",
               CommonParams.FQ, "{!tag=test1}str_s:b",
@@ -396,12 +391,12 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
           "tagging a collapse filter for exclusion should lead to a BAD_REQUEST",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!collapse tag=test1 field=str_s sort='score desc'}",
               CommonParams.FQ, "{!tag=test2}str_s:b",
               QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1,test2"),
-          SolrException.ErrorCode.BAD_REQUEST);
+          SolrException.ErrorCode.BAD_REQUEST,
+          "/elevate");
 
       // if a function range query is provided as a filter, it can be tagged for exclusion;
       // FunctionRangeQuery is special because it implements the PostFilter interface and
@@ -410,9 +405,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // behavior
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "{!frange tag=test1 l=100 cache=false cost=200}5.0",
               CommonParams.FQ, "{!tag=test2}str_s:b",
@@ -454,7 +449,6 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       try (SolrQueryRequest request =
           req(
               CommonParams.Q, "ZZZZ1",
-              CommonParams.QT, "/elevate",
               CommonParams.DF, "text",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "str_s:A",
@@ -524,7 +518,6 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       try (SolrQueryRequest request =
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CommonParams.DF, "text",
               CommonParams.FL, "id, score, [elevated]",
               CommonParams.FQ, "str_s:A",
@@ -677,9 +670,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "non-elevated group query",
+          "/elevate",
           req(
               CommonParams.Q, "AAAA",
-              CommonParams.QT, "/elevate",
               GroupParams.GROUP_FIELD, "str_s",
               GroupParams.GROUP, "true",
               GroupParams.GROUP_TOTAL_COUNT, "true",
@@ -703,9 +696,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "elevated group query",
+          "/elevate",
           req(
               CommonParams.Q, "AAAA",
-              CommonParams.QT, "/elevate",
               GroupParams.GROUP_FIELD, "str_s",
               GroupParams.GROUP, "true",
               GroupParams.GROUP_TOTAL_COUNT, "true",
@@ -728,9 +721,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "non-elevated because sorted group query",
+          "/elevate",
           req(
               CommonParams.Q, "AAAA",
-              CommonParams.QT, "/elevate",
               CommonParams.SORT, "id asc",
               GroupParams.GROUP_FIELD, "str_s",
               GroupParams.GROUP, "true",
@@ -754,9 +747,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "force-elevated sorted group query",
+          "/elevate",
           req(
               CommonParams.Q, "AAAA",
-              CommonParams.QT, "/elevate",
               CommonParams.SORT, "id asc",
               QueryElevationParams.FORCE_ELEVATION, "true",
               GroupParams.GROUP_FIELD, "str_s",
@@ -781,9 +774,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "non-elevated because of sort within group query",
+          "/elevate",
           req(
               CommonParams.Q, "AAAA",
-              CommonParams.QT, "/elevate",
               CommonParams.SORT, "id asc",
               GroupParams.GROUP_SORT, "id desc",
               GroupParams.GROUP_FIELD, "str_s",
@@ -808,9 +801,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "force elevated sort within sorted group query",
+          "/elevate",
           req(
               CommonParams.Q, "AAAA",
-              CommonParams.QT, "/elevate",
               CommonParams.SORT, "id asc",
               GroupParams.GROUP_SORT, "id desc",
               QueryElevationParams.FORCE_ELEVATION, "true",
@@ -859,13 +852,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AAAA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[2]/str[@name='id'][.='8']",
@@ -933,7 +921,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
         assertQ(
             "Make sure QEC handles null queries",
-            req("qt", "/elevate", "q.alt", "*:*", "defType", "dismax"),
+            "/elevate",
+            req("q.alt", "*:*", "defType", "dismax"),
             "//*[@numFound='0']");
       }
     } finally {
@@ -957,13 +946,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "XXXX",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "XXXX", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='4']",
@@ -974,26 +958,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AAAA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
 
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AAAA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elev]"),
+          "/elevate",
+          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elev]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "not(//result/doc[1]/bool[@name='[elevated]'][.='false'])",
@@ -1027,11 +1001,10 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q,
               "XXXX XXXX",
-              CommonParams.QT,
-              "/elevate",
               QueryElevationParams.MARK_EXCLUDES,
               "true",
               "indent",
@@ -1052,11 +1025,10 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // thus, number 6 should not be returned, b/c it is excluded
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q,
               "XXXX XXXX",
-              CommonParams.QT,
-              "/elevate",
               QueryElevationParams.MARK_EXCLUDES,
               "false",
               CommonParams.FL,
@@ -1075,11 +1047,10 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // excluded results)
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q,
               "QQQQ",
-              CommonParams.QT,
-              "/elevate",
               QueryElevationParams.ENABLE,
               "false",
               "indent",
@@ -1092,11 +1063,10 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
           "//result/doc[3]/str[@name='id'][.='8']");
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q,
               "QQQQ",
-              CommonParams.QT,
-              "/elevate",
               QueryElevationParams.MARK_EXCLUDES,
               "true",
               "indent",
@@ -1132,7 +1102,6 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       final SolrParams baseParams =
           params(
-              "qt", "/elevate",
               "q", query,
               "fl", "id,score",
               "indent", "true");
@@ -1143,6 +1112,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "Make sure standard sort works as expected",
+          "/elevate",
           req(baseParams),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='c']",
@@ -1154,6 +1124,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "All six should make it",
+          "/elevate",
           req(baseParams),
           "//*[@numFound='6']",
           "//result/doc[1]/str[@name='id'][.='x']",
@@ -1166,6 +1137,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // now switch the order:
       booster.setTopQueryResults(reader, query, false, new String[] {"a", "x"}, null);
       assertQ(
+          null,
+          "/elevate",
           req(baseParams),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='a']",
@@ -1177,6 +1150,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // default 'forceBoost' should be false
       assertFalse(booster.forceElevation);
       assertQ(
+          null,
+          "/elevate",
           req(baseParams, "sort", "id asc"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='a']",
@@ -1186,6 +1161,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "useConfiguredElevatedOrder=false",
+          "/elevate",
           req(baseParams, "sort", "str_s1 asc,id desc", "useConfiguredElevatedOrder", "false"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='x']", // group1
@@ -1195,6 +1171,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       booster.forceElevation = true;
       assertQ(
+          null,
+          "/elevate",
           req(baseParams, "sort", "id asc"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='a']",
@@ -1205,6 +1183,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       booster.forceElevation = true;
       assertQ(
           "useConfiguredElevatedOrder=false and forceElevation",
+          "/elevate",
           req(baseParams, "sort", "id desc", "useConfiguredElevatedOrder", "false"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='x']", // force elevated
@@ -1215,6 +1194,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Test exclusive (not to be confused with exclusion)
       booster.setTopQueryResults(reader, query, false, new String[] {"x", "a"}, new String[] {});
       assertQ(
+          null,
+          "/elevate",
           req(baseParams, "exclusive", "true"),
           "//*[@numFound='2']",
           "//result/doc[1]/str[@name='id'][.='x']",
@@ -1223,6 +1204,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Test exclusion
       booster.setTopQueryResults(reader, query, false, new String[] {"x"}, new String[] {"a"});
       assertQ(
+          null,
+          "/elevate",
           req(baseParams),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='x']",
@@ -1234,6 +1217,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       booster.clearElevationProviderCache();
       assertQ(
           "All five should make it",
+          "/elevate",
           req(baseParams, "elevateIds", "x,y,z", "excludeIds", "b"),
           "//*[@numFound='5']",
           "//result/doc[1]/str[@name='id'][.='x']",
@@ -1244,6 +1228,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "All four should make it",
+          "/elevate",
           req(baseParams, "elevateIds", "x,z,y", "excludeIds", "b,c"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='x']",
@@ -1363,37 +1348,22 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AAAA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "{!q.op=AND}AAAA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "{!q.op=AND}AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "{!q.op=AND v='AAAA'}",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "{!q.op=AND v='AAAA'}", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -1425,13 +1395,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Exact matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "XXXX",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "XXXX", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='4']",
@@ -1443,25 +1408,15 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Exact matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "QQQQ EE",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "QQQQ EE", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='0']");
 
       // Subset matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "BB DD CC VV",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "BB DD CC VV", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='10']",
           "//result/doc[2]/str[@name='id'][.='12']",
@@ -1475,13 +1430,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset + exact matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "BB CC",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "BB CC", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='13']",
           "//result/doc[2]/str[@name='id'][.='10']",
@@ -1495,13 +1445,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AA BB DD CC AA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AA BB DD CC AA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='10']",
           "//result/doc[2]/str[@name='id'][.='12']",
@@ -1515,13 +1460,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AA RR BB DD AA",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AA RR BB DD AA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='12']",
           "//result/doc[2]/str[@name='id'][.='14']",
@@ -1533,13 +1473,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset matching.
       assertQ(
           "",
-          req(
-              CommonParams.Q,
-              "AA BB EE",
-              CommonParams.QT,
-              "/elevate",
-              CommonParams.FL,
-              "id, score, [elevated]"),
+          "/elevate",
+          req(CommonParams.Q, "AA BB EE", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='0']");
     } finally {
       delete();
@@ -1598,9 +1533,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // default behaviour
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "YYYY",
-              CommonParams.QT, "/elevate",
               QueryElevationParams.ELEVATE_ONLY_DOCS_MATCHING_QUERY, "false",
               CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
@@ -1614,9 +1549,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // only docs that matches q
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "YYYY",
-              CommonParams.QT, "/elevate",
               QueryElevationParams.ELEVATE_ONLY_DOCS_MATCHING_QUERY, "true",
               CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='2']",
@@ -1644,9 +1579,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // default behaviour - all elevated docs are visible
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CollapsingQParserPlugin.COLLECT_ELEVATED_DOCS_WHEN_COLLAPSING, "true",
               CommonParams.FQ, "{!collapse field=str_s1 sort='score desc'}",
               CommonParams.FL, "id, score, [elevated]"),
@@ -1663,9 +1598,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // only representative elevated doc visible
       assertQ(
           "",
+          "/elevate",
           req(
               CommonParams.Q, "ZZZZ",
-              CommonParams.QT, "/elevate",
               CollapsingQParserPlugin.COLLECT_ELEVATED_DOCS_WHEN_COLLAPSING, "false",
               CommonParams.FQ, "{!collapse field=str_s1 sort='score desc'}",
               CommonParams.FL, "id, score, [elevated]"),
@@ -1698,7 +1633,6 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       final SolrParams baseParams =
           params(
-              "qt", "/elevate",
               "q", "title:ipod",
               "sort", "score desc, id asc",
               "fl", "id",
@@ -1707,12 +1641,14 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       // sanity check everything returned w/these elevation options...
       assertJQ(
+          "/elevate",
           req(baseParams),
           "/response/numFound==5",
           "/response/start==0",
           "/response/docs==[{'id':'x'},{'id':'y'},{'id':'z'},{'id':'c'},{'id':'a'}]");
       // same query using CURSOR_MARK_START should produce a 'next' cursor...
       assertCursorJQ(
+          "/elevate",
           req(baseParams, CURSOR_MARK_PARAM, CURSOR_MARK_START),
           "/response/numFound==5",
           "/response/start==0",
@@ -1722,18 +1658,21 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       String nextCursor = null;
       nextCursor =
           assertCursorJQ(
+              "/elevate",
               req(baseParams, CURSOR_MARK_PARAM, CURSOR_MARK_START, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
               "/response/docs==[{'id':'x'},{'id':'y'}]");
       nextCursor =
           assertCursorJQ(
+              "/elevate",
               req(baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
               "/response/docs==[{'id':'z'},{'id':'c'}]");
       nextCursor =
           assertCursorJQ(
+              "/elevate",
               req(baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
@@ -1741,6 +1680,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       final String lastCursor = nextCursor;
       nextCursor =
           assertCursorJQ(
+              "/elevate",
               req(baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
@@ -1762,8 +1702,9 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
    *
    * @see #assertJQ
    */
-  private static String assertCursorJQ(SolrQueryRequest req, String... tests) throws Exception {
-    String json = assertJQ(req, tests);
+  private static String assertCursorJQ(String handler, SolrQueryRequest req, String... tests)
+      throws Exception {
+    String json = assertJQ(handler, req, tests);
     Map<?, ?> rsp = (Map<?, ?>) fromJSONString(json);
     assertTrue(
         "response doesn't contain " + CURSOR_MARK_NEXT + ": " + json,

--- a/solr/core/src/test/org/apache/solr/handler/component/QueryElevationComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/QueryElevationComponentTest.java
@@ -118,8 +118,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[2]/str[@name='id'][.='9']",
@@ -151,10 +150,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // elevated docs 1, 2, and 3 are returned even though our query "ZZZZ" doesn't match them
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "ZZZZ", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -167,11 +163,14 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // exclude docs 1 and 3 even though those docs are elevated
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "str_s:b"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "str_s:b"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -181,12 +180,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // docs
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1,test2}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test3"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1,test2}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test3"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -195,12 +198,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // behavior as above; the filter still takes effect on the elevated docs
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1,test2}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, ","),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1,test2}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              ","),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -210,12 +217,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // the original filter
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1,test2}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test0,test2,test4"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1,test2}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test0,test2,test4"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -228,12 +239,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // this case, the main query); nor does including empty values in the list of tags to exclude
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "{!tag=test0}ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1,test1,test2,test2}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test0,test0,test2,test2,test4,test4,,,"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "{!tag=test0}ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1,test1,test2,test2}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test0,test0,test2,test2,test4,test4,,,"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -245,14 +260,20 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // we can exclude some filters while leaving others in place
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1}id:10",
-              CommonParams.FQ, "{!tag=test2}str_s:b",
-              CommonParams.FQ, "{!tag=test3}id:11",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1,test3"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1}id:10",
+              CommonParams.FQ,
+              "{!tag=test2}str_s:b",
+              CommonParams.FQ,
+              "{!tag=test3}id:11",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1,test3"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -260,14 +281,20 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // when filters are marked as cache=false, tag exclusion works the same as before
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1 cache=false}id:10",
-              CommonParams.FQ, "{!tag=test2 cache=false}str_s:b",
-              CommonParams.FQ, "{!tag=test3 cache=false}id:11",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1,test3"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1 cache=false}id:10",
+              CommonParams.FQ,
+              "{!tag=test2 cache=false}str_s:b",
+              CommonParams.FQ,
+              "{!tag=test3 cache=false}id:11",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1,test3"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -275,14 +302,20 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // we can apply the same tag to two different filters
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1}id:10",
-              CommonParams.FQ, "{!tag=test2}str_s:b",
-              CommonParams.FQ, "{!tag=test1}id:11",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1,test3"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1}id:10",
+              CommonParams.FQ,
+              "{!tag=test2}str_s:b",
+              CommonParams.FQ,
+              "{!tag=test1}id:11",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1,test3"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -290,13 +323,18 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // we can use filter() syntax inside fq's that are tagged for exclusion
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1}+filter(id:10) +filter(id:11)",
-              CommonParams.FQ, "{!tag=test2}filter(str_s:b)",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1}+filter(id:10) +filter(id:11)",
+              CommonParams.FQ,
+              "{!tag=test2}filter(str_s:b)",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -305,10 +343,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // if we search for MMMM we should get one match; no documents are elevated for this query
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "MMMM",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "MMMM", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='4']",
           "//result/doc[1]/bool[@name='[elevated]'][.='false']");
@@ -316,11 +351,14 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // if we add fq=str_s:b, our one document that matches MMMM will be filtered out
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "MMMM",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "str_s:b"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "MMMM",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "str_s:b"),
           "//*[@numFound='0']");
 
       // if we tag the filter and exclude it, we should see the same behavior as before; filters are
@@ -328,23 +366,30 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // subject to the filter
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "MMMM",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!tag=test1}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "MMMM",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!tag=test1}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1"),
           "//*[@numFound='0']");
 
       // the next few assertions confirm that collapsing works as expected when filters are
       // excluded; first, confirm that when collapsing, all elevated docs are visible by default
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!collapse field=str_s sort='score desc'}"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!collapse field=str_s sort='score desc'}"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -356,12 +401,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // when collapsing, an added filter has the expected effect
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!collapse field=str_s sort='score desc'}",
-              CommonParams.FQ, "str_s:b"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!collapse field=str_s sort='score desc'}",
+              CommonParams.FQ,
+              "str_s:b"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -370,13 +419,18 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // elevated documents
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!collapse field=str_s sort='score desc'}",
-              CommonParams.FQ, "{!tag=test1}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!collapse field=str_s sort='score desc'}",
+              CommonParams.FQ,
+              "{!tag=test1}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -389,14 +443,19 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // user should be informed
       assertQEx(
           "tagging a collapse filter for exclusion should lead to a BAD_REQUEST",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!collapse tag=test1 field=str_s sort='score desc'}",
-              CommonParams.FQ, "{!tag=test2}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1,test2"),
-          SolrException.ErrorCode.BAD_REQUEST,
-          "/elevate");
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!collapse tag=test1 field=str_s sort='score desc'}",
+              CommonParams.FQ,
+              "{!tag=test2}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1,test2"),
+          SolrException.ErrorCode.BAD_REQUEST);
 
       // if a function range query is provided as a filter, it can be tagged for exclusion;
       // FunctionRangeQuery is special because it implements the PostFilter interface and
@@ -405,13 +464,18 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // behavior
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CommonParams.FL, "id, score, [elevated]",
-              CommonParams.FQ, "{!frange tag=test1 l=100 cache=false cost=200}5.0",
-              CommonParams.FQ, "{!tag=test2}str_s:b",
-              QueryElevationParams.ELEVATE_EXCLUDE_TAGS, "test1,test2"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CommonParams.FL,
+              "id, score, [elevated]",
+              CommonParams.FQ,
+              "{!frange tag=test1 l=100 cache=false cost=200}5.0",
+              CommonParams.FQ,
+              "{!tag=test2}str_s:b",
+              QueryElevationParams.ELEVATE_EXCLUDE_TAGS,
+              "test1,test2"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -670,15 +734,22 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "non-elevated group query",
-          "/elevate",
-          req(
-              CommonParams.Q, "AAAA",
-              GroupParams.GROUP_FIELD, "str_s",
-              GroupParams.GROUP, "true",
-              GroupParams.GROUP_TOTAL_COUNT, "true",
-              GroupParams.GROUP_LIMIT, "100",
-              QueryElevationParams.ENABLE, "false",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AAAA",
+              GroupParams.GROUP_FIELD,
+              "str_s",
+              GroupParams.GROUP,
+              "true",
+              GroupParams.GROUP_TOTAL_COUNT,
+              "true",
+              GroupParams.GROUP_LIMIT,
+              "100",
+              QueryElevationParams.ENABLE,
+              "false",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@name='ngroups'][.='3']",
           "//*[@name='matches'][.='6']",
           groups + "/lst[1]//doc[1]/str[@name='id'][.='6']",
@@ -696,14 +767,20 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "elevated group query",
-          "/elevate",
-          req(
-              CommonParams.Q, "AAAA",
-              GroupParams.GROUP_FIELD, "str_s",
-              GroupParams.GROUP, "true",
-              GroupParams.GROUP_TOTAL_COUNT, "true",
-              GroupParams.GROUP_LIMIT, "100",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AAAA",
+              GroupParams.GROUP_FIELD,
+              "str_s",
+              GroupParams.GROUP,
+              "true",
+              GroupParams.GROUP_TOTAL_COUNT,
+              "true",
+              GroupParams.GROUP_LIMIT,
+              "100",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@name='ngroups'][.='3']",
           "//*[@name='matches'][.='6']",
           groups + "/lst[1]//doc[1]/str[@name='id'][.='7']",
@@ -721,15 +798,22 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "non-elevated because sorted group query",
-          "/elevate",
-          req(
-              CommonParams.Q, "AAAA",
-              CommonParams.SORT, "id asc",
-              GroupParams.GROUP_FIELD, "str_s",
-              GroupParams.GROUP, "true",
-              GroupParams.GROUP_TOTAL_COUNT, "true",
-              GroupParams.GROUP_LIMIT, "100",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AAAA",
+              CommonParams.SORT,
+              "id asc",
+              GroupParams.GROUP_FIELD,
+              "str_s",
+              GroupParams.GROUP,
+              "true",
+              GroupParams.GROUP_TOTAL_COUNT,
+              "true",
+              GroupParams.GROUP_LIMIT,
+              "100",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@name='ngroups'][.='3']",
           "//*[@name='matches'][.='6']",
           groups + "/lst[1]//doc[1]/str[@name='id'][.='2']",
@@ -747,16 +831,24 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "force-elevated sorted group query",
-          "/elevate",
-          req(
-              CommonParams.Q, "AAAA",
-              CommonParams.SORT, "id asc",
-              QueryElevationParams.FORCE_ELEVATION, "true",
-              GroupParams.GROUP_FIELD, "str_s",
-              GroupParams.GROUP, "true",
-              GroupParams.GROUP_TOTAL_COUNT, "true",
-              GroupParams.GROUP_LIMIT, "100",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AAAA",
+              CommonParams.SORT,
+              "id asc",
+              QueryElevationParams.FORCE_ELEVATION,
+              "true",
+              GroupParams.GROUP_FIELD,
+              "str_s",
+              GroupParams.GROUP,
+              "true",
+              GroupParams.GROUP_TOTAL_COUNT,
+              "true",
+              GroupParams.GROUP_LIMIT,
+              "100",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@name='ngroups'][.='3']",
           "//*[@name='matches'][.='6']",
           groups + "/lst[1]//doc[1]/str[@name='id'][.='7']",
@@ -774,16 +866,24 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "non-elevated because of sort within group query",
-          "/elevate",
-          req(
-              CommonParams.Q, "AAAA",
-              CommonParams.SORT, "id asc",
-              GroupParams.GROUP_SORT, "id desc",
-              GroupParams.GROUP_FIELD, "str_s",
-              GroupParams.GROUP, "true",
-              GroupParams.GROUP_TOTAL_COUNT, "true",
-              GroupParams.GROUP_LIMIT, "100",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AAAA",
+              CommonParams.SORT,
+              "id asc",
+              GroupParams.GROUP_SORT,
+              "id desc",
+              GroupParams.GROUP_FIELD,
+              "str_s",
+              GroupParams.GROUP,
+              "true",
+              GroupParams.GROUP_TOTAL_COUNT,
+              "true",
+              GroupParams.GROUP_LIMIT,
+              "100",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@name='ngroups'][.='3']",
           "//*[@name='matches'][.='6']",
           groups + "/lst[1]//doc[1]/str[@name='id'][.='22']",
@@ -801,17 +901,26 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "force elevated sort within sorted group query",
-          "/elevate",
-          req(
-              CommonParams.Q, "AAAA",
-              CommonParams.SORT, "id asc",
-              GroupParams.GROUP_SORT, "id desc",
-              QueryElevationParams.FORCE_ELEVATION, "true",
-              GroupParams.GROUP_FIELD, "str_s",
-              GroupParams.GROUP, "true",
-              GroupParams.GROUP_TOTAL_COUNT, "true",
-              GroupParams.GROUP_LIMIT, "100",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AAAA",
+              CommonParams.SORT,
+              "id asc",
+              GroupParams.GROUP_SORT,
+              "id desc",
+              QueryElevationParams.FORCE_ELEVATION,
+              "true",
+              GroupParams.GROUP_FIELD,
+              "str_s",
+              GroupParams.GROUP,
+              "true",
+              GroupParams.GROUP_TOTAL_COUNT,
+              "true",
+              GroupParams.GROUP_LIMIT,
+              "100",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@name='ngroups'][.='3']",
           "//*[@name='matches'][.='6']",
           groups + "/lst[1]//doc[1]/str[@name='id'][.='7']",
@@ -852,8 +961,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[2]/str[@name='id'][.='8']",
@@ -921,8 +1029,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
         assertQ(
             "Make sure QEC handles null queries",
-            "/elevate",
-            req("q.alt", "*:*", "defType", "dismax"),
+            reqWithPath("/elevate", "q.alt", "*:*", "defType", "dismax"),
             "//*[@numFound='0']");
       }
     } finally {
@@ -946,8 +1053,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "XXXX", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "XXXX", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='4']",
@@ -958,16 +1064,14 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
 
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elev]"),
+          reqWithPath("/elevate", CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elev]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "not(//result/doc[1]/bool[@name='[elevated]'][.='false'])",
@@ -1001,8 +1105,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          "/elevate",
-          req(
+          reqWithPath(
+              "/elevate",
               CommonParams.Q,
               "XXXX XXXX",
               QueryElevationParams.MARK_EXCLUDES,
@@ -1025,8 +1129,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // thus, number 6 should not be returned, b/c it is excluded
       assertQ(
           "",
-          "/elevate",
-          req(
+          reqWithPath(
+              "/elevate",
               CommonParams.Q,
               "XXXX XXXX",
               QueryElevationParams.MARK_EXCLUDES,
@@ -1047,8 +1151,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // excluded results)
       assertQ(
           "",
-          "/elevate",
-          req(
+          reqWithPath(
+              "/elevate",
               CommonParams.Q,
               "QQQQ",
               QueryElevationParams.ENABLE,
@@ -1063,8 +1167,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
           "//result/doc[3]/str[@name='id'][.='8']");
       assertQ(
           "",
-          "/elevate",
-          req(
+          reqWithPath(
+              "/elevate",
               CommonParams.Q,
               "QQQQ",
               QueryElevationParams.MARK_EXCLUDES,
@@ -1112,8 +1216,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "Make sure standard sort works as expected",
-          "/elevate",
-          req(baseParams),
+          reqWithPath("/elevate", baseParams),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='c']",
           "//result/doc[2]/str[@name='id'][.='b']",
@@ -1124,8 +1227,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "All six should make it",
-          "/elevate",
-          req(baseParams),
+          reqWithPath("/elevate", baseParams),
           "//*[@numFound='6']",
           "//result/doc[1]/str[@name='id'][.='x']",
           "//result/doc[2]/str[@name='id'][.='y']",
@@ -1137,9 +1239,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // now switch the order:
       booster.setTopQueryResults(reader, query, false, new String[] {"a", "x"}, null);
       assertQ(
-          null,
-          "/elevate",
-          req(baseParams),
+          reqWithPath("/elevate", baseParams),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='a']",
           "//result/doc[2]/str[@name='id'][.='x']",
@@ -1150,9 +1250,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // default 'forceBoost' should be false
       assertFalse(booster.forceElevation);
       assertQ(
-          null,
-          "/elevate",
-          req(baseParams, "sort", "id asc"),
+          reqWithPath("/elevate", baseParams, "sort", "id asc"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='a']",
           "//result/doc[2]/str[@name='id'][.='b']",
@@ -1161,8 +1259,13 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "useConfiguredElevatedOrder=false",
-          "/elevate",
-          req(baseParams, "sort", "str_s1 asc,id desc", "useConfiguredElevatedOrder", "false"),
+          reqWithPath(
+              "/elevate",
+              baseParams,
+              "sort",
+              "str_s1 asc,id desc",
+              "useConfiguredElevatedOrder",
+              "false"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='x']", // group1
           "//result/doc[2]/str[@name='id'][.='a']", // group1
@@ -1171,9 +1274,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       booster.forceElevation = true;
       assertQ(
-          null,
-          "/elevate",
-          req(baseParams, "sort", "id asc"),
+          reqWithPath("/elevate", baseParams, "sort", "id asc"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='a']",
           "//result/doc[2]/str[@name='id'][.='x']",
@@ -1183,8 +1284,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       booster.forceElevation = true;
       assertQ(
           "useConfiguredElevatedOrder=false and forceElevation",
-          "/elevate",
-          req(baseParams, "sort", "id desc", "useConfiguredElevatedOrder", "false"),
+          reqWithPath(
+              "/elevate", baseParams, "sort", "id desc", "useConfiguredElevatedOrder", "false"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='x']", // force elevated
           "//result/doc[2]/str[@name='id'][.='a']", // force elevated
@@ -1194,9 +1295,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Test exclusive (not to be confused with exclusion)
       booster.setTopQueryResults(reader, query, false, new String[] {"x", "a"}, new String[] {});
       assertQ(
-          null,
-          "/elevate",
-          req(baseParams, "exclusive", "true"),
+          reqWithPath("/elevate", baseParams, "exclusive", "true"),
           "//*[@numFound='2']",
           "//result/doc[1]/str[@name='id'][.='x']",
           "//result/doc[2]/str[@name='id'][.='a']");
@@ -1204,9 +1303,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Test exclusion
       booster.setTopQueryResults(reader, query, false, new String[] {"x"}, new String[] {"a"});
       assertQ(
-          null,
-          "/elevate",
-          req(baseParams),
+          reqWithPath("/elevate", baseParams),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='x']",
           "//result/doc[2]/str[@name='id'][.='c']",
@@ -1217,8 +1314,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       booster.clearElevationProviderCache();
       assertQ(
           "All five should make it",
-          "/elevate",
-          req(baseParams, "elevateIds", "x,y,z", "excludeIds", "b"),
+          reqWithPath("/elevate", baseParams, "elevateIds", "x,y,z", "excludeIds", "b"),
           "//*[@numFound='5']",
           "//result/doc[1]/str[@name='id'][.='x']",
           "//result/doc[2]/str[@name='id'][.='y']",
@@ -1228,8 +1324,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "All four should make it",
-          "/elevate",
-          req(baseParams, "elevateIds", "x,z,y", "excludeIds", "b,c"),
+          reqWithPath("/elevate", baseParams, "elevateIds", "x,z,y", "excludeIds", "b,c"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='x']",
           "//result/doc[2]/str[@name='id'][.='z']",
@@ -1348,22 +1443,29 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "AAAA", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "{!q.op=AND}AAAA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "{!q.op=AND}AAAA",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "{!q.op=AND v='AAAA'}", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "{!q.op=AND v='AAAA'}",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='1']",
           "//result/doc[1]/str[@name='id'][.='7']",
           "//result/doc[1]/bool[@name='[elevated]'][.='true']");
@@ -1395,8 +1497,7 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Exact matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "XXXX", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath("/elevate", CommonParams.Q, "XXXX", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='4']",
@@ -1408,15 +1509,15 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Exact matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "QQQQ EE", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate", CommonParams.Q, "QQQQ EE", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='0']");
 
       // Subset matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "BB DD CC VV", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate", CommonParams.Q, "BB DD CC VV", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='10']",
           "//result/doc[2]/str[@name='id'][.='12']",
@@ -1430,8 +1531,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset + exact matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "BB CC", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate", CommonParams.Q, "BB CC", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='13']",
           "//result/doc[2]/str[@name='id'][.='10']",
@@ -1445,8 +1546,12 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AA BB DD CC AA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AA BB DD CC AA",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='10']",
           "//result/doc[2]/str[@name='id'][.='12']",
@@ -1460,8 +1565,12 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AA RR BB DD AA", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "AA RR BB DD AA",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='12']",
           "//result/doc[2]/str[@name='id'][.='14']",
@@ -1473,8 +1582,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // Subset matching.
       assertQ(
           "",
-          "/elevate",
-          req(CommonParams.Q, "AA BB EE", CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate", CommonParams.Q, "AA BB EE", CommonParams.FL, "id, score, [elevated]"),
           "//*[@numFound='0']");
     } finally {
       delete();
@@ -1533,11 +1642,14 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // default behaviour
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "YYYY",
-              QueryElevationParams.ELEVATE_ONLY_DOCS_MATCHING_QUERY, "false",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "YYYY",
+              QueryElevationParams.ELEVATE_ONLY_DOCS_MATCHING_QUERY,
+              "false",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -1549,11 +1661,14 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // only docs that matches q
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "YYYY",
-              QueryElevationParams.ELEVATE_ONLY_DOCS_MATCHING_QUERY, "true",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "YYYY",
+              QueryElevationParams.ELEVATE_ONLY_DOCS_MATCHING_QUERY,
+              "true",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='2']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[2]/str[@name='id'][.='5']",
@@ -1579,12 +1694,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // default behaviour - all elevated docs are visible
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CollapsingQParserPlugin.COLLECT_ELEVATED_DOCS_WHEN_COLLAPSING, "true",
-              CommonParams.FQ, "{!collapse field=str_s1 sort='score desc'}",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CollapsingQParserPlugin.COLLECT_ELEVATED_DOCS_WHEN_COLLAPSING,
+              "true",
+              CommonParams.FQ,
+              "{!collapse field=str_s1 sort='score desc'}",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='4']",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='2']",
@@ -1598,12 +1717,16 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       // only representative elevated doc visible
       assertQ(
           "",
-          "/elevate",
-          req(
-              CommonParams.Q, "ZZZZ",
-              CollapsingQParserPlugin.COLLECT_ELEVATED_DOCS_WHEN_COLLAPSING, "false",
-              CommonParams.FQ, "{!collapse field=str_s1 sort='score desc'}",
-              CommonParams.FL, "id, score, [elevated]"),
+          reqWithPath(
+              "/elevate",
+              CommonParams.Q,
+              "ZZZZ",
+              CollapsingQParserPlugin.COLLECT_ELEVATED_DOCS_WHEN_COLLAPSING,
+              "false",
+              CommonParams.FQ,
+              "{!collapse field=str_s1 sort='score desc'}",
+              CommonParams.FL,
+              "id, score, [elevated]"),
           "//*[@numFound='3']",
           "//result/doc[1]/str[@name='id'][.='2']",
           "//result/doc[2]/str[@name='id'][.='3']",
@@ -1641,15 +1764,13 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
 
       // sanity check everything returned w/these elevation options...
       assertJQ(
-          "/elevate",
-          req(baseParams),
+          reqWithPath("/elevate", baseParams),
           "/response/numFound==5",
           "/response/start==0",
           "/response/docs==[{'id':'x'},{'id':'y'},{'id':'z'},{'id':'c'},{'id':'a'}]");
       // same query using CURSOR_MARK_START should produce a 'next' cursor...
       assertCursorJQ(
-          "/elevate",
-          req(baseParams, CURSOR_MARK_PARAM, CURSOR_MARK_START),
+          reqWithPath("/elevate", baseParams, CURSOR_MARK_PARAM, CURSOR_MARK_START),
           "/response/numFound==5",
           "/response/start==0",
           "/response/docs==[{'id':'x'},{'id':'y'},{'id':'z'},{'id':'c'},{'id':'a'}]");
@@ -1658,30 +1779,27 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
       String nextCursor = null;
       nextCursor =
           assertCursorJQ(
-              "/elevate",
-              req(baseParams, CURSOR_MARK_PARAM, CURSOR_MARK_START, "rows", "2"),
+              reqWithPath(
+                  "/elevate", baseParams, CURSOR_MARK_PARAM, CURSOR_MARK_START, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
               "/response/docs==[{'id':'x'},{'id':'y'}]");
       nextCursor =
           assertCursorJQ(
-              "/elevate",
-              req(baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
+              reqWithPath("/elevate", baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
               "/response/docs==[{'id':'z'},{'id':'c'}]");
       nextCursor =
           assertCursorJQ(
-              "/elevate",
-              req(baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
+              reqWithPath("/elevate", baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
               "/response/docs==[{'id':'a'}]");
       final String lastCursor = nextCursor;
       nextCursor =
           assertCursorJQ(
-              "/elevate",
-              req(baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
+              reqWithPath("/elevate", baseParams, CURSOR_MARK_PARAM, nextCursor, "rows", "2"),
               "/response/numFound==5",
               "/response/start==0",
               "/response/docs==[]");
@@ -1702,9 +1820,8 @@ public class QueryElevationComponentTest extends SolrTestCaseJ4 {
    *
    * @see #assertJQ
    */
-  private static String assertCursorJQ(String handler, SolrQueryRequest req, String... tests)
-      throws Exception {
-    String json = assertJQ(handler, req, tests);
+  private static String assertCursorJQ(SolrQueryRequest req, String... tests) throws Exception {
+    String json = assertJQ(req, tests);
     Map<?, ?> rsp = (Map<?, ?>) fromJSONString(json);
     assertTrue(
         "response doesn't contain " + CURSOR_MARK_NEXT + ": " + json,

--- a/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentTest.java
@@ -227,11 +227,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
 
   private void doBasics() throws Exception {
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             TermVectorComponent.COMPONENT_NAME,
@@ -246,11 +245,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_postv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // tv.fl diff from fl
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             "fl",
@@ -266,11 +264,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_offtv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // multi-valued tv.fl
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             "fl",
@@ -288,11 +285,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_offtv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // re-use fl glob
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             "fl",
@@ -309,11 +305,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_postv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // re-use fl, ignore things we can't handle
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             "fl",
@@ -327,11 +322,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_postv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // re-use (multi-valued) fl, ignore things we can't handle
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             "fl",
@@ -349,11 +343,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
 
   private void doOptions() throws Exception {
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             TermVectorComponent.COMPONENT_NAME,
@@ -371,11 +364,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
         "/termVectors/0/test_posofftv/anoth=={'tf':1, 'offsets':{'start':20, 'end':27}, 'positions':{'position':5}, 'df':2, 'tf-idf':0.5}");
 
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             TermVectorComponent.COMPONENT_NAME,
@@ -387,8 +379,7 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     // test each combination at random
     final List<String> list = new ArrayList<>();
     list.addAll(
-        Arrays.asList(
-            "json.nl", "map", "qt", tv, "q", "id:0", TermVectorComponent.COMPONENT_NAME, "true"));
+        Arrays.asList("json.nl", "map", "q", "id:0", TermVectorComponent.COMPONENT_NAME, "true"));
     String[][] options =
         new String[][] {
           {TermVectorParams.TF, "'tf':1"},
@@ -413,16 +404,15 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     }
 
     expected.append("}");
-    assertJQ(req(list.toArray(new String[0])), expected.toString());
+    assertJQ(tv, req(list.toArray(new String[0])), expected.toString());
   }
 
   private void doPerField() throws Exception {
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             TermVectorComponent.COMPONENT_NAME,
@@ -462,11 +452,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     // stuffs start (20) and end offset (27) into the
     // payload:
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             TermVectorComponent.COMPONENT_NAME,
@@ -498,11 +487,10 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     // Kind of an odd test, but we just want to know if we don't generate an NPE when there is
     // nothing to give back in the term vectors.
     assertJQ(
+        tv,
         req(
             "json.nl",
             "map",
-            "qt",
-            tv,
             "q",
             "id:0",
             TermVectorComponent.COMPONENT_NAME,

--- a/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentTest.java
@@ -227,8 +227,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
 
   private void doBasics() throws Exception {
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -245,8 +245,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_postv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // tv.fl diff from fl
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -264,8 +264,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_offtv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // multi-valued tv.fl
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -285,8 +285,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_offtv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // re-use fl glob
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -305,8 +305,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_postv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // re-use fl, ignore things we can't handle
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -322,8 +322,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
             + " 'test_postv':{'anoth':{'tf':1},'titl':{'tf':2}}}}");
     // re-use (multi-valued) fl, ignore things we can't handle
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -343,8 +343,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
 
   private void doOptions() throws Exception {
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -364,8 +364,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
         "/termVectors/0/test_posofftv/anoth=={'tf':1, 'offsets':{'start':20, 'end':27}, 'positions':{'position':5}, 'df':2, 'tf-idf':0.5}");
 
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -404,13 +404,13 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     }
 
     expected.append("}");
-    assertJQ(tv, req(list.toArray(new String[0])), expected.toString());
+    assertJQ(reqWithPath(tv, list.toArray(new String[0])), expected.toString());
   }
 
   private void doPerField() throws Exception {
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -452,8 +452,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     // stuffs start (20) and end offset (27) into the
     // payload:
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",
@@ -487,8 +487,8 @@ public class TermVectorComponentTest extends SolrTestCaseJ4 {
     // Kind of an odd test, but we just want to know if we don't generate an NPE when there is
     // nothing to give back in the term vectors.
     assertJQ(
-        tv,
-        req(
+        reqWithPath(
+            tv,
             "json.nl",
             "map",
             "q",

--- a/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
@@ -84,9 +84,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testEmptyLower() {
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "lowerfilt", "terms.upper", "b"),
+        reqWithPath("/terms", "indent", "true", "terms.fl", "lowerfilt", "terms.upper", "b"),
         "count(//lst[@name='lowerfilt']/*)=6",
         "//int[@name='a'] ",
         "//int[@name='aa'] ",
@@ -99,9 +97,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testMultipleFields() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -117,15 +114,13 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testUnlimitedRows() {
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "lowerfilt", "terms.fl", "standardfilt"),
+        reqWithPath(
+            "/terms", "indent", "true", "terms.fl", "lowerfilt", "terms.fl", "standardfilt"),
         "count(//lst[@name='lowerfilt']/*)=9",
         "count(//lst[@name='standardfilt']/*)=10");
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -141,9 +136,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testPrefix() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -169,9 +163,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testRegexp() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -223,9 +216,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   public void testRegexpWithFlags() {
     // TODO: there are no uppercase or mixed-case terms in the index!
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -248,9 +240,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testSortCount() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -273,9 +264,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   public void testTermsList() {
     // Terms list always returns in index order
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -291,9 +281,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
     // Test with numeric terms
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "foo_i", "terms.list", "2,1"),
+        reqWithPath("/terms", "indent", "true", "terms.fl", "foo_i", "terms.list", "2,1"),
         "count(//lst[@name='foo_i']/*)=2",
         "//lst[@name='foo_i']/int[1][@name='1'][.='2']",
         "//lst[@name='foo_i']/int[2][@name='2'][.='1']");
@@ -303,9 +291,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   public void testStats() {
     // Terms list always returns in index order
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -320,9 +307,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testSortIndex() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -344,9 +330,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testPastUpper() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -360,9 +345,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testLowerExclusive() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -381,9 +365,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "//int[@name='abc'] ");
 
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -400,9 +383,16 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void test() {
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "lowerfilt", "terms.lower", "a", "terms.upper", "b"),
+        reqWithPath(
+            "/terms",
+            "indent",
+            "true",
+            "terms.fl",
+            "lowerfilt",
+            "terms.lower",
+            "a",
+            "terms.upper",
+            "b"),
         "count(//lst[@name='lowerfilt']/*)=6",
         "//int[@name='a'] ",
         "//int[@name='aa'] ",
@@ -412,9 +402,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "//int[@name='abc'] ");
 
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -424,36 +413,34 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
             "terms.upper",
             "b",
             "terms.raw",
-            "true", // this should have no effect on a text field
+            "true",
+            // this should have no effect on a text field
             "terms.limit",
             "2"),
         "count(//lst[@name='lowerfilt']/*)=2",
         "//int[@name='a']",
         "//int[@name='aa']");
 
-    assertQ(null, "/terms", req("indent", "true", "terms.fl", "foo_i"), "//int[@name='1'][.='2']");
+    assertQ(
+        reqWithPath("/terms", "indent", "true", "terms.fl", "foo_i"), "//int[@name='1'][.='2']");
 
     /* terms.raw only applies to indexed fields
     assertQ(req("indent","true", "qt","/terms",
        "terms.fl","foo_i", "terms.raw","true")
-       ,"not(//int[@name='1'][.='2'])"
-    );
+       ,"not(//int[@name='1'][.='2'])");
     */
 
     // check something at the end of the index
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "zzz_i"),
+        reqWithPath("/terms", "indent", "true", "terms.fl", "zzz_i"),
         "count(//lst[@name='zzz_i']/*)=0");
   }
 
   @Test
   public void testMinMaxFreq() {
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -469,9 +456,8 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "count(//lst[@name='lowerfilt']/*)=1");
 
     assertQ(
-        null,
-        "/terms",
-        req(
+        reqWithPath(
+            "/terms",
             "indent",
             "true",
             "terms.fl",
@@ -492,13 +478,13 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     ModifiableSolrParams params =
         params("terms.fl", "standardfilt", "terms.lower", "a", "terms.sort", "index", "wt", "json");
 
-    assertJQ("/terms", req(params), "/terms/standardfilt/[0]==a", "/terms/standardfilt/[1]==1");
+    assertJQ(
+        reqWithPath("/terms", params), "/terms/standardfilt/[0]==a", "/terms/standardfilt/[1]==1");
 
     // enable terms.ttf
     params.set("terms.ttf", "true");
     assertJQ(
-        "/terms",
-        req(params),
+        reqWithPath("/terms", params),
         "/terms/standardfilt/[0]==a",
         "/terms/standardfilt/[1]/df==1",
         "/terms/standardfilt/[1]/ttf==1");
@@ -507,8 +493,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     params.set("terms.list", "spider,snake,shark");
     params.remove("terms.ttf");
     assertJQ(
-        "/terms",
-        req(params),
+        reqWithPath("/terms", params),
         "/terms/standardfilt/[0]==shark",
         "/terms/standardfilt/[1]==2",
         "/terms/standardfilt/[2]==snake",
@@ -518,8 +503,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     // with terms.list and terms.ttf=true
     params.set("terms.ttf", "true");
     assertJQ(
-        "/terms",
-        req(params),
+        reqWithPath("/terms", params),
         "/terms/standardfilt/[0]==shark",
         "/terms/standardfilt/[1]/df==2",
         "/terms/standardfilt/[1]/ttf==2",
@@ -534,14 +518,17 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testDocFreqAndTotalTermFreq() {
     SolrQueryRequest req =
-        req(
-            "indent", "true",
-            "terms.fl", "standardfilt",
-            "terms.ttf", "true",
-            "terms.list", "snake,spider,shark,ddddd");
+        reqWithPath(
+            "/terms",
+            "indent",
+            "true",
+            "terms.fl",
+            "standardfilt",
+            "terms.ttf",
+            "true",
+            "terms.list",
+            "snake,spider,shark,ddddd");
     assertQ(
-        null,
-        "/terms",
         req,
         "count(//lst[@name='standardfilt']/*)=4",
         "//lst[@name='standardfilt']/lst[@name='ddddd']/long[@name='df'][.='4']",
@@ -555,15 +542,19 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
     // terms.limit=-1 and terms.sort=count and NO terms.list
     req =
-        req(
-            "indent", "true",
-            "terms.fl", "standardfilt",
-            "terms.ttf", "true",
-            "terms.limit", "-1",
-            "terms.sort", "count");
+        reqWithPath(
+            "/terms",
+            "indent",
+            "true",
+            "terms.fl",
+            "standardfilt",
+            "terms.ttf",
+            "true",
+            "terms.limit",
+            "-1",
+            "terms.sort",
+            "count");
     assertQ(
-        null,
-        "/terms",
         req,
         "count(//lst[@name='standardfilt']/*)>=4", // it would be at-least 4
         "//lst[@name='standardfilt']/lst[@name='ddddd']/long[@name='df'][.='4']",
@@ -579,14 +570,17 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testDocFreqAndTotalTermFreqForNonExistingTerm() {
     SolrQueryRequest req =
-        req(
-            "indent", "true",
-            "terms.fl", "standardfilt",
-            "terms.ttf", "true",
-            "terms.list", "boo,snake");
+        reqWithPath(
+            "/terms",
+            "indent",
+            "true",
+            "terms.fl",
+            "standardfilt",
+            "terms.ttf",
+            "true",
+            "terms.list",
+            "boo,snake");
     assertQ(
-        null,
-        "/terms",
         req,
         "count(//lst[@name='standardfilt']/*)=1",
         "//lst[@name='standardfilt']/lst[@name='snake']/long[@name='df'][.='3']",
@@ -596,15 +590,19 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testDocFreqAndTotalTermFreqForMultipleFields() {
     SolrQueryRequest req =
-        req(
-            "indent", "true",
-            "terms.fl", "lowerfilt",
-            "terms.fl", "standardfilt",
-            "terms.ttf", "true",
-            "terms.list", "a,aa,aaa");
+        reqWithPath(
+            "/terms",
+            "indent",
+            "true",
+            "terms.fl",
+            "lowerfilt",
+            "terms.fl",
+            "standardfilt",
+            "terms.ttf",
+            "true",
+            "terms.list",
+            "a,aa,aaa");
     assertQ(
-        null,
-        "/terms",
         req,
         "count(//lst[@name='lowerfilt']/*)=3",
         "count(//lst[@name='standardfilt']/*)=3",
@@ -623,16 +621,21 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
     // terms.ttf=true, terms.sort=index and no terms list
     req =
-        req(
-            "indent", "true",
-            "terms.fl", "lowerfilt",
-            "terms.fl", "standardfilt",
-            "terms.ttf", "true",
-            "terms.sort", "index",
-            "terms.limit", "10");
+        reqWithPath(
+            "/terms",
+            "indent",
+            "true",
+            "terms.fl",
+            "lowerfilt",
+            "terms.fl",
+            "standardfilt",
+            "terms.ttf",
+            "true",
+            "terms.sort",
+            "index",
+            "terms.limit",
+            "10");
     assertQ(
-        null,
-        "/terms",
         req,
         "count(//lst[@name='lowerfilt']/*)<=10",
         "count(//lst[@name='standardfilt']/*)<=10",
@@ -772,9 +775,16 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
       assertEquals(i, nvals);
 
       assertQ(
-          null,
-          "/terms",
-          req("indent", "true", "terms.fl", "foo_pi", "terms.sort", "index", "terms.limit", "2"),
+          reqWithPath(
+              "/terms",
+              "indent",
+              "true",
+              "terms.fl",
+              "foo_pi",
+              "terms.sort",
+              "index",
+              "terms.limit",
+              "2"),
           "count(//lst[@name='foo_pi']/*)=2",
           "//lst[@name='foo_pi']/int[1][@name='" + val1 + "']",
           "//lst[@name='foo_pi']/int[2][@name='" + val2 + "']");
@@ -821,9 +831,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     assertU(commit());
 
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "foo_pdt", "terms.sort", "count"),
+        reqWithPath("/terms", "indent", "true", "terms.fl", "foo_pdt", "terms.sort", "count"),
         "count(//lst[@name='foo_pdt']/*)=2",
         "//lst[@name='foo_pdt']/int[1][@name='" + dates[1] + "'][.='51']",
         "//lst[@name='foo_pdt']/int[2][@name='" + dates[0] + "'][.='50']");
@@ -833,9 +841,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     assertU(commit());
 
     assertQ(
-        null,
-        "/terms",
-        req("indent", "true", "terms.fl", "foo_pdt", "terms.sort", "count"),
+        reqWithPath("/terms", "indent", "true", "terms.fl", "foo_pdt", "terms.sort", "count"),
         "count(//lst[@name='foo_pdt']/*)=0");
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
@@ -84,7 +84,9 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testEmptyLower() {
     assertQ(
-        req("indent", "true", "qt", "/terms", "terms.fl", "lowerfilt", "terms.upper", "b"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "lowerfilt", "terms.upper", "b"),
         "count(//lst[@name='lowerfilt']/*)=6",
         "//int[@name='a'] ",
         "//int[@name='aa'] ",
@@ -97,11 +99,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testMultipleFields() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             "terms.upper",
@@ -115,15 +117,17 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testUnlimitedRows() {
     assertQ(
-        req("indent", "true", "qt", "/terms", "terms.fl", "lowerfilt", "terms.fl", "standardfilt"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "lowerfilt", "terms.fl", "standardfilt"),
         "count(//lst[@name='lowerfilt']/*)=9",
         "count(//lst[@name='standardfilt']/*)=10");
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             "terms.fl",
@@ -137,11 +141,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testPrefix() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             "terms.upper",
@@ -165,11 +169,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testRegexp() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.lower",
@@ -219,11 +223,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   public void testRegexpWithFlags() {
     // TODO: there are no uppercase or mixed-case terms in the index!
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.lower",
@@ -244,11 +248,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testSortCount() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.lower",
@@ -269,11 +273,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   public void testTermsList() {
     // Terms list always returns in index order
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.list",
@@ -287,7 +291,9 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
     // Test with numeric terms
     assertQ(
-        req("indent", "true", "qt", "/terms", "terms.fl", "foo_i", "terms.list", "2,1"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "foo_i", "terms.list", "2,1"),
         "count(//lst[@name='foo_i']/*)=2",
         "//lst[@name='foo_i']/int[1][@name='1'][.='2']",
         "//lst[@name='foo_i']/int[2][@name='2'][.='1']");
@@ -297,11 +303,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   public void testStats() {
     // Terms list always returns in index order
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.stats",
@@ -314,11 +320,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testSortIndex() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.lower",
@@ -338,11 +344,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testPastUpper() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             // no upper bound, lower bound doesn't exist
@@ -354,11 +360,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testLowerExclusive() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             "terms.lower",
@@ -375,11 +381,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "//int[@name='abc'] ");
 
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.lower",
@@ -394,17 +400,9 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void test() {
     assertQ(
-        req(
-            "indent",
-            "true",
-            "qt",
-            "/terms",
-            "terms.fl",
-            "lowerfilt",
-            "terms.lower",
-            "a",
-            "terms.upper",
-            "b"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "lowerfilt", "terms.lower", "a", "terms.upper", "b"),
         "count(//lst[@name='lowerfilt']/*)=6",
         "//int[@name='a'] ",
         "//int[@name='aa'] ",
@@ -414,11 +412,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "//int[@name='abc'] ");
 
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             "terms.lower",
@@ -433,7 +431,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "//int[@name='a']",
         "//int[@name='aa']");
 
-    assertQ(req("indent", "true", "qt", "/terms", "terms.fl", "foo_i"), "//int[@name='1'][.='2']");
+    assertQ(null, "/terms", req("indent", "true", "terms.fl", "foo_i"), "//int[@name='1'][.='2']");
 
     /* terms.raw only applies to indexed fields
     assertQ(req("indent","true", "qt","/terms",
@@ -444,18 +442,20 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
     // check something at the end of the index
     assertQ(
-        req("indent", "true", "qt", "/terms", "terms.fl", "zzz_i"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "zzz_i"),
         "count(//lst[@name='zzz_i']/*)=0");
   }
 
   @Test
   public void testMinMaxFreq() {
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "lowerfilt",
             "terms.lower",
@@ -469,11 +469,11 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         "count(//lst[@name='lowerfilt']/*)=1");
 
     assertQ(
+        null,
+        "/terms",
         req(
             "indent",
             "true",
-            "qt",
-            "/terms",
             "terms.fl",
             "standardfilt",
             "terms.lower",
@@ -490,23 +490,14 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testTermsWithJSON() throws Exception {
     ModifiableSolrParams params =
-        params(
-            "qt",
-            "/terms",
-            "terms.fl",
-            "standardfilt",
-            "terms.lower",
-            "a",
-            "terms.sort",
-            "index",
-            "wt",
-            "json");
+        params("terms.fl", "standardfilt", "terms.lower", "a", "terms.sort", "index", "wt", "json");
 
-    assertJQ(req(params), "/terms/standardfilt/[0]==a", "/terms/standardfilt/[1]==1");
+    assertJQ("/terms", req(params), "/terms/standardfilt/[0]==a", "/terms/standardfilt/[1]==1");
 
     // enable terms.ttf
     params.set("terms.ttf", "true");
     assertJQ(
+        "/terms",
         req(params),
         "/terms/standardfilt/[0]==a",
         "/terms/standardfilt/[1]/df==1",
@@ -516,6 +507,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     params.set("terms.list", "spider,snake,shark");
     params.remove("terms.ttf");
     assertJQ(
+        "/terms",
         req(params),
         "/terms/standardfilt/[0]==shark",
         "/terms/standardfilt/[1]==2",
@@ -526,6 +518,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     // with terms.list and terms.ttf=true
     params.set("terms.ttf", "true");
     assertJQ(
+        "/terms",
         req(params),
         "/terms/standardfilt/[0]==shark",
         "/terms/standardfilt/[1]/df==2",
@@ -543,11 +536,12 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     SolrQueryRequest req =
         req(
             "indent", "true",
-            "qt", "/terms",
             "terms.fl", "standardfilt",
             "terms.ttf", "true",
             "terms.list", "snake,spider,shark,ddddd");
     assertQ(
+        null,
+        "/terms",
         req,
         "count(//lst[@name='standardfilt']/*)=4",
         "//lst[@name='standardfilt']/lst[@name='ddddd']/long[@name='df'][.='4']",
@@ -563,12 +557,13 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     req =
         req(
             "indent", "true",
-            "qt", "/terms",
             "terms.fl", "standardfilt",
             "terms.ttf", "true",
             "terms.limit", "-1",
             "terms.sort", "count");
     assertQ(
+        null,
+        "/terms",
         req,
         "count(//lst[@name='standardfilt']/*)>=4", // it would be at-least 4
         "//lst[@name='standardfilt']/lst[@name='ddddd']/long[@name='df'][.='4']",
@@ -586,11 +581,12 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     SolrQueryRequest req =
         req(
             "indent", "true",
-            "qt", "/terms",
             "terms.fl", "standardfilt",
             "terms.ttf", "true",
             "terms.list", "boo,snake");
     assertQ(
+        null,
+        "/terms",
         req,
         "count(//lst[@name='standardfilt']/*)=1",
         "//lst[@name='standardfilt']/lst[@name='snake']/long[@name='df'][.='3']",
@@ -602,12 +598,13 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     SolrQueryRequest req =
         req(
             "indent", "true",
-            "qt", "/terms",
             "terms.fl", "lowerfilt",
             "terms.fl", "standardfilt",
             "terms.ttf", "true",
             "terms.list", "a,aa,aaa");
     assertQ(
+        null,
+        "/terms",
         req,
         "count(//lst[@name='lowerfilt']/*)=3",
         "count(//lst[@name='standardfilt']/*)=3",
@@ -628,13 +625,14 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     req =
         req(
             "indent", "true",
-            "qt", "/terms",
             "terms.fl", "lowerfilt",
             "terms.fl", "standardfilt",
             "terms.ttf", "true",
             "terms.sort", "index",
             "terms.limit", "10");
     assertQ(
+        null,
+        "/terms",
         req,
         "count(//lst[@name='lowerfilt']/*)<=10",
         "count(//lst[@name='standardfilt']/*)<=10",
@@ -689,10 +687,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
       val2 = vals[i];
     }
 
-    SolrQueryRequest req =
-        req(
-            "qt", "/terms",
-            "terms.fl", "foo_pi");
+    SolrQueryRequest req = req("terms.fl", "foo_pi");
     ;
     try {
       /* SchemaField sf = req.getSchema().getField("foo_pi");
@@ -777,17 +772,9 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
       assertEquals(i, nvals);
 
       assertQ(
-          req(
-              "indent",
-              "true",
-              "qt",
-              "/terms",
-              "terms.fl",
-              "foo_pi",
-              "terms.sort",
-              "index",
-              "terms.limit",
-              "2"),
+          null,
+          "/terms",
+          req("indent", "true", "terms.fl", "foo_pi", "terms.sort", "index", "terms.limit", "2"),
           "count(//lst[@name='foo_pi']/*)=2",
           "//lst[@name='foo_pi']/int[1][@name='" + val1 + "']",
           "//lst[@name='foo_pi']/int[2][@name='" + val2 + "']");
@@ -834,7 +821,9 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     assertU(commit());
 
     assertQ(
-        req("indent", "true", "qt", "/terms", "terms.fl", "foo_pdt", "terms.sort", "count"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "foo_pdt", "terms.sort", "count"),
         "count(//lst[@name='foo_pdt']/*)=2",
         "//lst[@name='foo_pdt']/int[1][@name='" + dates[1] + "'][.='51']",
         "//lst[@name='foo_pdt']/int[2][@name='" + dates[0] + "'][.='50']");
@@ -844,7 +833,9 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     assertU(commit());
 
     assertQ(
-        req("indent", "true", "qt", "/terms", "terms.fl", "foo_pdt", "terms.sort", "count"),
+        null,
+        "/terms",
+        req("indent", "true", "terms.fl", "foo_pdt", "terms.sort", "count"),
         "count(//lst[@name='foo_pdt']/*)=0");
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/TestMatchedQueriesComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestMatchedQueriesComponent.java
@@ -47,7 +47,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testNotEnabledByDefault() throws Exception {
     assertJQ(
-        req("qt", HANDLER, "q", "{!term name=fantasy_cat f=cat_s}fantasy", "sort", "id asc"),
+        HANDLER,
+        req("q", "{!term name=fantasy_cat f=cat_s}fantasy", "sort", "id asc"),
         "!/matched_queries_per_hit==null",
         "!/matched_queries_summary==null");
   }
@@ -56,8 +57,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testSingleNamedTermQuery() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!term name=fantasy_cat f=cat_s}fantasy",
             "matched_queries", "true",
             "sort", "id asc",
@@ -75,8 +76,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testShortParamAlias() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!term name=fantasy_cat f=cat_s}fantasy",
             "mq", "true",
             "sort", "id asc",
@@ -92,8 +93,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testTwoNamedQueriesOr() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q",
                 "({!term name=fantasy_cat f=cat_s}fantasy) OR ({!term name=scifi_cat f=cat_s}scifi)",
             "matched_queries", "true",
@@ -110,8 +111,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testUnnamedQueryProducesNoOutput() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!term f=cat_s}fantasy",
             "matched_queries", "true",
             "sort", "id asc",
@@ -126,8 +127,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   public void testMultiValuedFieldBothNamesPresent() throws Exception {
     // docs 2 and 3 match both fantasy_cat and childrens_cat
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q",
                 "({!term name=fantasy_cat f=cat_s}fantasy) OR ({!term name=childrens_cat f=cat_s}childrens)",
             "matched_queries", "true",
@@ -146,8 +147,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testTermsNamedQuery() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!terms name=genre_all f=cat_s}fantasy,scifi",
             "matched_queries", "true",
             "sort", "id asc",
@@ -167,8 +168,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testBoolOuterAndInnerNamesComposed() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q",
                 "{!bool name=all_books"
                     + "  should='{!term name=fantasy_cat f=cat_s}fantasy'"
@@ -198,8 +199,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testBoolMultipleShouldNamedTerms() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q",
                 "{!bool should='{!term name=fantasy_cat f=cat_s}fantasy'"
                     + "     should='{!term name=scifi_cat f=cat_s}scifi'}",
@@ -225,8 +226,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   public void testBoolMustWithNamedShould() throws Exception {
     // MUST: all 4 fantasy docs; named SHOULD: only docs 2 and 3 (childrens)
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q",
                 "{!bool must='{!term f=cat_s}fantasy'"
                     + "     should='{!term name=childrens_cat f=cat_s}childrens'}",
@@ -251,8 +252,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testPrefixNamedQuery() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!prefix name=fanta_prefix f=cat_s}fanta",
             "matched_queries", "true",
             "sort", "id asc",
@@ -269,8 +270,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testEdismaxNamedQuery() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!edismax name=fantasy_edismax qf=cat_s}fantasy",
             "matched_queries", "true",
             "sort", "id asc",
@@ -287,8 +288,8 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testLuceneNamedQuery() throws Exception {
     assertJQ(
+        HANDLER,
         req(
-            "qt", HANDLER,
             "q", "{!lucene name=scifi_lucene df=cat_s}scifi",
             "matched_queries", "true",
             "sort", "id asc",

--- a/solr/core/src/test/org/apache/solr/handler/component/TestMatchedQueriesComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestMatchedQueriesComponent.java
@@ -47,8 +47,7 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testNotEnabledByDefault() throws Exception {
     assertJQ(
-        HANDLER,
-        req("q", "{!term name=fantasy_cat f=cat_s}fantasy", "sort", "id asc"),
+        reqWithPath(HANDLER, "q", "{!term name=fantasy_cat f=cat_s}fantasy", "sort", "id asc"),
         "!/matched_queries_per_hit==null",
         "!/matched_queries_summary==null");
   }
@@ -57,12 +56,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testSingleNamedTermQuery() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!term name=fantasy_cat f=cat_s}fantasy",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!term name=fantasy_cat f=cat_s}fantasy",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         "/matched_queries_per_hit/1/[0]=='fantasy_cat'",
         "/matched_queries_per_hit/2/[0]=='fantasy_cat'",
@@ -76,12 +79,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testShortParamAlias() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!term name=fantasy_cat f=cat_s}fantasy",
-            "mq", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!term name=fantasy_cat f=cat_s}fantasy",
+            "mq",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         "/matched_queries_summary/fantasy_cat/[0]=='1'");
   }
@@ -93,13 +100,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testTwoNamedQueriesOr() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
+        reqWithPath(
+            HANDLER,
             "q",
-                "({!term name=fantasy_cat f=cat_s}fantasy) OR ({!term name=scifi_cat f=cat_s}scifi)",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+            "({!term name=fantasy_cat f=cat_s}fantasy) OR ({!term name=scifi_cat f=cat_s}scifi)",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==7",
         "/matched_queries_per_hit/1/[0]=='fantasy_cat'",
         "/matched_queries_per_hit/5/[0]=='scifi_cat'",
@@ -111,12 +121,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testUnnamedQueryProducesNoOutput() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!term f=cat_s}fantasy",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!term f=cat_s}fantasy",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         "!/matched_queries_per_hit==null",
         "!/matched_queries_summary==null");
@@ -127,13 +141,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   public void testMultiValuedFieldBothNamesPresent() throws Exception {
     // docs 2 and 3 match both fantasy_cat and childrens_cat
     assertJQ(
-        HANDLER,
-        req(
+        reqWithPath(
+            HANDLER,
             "q",
-                "({!term name=fantasy_cat f=cat_s}fantasy) OR ({!term name=childrens_cat f=cat_s}childrens)",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+            "({!term name=fantasy_cat f=cat_s}fantasy) OR ({!term name=childrens_cat f=cat_s}childrens)",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         "/matched_queries_summary/fantasy_cat/[3]=='4'",
         "/matched_queries_summary/childrens_cat/[0]=='2'",
@@ -147,12 +164,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testTermsNamedQuery() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!terms name=genre_all f=cat_s}fantasy,scifi",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!terms name=genre_all f=cat_s}fantasy,scifi",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==7",
         "/matched_queries_per_hit/1/[0]=='genre_all'",
         "/matched_queries_per_hit/5/[0]=='genre_all'",
@@ -168,15 +189,18 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testBoolOuterAndInnerNamesComposed() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
+        reqWithPath(
+            HANDLER,
             "q",
-                "{!bool name=all_books"
-                    + "  should='{!term name=fantasy_cat f=cat_s}fantasy'"
-                    + "  should='{!term name=scifi_cat  f=cat_s}scifi'}",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+            "{!bool name=all_books"
+                + "  should='{!term name=fantasy_cat f=cat_s}fantasy'"
+                + "  should='{!term name=scifi_cat  f=cat_s}scifi'}",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==7",
         // every doc carries all_books (outer name)
         "/matched_queries_summary/all_books/[6]=='7'",
@@ -199,14 +223,17 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testBoolMultipleShouldNamedTerms() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
+        reqWithPath(
+            HANDLER,
             "q",
-                "{!bool should='{!term name=fantasy_cat f=cat_s}fantasy'"
-                    + "     should='{!term name=scifi_cat f=cat_s}scifi'}",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+            "{!bool should='{!term name=fantasy_cat f=cat_s}fantasy'"
+                + "     should='{!term name=scifi_cat f=cat_s}scifi'}",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==7",
         "/matched_queries_per_hit/1/[0]=='fantasy_cat'",
         "/matched_queries_per_hit/4/[0]=='fantasy_cat'",
@@ -226,14 +253,17 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   public void testBoolMustWithNamedShould() throws Exception {
     // MUST: all 4 fantasy docs; named SHOULD: only docs 2 and 3 (childrens)
     assertJQ(
-        HANDLER,
-        req(
+        reqWithPath(
+            HANDLER,
             "q",
-                "{!bool must='{!term f=cat_s}fantasy'"
-                    + "     should='{!term name=childrens_cat f=cat_s}childrens'}",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+            "{!bool must='{!term f=cat_s}fantasy'"
+                + "     should='{!term name=childrens_cat f=cat_s}childrens'}",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         // docs 2 and 3 matched the named SHOULD
         "/matched_queries_per_hit/2/[0]=='childrens_cat'",
@@ -252,12 +282,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testPrefixNamedQuery() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!prefix name=fanta_prefix f=cat_s}fanta",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!prefix name=fanta_prefix f=cat_s}fanta",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         "/matched_queries_summary/fanta_prefix/[3]=='4'",
         "/matched_queries_per_hit/1/[0]=='fanta_prefix'",
@@ -270,12 +304,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testEdismaxNamedQuery() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!edismax name=fantasy_edismax qf=cat_s}fantasy",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!edismax name=fantasy_edismax qf=cat_s}fantasy",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==4",
         "/matched_queries_summary/fantasy_edismax/[3]=='4'",
         "/matched_queries_per_hit/1/[0]=='fantasy_edismax'",
@@ -288,12 +326,16 @@ public class TestMatchedQueriesComponent extends SolrTestCaseJ4 {
   @Test
   public void testLuceneNamedQuery() throws Exception {
     assertJQ(
-        HANDLER,
-        req(
-            "q", "{!lucene name=scifi_lucene df=cat_s}scifi",
-            "matched_queries", "true",
-            "sort", "id asc",
-            "rows", "10"),
+        reqWithPath(
+            HANDLER,
+            "q",
+            "{!lucene name=scifi_lucene df=cat_s}scifi",
+            "matched_queries",
+            "true",
+            "sort",
+            "id asc",
+            "rows",
+            "10"),
         "/response/numFound==3",
         "/matched_queries_summary/scifi_lucene/[2]=='7'",
         "/matched_queries_per_hit/5/[0]=='scifi_lucene'",

--- a/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
+++ b/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
@@ -62,7 +62,7 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
         Arrays.asList(
             params(),
             // QEC boosting shouldn't impact what impl we get in any situation
-            params("qt", "/elevate", "elevateIds", "42"))) {
+            params("elevateIds", "42"))) {
 
       try (SolrQueryRequest req = req()) {
         // non-block based collapse situations, regardless of nullPolicy...
@@ -347,12 +347,17 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
 
             // same query, but boosting a diff p1 sku to change group head (and result order)
             assertQ(
+                null,
+                "/elevate",
                 req(
-                    "q", q,
-                    "qt", "/elevate",
-                    "elevateIds", "p1s1",
-                    "fq", "{!collapse " + opt + nullPolicy + "}",
-                    "sort", "score desc, num_i asc"),
+                    "q",
+                    q,
+                    "elevateIds",
+                    "p1s1",
+                    "fq",
+                    "{!collapse " + opt + nullPolicy + "}",
+                    "sort",
+                    "score desc, num_i asc"),
                 "*[count(//doc)=3]",
                 "//result/doc[1]/str[@name='id'][.='p1s1']",
                 "//result/doc[2]/str[@name='id'][.='p2s4']",
@@ -360,12 +365,17 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
 
             // same query, but boosting multiple skus from p1
             assertQ(
+                null,
+                "/elevate",
                 req(
-                    "q", q,
-                    "qt", "/elevate",
-                    "elevateIds", "p1s1,p1s2",
-                    "fq", "{!collapse " + opt + nullPolicy + "}",
-                    "sort", "score desc, num_i asc"),
+                    "q",
+                    q,
+                    "elevateIds",
+                    "p1s1,p1s2",
+                    "fq",
+                    "{!collapse " + opt + nullPolicy + "}",
+                    "sort",
+                    "score desc, num_i asc"),
                 "*[count(//doc)=4]",
                 "//result/doc[1]/str[@name='id'][.='p1s1']",
                 "//result/doc[2]/str[@name='id'][.='p1s2']",
@@ -386,9 +396,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3][str[@name='id'][.='p2s3'] and float[@name='score'][.=141.0]]");
             // same query, but boosting a diff child to change group head (and result order)
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "{!func}sum(42, num_i)",
-                    "qt", "/elevate",
                     "elevateIds", "p1s1",
                     "fq", "{!collapse " + opt + nullPolicy + "}",
                     "fl", "score,id",
@@ -399,9 +410,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3][str[@name='id'][.='p2s3'] and float[@name='score'][.=141.0]]");
             // same query, but boosting multiple skus from p1
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "{!func}sum(42, num_i)",
-                    "qt", "/elevate",
                     "elevateIds", "p1s2,p1s1",
                     "fq", "{!collapse " + opt + nullPolicy + "}",
                     "fl", "score,id",
@@ -467,9 +479,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3]/str[@name='id'][.='p2s2']");
             // same query, but boosting skus to change group head (and result order)
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "txt_t:* txt_t:XX",
-                    "qt", "/elevate",
                     "elevateIds", "p2s3,p1s1",
                     "fq", "{!collapse " + opt + selector + nullPolicy + "}",
                     "sort", "score desc, num_i asc"),
@@ -479,9 +492,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3]/str[@name='id'][.='p3s4']");
             // same query, but boosting multiple skus from p1
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "txt_t:* txt_t:XX",
-                    "qt", "/elevate",
                     "elevateIds", "p2s3,p1s4,p1s3",
                     "fq", "{!collapse " + opt + selector + nullPolicy + "}",
                     "sort", "score desc, num_i asc"),
@@ -525,9 +539,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3][str[@name='id'][.='p3s3'] and float[@name='score'][.=1276.0]]");
             // same query, but boosting multiple skus from p1
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "{!func}sum(42, num_i)",
-                    "qt", "/elevate",
                     "elevateIds", "p1s2,p1s1",
                     "fq", "{!collapse " + opt + selector + nullPolicy + "}",
                     "fl", "score,id",
@@ -565,9 +580,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
             // NOTE: this causes each boosted doc to be returned, but top level sort is not score,
             // so QEC doesn't hijack order
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "*:* txt_t:XX",
-                    "qt", "/elevate",
                     "elevateIds", "p3s3,p3s2",
                     "fq", "{!collapse " + opt + selector + nullPolicy + "}",
                     "fl", "id",
@@ -581,9 +597,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[4][str[@name='id'][.='p3s3']]");
             // same query, w/forceElevation to change top level order
             assertQ(
+                null,
+                "/elevate",
                 req(
                     "q", "*:* txt_t:XX",
-                    "qt", "/elevate",
                     "elevateIds", "p3s3,p3s2",
                     "forceElevation", "true",
                     "fq", "{!collapse " + opt + selector + nullPolicy + "}",
@@ -654,9 +671,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
             "//result/doc[7]/str[@name='id'][.='z100']");
         // same query, but boosting docs to change group heads (and result order)
         assertQ(
+            null,
+            "/elevate",
             req(
                 "q", "*:* txt_t:XX",
-                "qt", "/elevate",
                 "elevateIds", "z2,p3s3",
                 "fq", "{!collapse " + opt + " nullPolicy=expand}",
                 "sort", "score desc, num_i asc"),
@@ -686,9 +704,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
             "//result/doc[7][str[@name='id'][.='z1']   and float[@name='score'][.=43.0]]");
         // same query, but boosting docs to change group heads (and result order)
         assertQ(
+            null,
+            "/elevate",
             req(
                 "q", "{!func}sum(42, num_i)",
-                "qt", "/elevate",
                 "elevateIds", "p2s4,z2,p2s1",
                 "fq", "{!collapse " + opt + " nullPolicy=expand}",
                 "fl", "score,id",
@@ -758,9 +777,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
           // NOTE: this causes each boosted doc to be returned, but top level sort is not score, so
           // QEC doesn't hijack order
           assertQ(
+              null,
+              "/elevate",
               req(
                   "q", "num_i:* txt_t:XX",
-                  "qt", "/elevate",
                   "elevateIds", "p3s3,z3,p3s1",
                   "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
                   "sort", "num_i asc"),
@@ -775,9 +795,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
               "//result/doc[8]/str[@name='id'][.='p3s3']");
           // same query, w/forceElevation to change top level order
           assertQ(
+              null,
+              "/elevate",
               req(
                   "q", "num_i:* txt_t:XX",
-                  "qt", "/elevate",
                   "elevateIds", "p3s3,z3,p3s1",
                   "forceElevation", "true",
                   "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
@@ -832,9 +853,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
           // NOTE: this causes each boosted doc to be returned, but top level sort is not score, so
           // QEC doesn't hijack order
           assertQ(
+              null,
+              "/elevate",
               req(
                   "q", "{!func}sum(42, num_i)",
-                  "qt", "/elevate",
                   "elevateIds", "p3s1,z3,p3s4",
                   "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
                   "fl", "score,id",
@@ -850,9 +872,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
               "//result/doc[8][str[@name='id'][.='p1s3'] and float[@name='score'][.=819.0]]");
           // same query, w/forceElevation to change top level order
           assertQ(
+              null,
+              "/elevate",
               req(
                   "q", "{!func}sum(42, num_i)",
-                  "qt", "/elevate",
                   "elevateIds", "p3s1,z3,p3s4",
                   "forceElevation", "true",
                   "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
@@ -901,9 +924,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
           // NOTE: this causes each boosted doc to be returned, but top level sort is not score, so
           // QEC doesn't hijack order
           assertQ(
+              null,
+              "/elevate",
               req(
                   "q", "*:* txt_t:XX",
-                  "qt", "/elevate",
                   "elevateIds", "p3s3,z3,p3s4",
                   "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
                   "fl", "id",
@@ -920,9 +944,10 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
               );
           // same query, w/forceElevation to change top level order
           assertQ(
+              null,
+              "/elevate",
               req(
                   "q", "*:* txt_t:XX",
-                  "qt", "/elevate",
                   "elevateIds", "p3s3,z3,p3s4",
                   "forceElevation", "true",
                   "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
@@ -999,10 +1024,11 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
 
         // score based collapse with boost to change p1 group head
         assertQ(
+            null,
+            "/elevate",
             req(
                 "q", "txt_t:XX", // only child docs with XX match
                 "expand", "true",
-                "qt", "/elevate",
                 "elevateIds", "p1s1",
                 "fl", "id",
                 "fq", "{!collapse " + opt + nullPolicy + "}",

--- a/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
+++ b/solr/core/src/test/org/apache/solr/search/TestBlockCollapse.java
@@ -347,9 +347,8 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
 
             // same query, but boosting a diff p1 sku to change group head (and result order)
             assertQ(
-                null,
-                "/elevate",
-                req(
+                reqWithPath(
+                    "/elevate",
                     "q",
                     q,
                     "elevateIds",
@@ -365,9 +364,8 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
 
             // same query, but boosting multiple skus from p1
             assertQ(
-                null,
-                "/elevate",
-                req(
+                reqWithPath(
+                    "/elevate",
                     "q",
                     q,
                     "elevateIds",
@@ -396,28 +394,36 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3][str[@name='id'][.='p2s3'] and float[@name='score'][.=141.0]]");
             // same query, but boosting a diff child to change group head (and result order)
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "{!func}sum(42, num_i)",
-                    "elevateIds", "p1s1",
-                    "fq", "{!collapse " + opt + nullPolicy + "}",
-                    "fl", "score,id",
-                    "sort", "score desc, num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "{!func}sum(42, num_i)",
+                    "elevateIds",
+                    "p1s1",
+                    "fq",
+                    "{!collapse " + opt + nullPolicy + "}",
+                    "fl",
+                    "score,id",
+                    "sort",
+                    "score desc, num_i asc"),
                 "*[count(//doc)=3]",
                 "//result/doc[1][str[@name='id'][.='p1s1'] and float[@name='score'][.=84.0]]",
                 "//result/doc[2][str[@name='id'][.='p3s3'] and float[@name='score'][.=1276.0]]",
                 "//result/doc[3][str[@name='id'][.='p2s3'] and float[@name='score'][.=141.0]]");
             // same query, but boosting multiple skus from p1
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "{!func}sum(42, num_i)",
-                    "elevateIds", "p1s2,p1s1",
-                    "fq", "{!collapse " + opt + nullPolicy + "}",
-                    "fl", "score,id",
-                    "sort", "score desc, num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "{!func}sum(42, num_i)",
+                    "elevateIds",
+                    "p1s2,p1s1",
+                    "fq",
+                    "{!collapse " + opt + nullPolicy + "}",
+                    "fl",
+                    "score,id",
+                    "sort",
+                    "score desc, num_i asc"),
                 "*[count(//doc)=4]",
                 "//result/doc[1][str[@name='id'][.='p1s2'] and float[@name='score'][.=52.0]]",
                 "//result/doc[2][str[@name='id'][.='p1s1'] and float[@name='score'][.=84.0]]",
@@ -479,26 +485,32 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3]/str[@name='id'][.='p2s2']");
             // same query, but boosting skus to change group head (and result order)
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "txt_t:* txt_t:XX",
-                    "elevateIds", "p2s3,p1s1",
-                    "fq", "{!collapse " + opt + selector + nullPolicy + "}",
-                    "sort", "score desc, num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "txt_t:* txt_t:XX",
+                    "elevateIds",
+                    "p2s3,p1s1",
+                    "fq",
+                    "{!collapse " + opt + selector + nullPolicy + "}",
+                    "sort",
+                    "score desc, num_i asc"),
                 "*[count(//doc)=3]",
                 "//result/doc[1]/str[@name='id'][.='p2s3']",
                 "//result/doc[2]/str[@name='id'][.='p1s1']",
                 "//result/doc[3]/str[@name='id'][.='p3s4']");
             // same query, but boosting multiple skus from p1
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "txt_t:* txt_t:XX",
-                    "elevateIds", "p2s3,p1s4,p1s3",
-                    "fq", "{!collapse " + opt + selector + nullPolicy + "}",
-                    "sort", "score desc, num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "txt_t:* txt_t:XX",
+                    "elevateIds",
+                    "p2s3,p1s4,p1s3",
+                    "fq",
+                    "{!collapse " + opt + selector + nullPolicy + "}",
+                    "sort",
+                    "score desc, num_i asc"),
                 "*[count(//doc)=4]",
                 "//result/doc[1]/str[@name='id'][.='p2s3']",
                 "//result/doc[2]/str[@name='id'][.='p1s4']",
@@ -539,14 +551,18 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[3][str[@name='id'][.='p3s3'] and float[@name='score'][.=1276.0]]");
             // same query, but boosting multiple skus from p1
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "{!func}sum(42, num_i)",
-                    "elevateIds", "p1s2,p1s1",
-                    "fq", "{!collapse " + opt + selector + nullPolicy + "}",
-                    "fl", "score,id",
-                    "sort", "num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "{!func}sum(42, num_i)",
+                    "elevateIds",
+                    "p1s2,p1s1",
+                    "fq",
+                    "{!collapse " + opt + selector + nullPolicy + "}",
+                    "fl",
+                    "score,id",
+                    "sort",
+                    "num_i asc"),
                 "*[count(//doc)=4]",
                 "//result/doc[1][str[@name='id'][.='p1s2'] and float[@name='score'][.=52.0]]",
                 "//result/doc[2][str[@name='id'][.='p1s1'] and float[@name='score'][.=84.0]]",
@@ -580,14 +596,18 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
             // NOTE: this causes each boosted doc to be returned, but top level sort is not score,
             // so QEC doesn't hijack order
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "*:* txt_t:XX",
-                    "elevateIds", "p3s3,p3s2",
-                    "fq", "{!collapse " + opt + selector + nullPolicy + "}",
-                    "fl", "id",
-                    "sort", "num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "*:* txt_t:XX",
+                    "elevateIds",
+                    "p3s3,p3s2",
+                    "fq",
+                    "{!collapse " + opt + selector + nullPolicy + "}",
+                    "fl",
+                    "id",
+                    "sort",
+                    "num_i asc"),
                 "*[count(//doc)=4]",
                 "//result/doc[1][str[@name='id'][.='p2s4']]", // 13
                 // 100 (boosted so treated as own group)
@@ -597,15 +617,20 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
                 "//result/doc[4][str[@name='id'][.='p3s3']]");
             // same query, w/forceElevation to change top level order
             assertQ(
-                null,
-                "/elevate",
-                req(
-                    "q", "*:* txt_t:XX",
-                    "elevateIds", "p3s3,p3s2",
-                    "forceElevation", "true",
-                    "fq", "{!collapse " + opt + selector + nullPolicy + "}",
-                    "fl", "id",
-                    "sort", "num_i asc"),
+                reqWithPath(
+                    "/elevate",
+                    "q",
+                    "*:* txt_t:XX",
+                    "elevateIds",
+                    "p3s3,p3s2",
+                    "forceElevation",
+                    "true",
+                    "fq",
+                    "{!collapse " + opt + selector + nullPolicy + "}",
+                    "fl",
+                    "id",
+                    "sort",
+                    "num_i asc"),
                 "*[count(//doc)=4]",
                 // 1234 (boosted so treated as own group)
                 "//result/doc[1][str[@name='id'][.='p3s3']]",
@@ -671,13 +696,16 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
             "//result/doc[7]/str[@name='id'][.='z100']");
         // same query, but boosting docs to change group heads (and result order)
         assertQ(
-            null,
-            "/elevate",
-            req(
-                "q", "*:* txt_t:XX",
-                "elevateIds", "z2,p3s3",
-                "fq", "{!collapse " + opt + " nullPolicy=expand}",
-                "sort", "score desc, num_i asc"),
+            reqWithPath(
+                "/elevate",
+                "q",
+                "*:* txt_t:XX",
+                "elevateIds",
+                "z2,p3s3",
+                "fq",
+                "{!collapse " + opt + " nullPolicy=expand}",
+                "sort",
+                "score desc, num_i asc"),
             "*[count(//doc)=7]",
             "//result/doc[1]/str[@name='id'][.='z2']",
             "//result/doc[2]/str[@name='id'][.='p3s3']",
@@ -704,14 +732,18 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
             "//result/doc[7][str[@name='id'][.='z1']   and float[@name='score'][.=43.0]]");
         // same query, but boosting docs to change group heads (and result order)
         assertQ(
-            null,
-            "/elevate",
-            req(
-                "q", "{!func}sum(42, num_i)",
-                "elevateIds", "p2s4,z2,p2s1",
-                "fq", "{!collapse " + opt + " nullPolicy=expand}",
-                "fl", "score,id",
-                "sort", "score desc, num_i asc"),
+            reqWithPath(
+                "/elevate",
+                "q",
+                "{!func}sum(42, num_i)",
+                "elevateIds",
+                "p2s4,z2,p2s1",
+                "fq",
+                "{!collapse " + opt + " nullPolicy=expand}",
+                "fl",
+                "score,id",
+                "sort",
+                "score desc, num_i asc"),
             "*[count(//doc)=8]",
             "//result/doc[1][str[@name='id'][.='p2s4'] and float[@name='score'][.=55.0]]",
             "//result/doc[2][str[@name='id'][.='z2']   and float[@name='score'][.=44.0]]",
@@ -777,13 +809,16 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
           // NOTE: this causes each boosted doc to be returned, but top level sort is not score, so
           // QEC doesn't hijack order
           assertQ(
-              null,
-              "/elevate",
-              req(
-                  "q", "num_i:* txt_t:XX",
-                  "elevateIds", "p3s3,z3,p3s1",
-                  "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
-                  "sort", "num_i asc"),
+              reqWithPath(
+                  "/elevate",
+                  "q",
+                  "num_i:* txt_t:XX",
+                  "elevateIds",
+                  "p3s3,z3,p3s1",
+                  "fq",
+                  "{!collapse " + opt + selector + " nullPolicy=expand}",
+                  "sort",
+                  "num_i asc"),
               "*[count(//doc)=8]",
               "//result/doc[1]/str[@name='id'][.='z1']",
               "//result/doc[2]/str[@name='id'][.='z2']",
@@ -795,14 +830,18 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
               "//result/doc[8]/str[@name='id'][.='p3s3']");
           // same query, w/forceElevation to change top level order
           assertQ(
-              null,
-              "/elevate",
-              req(
-                  "q", "num_i:* txt_t:XX",
-                  "elevateIds", "p3s3,z3,p3s1",
-                  "forceElevation", "true",
-                  "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
-                  "sort", "num_i asc"),
+              reqWithPath(
+                  "/elevate",
+                  "q",
+                  "num_i:* txt_t:XX",
+                  "elevateIds",
+                  "p3s3,z3,p3s1",
+                  "forceElevation",
+                  "true",
+                  "fq",
+                  "{!collapse " + opt + selector + " nullPolicy=expand}",
+                  "sort",
+                  "num_i asc"),
               "*[count(//doc)=8]",
               "//result/doc[1]/str[@name='id'][.='p3s3']",
               "//result/doc[2]/str[@name='id'][.='z3']",
@@ -853,14 +892,18 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
           // NOTE: this causes each boosted doc to be returned, but top level sort is not score, so
           // QEC doesn't hijack order
           assertQ(
-              null,
-              "/elevate",
-              req(
-                  "q", "{!func}sum(42, num_i)",
-                  "elevateIds", "p3s1,z3,p3s4",
-                  "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
-                  "fl", "score,id",
-                  "sort", "num_i asc"),
+              reqWithPath(
+                  "/elevate",
+                  "q",
+                  "{!func}sum(42, num_i)",
+                  "elevateIds",
+                  "p3s1,z3,p3s4",
+                  "fq",
+                  "{!collapse " + opt + selector + " nullPolicy=expand}",
+                  "fl",
+                  "score,id",
+                  "sort",
+                  "num_i asc"),
               "*[count(//doc)=8]",
               "//result/doc[1][str[@name='id'][.='z1']   and float[@name='score'][.=43.0]]",
               "//result/doc[2][str[@name='id'][.='z2']   and float[@name='score'][.=44.0]]",
@@ -872,15 +915,20 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
               "//result/doc[8][str[@name='id'][.='p1s3'] and float[@name='score'][.=819.0]]");
           // same query, w/forceElevation to change top level order
           assertQ(
-              null,
-              "/elevate",
-              req(
-                  "q", "{!func}sum(42, num_i)",
-                  "elevateIds", "p3s1,z3,p3s4",
-                  "forceElevation", "true",
-                  "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
-                  "fl", "score,id",
-                  "sort", "num_i asc"),
+              reqWithPath(
+                  "/elevate",
+                  "q",
+                  "{!func}sum(42, num_i)",
+                  "elevateIds",
+                  "p3s1,z3,p3s4",
+                  "forceElevation",
+                  "true",
+                  "fq",
+                  "{!collapse " + opt + selector + " nullPolicy=expand}",
+                  "fl",
+                  "score,id",
+                  "sort",
+                  "num_i asc"),
               "*[count(//doc)=8]",
               "//result/doc[1][str[@name='id'][.='p3s1'] and float[@name='score'][.=57.0]]",
               "//result/doc[2][str[@name='id'][.='z3']   and float[@name='score'][.=45.0]]",
@@ -924,14 +972,18 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
           // NOTE: this causes each boosted doc to be returned, but top level sort is not score, so
           // QEC doesn't hijack order
           assertQ(
-              null,
-              "/elevate",
-              req(
-                  "q", "*:* txt_t:XX",
-                  "elevateIds", "p3s3,z3,p3s4",
-                  "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
-                  "fl", "id",
-                  "sort", "num_i asc"),
+              reqWithPath(
+                  "/elevate",
+                  "q",
+                  "*:* txt_t:XX",
+                  "elevateIds",
+                  "p3s3,z3,p3s4",
+                  "fq",
+                  "{!collapse " + opt + selector + " nullPolicy=expand}",
+                  "fl",
+                  "id",
+                  "sort",
+                  "num_i asc"),
               "*[count(//doc)=8]",
               "//result/doc[1][str[@name='id'][.='z1']]",
               "//result/doc[2][str[@name='id'][.='z2']]",
@@ -944,15 +996,20 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
               );
           // same query, w/forceElevation to change top level order
           assertQ(
-              null,
-              "/elevate",
-              req(
-                  "q", "*:* txt_t:XX",
-                  "elevateIds", "p3s3,z3,p3s4",
-                  "forceElevation", "true",
-                  "fq", "{!collapse " + opt + selector + " nullPolicy=expand}",
-                  "fl", "id",
-                  "sort", "num_i asc"),
+              reqWithPath(
+                  "/elevate",
+                  "q",
+                  "*:* txt_t:XX",
+                  "elevateIds",
+                  "p3s3,z3,p3s4",
+                  "forceElevation",
+                  "true",
+                  "fq",
+                  "{!collapse " + opt + selector + " nullPolicy=expand}",
+                  "fl",
+                  "id",
+                  "sort",
+                  "num_i asc"),
               "*[count(//doc)=8]",
               "//result/doc[1][str[@name='id'][.='p3s3']]", // 1234
               "//result/doc[2][str[@name='id'][.='z3']]",
@@ -1024,15 +1081,21 @@ public class TestBlockCollapse extends SolrTestCaseJ4 {
 
         // score based collapse with boost to change p1 group head
         assertQ(
-            null,
-            "/elevate",
-            req(
-                "q", "txt_t:XX", // only child docs with XX match
-                "expand", "true",
-                "elevateIds", "p1s1",
-                "fl", "id",
-                "fq", "{!collapse " + opt + nullPolicy + "}",
-                "sort", "score desc, num_i asc"),
+            reqWithPath(
+                "/elevate",
+                "q",
+                "txt_t:XX",
+                // only child docs with XX match
+                "expand",
+                "true",
+                "elevateIds",
+                "p1s1",
+                "fl",
+                "id",
+                "fq",
+                "{!collapse " + opt + nullPolicy + "}",
+                "sort",
+                "score desc, num_i asc"),
             "*[count(/response/result/doc)=3]",
             "/response/result/doc[1]/str[@name='id'][.='p1s1']",
             "/response/result/doc[2]/str[@name='id'][.='p2s4']",

--- a/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
@@ -186,9 +186,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("forceElevation", "true");
     params.add("elevateIds", "4");
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=2]",
         "//result/doc[1]/str[@name='id'][.='4']",
         "//result/doc[2]/str[@name='id'][.='5']");
@@ -200,9 +198,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("forceElevation", "true");
     params.add("elevateIds", "7");
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=2]",
         "//result/doc[1]/str[@name='id'][.='7']",
         "//result/doc[2]/str[@name='id'][.='1']");
@@ -570,9 +566,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("bf", "field(test_i)");
     params.add("qf", "term_s");
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=4]",
         "//result/doc[1]/str[@name='id'][.='1']",
         "//result/doc[2]/str[@name='id'][.='2']",
@@ -591,9 +585,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
       params.add("qf", "term_s");
       params.add("elevateIds", "1,5");
       assertQ(
-          null,
-          "/elevate",
-          req(params),
+          reqWithPath("/elevate", params),
           "*[count(//doc)=3]",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='5']",
@@ -611,9 +603,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
       params.add("qf", "term_s");
       params.add("elevateIds", "1,5");
       assertQ(
-          null,
-          "/elevate",
-          req(params),
+          reqWithPath("/elevate", params),
           "*[count(//doc)=3]",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='5']",
@@ -631,9 +621,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
       params.add("qf", "term_s");
       params.add("elevateIds", "1,5");
       assertQ(
-          null,
-          "/elevate",
-          req(params),
+          reqWithPath("/elevate", params),
           "*[count(//doc)=3]",
           "//result/doc[1]/str[@name='id'][.='1']",
           "//result/doc[2]/str[@name='id'][.='5']",
@@ -649,9 +637,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("qf", "term_s");
     params.add("elevateIds", "3,4");
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=4]",
         "//result/doc[1]/str[@name='id'][.='3']",
         "//result/doc[2]/str[@name='id'][.='4']",
@@ -983,9 +969,7 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("bf", "field(test_i)");
     params.add("qf", "term_s");
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=3]",
         "//result/doc[1]/str[@name='id'][.='3']",
         "//result/doc[2]/str[@name='id'][.='6']",
@@ -1388,9 +1372,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[3]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "1,5",
@@ -1405,9 +1388,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[4]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "0,7",
@@ -1423,9 +1405,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[5]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "6,0",
@@ -1455,9 +1436,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[4]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "1,5",
@@ -1473,9 +1453,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[5]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "0,7",
@@ -1491,9 +1470,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[5]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "6,0",
@@ -1525,9 +1503,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[6]/str[@name='id'][.='0']" // null
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "1,5",
@@ -1545,9 +1522,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[7]/str[@name='id'][.='0']" // null
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "0,7",
@@ -1564,9 +1540,8 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[6]/str[@name='id'][.='3']" // group B
               );
           assertQ(
-              null,
-              "/elevate",
-              req(
+              reqWithPath(
+                  "/elevate",
                   params(
                       "elevateIds",
                       "6,0",

--- a/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCollapseQParserPlugin.java
@@ -183,10 +183,11 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("q", "*:*");
     params.add("fq", "{!collapse field=group_s sort='term_s desc, test_l asc'}");
     params.add("sort", "test_l asc");
-    params.add("qt", "/elevate");
     params.add("forceElevation", "true");
     params.add("elevateIds", "4");
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=2]",
         "//result/doc[1]/str[@name='id'][.='4']",
@@ -196,10 +197,11 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("q", "*:*");
     params.add("fq", "{!collapse field=group_s sort='term_s desc, test_l asc'}");
     params.add("sort", "test_l asc");
-    params.add("qt", "/elevate");
     params.add("forceElevation", "true");
     params.add("elevateIds", "7");
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=2]",
         "//result/doc[1]/str[@name='id'][.='7']",
@@ -567,8 +569,9 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("defType", "edismax");
     params.add("bf", "field(test_i)");
     params.add("qf", "term_s");
-    params.add("qt", "/elevate");
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=4]",
         "//result/doc[1]/str[@name='id'][.='1']",
@@ -586,9 +589,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
       params.add("defType", "edismax");
       params.add("bf", "field(test_i)");
       params.add("qf", "term_s");
-      params.add("qt", "/elevate");
       params.add("elevateIds", "1,5");
       assertQ(
+          null,
+          "/elevate",
           req(params),
           "*[count(//doc)=3]",
           "//result/doc[1]/str[@name='id'][.='1']",
@@ -605,9 +609,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
       params.add("defType", "edismax");
       params.add("bf", "field(test_i)");
       params.add("qf", "term_s");
-      params.add("qt", "/elevate");
       params.add("elevateIds", "1,5");
       assertQ(
+          null,
+          "/elevate",
           req(params),
           "*[count(//doc)=3]",
           "//result/doc[1]/str[@name='id'][.='1']",
@@ -624,9 +629,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
       params.add("defType", "edismax");
       params.add("bf", "field(test_i)");
       params.add("qf", "term_s");
-      params.add("qt", "/elevate");
       params.add("elevateIds", "1,5");
       assertQ(
+          null,
+          "/elevate",
           req(params),
           "*[count(//doc)=3]",
           "//result/doc[1]/str[@name='id'][.='1']",
@@ -641,9 +647,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("defType", "edismax");
     params.add("bf", "field(test_i)");
     params.add("qf", "term_s");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "3,4");
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=4]",
         "//result/doc[1]/str[@name='id'][.='3']",
@@ -975,8 +982,9 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
     params.add("defType", "edismax");
     params.add("bf", "field(test_i)");
     params.add("qf", "term_s");
-    params.add("qt", "/elevate");
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=3]",
         "//result/doc[1]/str[@name='id'][.='3']",
@@ -1380,10 +1388,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[3]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "1,5",
                       "q",
@@ -1397,10 +1405,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[4]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "0,7",
                       "q",
@@ -1415,10 +1423,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[5]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "6,0",
                       "q",
@@ -1447,10 +1455,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[4]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "1,5",
                       "q",
@@ -1465,10 +1473,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[5]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "0,7",
                       "q",
@@ -1483,10 +1491,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[5]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "6,0",
                       "q",
@@ -1517,10 +1525,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[6]/str[@name='id'][.='0']" // null
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "1,5",
                       "q",
@@ -1537,10 +1545,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[7]/str[@name='id'][.='0']" // null
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "0,7",
                       "q",
@@ -1556,10 +1564,10 @@ public class TestCollapseQParserPlugin extends SolrTestCaseJ4 {
               "//result/doc[6]/str[@name='id'][.='3']" // group B
               );
           assertQ(
+              null,
+              "/elevate",
               req(
                   params(
-                      "qt",
-                      "/elevate",
                       "elevateIds",
                       "6,0",
                       "q",

--- a/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
@@ -493,9 +493,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("rows", "10");
     params.add("elevateIds", "1");
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='1']",
         "//result/doc[2]/str[@name='id'][.='2']",
@@ -557,9 +555,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("elevateIds", "1,4");
 
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='1']", // Elevated
         "//result/doc[2]/str[@name='id'][.='4']", // Elevated
@@ -590,9 +586,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("elevateIds", "4,1");
 
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='4']", // Elevated
         "//result/doc[2]/str[@name='id'][.='1']", // Elevated
@@ -622,9 +616,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("elevateIds", "4,1");
 
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='4']", // Elevated
         "//result/doc[2]/str[@name='id'][.='1']", // Elevated
@@ -656,9 +648,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("elevateIds", "4,1");
 
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=2]",
         "//result/doc[1]/str[@name='id'][.='3']",
         "//result/doc[2]/str[@name='id'][.='2']" // Was not in reRankDocs
@@ -685,7 +675,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("rows", "10");
     params.add("elevateIds", "4,1");
 
-    assertQ(null, "/elevate", req(params), "*[count(//doc)=0]");
+    assertQ(reqWithPath("/elevate", params), "*[count(//doc)=0]");
 
     // Pass in reRankDocs lower than the length being collected.
     params = new ModifiableSolrParams();
@@ -1102,9 +1092,7 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("elevateIds", "1,4");
 
     assertQ(
-        null,
-        "/elevate",
-        req(params),
+        reqWithPath("/elevate", params),
         "*[count(//doc)=3]",
         "//result/doc[1]/str[@name='id'][.='1']", // Elevated
         "//result/doc[2]/str[@name='id'][.='4']", // Elevated

--- a/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
@@ -491,9 +491,10 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "0");
     params.add("rows", "10");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "1");
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='1']",
@@ -553,10 +554,11 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "0");
     params.add("rows", "10");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "1,4");
 
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='1']", // Elevated
@@ -585,10 +587,11 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "0");
     params.add("rows", "10");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "4,1");
 
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='4']", // Elevated
@@ -616,10 +619,11 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "0");
     params.add("rows", "10");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "4,1");
 
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=6]",
         "//result/doc[1]/str[@name='id'][.='4']", // Elevated
@@ -649,10 +653,11 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "4");
     params.add("rows", "10");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "4,1");
 
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=2]",
         "//result/doc[1]/str[@name='id'][.='3']",
@@ -678,10 +683,9 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "4");
     params.add("rows", "10");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "4,1");
 
-    assertQ(req(params), "*[count(//doc)=0]");
+    assertQ(null, "/elevate", req(params), "*[count(//doc)=0]");
 
     // Pass in reRankDocs lower than the length being collected.
     params = new ModifiableSolrParams();
@@ -1095,10 +1099,11 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("fl", "id,score");
     params.add("start", "0");
     params.add("rows", "3");
-    params.add("qt", "/elevate");
     params.add("elevateIds", "1,4");
 
     assertQ(
+        null,
+        "/elevate",
         req(params),
         "*[count(//doc)=3]",
         "//result/doc[1]/str[@name='id'][.='1']", // Elevated

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -846,19 +846,9 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     assertQ(null, req, tests);
   }
 
-  /**
-   * The handler that should process {@code req}: its {@link SolrQueryRequest#getPath()} if set,
-   * otherwise falls back to the deprecated "qt" request param.
-   */
-  private static String handlerOf(SolrQueryRequest req) {
-    String path = req.getPath();
-    return path != null ? path : req.getParams().get(CommonParams.QT);
-  }
-
   /** Validates a query matches some XPath test expressions and closes the query */
   public static void assertQ(String message, SolrQueryRequest req, String... tests) {
     try {
-      String handler = handlerOf(req);
       String m = (null == message) ? "" : message + " "; // TODO log 'm' !!!
       // since the default (standard) response format is now JSON
       // need to explicitly request XML since this class uses XPath
@@ -867,7 +857,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       // for tests, let's turn indention off so we don't have to handle extraneous spaces
       xmlWriterTypeParams.set("indent", xmlWriterTypeParams.get("indent", "off"));
       req.setParams(xmlWriterTypeParams);
-      String response = h.query(handler, req);
+      String response = h.query(req);
 
       if (req.getParams().getBool("facet", false)) {
         // add a test to ensure that faceting did not throw an exception
@@ -901,7 +891,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   /** Makes a query request and returns the JSON string response */
   public static String JQ(SolrQueryRequest req) throws Exception {
-    String handler = handlerOf(req);
     SolrParams params = req.getParams();
     if (!"json".equals(params.get("wt", "xml")) || params.get("indent") == null) {
       ModifiableSolrParams newParams = new ModifiableSolrParams(params);
@@ -913,7 +902,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     String response;
     boolean failed = true;
     try {
-      response = h.query(handler, req);
+      response = h.query(req);
       failed = false;
     } finally {
       if (failed) {
@@ -965,7 +954,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    */
   public static String assertJQ(SolrQueryRequest req, double delta, String... tests)
       throws Exception {
-    String handler = handlerOf(req);
     SolrParams params = null;
     try {
       params = req.getParams();
@@ -979,7 +967,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       String response;
       boolean failed = true;
       try {
-        response = h.query(handler, req);
+        response = h.query(req);
         failed = false;
       } finally {
         if (failed) {
@@ -1039,7 +1027,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   @SuppressWarnings("unchecked")
   public static <T> String assertThatJQ(SolrQueryRequest req, String message, Matcher<T> test)
       throws Exception {
-    String handler = handlerOf(req);
     final SolrParams params = req.getParams();
     try {
       if (!"json".equals(params.get("wt", "xml")) || params.get("indent") == null) {
@@ -1052,7 +1039,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       String response;
       boolean failed = true;
       try {
-        response = h.query(handler, req);
+        response = h.query(req);
         failed = false;
       } finally {
         if (failed) {
@@ -1082,7 +1069,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   public static void assertQEx(String message, SolrQueryRequest req, int code) {
     try {
       ignoreException(".");
-      h.query(handlerOf(req), req);
+      h.query(req);
       fail(message);
     } catch (SolrException sex) {
       assertEquals(code, sex.code());
@@ -1097,7 +1084,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   public static void assertQEx(String message, SolrQueryRequest req, SolrException.ErrorCode code) {
     try {
       ignoreException(".");
-      h.query(handlerOf(req), req);
+      h.query(req);
       fail(message);
     } catch (SolrException e) {
       assertEquals(code.code, e.code());
@@ -1124,7 +1111,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       SolrException.ErrorCode code) {
     try {
       ignoreException(".");
-      h.query(handlerOf(req), req);
+      h.query(req);
       fail(failMessage);
     } catch (SolrException e) {
       assertEquals(code.code, e.code());

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -900,6 +900,11 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   /** Makes a query request and returns the JSON string response */
   public static String JQ(SolrQueryRequest req) throws Exception {
+    return JQ(req.getParams().get(CommonParams.QT), req);
+  }
+
+  /** Makes a query request against the named handler and returns the JSON string response */
+  public static String JQ(String handler, SolrQueryRequest req) throws Exception {
     SolrParams params = req.getParams();
     if (!"json".equals(params.get("wt", "xml")) || params.get("indent") == null) {
       ModifiableSolrParams newParams = new ModifiableSolrParams(params);
@@ -911,7 +916,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     String response;
     boolean failed = true;
     try {
-      response = h.query(req);
+      response = h.query(handler, req);
       failed = false;
     } finally {
       if (failed) {
@@ -949,6 +954,19 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
 
   /**
+   * Validates a query against the named handler matches some JSON test expressions using the
+   * default double delta tolerance.
+   *
+   * @see JSONTestUtil#DEFAULT_DELTA
+   * @see #assertJQ(String,SolrQueryRequest,double,String...)
+   * @return The request response as a JSON String if all test patterns pass
+   */
+  public static String assertJQ(String handler, SolrQueryRequest req, String... tests)
+      throws Exception {
+    return assertJQ(handler, req, JSONTestUtil.DEFAULT_DELTA, tests);
+  }
+
+  /**
    * Validates a query matches some JSON test expressions and closes the query. The text expression
    * is of the form path:JSON. The Noggit JSON parser used accepts single quoted strings and bare
    * strings to allow easy embedding in Java Strings.
@@ -963,6 +981,21 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    */
   public static String assertJQ(SolrQueryRequest req, double delta, String... tests)
       throws Exception {
+    return assertJQ(req.getParams().get(CommonParams.QT), req, delta, tests);
+  }
+
+  /**
+   * Validates a query against the named handler matches some JSON test expressions and closes the
+   * query.
+   *
+   * @param handler the name of the request handler to process the request
+   * @param req Solr request to execute
+   * @param delta tolerance allowed in comparing float/double values
+   * @param tests JSON path expression + '==' + expected value
+   * @return The request response as a JSON String if all test patterns pass
+   */
+  public static String assertJQ(String handler, SolrQueryRequest req, double delta, String... tests)
+      throws Exception {
     SolrParams params = null;
     try {
       params = req.getParams();
@@ -976,7 +1009,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       String response;
       boolean failed = true;
       try {
-        response = h.query(req);
+        response = h.query(handler, req);
         failed = false;
       } finally {
         if (failed) {
@@ -1021,6 +1054,11 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     return assertThatJQ(req, "", test);
   }
 
+  public static <T> String assertThatJQ(String handler, SolrQueryRequest req, Matcher<T> test)
+      throws Exception {
+    return assertThatJQ(handler, req, "", test);
+  }
+
   /**
    * Validates a query completes and, using JSON deserialization, returns an object that passes the
    * given Matcher test.
@@ -1033,9 +1071,24 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    * @param test Matcher for the given object returned from deserializing the response
    * @return The request response as a JSON String if the test matcher passes
    */
-  @SuppressWarnings("unchecked")
   public static <T> String assertThatJQ(SolrQueryRequest req, String message, Matcher<T> test)
       throws Exception {
+    return assertThatJQ(req.getParams().get(CommonParams.QT), req, message, test);
+  }
+
+  /**
+   * Validates a query against the named handler completes and, using JSON deserialization, returns
+   * an object that passes the given Matcher test.
+   *
+   * @param handler the name of the request handler to process the request
+   * @param req Solr request to execute
+   * @param message Failure message for test
+   * @param test Matcher for the given object returned from deserializing the response
+   * @return The request response as a JSON String if the test matcher passes
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> String assertThatJQ(
+      String handler, SolrQueryRequest req, String message, Matcher<T> test) throws Exception {
     final SolrParams params = req.getParams();
     try {
       if (!"json".equals(params.get("wt", "xml")) || params.get("indent") == null) {
@@ -1048,7 +1101,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       String response;
       boolean failed = true;
       try {
-        response = h.query(req);
+        response = h.query(handler, req);
         failed = false;
       } finally {
         if (failed) {
@@ -1076,9 +1129,14 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   /** Makes sure a query throws a SolrException with the listed response code */
   public static void assertQEx(String message, SolrQueryRequest req, int code) {
+    assertQEx(message, req, code, req.getParams().get(CommonParams.QT));
+  }
+
+  /** Makes sure a query against the named handler throws a SolrException with the given code */
+  public static void assertQEx(String message, SolrQueryRequest req, int code, String handler) {
     try {
       ignoreException(".");
-      h.query(req);
+      h.query(handler, req);
       fail(message);
     } catch (SolrException sex) {
       assertEquals(code, sex.code());
@@ -1090,9 +1148,15 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
 
   public static void assertQEx(String message, SolrQueryRequest req, SolrException.ErrorCode code) {
+    assertQEx(message, req, code, req.getParams().get(CommonParams.QT));
+  }
+
+  /** Makes sure a query against the named handler throws a SolrException with the given code */
+  public static void assertQEx(
+      String message, SolrQueryRequest req, SolrException.ErrorCode code, String handler) {
     try {
       ignoreException(".");
-      h.query(req);
+      h.query(handler, req);
       fail(message);
     } catch (SolrException e) {
       assertEquals(code.code, e.code());
@@ -1117,9 +1181,29 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       String exceptionMessage,
       SolrQueryRequest req,
       SolrException.ErrorCode code) {
+    assertQEx(failMessage, exceptionMessage, req, code, req.getParams().get(CommonParams.QT));
+  }
+
+  /**
+   * Makes sure a query against the named handler throws a SolrException with the listed response
+   * code and expected message
+   *
+   * @param failMessage The assert message to show when the query doesn't throw the expected
+   *     exception
+   * @param exceptionMessage A substring of the message expected in the exception
+   * @param req Solr request
+   * @param code expected error code for the query
+   * @param handler the name of the request handler to process the request
+   */
+  public static void assertQEx(
+      String failMessage,
+      String exceptionMessage,
+      SolrQueryRequest req,
+      SolrException.ErrorCode code,
+      String handler) {
     try {
       ignoreException(".");
-      h.query(req);
+      h.query(handler, req);
       fail(failMessage);
     } catch (SolrException e) {
       assertEquals(code.code, e.code());

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -846,18 +846,19 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     assertQ(null, req, tests);
   }
 
-  /** Validates a query matches some XPath test expressions and closes the query */
-  public static void assertQ(String message, SolrQueryRequest req, String... tests) {
-    assertQ(message, req.getParams().get(CommonParams.QT), req, tests);
+  /**
+   * The handler that should process {@code req}: its {@link SolrQueryRequest#getPath()} if set,
+   * otherwise falls back to the deprecated "qt" request param.
+   */
+  private static String handlerOf(SolrQueryRequest req) {
+    String path = req.getPath();
+    return path != null ? path : req.getParams().get(CommonParams.QT);
   }
 
-  /**
-   * Validates a query against the named handler matches some XPath test expressions and closes the
-   * query
-   */
-  public static void assertQ(
-      String message, String handler, SolrQueryRequest req, String... tests) {
+  /** Validates a query matches some XPath test expressions and closes the query */
+  public static void assertQ(String message, SolrQueryRequest req, String... tests) {
     try {
+      String handler = handlerOf(req);
       String m = (null == message) ? "" : message + " "; // TODO log 'm' !!!
       // since the default (standard) response format is now JSON
       // need to explicitly request XML since this class uses XPath
@@ -900,11 +901,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   /** Makes a query request and returns the JSON string response */
   public static String JQ(SolrQueryRequest req) throws Exception {
-    return JQ(req.getParams().get(CommonParams.QT), req);
-  }
-
-  /** Makes a query request against the named handler and returns the JSON string response */
-  public static String JQ(String handler, SolrQueryRequest req) throws Exception {
+    String handler = handlerOf(req);
     SolrParams params = req.getParams();
     if (!"json".equals(params.get("wt", "xml")) || params.get("indent") == null) {
       ModifiableSolrParams newParams = new ModifiableSolrParams(params);
@@ -954,19 +951,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
   }
 
   /**
-   * Validates a query against the named handler matches some JSON test expressions using the
-   * default double delta tolerance.
-   *
-   * @see JSONTestUtil#DEFAULT_DELTA
-   * @see #assertJQ(String,SolrQueryRequest,double,String...)
-   * @return The request response as a JSON String if all test patterns pass
-   */
-  public static String assertJQ(String handler, SolrQueryRequest req, String... tests)
-      throws Exception {
-    return assertJQ(handler, req, JSONTestUtil.DEFAULT_DELTA, tests);
-  }
-
-  /**
    * Validates a query matches some JSON test expressions and closes the query. The text expression
    * is of the form path:JSON. The Noggit JSON parser used accepts single quoted strings and bare
    * strings to allow easy embedding in Java Strings.
@@ -981,21 +965,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    */
   public static String assertJQ(SolrQueryRequest req, double delta, String... tests)
       throws Exception {
-    return assertJQ(req.getParams().get(CommonParams.QT), req, delta, tests);
-  }
-
-  /**
-   * Validates a query against the named handler matches some JSON test expressions and closes the
-   * query.
-   *
-   * @param handler the name of the request handler to process the request
-   * @param req Solr request to execute
-   * @param delta tolerance allowed in comparing float/double values
-   * @param tests JSON path expression + '==' + expected value
-   * @return The request response as a JSON String if all test patterns pass
-   */
-  public static String assertJQ(String handler, SolrQueryRequest req, double delta, String... tests)
-      throws Exception {
+    String handler = handlerOf(req);
     SolrParams params = null;
     try {
       params = req.getParams();
@@ -1054,11 +1024,6 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     return assertThatJQ(req, "", test);
   }
 
-  public static <T> String assertThatJQ(String handler, SolrQueryRequest req, Matcher<T> test)
-      throws Exception {
-    return assertThatJQ(handler, req, "", test);
-  }
-
   /**
    * Validates a query completes and, using JSON deserialization, returns an object that passes the
    * given Matcher test.
@@ -1071,24 +1036,10 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
    * @param test Matcher for the given object returned from deserializing the response
    * @return The request response as a JSON String if the test matcher passes
    */
+  @SuppressWarnings("unchecked")
   public static <T> String assertThatJQ(SolrQueryRequest req, String message, Matcher<T> test)
       throws Exception {
-    return assertThatJQ(req.getParams().get(CommonParams.QT), req, message, test);
-  }
-
-  /**
-   * Validates a query against the named handler completes and, using JSON deserialization, returns
-   * an object that passes the given Matcher test.
-   *
-   * @param handler the name of the request handler to process the request
-   * @param req Solr request to execute
-   * @param message Failure message for test
-   * @param test Matcher for the given object returned from deserializing the response
-   * @return The request response as a JSON String if the test matcher passes
-   */
-  @SuppressWarnings("unchecked")
-  public static <T> String assertThatJQ(
-      String handler, SolrQueryRequest req, String message, Matcher<T> test) throws Exception {
+    String handler = handlerOf(req);
     final SolrParams params = req.getParams();
     try {
       if (!"json".equals(params.get("wt", "xml")) || params.get("indent") == null) {
@@ -1129,14 +1080,9 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
 
   /** Makes sure a query throws a SolrException with the listed response code */
   public static void assertQEx(String message, SolrQueryRequest req, int code) {
-    assertQEx(message, req, code, req.getParams().get(CommonParams.QT));
-  }
-
-  /** Makes sure a query against the named handler throws a SolrException with the given code */
-  public static void assertQEx(String message, SolrQueryRequest req, int code, String handler) {
     try {
       ignoreException(".");
-      h.query(handler, req);
+      h.query(handlerOf(req), req);
       fail(message);
     } catch (SolrException sex) {
       assertEquals(code, sex.code());
@@ -1147,16 +1093,11 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     }
   }
 
+  /** Makes sure a query throws a SolrException with the listed response code */
   public static void assertQEx(String message, SolrQueryRequest req, SolrException.ErrorCode code) {
-    assertQEx(message, req, code, req.getParams().get(CommonParams.QT));
-  }
-
-  /** Makes sure a query against the named handler throws a SolrException with the given code */
-  public static void assertQEx(
-      String message, SolrQueryRequest req, SolrException.ErrorCode code, String handler) {
     try {
       ignoreException(".");
-      h.query(handler, req);
+      h.query(handlerOf(req), req);
       fail(message);
     } catch (SolrException e) {
       assertEquals(code.code, e.code());
@@ -1181,29 +1122,9 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       String exceptionMessage,
       SolrQueryRequest req,
       SolrException.ErrorCode code) {
-    assertQEx(failMessage, exceptionMessage, req, code, req.getParams().get(CommonParams.QT));
-  }
-
-  /**
-   * Makes sure a query against the named handler throws a SolrException with the listed response
-   * code and expected message
-   *
-   * @param failMessage The assert message to show when the query doesn't throw the expected
-   *     exception
-   * @param exceptionMessage A substring of the message expected in the exception
-   * @param req Solr request
-   * @param code expected error code for the query
-   * @param handler the name of the request handler to process the request
-   */
-  public static void assertQEx(
-      String failMessage,
-      String exceptionMessage,
-      SolrQueryRequest req,
-      SolrException.ErrorCode code,
-      String handler) {
     try {
       ignoreException(".");
-      h.query(handler, req);
+      h.query(handlerOf(req), req);
       fail(failMessage);
     } catch (SolrException e) {
       assertEquals(code.code, e.code());
@@ -1392,6 +1313,37 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
       mp.add(moreParams[i], moreParams[i + 1]);
     }
     return new SolrQueryRequestBase(h.getCore(), mp);
+  }
+
+  /**
+   * Generates a SolrQueryRequest representing the specified path and query params
+   *
+   * <p>Path information is used by {@link #assertQ(SolrQueryRequest, String...)} and similar
+   * helpers to look up the request handler to invoke. When used with these helpers, typically only
+   * the requestHandler path segment need by provided ("/select", "/export", etc.)
+   *
+   * @see #req(String...)
+   */
+  public static SolrQueryRequest reqWithPath(String path, String... params) {
+    return withPath(path, req(params));
+  }
+
+  /**
+   * Generates a SolrQueryRequest representing the specified path and query params
+   *
+   * <p>Path information is used by {@link #assertQ(SolrQueryRequest, String...)} and similar
+   * helpers to look up the request handler to invoke. When used with these helpers, typically only
+   * the requestHandler path segment need by provided ("/select", "/export", etc.)
+   *
+   * @see #req(SolrParams, String...)
+   */
+  public static SolrQueryRequest reqWithPath(String path, SolrParams params, String... moreParams) {
+    return withPath(path, req(params, moreParams));
+  }
+
+  public static SolrQueryRequest withPath(String path, SolrQueryRequest req) {
+    req.getContext().put(CommonParams.PATH, path);
+    return req;
   }
 
   /** Necessary to make method signatures un-ambiguous */

--- a/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
@@ -307,7 +307,9 @@ public class TestHarness extends BaseTestHarness {
    * @see SolrQueryRequestBase
    */
   public String query(SolrQueryRequest req) throws Exception {
-    return query(req.getParams().get(CommonParams.QT), req);
+    String path = req.getPath();
+    String handler = path != null ? path : req.getParams().get(CommonParams.QT);
+    return query(handler, req);
   }
 
   /**


### PR DESCRIPTION
The 'qt' parameter and several related methods in SolrJ are deprecated.
This deprecation may not stick, but it's still worth minimizing use of this
feature as much as possible.

Many tests rely on it unnecessarily; this PR is one in a number of batches
slowly removing these usages. This one focuses on solr-core tests that
dispatch through the req()/assertQ/assertJQ/assertQEx helpers; passing the
handler explicitly instead of embedding it as a 'qt' request param.
