### PR TITLE
SOLR-18372: remove FunctionQParser.parseMultipleSources accessors

### DIFF
--- a/changelog/unreleased/SOLR-18372-remove-parsemultiplesources-accessors.yml
+++ b/changelog/unreleased/SOLR-18372-remove-parsemultiplesources-accessors.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated FunctionQParser.setParseMultipleSources and getParseMultipleSources accessors, and the undocumented multiple=true local param that used them. Multi-value parsing itself is unaffected for functions such as geodist and dist, which still work when a $param reference holds a comma separated point.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18372
+    url: https://issues.apache.org/jira/browse/SOLR-18372

--- a/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
@@ -59,7 +59,6 @@ public class FunctionQParser extends QParser {
    */
   public StrParser sp;
 
-  @Deprecated private boolean parseMultipleSources = false;
   private boolean parseToEnd = true;
 
   public FunctionQParser(
@@ -67,9 +66,6 @@ public class FunctionQParser extends QParser {
     super(qstr, localParams, params, req);
     setFlags(FLAG_DEFAULT);
     setString(qstr);
-    if (localParams != null && localParams.getPrimitiveBool("multiple")) {
-      setParseMultipleSources(true);
-    }
   }
 
   /**
@@ -88,22 +84,6 @@ public class FunctionQParser extends QParser {
     if (s != null) {
       sp = new StrParser(s);
     }
-  }
-
-  @Deprecated
-  public void setParseMultipleSources(boolean parseMultipleSources) {
-    this.parseMultipleSources = parseMultipleSources;
-  }
-
-  /**
-   * Parse multiple comma separated value sources encapsulated into a {@link VectorValueSource} when
-   * {@link #getQuery()} or {@link #parseAsValueSource()} is called.
-   *
-   * @deprecated this is only needed for an unusual use-case and seems hard to support
-   */
-  @Deprecated
-  public boolean getParseMultipleSources() {
-    return parseMultipleSources;
   }
 
   public void setParseToEnd(boolean parseToEnd) {
@@ -125,17 +105,21 @@ public class FunctionQParser extends QParser {
    * ValueSourceParser#parse(FunctionQParser)}; it's intended for general code that has a {@link
    * QParser} but actually wants to parse a ValueSource.
    *
-   * @return A {@link VectorValueSource} for multiple VS, otherwise just the single VS.
+   * @return the parsed {@link ValueSource}.
    */
   @Override
   public ValueSource parseAsValueSource() throws SyntaxError {
+    return parseAsValueSource(false);
+  }
+
+  private ValueSource parseAsValueSource(boolean collectMultiple) throws SyntaxError {
     ValueSource vs = null;
     List<ValueSource> lst = null;
 
     for (; ; ) {
       ValueSource valsource = parseValueSource(getFlags() & ~FLAG_CONSUME_DELIMITER);
       sp.eatws();
-      if (!parseMultipleSources) {
+      if (!collectMultiple) {
         vs = valsource;
         break;
       } else {
@@ -462,10 +446,12 @@ public class FunctionQParser extends QParser {
       } else {
         QParser subParser = subQuery(val, "func");
         if (subParser instanceof FunctionQParser subFunc) {
-          subFunc.setParseMultipleSources(true);
           subFunc.setFlags(flags);
+          // e.g. geodist($pt) with pt=lat,lon: collect the referenced comma separated values
+          valueSource = subFunc.parseAsValueSource(true);
+        } else {
+          valueSource = subParser.parseAsValueSource();
         }
-        valueSource = subParser.parseAsValueSource();
       }
 
       /*


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18372

## Spec

`FunctionQParser` parses a function-query string into a `ValueSource`. By default it expects exactly one value expression; trailing comma separated content is a syntax error — this is the guard against malformed queries (e.g. a stray comma).

Functions over multi-dimensional points — `geodist`, `dist`, `hsin`, `sqedist`, all documented in the ref guide as taking "two or more" value sources in pairs — may receive their point via a `$param` reference (`geodist($pt)`, `pt=lat,lon`) instead of inline literals. A referenced value carries no syntax of its own to opt into multiple values, so the parser must collect a comma separated `$param` value into a vector on the referencing function's behalf.

## ACs

- `{!func}5` — single value, unaffected.
- `{!func}x,y,z,w,0,0,0` (no wrapping function) — still `SyntaxError`, unaffected.
- `geodist($pt)`, `dist(...,$pt)` and any other `$param` dereference still resolve into a vector — pinned by `QueryEqualityTest#testFuncGeodist`, `TestFunctionQuery#testGeneral`, `DistanceFunctionTest#testLatLon`, all pre-existing and unmodified.
- `setParseMultipleSources`/`getParseMultipleSources` removed — zero external callers anywhere in the tree.
- `multiple=true` local param removed too: zero ref-guide mentions, zero tests, zero CHANGES.txt history — never a documented contract. `{!func multiple=true}1,2,3` now throws `SyntaxError`.

## Design

The removed field was a mutable flag written from two places and read once elsewhere — the diff replaces it with a private overload taking an explicit argument, no shared mutable state.

AI-assisted (Claude Sonnet 5)

