### PR TITLE
SOLR-18377: remove deprecated DenseVectorField HNSW alias accessors

### DIFF
--- a/changelog/unreleased/SOLR-18377-remove-densevectorfield-hnsw-alias-accessors.yml
+++ b/changelog/unreleased/SOLR-18377-remove-densevectorfield-hnsw-alias-accessors.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated DenseVectorField accessors getHnswMaxConn and getHnswBeamWidth; use getHnswM and getHnswEfConstruction instead.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18377
+    url: https://issues.apache.org/jira/browse/SOLR-18377

--- a/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
+++ b/solr/core/src/java/org/apache/solr/schema/DenseVectorField.java
@@ -266,16 +266,6 @@ public class DenseVectorField extends FloatPointField {
     return knnAlgorithm;
   }
 
-  @Deprecated
-  public Integer getHnswMaxConn() {
-    return hnswM;
-  }
-
-  @Deprecated
-  public Integer getHnswBeamWidth() {
-    return hnswEfConstruction;
-  }
-
   public Integer getHnswM() {
     return hnswM;
   }

--- a/solr/core/src/test/org/apache/solr/schema/DenseVectorFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DenseVectorFieldTest.java
@@ -149,8 +149,6 @@ public class DenseVectorFieldTest extends AbstractBadConfigTestBase {
       assertThat(type1.getKnnAlgorithm(), is("hnsw"));
       assertThat(type1.getHnswM(), is(10));
       assertThat(type1.getHnswEfConstruction(), is(40));
-      assertThat(type1.getHnswMaxConn(), is(type1.getHnswM()));
-      assertThat(type1.getHnswBeamWidth(), is(type1.getHnswEfConstruction()));
 
       SchemaField vector2 = schema.getField("vector2");
       assertNotNull(vector2);
@@ -161,8 +159,6 @@ public class DenseVectorFieldTest extends AbstractBadConfigTestBase {
       assertThat(type2.getKnnAlgorithm(), is("hnsw"));
       assertThat(type2.getHnswM(), is(6));
       assertThat(type2.getHnswEfConstruction(), is(60));
-      assertThat(type2.getHnswMaxConn(), is(type2.getHnswM()));
-      assertThat(type2.getHnswBeamWidth(), is(type2.getHnswEfConstruction()));
 
       SchemaField vector3 = schema.getField("vector3");
       assertNotNull(vector3);
@@ -174,8 +170,6 @@ public class DenseVectorFieldTest extends AbstractBadConfigTestBase {
       assertThat(type3.getKnnAlgorithm(), is("hnsw"));
       assertThat(type3.getHnswM(), is(8));
       assertThat(type3.getHnswEfConstruction(), is(46));
-      assertThat(type3.getHnswMaxConn(), is(type3.getHnswM()));
-      assertThat(type3.getHnswBeamWidth(), is(type3.getHnswEfConstruction()));
 
       SchemaField vectorDefault = schema.getField("vector_default");
       assertNotNull(vectorDefault);
@@ -186,8 +180,6 @@ public class DenseVectorFieldTest extends AbstractBadConfigTestBase {
       assertThat(typeDefault.getDimension(), is(4));
       assertThat(typeDefault.getHnswM(), is(16));
       assertThat(typeDefault.getHnswEfConstruction(), is(100));
-      assertThat(typeDefault.getHnswMaxConn(), is(typeDefault.getHnswM()));
-      assertThat(typeDefault.getHnswBeamWidth(), is(typeDefault.getHnswEfConstruction()));
     } finally {
       deleteCore();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18377

Removes `getHnswMaxConn`/`getHnswBeamWidth` on `DenseVectorField` — aliases for `getHnswM`/`getHnswEfConstruction`, 0 external callers. Their only in-tree references were 4 assertions per accessor in `DenseVectorFieldTest`, asserting the alias equalled the replacement; deleted rather than rewritten, every field-type block still pins the replacement to a literal. The `hnswMaxConnections`/`hnswBeamWidth` schema params stay live on purpose — that's user-facing config, not this ticket's scope. `DenseVectorFieldTest`, 48 tests, 0 failures.

AI-assisted (Claude Sonnet 5)

