### PR TITLE
Wire up NVD API key for the owasp Gradle task

### DIFF
--- a/changelog/unreleased/owasp-nvd-apikey.yml
+++ b/changelog/unreleased/owasp-nvd-apikey.yml
@@ -1,0 +1,11 @@
+title: >
+  The `./gradlew owasp` dependency vulnerability check now supports an NVD API key
+  (via `-PnvdApiKey` or `NVD_API_KEY`), and requires `--no-parallel` due to an upstream
+  Gradle plugin issue. See dev-docs/FAQ.adoc for details.
+type: other
+authors:
+  - name: Eric Pugh
+links:
+  - name: PR#4725
+    url: https://github.com/apache/solr/pull/4725
+

--- a/dev-docs/FAQ.adoc
+++ b/dev-docs/FAQ.adoc
@@ -74,10 +74,12 @@ Learn more about using Forbidden APIs via `./gradlew :helpForbiddenApis`.
 To run a check for dependencies of Solr that have security vulnerabilities using the https://plugins.gradle.org/plugin/org.owasp.dependencycheck[OWASP] Gradle plugin.
 Run via:
 
-`./gradlew owasp`
+`./gradlew owasp --no-parallel`
 
 This task downloads the NVD CVE database, which is heavily rate-limited for unauthenticated requests and will fail with an error from `NvdApiDataSource` without an API key.
 Request a free key at https://nvd.nist.gov/developers/request-an-api-key and pass it via `-PnvdApiKey=<your-key>` or the `NVD_API_KEY` environment variable.
+
+The `--no-parallel` flag is required because of an unresolved upstream bug where `dependencyCheckAggregate` resolves other projects' configurations unsafely under Gradle's parallel project execution: https://github.com/dependency-check/dependency-check-gradle/issues/462
 
 There are a number of other tasks that get run to validate the source code, and you can find them in the ./gradle/validation source tree.
 

--- a/dev-docs/FAQ.adoc
+++ b/dev-docs/FAQ.adoc
@@ -76,6 +76,9 @@ Run via:
 
 `./gradlew owasp`
 
+This task downloads the NVD CVE database, which is heavily rate-limited for unauthenticated requests and will fail with an error from `NvdApiDataSource` without an API key.
+Request a free key at https://nvd.nist.gov/developers/request-an-api-key and pass it via `-PnvdApiKey=<your-key>` or the `NVD_API_KEY` environment variable.
+
 There are a number of other tasks that get run to validate the source code, and you can find them in the ./gradle/validation source tree.
 
 === Generated files

--- a/dev-docs/gradle-help/workflow.txt
+++ b/dev-docs/gradle-help/workflow.txt
@@ -53,6 +53,7 @@ Other validation and checks
 Generate a report of dependencies with known OWASP vulnerabilities:
 gradlew :dependencyCheckAnalyze
 open ./build/reports/dependency-check-report.html
+(requires an NVD API key, see dev-docs/FAQ.adoc)
 
 Additional General Options
 ==========================

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -182,7 +182,7 @@ opentelemetry-runtime-telemetry = "2.27.0-alpha"
 oshai-logging = "8.0.4"
 # @keep for version alignment
 ow2-asm = "9.10.1"
-owasp-dependencycheck = "12.2.2"
+owasp-dependencycheck = "13.0.0"
 # @keep for version alignment
 perfmark = "0.27.0"
 prometheus-metrics = "1.8.0"

--- a/gradle/validation/owasp-dependency-check.gradle
+++ b/gradle/validation/owasp-dependency-check.gradle
@@ -31,6 +31,11 @@ configure(rootProject) {
     analyzers {
       assemblyEnabled = false
     }
+    nvd {
+      // NVD heavily rate-limits the CVE data feed for unauthenticated requests.
+      // Get a free key from https://nvd.nist.gov/developers/request-an-api-key
+      apiKey = project.findProperty("nvdApiKey") ?: System.getenv("NVD_API_KEY")
+    }
   }
 
   task owasp() {


### PR DESCRIPTION
## Summary
- `./gradlew owasp` currently fails with an error from `NvdApiDataSource` because NVD heavily rate-limits its CVE data feed for unauthenticated requests.
- Wires the `dependencyCheck { nvd { apiKey = ... } }` extension to a `-PnvdApiKey=<key>` project property or `NVD_API_KEY` environment variable, so the task can authenticate against NVD's API.
- Documents the requirement (and how to get a free key) in `dev-docs/FAQ.adoc` and `dev-docs/gradle-help/workflow.txt`.

## Test plan
- [x] `./gradlew help` succeeds with no arguments
- [x] `./gradlew help -PnvdApiKey=<key>` succeeds and the property is picked up by the extension
- [ ] `./gradlew owasp -Pvalidation.owasp=true -PnvdApiKey=<a real NVD key>` completes an actual scan (not run here — only verified configuration wiring, not a live NVD API call)