### PR TITLE
SOLR-17841: Use DocSetCollector for multithreaded DocSet(Faceted) search

### DIFF
--- a/changelog/unreleased/SOLR-17841-mt-docset-collector.yml
+++ b/changelog/unreleased/SOLR-17841-mt-docset-collector.yml
@@ -1,6 +1,5 @@
 title: >
-  Multithreaded search now builds DocSets with DocSetCollector and skips the
-  parallel path when no searcher executor is configured.
+  Improved multiThreaded=true performance when a docset is needed (e.g. faceting).
 type: fixed
 authors:
   - name: Puneet Ahuja

--- a/changelog/unreleased/SOLR-17841-mt-docset-collector.yml
+++ b/changelog/unreleased/SOLR-17841-mt-docset-collector.yml
@@ -1,0 +1,10 @@
+title: >
+  Multithreaded search now builds DocSets with DocSetCollector and skips the
+  parallel path when no searcher executor is configured.
+type: fixed
+authors:
+  - name: Puneet Ahuja
+    nick: punAhuja
+links:
+  - name: SOLR-17841
+    url: https://issues.apache.org/jira/browse/SOLR-17841

--- a/changelog/unreleased/SOLR-17841-mt-docset-collector.yml
+++ b/changelog/unreleased/SOLR-17841-mt-docset-collector.yml
@@ -1,6 +1,6 @@
 title: >
   Improved multiThreaded=true performance when a docset is needed (e.g. faceting).
-type: fixed
+type: changed
 authors:
   - name: Puneet Ahuja
     nick: punAhuja

--- a/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TaskExecutor;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopFieldDocs;
@@ -116,14 +117,14 @@ public class MultiThreadedSearcher {
     return new SearchResult(scoreMode, ret);
   }
 
