### PR TITLE
SOLR-18344: Report in-progress backup status on /replication?command=details

### DIFF
--- a/changelog/unreleased/SOLR-18344-report-in-progress-backup-status.yml
+++ b/changelog/unreleased/SOLR-18344-report-in-progress-backup-status.yml
@@ -1,5 +1,6 @@
 # See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
-title: /replication?command=details now reports a backup while it is still running, with file counts, instead of showing the previous backup's status until the new one completes
+title: /replication?command=details now reports backup details while the backup is
+  still running, including file counts, instead of the previous backup's status
 type: fixed # added, changed, fixed, deprecated, removed, dependency_update, security, other
 authors:
   - name: Idan Tepper

--- a/changelog/unreleased/SOLR-18344-report-in-progress-backup-status.yml
+++ b/changelog/unreleased/SOLR-18344-report-in-progress-backup-status.yml
@@ -1,0 +1,9 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: /replication?command=details now reports a backup while it is still running, with file counts, instead of showing the previous backup's status until the new one completes
+type: fixed # added, changed, fixed, deprecated, removed, dependency_update, security, other
+authors:
+  - name: Idan Tepper
+    nick: idantepper
+links:
+  - name: SOLR-18344
+    url: https://issues.apache.org/jira/browse/SOLR-18344

