### PR TITLE
SOLR-18371: remove the deprecated pre-QueryCommand SolrIndexSearcher methods

### DIFF
--- a/changelog/unreleased/SOLR-18371-remove-prequerycommand-solrindexsearcher-methods.yml
+++ b/changelog/unreleased/SOLR-18371-remove-prequerycommand-solrindexsearcher-methods.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated pre-QueryCommand SolrIndexSearcher methods - search(QueryResult, QueryCommand), three getDocList overloads and five getDocListAndSet overloads. Build a QueryCommand and call search(searcher) instead, using setNeedDocSet(true) where getDocListAndSet was used.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18371
+    url: https://issues.apache.org/jira/browse/SOLR-18371

--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -415,13 +415,16 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
           BooleanClause.Occur.MUST_NOT);
       this.realMLTQuery = realMLTQuery.build();
 
-      DocListAndSet results = new DocListAndSet();
-      if (this.needDocSet) {
-        results = searcher.getDocListAndSet(this.realMLTQuery, filters, null, start, rows, flags);
-      } else {
-        results.docList = searcher.getDocList(this.realMLTQuery, filters, null, start, rows, flags);
-      }
-      return results;
+      // setNeedDocSet must follow setFlags: it sets or clears GET_DOCSET within the flags
+      QueryCommand qc =
+          new QueryCommand()
+              .setQuery(this.realMLTQuery)
+              .setFilterList(filters)
+              .setOffset(start)
+              .setLen(rows)
+              .setFlags(flags)
+              .setNeedDocSet(this.needDocSet);
+      return qc.search(searcher).getDocListAndSet();
     }
 
     /** Sets {@link #boostedMLTQuery} and returns it */
@@ -455,13 +458,16 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
         rawMLTQuery = mlt.like(multifieldDoc);
       }
       boostedMLTQuery = getBoostedQuery(rawMLTQuery);
-      DocListAndSet results = new DocListAndSet();
-      if (this.needDocSet) {
-        results = searcher.getDocListAndSet(boostedMLTQuery, filters, null, start, rows, flags);
-      } else {
-        results.docList = searcher.getDocList(boostedMLTQuery, filters, null, start, rows, flags);
-      }
-      return results;
+      // setNeedDocSet must follow setFlags: it sets or clears GET_DOCSET within the flags
+      QueryCommand qc =
+          new QueryCommand()
+              .setQuery(boostedMLTQuery)
+              .setFilterList(filters)
+              .setOffset(start)
+              .setLen(rows)
+              .setFlags(flags)
+              .setNeedDocSet(this.needDocSet);
+      return qc.search(searcher).getDocListAndSet();
     }
 
     /**

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -778,8 +778,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
                   .setLen(nDocs)
                   .setSupersetMaxDoc(nDocs)
                   .setFlags(flags);
-              QueryResult qr = new QueryResult();
-              newSearcher.getDocListC(qr, qc);
+              // called for its cache side effect; the returned QueryResult is unused
+              newSearcher.getDocListC(qc);
               return true;
             }
           });
@@ -788,13 +788,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
   /** Primary entrypoint for searching, using a {@link QueryCommand}. */
   public QueryResult search(QueryCommand cmd) throws IOException {
-    return search(new QueryResult(), cmd);
-  }
-
-  @Deprecated
-  public QueryResult search(QueryResult qr, QueryCommand cmd) throws IOException {
-    getDocListC(qr, cmd);
-    return qr;
+    return getDocListC(cmd);
   }
 
   /**
@@ -834,46 +828,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       }.searchWithTimeout();
     }
   }
-
-  /**
-   * Retrieve the {@link Document} instance corresponding to the document id.
-   *
-   * @see SolrDocumentFetcher
-   */
-  /* @Override
-  @Deprecated
-  public Document doc(int docId) throws IOException {
-    return doc(docId, (Set<String>) null);
-  }*/
-
-  /**
-   * Visit a document's fields using a {@link StoredFieldVisitor}. This method does not currently
-   * add to the Solr document cache.
-   *
-   * @see IndexReader#document(int, StoredFieldVisitor)
-   * @see SolrDocumentFetcher
-   */
-  /*@Override
-  @Deprecated
-  public final void doc(int docId, StoredFieldVisitor visitor) throws IOException {
-    getDocFetcher().doc(docId, visitor);
-  }*/
-
-  /**
-   * Retrieve the {@link Document} instance corresponding to the document id.
-   *
-   * <p><b>NOTE</b>: the document will have all fields accessible, but if a field filter is
-   * provided, only the provided fields will be loaded (the remainder will be available lazily).
-   *
-   * @see SolrDocumentFetcher
-   */
-  /*
-    @Override
-    @Deprecated
-    public final Document doc(int i, Set<String> fields) throws IOException {
-      return getDocFetcher().doc(i, fields);
-    }
-  */
 
   /** expert: internal API, subject to change */
   public SolrCache<String, UnInvertedField> getFieldValueCache() {
@@ -1529,66 +1483,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     }
   }
 
