### PR TITLE
Tolerate JVM warning lines when detecting Java version

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -175,7 +175,7 @@ if [[ $? -ne 0 ]] ; then
   echo >&2 "${PATH}"
   exit 1
 else
-  JAVA_VER_NUM=$(echo "$JAVA_VER" | grep -v '_OPTIONS' | head -1 | awk -F '"' '/version/ {print $2}' | sed -e's/^1\.//' | sed -e's/[._-].*$//')
+  JAVA_VER_NUM=$(echo "$JAVA_VER" | grep -v '_OPTIONS' | awk -F '"' '/ version "/ {print $2; exit}' | sed -e's/^1\.//' | sed -e's/[._-].*$//')
   if (( JAVA_VER_NUM < JAVA_VER_REQ )) ; then
     echo >&2 "Your current version of Java is too old to run this version of Solr."
     echo >&2 "We found major version $JAVA_VER_NUM, using command '${JAVA} -version', with response:"


### PR DESCRIPTION
I am trying to start Solr in a Docker container in a virtual `arm64` Linux machine on Apple Silicon hardware using Parallels Desktop virtualization. Seems this configuration does not support SVE vector length detection.

When `bin/solr` runs `java -version`, this makes the JVM emit a notice:

```
Starting Solr
Your current version of Java is too old to run this version of Solr.
We found major version , using command '/opt/java/openjdk/bin/java -version', with response:
OpenJDK 64-Bit Server VM warning: Unable to get SVE vector length on this system. Disabling SVE. Specify -XX:UseSVE=0 to shun this warning.
openjdk version "25.0.3" 2026-04-21 LTS
OpenJDK Runtime Environment Temurin-25.0.3+9 (build 25.0.3+9-LTS)
OpenJDK 64-Bit Server VM Temurin-25.0.3+9 (build 25.0.3+9-LTS, mixed mode, sharing)

Please install latest version of Java 21 or set JAVA_HOME properly.
```

Version detection trips over this extra warning line. So, improve version parsing logic to go over warning lines and lock to the first `version` line.