--- a/solr/core/src/java/org/apache/solr/handler/SnapShooter.java
+++ b/solr/core/src/java/org/apache/solr/handler/SnapShooter.java
@@ -66,6 +66,12 @@ public class SnapShooter {
   private BackupRepository backupRepo = null;
   private String commitName; // can be null
 
+  /**
+   * Receives in-progress status while the snapshot is being created, so that it can be reported
+   * before the snapshot completes. A no-op unless set by {@link #createSnapAsync}.
+   */
+  private volatile Consumer<NamedList<?>> progressListener = nl -> {};
+
   public SnapShooter(
       BackupRepository backupRepo,
       SolrCore core,
@@ -228,7 +234,42 @@ public class SnapShooter {
             + solrCore.getName());
   }
 
+  /**
+   * The status of a snapshot that has been requested but has not finished yet. A null {@link
+   * #snapshotName} is omitted rather than reported, matching how {@link CoreSnapshotResponse}
+   * reports the same snapshot once it has completed.
+   */
+  private NamedList<Object> inProgressDetails(String startTime, String status) {
+    NamedList<Object> details = new SimpleOrderedMap<>();
+    details.add("startTime", startTime);
+    details.add("status", status);
+    if (snapshotName != null) {
+      details.add("snapshotName", snapshotName);
+    }
+    details.add("directoryName", directoryName);
+    return details;
+  }
+
+  /**
+   * The status of a snapshot whose files are being copied. Only reported once the index commit has
+   * been resolved, since until then there is no file list to count.
+   *
+   * @param fileCount the total number of files this snapshot will copy
+   * @param finishedFileCount how many of them have been copied so far
+   */
+  private NamedList<Object> runningDetails(String startTime, int fileCount, int finishedFileCount) {
+    NamedList<Object> details = inProgressDetails(startTime, RUNNING_STATUS);
+    details.add("fileCount", fileCount);
+    details.add("finishedFileCount", finishedFileCount);
+    return details;
+  }
+
   public void createSnapAsync(final int numberToKeep, Consumer<NamedList<?>> result) {
+    this.progressListener = result;
+    // Report before the thread starts, otherwise the previously reported status (possibly a
+    // "success" from an earlier snapshot) stays visible until the index commit has been resolved.
+    // The file list isn't known until then, so this status carries no file counts.
+    result.accept(inProgressDetails(Instant.now().toString(), WAITING_FOR_COMMIT_STATUS));
     // TODO should use Solr's ExecutorUtil
     new Thread(
             () -> {
@@ -277,6 +318,7 @@ public class SnapShooter {
       details.startTime = Instant.now().toString();
 
       Collection<String> files = indexCommit.getFileNames();
+      progressListener.accept(runningDetails(details.startTime, files.size(), 0));
       Directory dir =
           solrCore
               .getDirectoryFactory()
@@ -285,10 +327,13 @@ public class SnapShooter {
                   DirContext.DEFAULT,
                   solrCore.getSolrConfig().indexConfig.lockType);
       try {
+        int finishedFileCount = 0;
         for (String fileName : files) {
           log.debug(
               "Copying fileName={} from dir={} to snapshot={}", fileName, dir, snapshotDirPath);
           backupRepo.copyFileFrom(dir, fileName, snapshotDirPath);
+          progressListener.accept(
+              runningDetails(details.startTime, files.size(), ++finishedFileCount));
         }
       } finally {
         solrCore.getDirectoryFactory().release(dir);
@@ -375,6 +420,15 @@ public class SnapShooter {
   }
 
   public static final String DATE_FMT = "yyyyMMddHHmmssSSS";
+
+  /**
+   * Status reported after a snapshot has been requested but before its index commit -- and with it
+   * the list of files to copy -- has been resolved.
+   */
+  public static final String WAITING_FOR_COMMIT_STATUS = "waiting for commit";
+
+  /** Status reported while a snapshot's files are being copied. */
+  public static final String RUNNING_STATUS = "running";
 
   public static class CoreSnapshotResponse extends SolrJerseyResponse {
     @Schema(description = "The time at which snapshot started at.")

--- a/solr/core/src/test/org/apache/solr/handler/TestSnapshotCoreBackup.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSnapshotCoreBackup.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
@@ -29,9 +32,12 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.handler.admin.CoreAdminHandler;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.util.TimeOut;
 import org.junit.After;
 import org.junit.Before;
 
@@ -367,6 +373,101 @@ public class TestSnapshotCoreBackup extends SolrTestCaseJ4 {
       simpleBackupCheck(backupDir.resolve("snapshot." + name), 1, oneDocSegmentFile);
     }
     admin.close();
+  }
+
+  /**
+   * Backups run asynchronously, so the status reported to /replication?command=details must
+   * describe a snapshot that is still running -- not stay silent (or keep describing the previously
+   * completed snapshot) until it finishes.
+   *
+   * <p>Rather than racing a live backup by polling "details", this collects every status the
+   * handler would have published and asserts on the whole sequence, which is deterministic.
+   */
+  public void testBackupReportsProgressWhileRunning() throws Exception {
+    for (int i = 0; i < 50; i++) {
+      assertU(adoc("id", String.valueOf(i)));
+    }
+    assertU(commit());
+
+    final Path backupDir = createTempDir();
+    h.getCoreContainer().getAllowPaths().add(backupDir);
+
+    // this is what /replication?command=backup does, minus the http plumbing
+    final List<NamedList<?>> reports = new CopyOnWriteArrayList<>();
+    ReplicationHandler.doSnapShoot(
+        0, 0, backupDir.toString(), null, null, "progress_backup", h.getCore(), reports::add);
+
+    final TimeOut timeOut = new TimeOut(60, TimeUnit.SECONDS, TimeSource.NANO_TIME);
+    NamedList<?> last = null;
+    while (!timeOut.hasTimedOut()) {
+      if (!reports.isEmpty()) {
+        last = reports.get(reports.size() - 1);
+        assertNull("Backup failed: " + last, last.get("exception"));
+        if ("success".equals(last.get("status"))) {
+          break;
+        }
+      }
+      timeOut.sleep(20);
+    }
+    assertNotNull("No backup status was ever reported", last);
+    assertEquals(
+        "Backup did not succeed before the TimeOut elapsed: " + last,
+        "success",
+        last.get("status"));
+    // the backup is over, so no further reports can arrive and 'reports' is now stable
+    final int totalFileCount = ((Number) last.get("fileCount")).intValue();
+    assertTrue(
+        "Test needs a backup of more than one file, got " + totalFileCount, 1 < totalFileCount);
+
+    // the very first status is published before the index commit is resolved, so it names no files
+    final NamedList<?> waiting = reports.get(0);
+    assertEquals(
+        "backup should first report itself as waiting: " + waiting,
+        SnapShooter.WAITING_FOR_COMMIT_STATUS,
+        waiting.get("status"));
+    assertNull("no file list is known yet: " + waiting, waiting.get("fileCount"));
+    assertNull("no file list is known yet: " + waiting, waiting.get("finishedFileCount"));
+
+    final List<NamedList<?>> running = reports.subList(1, reports.size() - 1);
+    assertFalse("Backup was never reported as running", running.isEmpty());
+
+    int previousFinished = -1;
+    for (NamedList<?> report : running) {
+      assertEquals(
+          "not reported as running: " + report, SnapShooter.RUNNING_STATUS, report.get("status"));
+
+      final int finished = ((Number) report.get("finishedFileCount")).intValue();
+      assertTrue(
+          "finishedFileCount went backwards: " + previousFinished + " -> " + finished,
+          previousFinished <= finished);
+      previousFinished = finished;
+    }
+
+    // every in-progress status must identify the backup it is about
+    for (NamedList<?> report : reports.subList(0, reports.size() - 1)) {
+      assertNotNull("in-progress report has no startTime: " + report, report.get("startTime"));
+      assertEquals(
+          "in-progress report names the wrong snapshot: " + report,
+          "progress_backup",
+          report.get("snapshotName"));
+      assertEquals(
+          "in-progress report has the wrong directoryName: " + report,
+          "snapshot.progress_backup",
+          report.get("directoryName"));
+    }
+
+    // by the last report before completion, every file must be accounted for
+    final NamedList<?> lastRunning = running.get(running.size() - 1);
+    assertEquals(
+        "last running report disagrees with the completed backup: " + lastRunning,
+        totalFileCount,
+        ((Number) lastRunning.get("fileCount")).intValue());
+    assertEquals(
+        "last running report did not finish every file: " + lastRunning,
+        totalFileCount,
+        ((Number) lastRunning.get("finishedFileCount")).intValue());
+
+    simpleBackupCheck(backupDir.resolve("snapshot.progress_backup"), 50);
   }
 
   /**

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/backup-restore.adoc
@@ -129,7 +129,7 @@ The name of the commit which was used while taking a snapshot using the CREATESN
 
 === Backup Status
 
-The `backup` operation can be monitored to see if it has completed by sending the `details` command to the `/replication` handler, as in this example:
+The `backup` operation can be monitored by sending the `details` command to the `/replication` handler, as in this example:
 
 .Status API Example
 [source,text]
@@ -137,7 +137,35 @@ The `backup` operation can be monitored to see if it has completed by sending th
 http://localhost:8983/solr/gettingstarted/replication?command=details&wt=xml
 ----
 
-.Output Snippet
+The `backup` section of the response describes the most recent backup on the core, whether it is still running or has already finished.
+While a backup is in progress, `status` is one of:
+
+`waiting for commit`::
+The backup has been requested, but its index commit -- and with it the list of files to copy -- has not been resolved yet.
+No file counts are reported.
+
+`running`::
+The backup's files are being copied.
+`fileCount` is the total number of files to copy, and `finishedFileCount` how many of them have been copied so far.
+
+.Output Snippet: a running backup
+[source,xml]
+----
+<lst name="backup">
+  <str name="startTime">2022-02-11T17:19:33.271461700Z</str>
+  <str name="status">running</str>
+  <str name="snapshotName">my_backup</str>
+  <str name="directoryName">snapshot.my_backup</str>
+  <int name="fileCount">10</int>
+  <int name="finishedFileCount">4</int>
+</lst>
+----
+
+`snapshotName` is only reported for a named backup.
+
+Once the backup completes, `status` becomes `success`:
+
+.Output Snippet: a completed backup
 [source,xml]
 ----
 <lst name="backup">
@@ -151,7 +179,10 @@ http://localhost:8983/solr/gettingstarted/replication?command=details&wt=xml
 </lst>
 ----
 
-If it failed then a `snapShootException` will be sent in the response.
+If it failed then an `exception` will be sent in the response.
+
+The reported status is retained until the next backup is started on the core, or until the core is reloaded.
+A `success` may therefore describe an earlier backup rather than one that was just requested; a newly requested backup replaces it with `waiting for commit` as soon as it is accepted.
 
 === Restore API
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18344

# Description

The `backup` key in the `/replication?command=details` response is only populated once a backup has *finished*. While one runs there is no sign of it, and the key still holds the **previous** backup's payload — including `"status": "success"`.

So a client that issues `command=backup` and then polls `command=details` reads the stale `success` of an earlier backup as the result of the one it just started, and concludes the new backup is already done. With no prior backup the key is simply absent, so a poller cannot distinguish "running" from "never started" either.

# Solution

The plumbing already existed and was only used once. `SnapShooter.createSnapAsync` takes a `Consumer<NamedList<?>>` that `ReplicationHandler` wires to its volatile `snapShootDetails` field, which `getReplicationDetails` already publishes under the `backup` key — it was just invoked a single time, at the very end of the snapshot.

That consumer is now kept in a `volatile progressListener` field and emitted through as the copy loop advances, adding two in-progress statuses ahead of the existing terminal ones:

| `status` | When | Extra keys |
|---|---|---|
| `waiting for commit` | Published **synchronously**, before the worker thread starts | none |
| `running` | After each `backupRepo.copyFileFrom` | `fileCount`, `finishedFileCount` |
| `success` / exception | Unchanged | unchanged |

The synchronous first publish is the part that fixes the stale-`success` read. It carries no file counts because the index commit — and with it the list of files to copy — has not been resolved yet.

All in-progress statuses carry `startTime`, `directoryName`, and `snapshotName`; a null `snapshotName` is omitted rather than reported, matching how `CoreSnapshotResponse` renders a completed snapshot via `putIfNotNull`.

The change is purely additive to the response, involves no API change, and **`ReplicationHandler` is untouched** — which keeps this to a single main-source file.

# Tests

`TestSnapshotCoreBackup#testBackupReportsProgressWhileRunning` collects every status the handler would publish and asserts on the whole sequence, rather than racing a live backup by polling — so it is deterministic. It asserts that:

- the first report is `waiting for commit`, carrying neither `fileCount` nor `finishedFileCount`;
- `running` reports follow, with a non-decreasing `finishedFileCount`;
- every in-progress report identifies its own snapshot (`startTime`, `snapshotName`, `directoryName`);
- the last `running` report accounts for every file in the completed backup;
- the resulting backup still passes `simpleBackupCheck`.

I verified the test fails without the fix — with the three progress emissions removed it fails on `Backup was never reported as running`.

`./gradlew tidy updateLicenses check -x test` was run. Two tasks fail in my local environment for reasons unrelated to this change, both of which reproduce on unmodified `main`:

- `:rat` — my checkout is a **git worktree**, where `.git` is a file rather than a directory. `rat-sources.gradle` treats that as "not a git repository", so the git-index lookup returns `null` and the `exclude "dev-docs"` / `exclude "**/AGENTS.md"` / `exclude "**/.*"` rules in that same branch never apply; rat then scans the whole tree and flags upstream files such as `dev-docs/*.adoc`, `.github/*` and `AGENTS.md`.
- `:solr-ref-guide:buildLocalAntoraSite` — my repository path contains a space, which the `npx` invocation does not quote (`Error: Cannot find module '/Users/idantepper/Desktop/Developing'`).

All other checks pass, including `spotlessCheck`, `ecjLint`, `forbiddenApis`, `validateLogCalls`, `validateSourcePatterns` and `javadoc`.

# AI assistance disclosure

This change was developed with the assistance of Claude (Anthropic), following the guidance in `dev-docs/how-to-contribute.adoc`. The commit carries a `Co-Authored-By` trailer. I have reviewed the diff and the test in full, confirmed the test fails without the fix, and I take responsibility for the contribution.

# Checklist

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch.
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide) — `backup-restore.adoc` §"Backup Status" now documents the two in-progress statuses, and states that the reported status is retained until the next backup starts. (An earlier revision of this description claimed the ref guide did not document this response; that was wrong.)
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change.

