### PR TITLE
Fix renovate pin for consistent-versions plugin on branch_9x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,17 +22,17 @@
     },
     {
       "description": "Keep org.apache.hadoop on 3.4.x; 3.5.0 requires Java 17 but branch_9x builds with Java 11",
-      "matchPackagePrefixes": ["org.apache.hadoop:"],
+      "matchPackageNames": ["org.apache.hadoop:**"],
       "allowedVersions": "<3.5.0"
     },
     {
       "description": "Pin dev.langchain4j to 0.35.0; 0.36.2 requires Java 17 but branch_9x builds with Java 11",
-      "matchPackagePrefixes": ["dev.langchain4j:"],
+      "matchPackageNames": ["dev.langchain4j:**"],
       "allowedVersions": "0.35.0"
     },
     {
       "description": "Keep Error Prone on 2.31.0; the build hard-pins it to 2.31.0 for JDK11 compatibility on branch_9x",
-      "matchPackagePrefixes": ["com.google.errorprone:"],
+      "matchPackageNames": ["com.google.errorprone:**"],
       "allowedVersions": "2.31.0"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
   "packageRules": [
     {
       "description": "Pin com.palantir.consistent-versions to 2.32.0; newer versions require Java 17 but branch_9x builds with Java 11",
-      "matchPackageNames": ["com.palantir.consistent-versions"],
+      "matchDepNames": ["com.palantir.consistent-versions"],
       "allowedVersions": "2.32.0"
     },
     {


### PR DESCRIPTION
The 2.32.0 pin added in #4733 never matched the `com.palantir.consistent-versions` Gradle plugin: for plugins, Renovate's `matchPackageNames` matches the plugin marker artifact (`com.palantir.consistent-versions:com.palantir.consistent-versions.gradle.plugin`), not the plugin id. That is why solrbot still opened #4734. The plugin id is the `depName`, so switch the rule to `matchDepNames`.

Second commit replaces the deprecated `matchPackagePrefixes` with equivalent `matchPackageNames` globs (no behavior change).