-  /**
-   * Returns documents matching both <code>query</code> and <code>filter</code> and sorted by <code>
-   * sort</code>.
-   *
-   * <p>This method is cache aware and may retrieve <code>filter</code> from the cache or make an
-   * insertion into the cache as a result of this call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * @param filter may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @return DocList meeting the specified criteria, should <b>not</b> be modified by the caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocList getDocList(Query query, Query filter, Sort lsort, int offset, int len)
-      throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setFilterList(filter)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .search(this)
-        .getDocList();
-  }
-
-  /**
-   * Returns documents matching both <code>query</code> and the intersection of the <code>filterList
-   * </code>, sorted by <code>sort</code>.
-   *
-   * <p>This method is cache aware and may retrieve <code>filter</code> from the cache or make an
-   * insertion into the cache as a result of this call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * @param filterList may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @return DocList meeting the specified criteria, should <b>not</b> be modified by the caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocList getDocList(
-      Query query, List<Query> filterList, Sort lsort, int offset, int len, int flags)
-      throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setFilterList(filterList)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setFlags(flags)
-        .search(this)
-        .getDocList();
-  }
-
   public static final int NO_CHECK_QCACHE = 0x80000000;
   public static final int GET_DOCSET = 0x40000000;
   static final int NO_CHECK_FILTERCACHE = 0x20000000;
@@ -1630,8 +1524,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    * getDocList version that uses+populates query and filter caches. In the event of a timeout, the
    * cache is not populated.
    */