-  static boolean allowMT(DelegatingCollector postFilter, QueryCommand cmd, boolean hasExecutor) {
+  static boolean allowMT(DelegatingCollector postFilter, QueryCommand cmd, TaskExecutor executor) {
     // TODO: it's unclear if segmentTerminateEarly is truly incompatible but
     //  since it has to appropriately denote partial results this needs to be
     //  investigated/tested before we can remove this check (perhaps for 9.8).
     return postFilter == null
         && !cmd.getSegmentTerminateEarly()
         && cmd.getMultiThreaded()
-        && hasExecutor;
+        && executor != null;
   }
 
   static class MaxScoreResult {

--- a/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/MultiThreadedSearcher.java
@@ -22,14 +22,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.concurrent.ExecutionException;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopFieldDocs;
@@ -119,11 +116,14 @@ public class MultiThreadedSearcher {
     return new SearchResult(scoreMode, ret);
   }
 
-  static boolean allowMT(DelegatingCollector postFilter, QueryCommand cmd) {
+  static boolean allowMT(DelegatingCollector postFilter, QueryCommand cmd, boolean hasExecutor) {
     // TODO: it's unclear if segmentTerminateEarly is truly incompatible but
     //  since it has to appropriately denote partial results this needs to be
     //  investigated/tested before we can remove this check (perhaps for 9.8).
-    return postFilter == null && !cmd.getSegmentTerminateEarly() && cmd.getMultiThreaded();
+    return postFilter == null
+        && !cmd.getSegmentTerminateEarly()
+        && cmd.getMultiThreaded()
+        && hasExecutor;
   }
 
   static class MaxScoreResult {
@@ -131,67 +131,6 @@ public class MultiThreadedSearcher {
 
     public MaxScoreResult(float maxScore) {
       this.maxScore = maxScore;
-    }
-  }
-
-  static class FixedBitSetCollector extends SimpleCollector {
-    @SuppressWarnings("JdkObsolete")
-    private final LinkedList<FixedBitSet> bitSets = new LinkedList<>();
-
-    @SuppressWarnings("JdkObsolete")
-    private final LinkedList<Integer> skipWords = new LinkedList<>();
-
-    @SuppressWarnings("JdkObsolete")
-    private final LinkedList<Integer> skipBits = new LinkedList<>();
-
-    FixedBitSetCollector() {}
-
-    @Override
-    protected void doSetNextReader(LeafReaderContext context) throws IOException {
-      this.bitSets.add(null); // lazy allocate when collecting document(s)
-      this.skipWords.add(context.docBase / 64);
-      this.skipBits.add(context.docBase % 64);
-    }
-
-    @Override
-    public void collect(int doc) throws IOException {
-      FixedBitSet bitSet = this.bitSets.getLast();
-      final int idx = this.skipBits.getLast() + doc;
-
-      final int numWords = FixedBitSet.bits2words(idx + 1); // +1 to ensure minimum 1 word
-
-      if (bitSet == null) {
-        this.bitSets.removeLast();
-        bitSet = new FixedBitSet(numWords * 64);
-        this.bitSets.addLast(bitSet);
-
-      } else if (bitSet.getBits().length < numWords) {
-        FixedBitSet smallerBitSet = this.bitSets.removeLast();
-        bitSet = new FixedBitSet(numWords * 64);
-        bitSet.xor(smallerBitSet);
-        this.bitSets.addLast(bitSet);
-      }
-
-      bitSet.set(idx);
-    }
-
-    void update(FixedBitSet allBitSet) {
-      final long[] allBits = allBitSet.getBits();
-      for (int bs_idx = 0; bs_idx < this.bitSets.size(); ++bs_idx) {
-        final FixedBitSet itBitSet = this.bitSets.get(bs_idx);
-        if (itBitSet != null) {
-          final int skipWords = this.skipWords.get(bs_idx);
-          final long[] itBits = itBitSet.getBits();
-          for (int idx = 0; idx < itBits.length && skipWords + idx < allBits.length; ++idx) {
-            allBits[skipWords + idx] ^= itBits[idx];
-          }
-        }
-      }
-    }
-
-    @Override
-    public ScoreMode scoreMode() {
-      return ScoreMode.COMPLETE_NO_SCORES;
     }
   }
 
@@ -283,8 +222,7 @@ public class MultiThreadedSearcher {
 
     @Override
     public Collector newCollector() throws IOException {
-      // TODO: add to firstCollectors here? or if not have comment w.r.t. why not adding
-      return new FixedBitSetCollector();
+      return new DocSetCollector(maxDoc);
     }
 
     @Override
@@ -292,11 +230,25 @@ public class MultiThreadedSearcher {
     public Object reduce(Collection collectors) throws IOException {
       final FixedBitSet reduced = new FixedBitSet(maxDoc);
       for (Object collector : collectors) {
-        if (collector instanceof FixedBitSetCollector fixedBitSetCollector) {
-          fixedBitSetCollector.update(reduced);
+        if (collector instanceof EarlyTerminatingCollector earlyTerminatingCollector) {
+          collector = earlyTerminatingCollector.getDelegate();
+        }
+        if (collector instanceof DocSetCollector docSetCollector) {
+          mergeDocSetIntoFixedBitSet(docSetCollector.getDocSet(), reduced);
         }
       }
       return reduced;
+    }
+
+    private static void mergeDocSetIntoFixedBitSet(DocSet docSet, FixedBitSet reduced) {
+      if (docSet instanceof BitDocSet bitDocSet) {
+        reduced.or(bitDocSet.getBits());
+      } else {
+        DocIterator iter = docSet.iterator();
+        while (iter.hasNext()) {
+          reduced.set(iter.nextDoc());
+        }
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1982,7 +1982,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       }
       final TopDocs topDocs;
       final ScoreMode scoreModeUsed;
-      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd)) {
+      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, getTaskExecutor() != null)) {
         log.trace("SINGLE THREADED search, skipping collector manager in getDocListNC");
         final TopDocsCollector<?> topCollector = buildTopDocsCollector(len, cmd);
         MaxScoreCollector maxScoreCollector = null;
@@ -2093,7 +2093,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
       final TopDocs topDocs;
-      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd)) {
+      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, getTaskExecutor() != null)) {
         log.trace("SINGLE THREADED search, skipping collector manager in getDocListAndSetNC");
 
         @SuppressWarnings({"rawtypes"})

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1982,7 +1982,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       }
       final TopDocs topDocs;
       final ScoreMode scoreModeUsed;
-      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, getTaskExecutor() != null)) {
+      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, getTaskExecutor())) {
         log.trace("SINGLE THREADED search, skipping collector manager in getDocListNC");
         final TopDocsCollector<?> topCollector = buildTopDocsCollector(len, cmd);
         MaxScoreCollector maxScoreCollector = null;
@@ -2093,7 +2093,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
       final TopDocs topDocs;
-      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, getTaskExecutor() != null)) {
+      if (!MultiThreadedSearcher.allowMT(pf.postFilter, cmd, getTaskExecutor())) {
         log.trace("SINGLE THREADED search, skipping collector manager in getDocListAndSetNC");
 
         @SuppressWarnings({"rawtypes"})

--- a/solr/core/src/test/org/apache/solr/search/TestMultiThreadedSearcher.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMultiThreadedSearcher.java
@@ -123,6 +123,37 @@ public class TestMultiThreadedSearcher extends SolrTestCaseJ4 {
             });
   }
 
