### PR TITLE
Move branch9x solrbot to monthly run

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,7 +46,7 @@
       "allowedVersions": "0.10.0"
     }
   ],
-  "schedule": ["* * * * *"],
+  "schedule": ["before 9am on the first day of the month"],
   "prConcurrentLimit": 100,
   "prHourlyLimit": 10,
   "branchPrefix": "renovate-9x/",


### PR DESCRIPTION
Hi all, I wanted to reduce the noise that solrbot creates by constantly opening dependency upgrades, so this PR moves the `branch_9x` configuration to match `main`, which is to do it monthly.   I personally much rather on the first day of the month deal with all hte various automated updates as one activity.

Apparently 4 times a day the jobs runs, but it only actually does it's work on the first day of the month!  Should we change that?

Also, maybe if we didn't have this line at all, then we would pick up the corresponding configuration on the `main` branch?


WDYT @janhoy @dsmiley 

Eric