### PR TITLE
SOLR-18332: More 'qt' removal, rd 5

### DIFF
--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -728,12 +728,12 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
     assertQ(
         "defaults handler returns fewer matches",
-        req("q", "id:[42 TO 47]", "qt", "/defaults"),
+        reqWithPath("/defaults", "q", "id:[42 TO 47]"),
         "*[count(//doc)=4]");
 
     assertQ(
         "defaults handler includes highlighting",
-        req("q", "name:Zapp OR title:General", "qt", "/defaults"),
+        reqWithPath("/defaults", "q", "name:Zapp OR title:General"),
         "//lst[@name='highlighting']");
   }
 

--- a/solr/core/src/test/org/apache/solr/CursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/CursorPagingTest.java
@@ -141,9 +141,9 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
             params(),
             params(CURSOR_MARK_PARAM, "gibberish"),
             params(CURSOR_MARK_PARAM, "gibberish", "sort", "id asc"))) {
-      assertJQ(req(p, "qt", "/get", "fl", "id", "id", "yyy"), "=={'doc':{'id':'yyy'}}");
+      assertJQ(reqWithPath("/get", p, "fl", "id", "id", "yyy"), "=={'doc':{'id':'yyy'}}");
       assertJQ(
-          req(p, "qt", "/get", "fl", "id", "id", "xxx"), // doesn't exist in our collection
+          reqWithPath("/get", p, "fl", "id", "id", "xxx"), // doesn't exist in our collection
           "=={'doc':null}");
     }
   }
@@ -629,19 +629,7 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
     String cursorMark, nextCursorMark = CURSOR_MARK_START;
 
     SolrParams params =
-        params(
-            "q",
-            "name:a*",
-            "fl",
-            "id",
-            "sort",
-            "id asc",
-            "rows",
-            "50",
-            "qt",
-            "/delayed",
-            "sleep",
-            "10");
+        params("q", "name:a*", "fl", "id", "sort", "id asc", "rows", "50", "sleep", "10");
 
     List<String> foundDocIds = new ArrayList<>();
     String[] timeAllowedVariants = {"1", "50", wontExceedTimeout};
@@ -652,7 +640,9 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
 
         // execute the query
         String json =
-            assertJQ(req(params, CURSOR_MARK_PARAM, cursorMark, TIME_ALLOWED, timeAllowed));
+            assertJQ(
+                reqWithPath(
+                    "/delayed", params, CURSOR_MARK_PARAM, cursorMark, TIME_ALLOWED, timeAllowed));
 
         Map<?, ?> response = (Map<?, ?>) fromJSONString(json);
         Map<?, ?> responseHeader = (Map<?, ?>) response.get("responseHeader");