+  /** Multi-threaded DocSet collection must match single-threaded for the same query. */
+  public void testMultiThreadedDocSetMatchesSingleThreaded() throws Exception {
+    h.getCore()
+        .withSearcher(
+            searcher -> {
+              assertTrue(searcher.getSlices().length > 1);
+
+              final Query query = new TermQuery(new Term("field1_s", "xyzrareterm"));
+              final QueryCommand cmdSingle = new QueryCommand();
+              cmdSingle.setQuery(query);
+              cmdSingle.setNeedDocSet(true);
+              cmdSingle.setLen(10);
+              cmdSingle.setMultiThreaded(false);
+
+              final QueryCommand cmdMulti = new QueryCommand();
+              cmdMulti.setQuery(query);
+              cmdMulti.setNeedDocSet(true);
+              cmdMulti.setLen(10);
+              cmdMulti.setMultiThreaded(true);
+
+              final QueryResult singleThreaded = searcher.search(cmdSingle);
+              final QueryResult multiThreaded = searcher.search(cmdMulti);
+
+              final DocSet stSet = singleThreaded.getDocListAndSet().docSet;
+              final DocSet mtSet = multiThreaded.getDocListAndSet().docSet;
+              assertEquals(stSet.size(), mtSet.size());
+              assertTrue(DocSetUtil.equals(stSet, mtSet));
+              return null;
+            });
+  }
+
   private static final class SimpleReRankQuery extends RankQuery {
 
     private Query q;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17841

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA.
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-17841: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Multithreaded(MT) search was slower than Singlethreaded(ST) search in the case of faceted queries. Faceted queries need a DocSet. ST already builds that with `DocSetCollector`. MT used a custom `FixedBitSetCollector` instead, and that made faceted search slower with MT on.

This PR fixes that DocSet path so enabling MT no longer makes faceting worse.
# Solution

Two changes in `MultiThreadedSearcher` / `SolrIndexSearcher`:
1. Multithreaded DocSet search now uses `DocSetCollector`, same as the single-threaded path. Each thread collects its own DocSet, then we OR them together. The old `FixedBitSetCollector` was only used here, so I removed it.
2. `multiThreaded=true` now also needs a searcher thread pool. If `indexSearcherExecutorThreads=0`, we used to take the multithreaded path anyway and it could get very slow. That case now falls back to single-threaded.
I used an AI coding assistant (Cursor) while investigating and drafting the change. I reviewed the diff, ran the tests, and did the benchmarks myself.

# Tests

Unit test: `TestMultiThreadedSearcher.testMultiThreadedDocSetMatchesSingleThreaded` — same query, `needDocSet=true`, ST vs MT DocSets must match on a multi-segment index.


Latency was measured with solr-bench (one client query at a time; searcher
pool `-Dsolr.searchThreads=-1`). Suites, generator, NoMerge configset, and
how to run it:

https://github.com/SearchScale/solr-bench/tree/puneet/SOLR-17841-mt-search

I compared the same 1M-doc index merged vs forced to ~500 segments
(`NoMergePolicy`, flush every 2000 docs). Queries are `event_time` range +
`event_type` filter, with and without facets.

| | mean | p50 | p95 |
|---|---|---|---|
| facet, few segments, MT before | ~15.1 | ~6.0 | ~66 |
| facet, few segments, after (ST / MT) | 7.14 / 7.65 | 6.38 / 6.86 | 12.43 / 13.80 |
| plain, many segments (ST / MT) | 4.55 / 3.36 | 2.75 / 2.78 | 21.56 / 7.75 |
| facet, many segments (ST / MT) | 15.79 / 14.78 | 12.22 / 12.44 | 38.28 / 30.59 |

After the fix, facet MT is no longer worse on a normal index. With many
segments MT can win, especially on plain queries and p95.

NOTE: Still investigating whether MT can actually beat ST more broadly.

This PR only addresses the DocSet collector used for faceting. After the change, facet MT is no longer worse on a normal index, and with many segments MT can win (especially plain queries and p95).
Renato's findings on SOLR-17841 look like a separate bottleneck. Even with 50M docs force-merged to 5 segments, range queries were ~5× slower under MT; the profile pointed at `SolrRangeQuery` / `FixedBitSet.or`, not this collector. I want to look at that next.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change
