### PR TITLE
SOLR-18384: remove deprecated ShardParams.SHARD_URL

### DIFF
--- a/changelog/unreleased/SOLR-18384-remove-shardparams-shard-url.yml
+++ b/changelog/unreleased/SOLR-18384-remove-shardparams-shard-url.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated ShardParams.SHARD_URL constant, an internal param never meant for clients to specify.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18384
+    url: https://issues.apache.org/jira/browse/SOLR-18384

--- a/solr/solrj/src/java/org/apache/solr/common/params/ShardParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/ShardParams.java
@@ -40,14 +40,6 @@ public interface ShardParams {
   /** whether the request goes to a shard */
   String IS_SHARD = "isShard";
 
-  /**
-   * The requested URL for this shard
-   *
-   * @deprecated This was an internally used param, never meant for clients to specify; it is no
-   *     longer used by Solr.
-   */
-  @Deprecated String SHARD_URL = "shard.url";
-
   /** The requested shard name */
   String SHARD_NAME = "shard.name";
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18384

# Description

`ShardParams.SHARD_URL` has been deprecated since 10.0; the javadoc says it "was an internally used param, never meant for clients to specify; it is no longer used by Solr".

# Solution

Removed the constant together with its javadoc block. It has no callers: `SHARD_URL` occurs once in the tree, its own declaration, and `shard.url` appears nowhere in code, tests, the reference guide or config. `ShardParams` is left with no deprecated members.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

# Tests

No test needed changing, because nothing referenced the constant.

`./gradlew check -x test` passes on `0a0c25046ea` with JDK 21 — 602 tasks, including `rat`, `forbiddenApis`, `licenses`, `ecjLint`, `spotless`, `renderJavadoc`, `validateSourcePatterns`, `validateLogCalls` and the Antora site build.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch.
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes. — not applicable: the constant had no callers, so there is no behaviour to test
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide) — not applicable: the constant is not mentioned in the guide
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change
