### PR TITLE
SOLR-18375: remove the deprecated zkHost-based StreamFactory connection API

### DIFF
--- a/changelog/unreleased/SOLR-18375-remove-zkhost-streaming-connection-api.yml
+++ b/changelog/unreleased/SOLR-18375-remove-zkhost-streaming-connection-api.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Removed the deprecated zkHost-based StreamFactory connection API (withCollectionZkHost, withDefaultZkHost, getDefaultZkHost, getCollectionZkHost); use the CloudSolrClientConnection-based withCollectionUseThisConnection, withDefaultSolrConnection, getDefaultSolrConnection and buildSolrConnection instead.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18375
+    url: https://issues.apache.org/jira/browse/SOLR-18375

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamFactory.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamFactory.java
@@ -60,16 +60,6 @@ public class StreamFactory implements Serializable {
     collectionSolrConnection = new HashMap<>();
   }
 
-  /**
-   * @deprecated use {@link #withCollectionUseThisConnection(String,
-   *     CloudSolrClient.CloudSolrClientConnection)}
-   */
-  @Deprecated
-  public StreamFactory withCollectionZkHost(String collectionName, String zkHost) {
-    var solrConnection = zkHostToSolrConnection(zkHost);
-    return withCollectionUseThisConnection(collectionName, solrConnection);
-  }
-
   /** If an expressions references this collection, then use the specified Solr connection. */
   public StreamFactory withCollectionUseThisConnection(
       String collectionName, CloudSolrClient.CloudSolrClientConnection solrConnection) {
@@ -80,15 +70,6 @@ public class StreamFactory implements Serializable {
 
   public String getDefaultCollection() {
     return defaultCollection;
-  }
-
-  /**
-   * @deprecated use {@link #withDefaultSolrConnection(CloudSolrClient.CloudSolrClientConnection)}
-   */
-  @Deprecated
-  public StreamFactory withDefaultZkHost(String zkHost) {
-    var solrConnection = zkHostToSolrConnection(zkHost);
-    return withDefaultSolrConnection(solrConnection);
   }
 
   public StreamFactory withDefaultSolrConnection(
@@ -135,16 +116,6 @@ public class StreamFactory implements Serializable {
     return solrConnection;
   }
 
-  private static CloudSolrClient.CloudSolrClientConnection zkHostToSolrConnection(String zkHost) {
-    var solrConnection = CloudSolrClient.CloudSolrClientConnection.parse(zkHost);
-    if (!solrConnection.isZookeeper()) {
-      throw new IllegalArgumentException(
-          String.format(
-              Locale.ROOT, "Expected ZooKeeper connection string, but got: '%s'.", zkHost));
-    }
-    return solrConnection;
-  }
-
   @Override
   public Object clone() {
     // Shallow copy
@@ -163,24 +134,8 @@ public class StreamFactory implements Serializable {
     return this.defaultSort;
   }
 
-  /**
-   * @deprecated use {@link #buildSolrConnection(StreamExpression, String)} ()}
-   */
-  @Deprecated
-  public String getDefaultZkHost() {
-    return getDefaultSolrConnection().toString();
-  }
-
   public CloudSolrClient.CloudSolrClientConnection getDefaultSolrConnection() {
     return this.defaultSolrConnection;
-  }
-
-  /**
-   * @deprecated use {@link #buildSolrConnection(StreamExpression, String)}
-   */
-  @Deprecated
-  public String getCollectionZkHost(String collectionName) {
-    return getConnectionForCollection(collectionName).toString();
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18375

Removes all 4 deprecated `StreamFactory` connection methods (`withCollectionZkHost`, `withDefaultZkHost`, `getDefaultZkHost`, `getCollectionZkHost`) plus the private `zkHostToSolrConnection` helper they alone used. Zero external callers anywhere in the tree. `@Deprecated` count 4 → 0. `StreamExpressionTest` + `StreamingTest`, 67 tests, 0 failures.

AI-assisted (Claude Sonnet 5)