-  private QueryResult getDocListC(QueryResult qr, QueryCommand cmd) throws IOException {
-    // TODO don't take QueryResult as arg; create one here
+  private QueryResult getDocListC(QueryCommand cmd) throws IOException {
+    QueryResult qr = new QueryResult();
     if (cmd.getSegmentTerminateEarly()) {
       qr.setSegmentTerminatedEarly(Boolean.FALSE);
     }
@@ -2150,197 +2044,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     // TODO: currently we don't generate the DocSet for the base query,
     // but the QueryDocSet == CompleteDocSet if filter==null.
     return pf.filter == null && pf.postFilter == null ? qr.getDocSet() : null;
-  }
-
-  /**
-   * Returns documents matching <code>query</code>, sorted by <code>sort</code>.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @return DocList meeting the specified criteria, should <b>not</b> be modified by the caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocList getDocList(Query query, Sort lsort, int offset, int len) throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .search(this)
-        .getDocList();
-  }
-
-  /**
-   * Returns documents matching both <code>query</code> and <code>filter</code> and sorted by <code>
-   * sort</code>. Also returns the complete set of documents matching <code>query</code> and <code>
-   * filter</code> (regardless of <code>offset</code> and <code>len</code>).
-   *
-   * <p>This method is cache aware and may retrieve <code>filter</code> from the cache or make an
-   * insertion into the cache as a result of this call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * <p>The DocList and DocSet returned should <b>not</b> be modified.
-   *
-   * @param filter may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @return DocListAndSet meeting the specified criteria, should <b>not</b> be modified by the
-   *     caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocListAndSet getDocListAndSet(Query query, Query filter, Sort lsort, int offset, int len)
-      throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setFilterList(filter)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setNeedDocSet(true)
-        .search(this)
-        .getDocListAndSet();
-  }
-
-  /**
-   * Returns documents matching both <code>query</code> and <code>filter</code> and sorted by <code>
-   * sort</code>. Also returns the compete set of documents matching <code>query</code> and <code>
-   * filter</code> (regardless of <code>offset</code> and <code>len</code>).
-   *
-   * <p>This method is cache aware and may retrieve <code>filter</code> from the cache or make an
-   * insertion into the cache as a result of this call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * <p>The DocList and DocSet returned should <b>not</b> be modified.
-   *
-   * @param filter may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @param flags user supplied flags for the result set
-   * @return DocListAndSet meeting the specified criteria, should <b>not</b> be modified by the
-   *     caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocListAndSet getDocListAndSet(
-      Query query, Query filter, Sort lsort, int offset, int len, int flags) throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setFilterList(filter)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setFlags(flags)
-        .setNeedDocSet(true)
-        .search(this)
-        .getDocListAndSet();
-  }
-
-  /**
-   * Returns documents matching both <code>query</code> and the intersection of <code>filterList
-   * </code>, sorted by <code>sort</code>. Also returns the compete set of documents matching <code>
-   * query</code> and <code>filter</code> (regardless of <code>offset</code> and <code>len</code>).
-   *
-   * <p>This method is cache aware and may retrieve <code>filter</code> from the cache or make an
-   * insertion into the cache as a result of this call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * <p>The DocList and DocSet returned should <b>not</b> be modified.
-   *
-   * @param filterList may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @return DocListAndSet meeting the specified criteria, should <b>not</b> be modified by the
-   *     caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocListAndSet getDocListAndSet(
-      Query query, List<Query> filterList, Sort lsort, int offset, int len) throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setFilterList(filterList)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setNeedDocSet(true)
-        .search(this)
-        .getDocListAndSet();
-  }
-
-  /**
-   * Returns documents matching both <code>query</code> and the intersection of <code>filterList
-   * </code>, sorted by <code>sort</code>. Also returns the complete set of documents matching
-   * <code>query</code> and <code>filter</code> (regardless of <code>offset</code> and <code>len
-   * </code>).
-   *
-   * <p>This method is cache aware and may retrieve filters from the cache or make an insertion into
-   * the cache as a result of this call.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * <p>The DocList and DocSet returned should <b>not</b> be modified.
-   *
-   * @param filterList may be null
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @param flags user supplied flags for the result set
-   * @return DocListAndSet meeting the specified criteria, should <b>not</b> be modified by the
-   *     caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocListAndSet getDocListAndSet(
-      Query query, List<Query> filterList, Sort lsort, int offset, int len, int flags)
-      throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setFilterList(filterList)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setFlags(flags)
-        .setNeedDocSet(true)
-        .search(this)
-        .getDocListAndSet();
-  }
-
-  /**
-   * Returns the top documents matching the <code>query</code> and sorted by <code>
-   * sort</code>, limited by <code>offset</code> and <code>len</code>. Also returns compete set of
-   * matching documents as a {@link DocSet}.
-   *
-   * <p>FUTURE: The returned DocList may be retrieved from a cache.
-   *
-   * @param lsort criteria by which to sort (if null, query relevance is used)
-   * @param offset offset into the list of documents to return
-   * @param len maximum number of documents to return
-   * @return DocListAndSet meeting the specified criteria, should <b>not</b> be modified by the
-   *     caller.
-   * @throws IOException If there is a low-level I/O error.
-   */
-  @Deprecated
-  public DocListAndSet getDocListAndSet(Query query, Sort lsort, int offset, int len)
-      throws IOException {
-    return new QueryCommand()
-        .setQuery(query)
-        .setSort(lsort)
-        .setOffset(offset)
-        .setLen(len)
-        .setNeedDocSet(true)
-        .search(this)
-        .getDocListAndSet();
   }
 
   private DocList constantScoreDocList(int offset, int length, DocSet docs) {

--- a/solr/core/src/test/org/apache/solr/highlight/HighlighterTest.java
+++ b/solr/core/src/test/org/apache/solr/highlight/HighlighterTest.java
@@ -41,6 +41,7 @@ import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.search.QueryCommand;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1397,7 +1398,14 @@ public class HighlighterTest extends SolrTestCaseJ4 {
       SolrQueryResponse resp = new SolrQueryResponse();
       ResponseBuilder rb = new ResponseBuilder(req, resp, List.of(hlComp));
       rb.setHighlightQuery(query);
-      rb.setResults(req.getSearcher().getDocListAndSet(query, null, 0, 1));
+      rb.setResults(
+          new QueryCommand()
+              .setQuery(query)
+              .setOffset(0)
+              .setLen(1)
+              .setNeedDocSet(true)
+              .search(req.getSearcher())
+              .getDocListAndSet());
       // highlight:
       hlComp.prepare(rb);
       hlComp.process(rb);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18371

Removes all 9 deprecated `SolrIndexSearcher` members the ticket names — `search(QueryResult, QueryCommand)` plus 8 `getDocList`/`getDocListAndSet` overloads — and the 3 already-commented-out `doc(...)` blocks with their stale javadoc. `@Deprecated` count 12 → 0, verified by listing each exact signature against `origin/main`, not by counting. One correction to the ticket text: none of the 9 carry an explicit `@deprecated Use X instead` javadoc sentence — the replacement is visible only in each method's own body, not its documentation.

5 in-tree call sites migrated (4 in `MoreLikeThisHandler`, 1 in `HighlighterTest`) — the only ones in the whole tree; a naive grep returns ~100 hits, almost all surviving overloads or unrelated classes. 84 tests, 0 failures.

On the ticket's own caution about third-party usage: no `@lucene.experimental`/internal markers, no ref-guide/upgrade-notes mentions either way. The deprecation shipped in 10.0.0 (`#2524`, 2024-07-03), so it's had a real release's exposure.

Two small cleanups made possible by the removal: `search(QueryCommand)`'s body is now the two lines the deprecated overload contained, and `getDocListC` builds its own `QueryResult` instead of taking one as an always-fresh, discarded-by-callers out-parameter — resolving the `// TODO don't take QueryResult as arg` comment that sat on it.

AI-assisted (Claude Sonnet 5)