@@ -789,7 +779,6 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
             assertFullWalkNoDupsElevated(
                 wrapDefaults(
                     params(
-                        "qt", "/elevate",
                         "fl", "id,[elevated]",
                         "forceElevation", "true",
                         "elevateIds", "50,20,80"),
@@ -835,8 +824,6 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
           assertFullWalkNoDupsElevated(
               wrapDefaults(
                   params(
-                      "qt",
-                      "/elevate",
                       "fl",
                       fl + ",[elevated]",
                       // HACK: work around SOLR-15307... same results should match, just not same
@@ -917,6 +904,7 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
     final SentinelIntSet idsElevated = new SentinelIntSet(32, -1);
 
     assertFullWalkNoDups(
+        "/elevate",
         params,
         (doc) -> {
           final int id = Integer.parseInt(doc.get("id").toString());
@@ -972,11 +960,20 @@ public class CursorPagingTest extends SolrTestCaseJ4 {
    */
   public void assertFullWalkNoDups(SolrParams params, Consumer<Map<Object, Object>> consumer)
       throws Exception {
+    assertFullWalkNoDups(null, params, consumer);
+  }
+
+  /**
+   * Identical to {@link #assertFullWalkNoDups(SolrParams,Consumer)}, but dispatches the query to
+   * the specified request handler path.
+   */
+  public void assertFullWalkNoDups(
+      String handler, SolrParams params, Consumer<Map<Object, Object>> consumer) throws Exception {
 
     String cursorMark = CURSOR_MARK_START;
     int docsOnThisPage = Integer.MAX_VALUE;
     while (0 < docsOnThisPage) {
-      String json = assertJQ(req(params, CURSOR_MARK_PARAM, cursorMark));
+      String json = assertJQ(reqWithPath(handler, params, CURSOR_MARK_PARAM, cursorMark));
       Map<?, ?> rsp = (Map<?, ?>) fromJSONString(json);
       assertTrue(
           "response doesn't contain " + CURSOR_MARK_NEXT + ": " + json,

--- a/solr/core/src/test/org/apache/solr/handler/NoOpRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/NoOpRequestHandlerTest.java
@@ -41,7 +41,7 @@ public class NoOpRequestHandlerTest extends SolrTestCaseJ4 {
         expectThrows(
             SolrException.class,
             () -> {
-              try (SolrQueryRequest req = req("qt", "/schema")) {
+              try (SolrQueryRequest req = reqWithPath("/schema")) {
                 SolrQueryResponse rsp = new SolrQueryResponse();
                 h.getCore().execute(h.getCore().getRequestHandler("/schema"), req, rsp);
                 if (rsp.getException() != null) {
@@ -66,7 +66,7 @@ public class NoOpRequestHandlerTest extends SolrTestCaseJ4 {
         expectThrows(
             SolrException.class,
             () -> {
-              try (SolrQueryRequest req = req("qt", "/schema/fields")) {
+              try (SolrQueryRequest req = reqWithPath("/schema/fields")) {
                 SolrQueryResponse rsp = new SolrQueryResponse();
                 h.getCore().execute(h.getCore().getRequestHandler("/schema"), req, rsp);
                 if (rsp.getException() != null) {

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -50,8 +50,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -77,8 +76,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -102,8 +100,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -123,8 +120,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -153,8 +149,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -183,8 +178,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -205,8 +199,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,
@@ -240,8 +233,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     SolrQueryResponse resp = new SolrQueryResponse();
     handler.handleRequestBody(
-        req(
-            CommonParams.QT,
+        reqWithPath(
             CommonParams.METRICS_PATH,
             CommonParams.WT,
             MetricUtils.PROMETHEUS_METRICS_WT,

--- a/solr/core/src/test/org/apache/solr/handler/admin/StatsReloadRaceTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/StatsReloadRaceTest.java
@@ -21,7 +21,6 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.CoreAdminParams.CoreAdminAction;
 import org.apache.solr.common.util.RetryUtil;
@@ -59,8 +58,7 @@ public class StatsReloadRaceTest extends SolrTestCaseJ4 {
       h.getCoreContainer()
           .getMultiCoreHandler()
           .handleRequest(
-              req(
-                  CommonParams.QT,
+              reqWithPath(
                   "/admin/cores",
                   CoreAdminParams.ACTION,
                   CoreAdminParams.CoreAdminAction.RELOAD.toString(),

--- a/solr/core/src/test/org/apache/solr/handler/export/TestExportWriter.java
+++ b/solr/core/src/test/org/apache/solr/handler/export/TestExportWriter.java
@@ -74,7 +74,8 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     assertU(commit());
 
     String resp =
-        h.query(req("q", "*:*", "qt", "/export", "fl", "id,field2_i_p", "sort", "field2_i_p asc"));
+        h.query(
+            reqWithPath("/export", "q", "*:*", "fl", "id,field2_i_p", "sort", "field2_i_p asc"));
     assertJsonEquals(
         resp,
         "{\n"
@@ -113,15 +114,8 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     for (String sortField : fieldNames) {
       String resp =
           h.query(
-              req(
-                  "q",
-                  "*:*",
-                  "qt",
-                  "/export",
-                  "fl",
-                  "id," + sortField,
-                  "sort",
-                  sortField + " desc"));
+              reqWithPath(
+                  "/export", "q", "*:*", "fl", "id," + sortField, "sort", sortField + " desc"));
       assertJsonEquals(
           resp,
           "{\n"
@@ -368,7 +362,8 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Expected for asc sort doc3 -> doc2 -> doc1
     String s =
         h.query(
-            req("q", "*:*", "qt", "/export", "fl", "id", "sort", "field1_i_p asc,field2_i_p asc"));
+            reqWithPath(
+                "/export", "q", "*:*", "fl", "id", "sort", "field1_i_p asc,field2_i_p asc"));
     assertJsonEquals(
         s,
         "{\n"
@@ -456,11 +451,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "*:*",
-                "qt",
-                "/export",
                 "fl",
                 "id",
                 "sort",
@@ -507,10 +501,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
             + "      ,{\n"
             + "        \"id\":\"4\"}]}}";
 
-    String s = h.query(req("q", "*:*", "qt", "/export", "fl", "id", "sort", "stringdv asc"));
+    String s = h.query(reqWithPath("/export", "q", "*:*", "fl", "id", "sort", "stringdv asc"));
     assertJsonEquals(s, expectedResult);
 
-    s = h.query(req("q", "*:*", "qt", "/export", "fl", "id", "sort", "stringdv desc"));
+    s = h.query(reqWithPath("/export", "q", "*:*", "fl", "id", "sort", "stringdv desc"));
     assertJsonEquals(s, expectedResult);
   }
 
@@ -528,7 +522,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     assertU(commit());
 
-    String s = h.query(req("q", "*:*", "qt", "/export", "fl", "id", "sort", "stringdv desc"));
+    String s = h.query(reqWithPath("/export", "q", "*:*", "fl", "id", "sort", "stringdv desc"));
     assertJsonEquals(
         s,
         "{\n"
@@ -555,7 +549,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     assertU(adoc("id", "2", "booleandv", "false"));
     assertU(commit());
 
-    String s = h.query(req("q", "*:*", "qt", "/export", "fl", "id", "sort", "booleandv asc"));
+    String s = h.query(reqWithPath("/export", "q", "*:*", "fl", "id", "sort", "booleandv asc"));
     assertJsonEquals(
         s,
         "{\n"
@@ -567,7 +561,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
             + "      ,{\n"
             + "        \"id\":\"1\"}]}}");
 
-    s = h.query(req("q", "*:*", "qt", "/export", "fl", "id", "sort", "booleandv desc"));
+    s = h.query(reqWithPath("/export", "q", "*:*", "fl", "id", "sort", "booleandv desc"));
     assertJsonEquals(
         s,
         "{\n"
@@ -585,11 +579,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test single value DocValue output
     String s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:1",
-                "qt",
-                "/export",
                 "fl",
                 "floatdv,intdv,stringdv,longdv,doubledv",
                 "sort",
@@ -602,11 +595,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test null value string:
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:7",
-                "qt",
-                "/export",
                 "fl",
                 "floatdv,intdv,stringdv,longdv,doubledv",
                 "sort",
@@ -619,11 +611,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test multiValue docValues output
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:1",
-                "qt",
-                "/export",
                 "fl",
                 "intdv_m,floatdv_m,doubledv_m,longdv_m,stringdv_m",
                 "sort",
@@ -635,11 +626,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test multiValues docValues output with nulls
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:7",
-                "qt",
-                "/export",
                 "fl",
                 "intdv_m,floatdv_m,doubledv_m,longdv_m,stringdv_m",
                 "sort",
@@ -649,24 +639,24 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":1, \"docs\":[{\"floatdv_m\":[123.321,345.123],\"doubledv_m\":[3444.222,23232.2],\"longdv_m\":[343332,43434343434]}]}}");
 
     // Test single sort param is working
-    s = h.query(req("q", "id:(1 2)", "qt", "/export", "fl", "intdv", "sort", "intdv desc"));
+    s = h.query(reqWithPath("/export", "q", "id:(1 2)", "fl", "intdv", "sort", "intdv desc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":2, \"docs\":[{\"intdv\":2},{\"intdv\":1}]}}");
 
-    s = h.query(req("q", "id:(1 2)", "qt", "/export", "fl", "intdv", "sort", "intdv asc"));
+    s = h.query(reqWithPath("/export", "q", "id:(1 2)", "fl", "intdv", "sort", "intdv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":2, \"docs\":[{\"intdv\":1},{\"intdv\":2}]}}");
 
     // Test sort on String will null value. Null value should sort last on desc and first on asc.
 
-    s = h.query(req("q", "id:(1 7)", "qt", "/export", "fl", "intdv", "sort", "stringdv desc"));
+    s = h.query(reqWithPath("/export", "q", "id:(1 7)", "fl", "intdv", "sort", "stringdv desc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":2, \"docs\":[{\"intdv\":1},{\"intdv\":7}]}}");
 
-    s = h.query(req("q", "id:(1 7)", "qt", "/export", "fl", "intdv", "sort", "stringdv asc"));
+    s = h.query(reqWithPath("/export", "q", "id:(1 7)", "fl", "intdv", "sort", "stringdv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":2, \"docs\":[{\"intdv\":7},{\"intdv\":1}]}}");
@@ -674,14 +664,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test multi-sort params
     s =
         h.query(
-            req("q", "id:(1 2)", "qt", "/export", "fl", "intdv", "sort", "floatdv asc,intdv desc"));
+            reqWithPath(
+                "/export", "q", "id:(1 2)", "fl", "intdv", "sort", "floatdv asc,intdv desc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":2, \"docs\":[{\"intdv\":2},{\"intdv\":1}]}}");
 
     s =
         h.query(
-            req("q", "id:(1 2)", "qt", "/export", "fl", "intdv", "sort", "floatdv desc,intdv asc"));
+            reqWithPath(
+                "/export", "q", "id:(1 2)", "fl", "intdv", "sort", "floatdv desc,intdv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":2, \"docs\":[{\"intdv\":1},{\"intdv\":2}]}}");
@@ -689,11 +681,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test three sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -705,11 +696,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test three sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -721,11 +711,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test four sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -737,11 +726,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test five sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -751,11 +739,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":3},{\"intdv\":2},{\"intdv\":1}]}}");
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -767,11 +754,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test six sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -783,11 +769,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test seven sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -799,11 +784,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test eight sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -813,11 +797,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":3},{\"intdv\":2},{\"intdv\":1}]}}");
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -829,11 +812,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test nine sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -843,11 +825,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":1},{\"intdv\":2},{\"intdv\":3}]}}");
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -859,11 +840,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test ten sort fields
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -873,11 +853,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":1},{\"intdv\":2},{\"intdv\":3}]}}");
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 2 3)",
-                "qt",
-                "/export",
                 "fl",
                 "intdv",
                 "sort",
@@ -886,23 +865,26 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":3},{\"intdv\":2},{\"intdv\":1}]}}");
 
-    s = h.query(req("q", "id:(1 2 3)", "qt", "/export", "fl", "intdv", "sort", "doubledv desc"));
+    s = h.query(reqWithPath("/export", "q", "id:(1 2 3)", "fl", "intdv", "sort", "doubledv desc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":3},{\"intdv\":1},{\"intdv\":2}]}}");
 
     s =
         h.query(
-            req("q", "intdv:[2 TO 1000]", "qt", "/export", "fl", "intdv", "sort", "doubledv desc"));
+            reqWithPath(
+                "/export", "q", "intdv:[2 TO 1000]", "fl", "intdv", "sort", "doubledv desc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":3, \"docs\":[{\"intdv\":3},{\"intdv\":7},{\"intdv\":2}]}}");
 
-    s = h.query(req("q", "stringdv:blah", "qt", "/export", "fl", "intdv", "sort", "doubledv desc"));
+    s =
+        h.query(
+            reqWithPath("/export", "q", "stringdv:blah", "fl", "intdv", "sort", "doubledv desc"));
     assertJsonEquals(
         s, "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":0, \"docs\":[]}}");
 
-    s = h.query(req("q", "id:8", "qt", "/export", "fl", "stringdv", "sort", "intdv asc"));
+    s = h.query(reqWithPath("/export", "q", "id:8", "fl", "stringdv", "sort", "intdv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":1, \"docs\":[{\"stringdv\":\"chello \\\"world\\\"\"}]}}");
@@ -910,11 +892,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Test sortable text fields:
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 OR 3 OR 8)",
-                "qt",
-                "/export",
                 "fl",
                 "sortabledv_m_udvas,sortabledv_udvas",
                 "sort",
@@ -939,11 +920,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 OR 3 OR 8)",
-                "qt",
-                "/export",
                 "fl",
                 "sortabledv_m",
                 "sort",
@@ -957,11 +937,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     s =
         h.query(
-            req(
+            reqWithPath(
+                "/export",
                 "q",
                 "id:(1 OR 3 OR 8)",
-                "qt",
-                "/export",
                 "fl",
                 "sortabledv",
                 "sort",
@@ -987,21 +966,21 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // String s =  h.query(req("q", "id:1", "qt", "/export", "fl",
     // "floatdv,intdv,stringdv,longdv,doubledv", "sort", "intdv asc"));
     String s;
-    s = h.query(req("qt", "/export"));
+    s = h.query(reqWithPath("/export"));
     assertTrue("Should have had a sort error", s.contains("No sort criteria"));
-    s = h.query(req("sort", "intdv asc", "qt", "/export"));
+    s = h.query(reqWithPath("/export", "sort", "intdv asc"));
     assertTrue("Should have had fl error", s.contains("export field list (fl) must be specified"));
-    s = h.query(req("sort", "intdv asc", "qt", "/export", "fl", "stringdv"));
+    s = h.query(reqWithPath("/export", "sort", "intdv asc", "fl", "stringdv"));
     // Interesting you don't even need to specify a "q" parameter.
 
   }
 
   private void testDates() throws Exception {
-    String s = h.query(req("q", "id:1", "qt", "/export", "fl", "datedv", "sort", "datedv asc"));
+    String s = h.query(reqWithPath("/export", "q", "id:1", "fl", "datedv", "sort", "datedv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":1, \"docs\":[{\"datedv\":\"2017-06-16T07:00:00Z\"}]}}");
-    s = h.query(req("q", "id:1", "qt", "/export", "fl", "datedv_m", "sort", "datedv asc"));
+    s = h.query(reqWithPath("/export", "q", "id:1", "fl", "datedv_m", "sort", "datedv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":1, \"docs\":[{\"datedv_m\":[\"2017-06-16T01:00:00Z\",\"2017-06-16T02:00:00Z\",\"2017-06-16T03:00:00Z\",\"2017-06-16T04:00:00Z\"]}]}}");
@@ -1013,7 +992,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         h.getCore().getLatestSchema().getField("int_is_t").getType().isPointField()
             ? "1,1,1,1"
             : "1";
-    String s = h.query(req("q", "id:3", "qt", "/export", "fl", "int_is_t", "sort", "intdv asc"));
+    String s = h.query(reqWithPath("/export", "q", "id:3", "fl", "int_is_t", "sort", "intdv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":1, \"docs\":[{\"int_is_t\":["
@@ -1023,7 +1002,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         h.getCore().getLatestSchema().getField("int_is_p").getType().isPointField()
             ? "1,1,1,1"
             : "1";
-    s = h.query(req("q", "id:8", "qt", "/export", "fl", "int_is_p", "sort", "intdv asc"));
+    s = h.query(reqWithPath("/export", "q", "id:8", "fl", "int_is_p", "sort", "intdv asc"));
     assertJsonEquals(
         s,
         "{\"responseHeader\": {\"status\": 0}, \"response\":{\"numFound\":1, \"docs\":[{\"int_is_p\":[1,1,1,1]}]}}");
@@ -1198,11 +1177,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     assertU(commit());
     createLargeIndex();
     SolrQueryRequest req =
-        req(
+        reqWithPath(
+            "/export",
             "q",
             "*:*",
-            "qt",
-            "/export",
             "fl",
             "id",
             "sort",
@@ -1215,11 +1193,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "response/docs/[0]/id=='99999'",
         "response/docs/[1]/id=='99998'");
     req =
-        req(
+        reqWithPath(
+            "/export",
             "q",
             "*:*",
-            "qt",
-            "/export",
             "fl",
             "id,sortabledv_udvas",
             "sort",
@@ -1244,11 +1221,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
       assertTrue("missing value " + i + " in results", found);
     }
     req =
-        req(
+        reqWithPath(
+            "/export",
             "q",
             "*:*",
-            "qt",
-            "/export",
             "fl",
             "id,sortabledv_udvas,small_i_p",
             "sort",
@@ -1270,11 +1246,10 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     }
     // try invalid field types
     req =
-        req(
+        reqWithPath(
+            "/export",
             "q",
             "*:*",
-            "qt",
-            "/export",
             "fl",
             "id,sortabledv,small_i_p",
             "sort",
@@ -1302,7 +1277,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     assertU(commit());
     createLargeIndex();
     SolrQueryRequest req =
-        req("q", "*:*", "qt", "/export", "fl", "id,*_udvas,*_i_p", "sort", "id asc");
+        reqWithPath("/export", "q", "*:*", "fl", "id,*_udvas,*_i_p", "sort", "id asc");
     assertJQ(
         req,
         "response/numFound==100000",
@@ -1316,7 +1291,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     assertU(delQ("*:*"));
     assertU(commit());
     createLargeIndex();
-    req = req("q", "*:*", "qt", "/export", "fl", "*", "sort", "id asc");
+    req = reqWithPath("/export", "q", "*:*", "fl", "*", "sort", "id asc");
     assertJQ(
         req,
         "response/numFound==100000",
@@ -1368,17 +1343,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     List<?> exportDocs =
         queryJsonReturnDocs(
-            req("q", "*:*", "qt", "/export", "fl", "id," + fieldsStr, "sort", sortStr));
+            reqWithPath("/export", "q", "*:*", "fl", "id," + fieldsStr, "sort", sortStr));
     assertEquals(exportDocs.size(), numDocs);
 
     // equivalent for /select
     List<?> selectDocs =
         queryJsonReturnDocs(
-            req(
+            reqWithPath(
+                "/select",
                 "q",
                 "*:*",
-                "qt",
-                "/select",
                 "fl",
                 "id," + fieldsStr,
                 "sort",
@@ -1443,9 +1417,9 @@ public class TestExportWriter extends SolrTestCaseJ4 {
                 .replace("s_", "_")
             + pickRandom(" asc", " desc");
     String resultPoints =
-        h.query(req("q", query, "qt", "/export", "fl", pointFieldsFl, "sort", sort));
+        h.query(reqWithPath("/export", "q", query, "fl", pointFieldsFl, "sort", sort));
     String resultTries =
-        h.query(req("q", query, "qt", "/export", "fl", trieFieldsFl, "sort", sort));
+        h.query(reqWithPath("/export", "q", query, "fl", trieFieldsFl, "sort", sort));
     assertJsonEquals(resultPoints.replace("_p", ""), resultTries.replace("_t", ""));
   }
 
@@ -1496,13 +1470,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     String resp =
         h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
+            reqWithPath(
+                "/export",
+                "q",
+                "*:*",
                 "fl",
-                    "id,str_s_stored,num_i_stored,num_l_stored,num_f_stored,num_d_stored,date_dt_stored,bool_b_stored",
-                "sort", "intdv asc",
-                "includeStoredFields", "true"));
+                "id,str_s_stored,num_i_stored,num_l_stored,num_f_stored,num_d_stored,date_dt_stored,bool_b_stored",
+                "sort",
+                "intdv asc",
+                "includeStoredFields",
+                "true"));
 
     assertJsonEquals(
         resp,
@@ -1534,12 +1511,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     // Request stored-only field without includeStoredFields=true should error
     String resp =
-        h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
-                "fl", "id,str_s_stored",
-                "sort", "intdv asc"));
+        h.query(reqWithPath("/export", "q", "*:*", "fl", "id,str_s_stored", "sort", "intdv asc"));
 
     assertTrue(
         "Expected error message to contain hint about includeStoredFields",
@@ -1563,11 +1535,14 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Explicit fl with stored-only field should error
     String resp =
         h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
-                "fl", "id,intdv,stringdv,str_s_stored",
-                "sort", "intdv asc"));
+            reqWithPath(
+                "/export",
+                "q",
+                "*:*",
+                "fl",
+                "id,intdv,stringdv,str_s_stored",
+                "sort",
+                "intdv asc"));
 
     // Should error because str_s_stored is explicitly requested
     assertTrue(
@@ -1576,13 +1551,7 @@ public class TestExportWriter extends SolrTestCaseJ4 {
         "Expected hint about includeStoredFields", resp.contains("includeStoredFields=true"));
 
     // Now test with glob - should silently skip stored-only fields and succeed
-    resp =
-        h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
-                "fl", "intdv,*",
-                "sort", "intdv asc"));
+    resp = h.query(reqWithPath("/export", "q", "*:*", "fl", "intdv,*", "sort", "intdv asc"));
 
     assertJsonEquals(
         resp,
@@ -1614,12 +1583,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
     // Glob fl=* with includeStoredFields=true should include stored-only fields
     String resp =
         h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
-                "fl", "*",
-                "sort", "intdv asc",
-                "includeStoredFields", "true"));
+            reqWithPath(
+                "/export",
+                "q",
+                "*:*",
+                "fl",
+                "*",
+                "sort",
+                "intdv asc",
+                "includeStoredFields",
+                "true"));
 
     assertJsonEquals(
         resp,
@@ -1655,12 +1628,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     String resp =
         h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
-                "fl", "id,strs_ss_stored,nums_is_stored",
-                "sort", "intdv asc",
-                "includeStoredFields", "true"));
+            reqWithPath(
+                "/export",
+                "q",
+                "*:*",
+                "fl",
+                "id,strs_ss_stored,nums_is_stored",
+                "sort",
+                "intdv asc",
+                "includeStoredFields",
+                "true"));
 
     assertJsonEquals(
         resp,
@@ -1707,13 +1684,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
 
     String resp =
         h.query(
-            req(
-                "qt", "/export",
-                "q", "*:*",
+            reqWithPath(
+                "/export",
+                "q",
+                "*:*",
                 "fl",
-                    "id,str_s_stored,num_i_stored,num_l_stored,num_f_stored,num_d_stored,date_dt_stored,bool_b_stored",
-                "sort", "intdv asc",
-                "includeStoredFields", "true"));
+                "id,str_s_stored,num_i_stored,num_l_stored,num_f_stored,num_d_stored,date_dt_stored,bool_b_stored",
+                "sort",
+                "intdv asc",
+                "includeStoredFields",
+                "true"));
 
     assertJsonEquals(
         resp,
@@ -1759,12 +1739,16 @@ public class TestExportWriter extends SolrTestCaseJ4 {
             IOException.class,
             () ->
                 h.query(
-                    req(
-                        "qt", "/export",
-                        "q", "*:*",
-                        "fl", "id",
-                        "sort", "sorted_i_stored asc",
-                        "includeStoredFields", "true")));
+                    reqWithPath(
+                        "/export",
+                        "q",
+                        "*:*",
+                        "fl",
+                        "id",
+                        "sort",
+                        "sorted_i_stored asc",
+                        "includeStoredFields",
+                        "true")));
 
     assertTrue(
         "Error message should mention DocValues requirement",

--- a/solr/core/src/test/org/apache/solr/request/SimpleFacetsTest.java
+++ b/solr/core/src/test/org/apache/solr/request/SimpleFacetsTest.java
@@ -297,7 +297,8 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
   public void testDefaultsAndAppends() {
     // all defaults
     assertQ(
-        req("indent", "true", "q", "*:*", "rows", "0", "facet", "true", "qt", "/search-facet-def"),
+        reqWithPath(
+            "/search-facet-def", "indent", "true", "q", "*:*", "rows", "0", "facet", "true"),
         // only one default facet.field
         "//lst[@name='facet_fields']/lst[@name='foo_s']",
         "count(//lst[@name='facet_fields']/lst[@name='foo_s'])=1",
@@ -309,7 +310,8 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
 
     // override default & pre-pend to appends
     assertQ(
-        req(
+        reqWithPath(
+            "/search-facet-def",
             "indent",
             "true",
             "q",
@@ -318,8 +320,6 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
             "0",
             "facet",
             "true",
-            "qt",
-            "/search-facet-def",
             "facet.field",
             "bar_s",
             "facet.query",
@@ -341,7 +341,8 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
     for (String ff : new String[] {"facet.field", "bogus"}) {
       for (String fq : new String[] {"facet.query", "bogus"}) {
         assertQ(
-            req(
+            reqWithPath(
+                "/search-facet-invariants",
                 "indent",
                 "true",
                 "q",
@@ -350,8 +351,6 @@ public class SimpleFacetsTest extends SolrTestCaseJ4 {
                 "0",
                 "facet",
                 "true",
-                "qt",
-                "/search-facet-invariants",
                 ff,
                 "bar_s",
                 fq,


### PR DESCRIPTION
The 'qt' parameter and several related methods in SolrJ are deprecated.
This deprecation may not stick, but it's still worth minimizing use of this
feature as much as possible.

Many tests rely on it unnecessarily; this PR is one in a number of batches
slowly removing these usages. This one in particular completes our efforts
to remove all usages of the `req(..., "qt", "/somepath"...)` pattern, replacing
instances with `reqWithPath("/somepath", ...)` instead.