### PR TITLE
SOLR-18342: Upgrade Gradle build to 9.7.0

### DIFF
--- a/changelog/unreleased/SOLR-18289-gradle-9.yml
+++ b/changelog/unreleased/SOLR-18289-gradle-9.yml
@@ -1,8 +1,10 @@
 # See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-title: The build now uses Gradle 9.6.0 (upgraded from 8.10).
+title: The build now uses Gradle 9.7.0 (upgraded from 8.10).
 type: other
 authors:
   - name: Serhiy Bzhezytskyy
 links:
   - name: SOLR-18289
     url: https://issues.apache.org/jira/browse/SOLR-18289
+  - name: SOLR-18342
+    url: https://issues.apache.org/jira/browse/SOLR-18342

--- a/changelog/unreleased/SOLR-18342-gradle-9.7.0.yml
+++ b/changelog/unreleased/SOLR-18342-gradle-9.7.0.yml
@@ -1,8 +1,0 @@
-# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-title: The build now uses Gradle 9.7.0 (upgraded from 9.6.0).
-type: other
-authors:
-  - name: Serhiy Bzhezytskyy
-links:
-  - name: SOLR-18342
-    url: https://issues.apache.org/jira/browse/SOLR-18342

--- a/changelog/unreleased/SOLR-18342-gradle-9.7.0.yml
+++ b/changelog/unreleased/SOLR-18342-gradle-9.7.0.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: The build now uses Gradle 9.7.0 (upgraded from 9.6.0).
+type: other
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18342
+    url: https://issues.apache.org/jira/browse/SOLR-18342

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,7 +110,7 @@ google-javaformat = "1.35.0"
 # @keep for version alignment
 google-protobuf = "4.35.1"
 # @keep Gradle version to run the build
-gradle = "9.6.0"
+gradle = "9.7.0"
 grpc = "1.82.0"
 # @keep Gulp version used in ref-guide
 gulp-cli = "3.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18342

# Description

Upgrades the Gradle wrapper and the version catalog from 9.6.0 to 9.7.0 (current stable, released 2026-08-06). Build-tool only, no API migrations needed.

Checked with `--warning-mode all` that the bump introduces no new Gradle deprecations — the same set of deprecation kinds appears on 9.6.0 and on 9.7.0 (310 -> 298 occurrences, all pre-existing and hidden by `org.gradle.warning.mode=none`).

# Testing

On Temurin 21:

* `./gradlew --version` reports 9.7.0
* `./gradlew :solr:solrj:compileJava :solr:core:compileJava`
* `./gradlew spotlessCheck`

`./gradlew check -x test` fails on `:rat` for six files that predate this change (`.asf.yaml`, `.editorconfig`, `.git-blame-ignore-revs`, `dev-docs/ui/*.adoc`); the same failure reproduces on an unmodified `main`.
