### PR TITLE
SOLR-18386: remove the deprecated Utils.getBaseUrlForNodeName overloads

### DIFF
--- a/changelog/unreleased/SOLR-18386-remove-utils-getbaseurlfornodename.yml
+++ b/changelog/unreleased/SOLR-18386-remove-utils-getbaseurlfornodename.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated Utils.getBaseUrlForNodeName(String, String) and Utils.getBaseUrlForNodeName(String, String, boolean) methods; use the identically named URLUtil methods instead.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18386
+    url: https://issues.apache.org/jira/browse/SOLR-18386

--- a/solr/core/src/test/org/apache/solr/cloud/ClusterStateMockUtil.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ClusterStateMockUtil.java
@@ -33,6 +33,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Replica.ReplicaStateProps;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 
@@ -245,7 +246,8 @@ public class ClusterStateMockUtil {
     int port = 8982 + Integer.parseInt(node);
     String nodeName = String.format(Locale.ROOT, "baseUrl%s:%d_", node, port);
     replicaPropMap.put(ZkStateReader.NODE_NAME_PROP, nodeName);
-    replicaPropMap.put(ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName(nodeName, "http"));
+    replicaPropMap.put(
+        ZkStateReader.BASE_URL_PROP, URLUtil.getBaseUrlForNodeName(nodeName, "http"));
     replicaPropMap.put(ZkStateReader.STATE_PROP, state.toString());
     replicaPropMap.put(ZkStateReader.CORE_NAME_PROP, sliceName + "_" + replicaName);
     replicaPropMap.put(ZkStateReader.REPLICA_TYPE, replicaType.name());

--- a/solr/core/src/test/org/apache/solr/cloud/ClusterStateTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ClusterStateTest.java
@@ -28,6 +28,7 @@ import org.apache.solr.common.cloud.DocRouter;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 import org.junit.Test;
@@ -47,7 +48,7 @@ public class ClusterStateTest extends SolrTestCaseJ4 {
     Map<String, Object> props = new HashMap<>();
     String nodeName = "node1:10000_solr";
     props.put(ZkStateReader.NODE_NAME_PROP, nodeName);
-    props.put(ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName(nodeName, "http"));
+    props.put(ZkStateReader.BASE_URL_PROP, URLUtil.getBaseUrlForNodeName(nodeName, "http"));
     props.put(ZkStateReader.CORE_NAME_PROP, "core1");
 
     props.put("prop1", "value");

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
@@ -35,7 +35,7 @@ import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.RetryUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.KeeperException.SessionExpiredException;
@@ -258,8 +258,8 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
     Thread.sleep(1000);
 
     String urlScheme = zkStateReader.getUrlScheme();
-    String url1 = Utils.getBaseUrlForNodeName("127.0.0.1:80_solr", urlScheme) + "/1/";
-    String url2 = Utils.getBaseUrlForNodeName("127.0.0.1:80_solr", urlScheme) + "/2/";
+    String url1 = URLUtil.getBaseUrlForNodeName("127.0.0.1:80_solr", urlScheme) + "/1/";
+    String url2 = URLUtil.getBaseUrlForNodeName("127.0.0.1:80_solr", urlScheme) + "/2/";
 
     assertEquals("original leader was not registered", url1, getLeaderUrl("collection2", "slice1"));
 

--- a/solr/core/src/test/org/apache/solr/cloud/SliceStateTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SliceStateTest.java
@@ -28,6 +28,7 @@ import org.apache.solr.common.cloud.DocRouter;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class SliceStateTest extends SolrTestCaseJ4 {
     Map<String, Object> props = new HashMap<>();
     String nodeName = "127.0.0.1:10000_solr";
     props.put(ZkStateReader.NODE_NAME_PROP, nodeName);
-    props.put(ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName(nodeName, "http"));
+    props.put(ZkStateReader.BASE_URL_PROP, URLUtil.getBaseUrlForNodeName(nodeName, "http"));
     props.put(ZkStateReader.CORE_NAME_PROP, "core1");
     props.put(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME);
 

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -60,6 +60,7 @@ import org.apache.solr.common.util.CommonTestInjection;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.common.util.ZLibCompressor;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
@@ -818,7 +819,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     // now create the replica, take note that this has to be done after DocCollection creation with
     // empty slice, otherwise the DocCollection ctor would fetch the PRS entries and throw
     // exceptions
-    String replicaBaseUrl = Utils.getBaseUrlForNodeName(nodeName, "http");
+    String replicaBaseUrl = URLUtil.getBaseUrlForNodeName(nodeName, "http");
 
     String replicaName = "replica1";
     Replica replica =

--- a/solr/core/src/test/org/apache/solr/core/CoreSorterTest.java
+++ b/solr/core/src/test/org/apache/solr/core/CoreSorterTest.java
@@ -38,7 +38,7 @@ import org.apache.solr.common.cloud.DocRouter;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.core.CoreSorter.CountsForEachShard;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 import org.junit.Test;
@@ -227,7 +227,7 @@ public class CoreSorterTest extends SolrTestCaseJ4 {
                 ZkStateReader.NODE_NAME_PROP,
                 node,
                 ZkStateReader.BASE_URL_PROP,
-                Utils.getBaseUrlForNodeName(node, "http")),
+                URLUtil.getBaseUrlForNodeName(node, "http")),
             collection,
             slice);
     replicaList.add(r);

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/sql/DatabaseMetaDataImpl.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/sql/DatabaseMetaDataImpl.java
@@ -31,7 +31,7 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.SystemInfoRequest;
 import org.apache.solr.client.solrj.response.SystemInfoResponse;
 import org.apache.solr.common.cloud.ClusterState;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 
 class DatabaseMetaDataImpl implements DatabaseMetaData {
   private final ConnectionImpl connection;
@@ -120,7 +120,7 @@ class DatabaseMetaDataImpl implements DatabaseMetaData {
             .getClusterProperty(ClusterState.URL_SCHEME, "http");
     for (String node : liveNodes) {
       try {
-        String nodeURL = Utils.getBaseUrlForNodeName(node, urlScheme);
+        String nodeURL = URLUtil.getBaseUrlForNodeName(node, urlScheme);
         solrClient = HttpSolrClient.builder(nodeURL).build();
 
         SystemInfoRequest req = new SystemInfoRequest();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -79,7 +79,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.StrUtils;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -979,13 +979,13 @@ public abstract class CloudSolrClient extends SolrClient {
       if (!liveNodes.isEmpty()) {
         List<String> liveNodesList = new ArrayList<>(liveNodes);
         Collections.shuffle(liveNodesList, rand);
-        final var chosenNodeUrl = Utils.getBaseUrlForNodeName(liveNodesList.get(0), urlScheme);
+        final var chosenNodeUrl = URLUtil.getBaseUrlForNodeName(liveNodesList.get(0), urlScheme);
         requestEndpoints.add(new LBSolrClient.Endpoint(chosenNodeUrl));
       }
 
     } else if (!request.requiresCollection()) {
       for (String liveNode : liveNodes) {
-        final var nodeBaseUrl = Utils.getBaseUrlForNodeName(liveNode, urlScheme);
+        final var nodeBaseUrl = URLUtil.getBaseUrlForNodeName(liveNode, urlScheme);
         requestEndpoints.add(new LBSolrClient.Endpoint(nodeBaseUrl));
       }
     } else { // API call to a particular collection / core / alias (i.e.
@@ -1003,7 +1003,7 @@ public abstract class CloudSolrClient extends SolrClient {
         String joinedInputCollections = StrUtils.join(inputCollections, ',');
         final var endpoints =
             preferredNodes.stream()
-                .map(nodeName -> Utils.getBaseUrlForNodeName(nodeName, urlScheme))
+                .map(nodeName -> URLUtil.getBaseUrlForNodeName(nodeName, urlScheme))
                 .map(nodeUrl -> new LBSolrClient.Endpoint(nodeUrl, joinedInputCollections))
                 .collect(Collectors.toList());
         if (!endpoints.isEmpty()) {

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -697,39 +697,6 @@ public class Utils {
     return isModified;
   }
 
-  /**
-   * Construct a V1 base url for the Solr node, given its name (e.g., 'app-node-1:8983_solr') and a
-   * URL scheme.
-   *
-   * @param nodeName name of the Solr node
-   * @param urlScheme scheme for the base url ('http' or 'https')
-   * @return url that looks like {@code https://app-node-1:8983/solr}
-   * @throws IllegalArgumentException if the provided node name is malformed
-   * @deprecated Use {@link URLUtil#getBaseUrlForNodeName(String, String)}
-   */
-  @Deprecated
-  public static String getBaseUrlForNodeName(final String nodeName, final String urlScheme) {
-    return URLUtil.getBaseUrlForNodeName(nodeName, urlScheme, false);
-  }
-
-  /**
-   * Construct a V1 or a V2 base url for the Solr node, given its name (e.g.,
-   * 'app-node-1:8983_solr') and a URL scheme.
-   *
-   * @param nodeName name of the Solr node
-   * @param urlScheme scheme for the base url ('http' or 'https')
-   * @param isV2 whether a V2 url should be constructed
-   * @return url that looks like {@code https://app-node-1:8983/api} (V2) or {@code
-   *     https://app-node-1:8983/solr} (V1)
-   * @throws IllegalArgumentException if the provided node name is malformed
-   * @deprecated Use {@link URLUtil#getBaseUrlForNodeName(String, String, boolean)}
-   */
-  @Deprecated
-  public static String getBaseUrlForNodeName(
-      final String nodeName, final String urlScheme, boolean isV2) {
-    return URLUtil.getBaseUrlForNodeName(nodeName, urlScheme, isV2);
-  }
-
   public static long time(TimeSource timeSource, TimeUnit unit) {
     return unit.convert(timeSource.getTimeNs(), TimeUnit.NANOSECONDS);
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/routing/NodePreferenceRulesComparatorTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/routing/NodePreferenceRulesComparatorTest.java
@@ -26,7 +26,7 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ShardParams;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 import org.junit.Test;
 
 @SolrTestCaseJ4.SuppressSSL // this test is all about http://
@@ -184,7 +184,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node4",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node4:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node4:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node4:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "TLOG"),
             "collection1",
@@ -277,7 +278,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node1",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node1:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node1:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node1:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "NRT",
                 ZkStateReader.LEADER_PROP, "true"),
@@ -321,7 +323,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node1",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node1:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node1:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node1:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "NRT",
                 ZkStateReader.LEADER_PROP, "true"),
@@ -332,7 +335,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node2",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node2:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node2:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node2:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "TLOG"),
             "collection1",
@@ -342,7 +346,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node3",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node3:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node3:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node3:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "PULL"),
             "collection1",
@@ -357,7 +362,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node1",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node1:8984_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node1:8984_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node1:8984_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "TLOG",
                 ZkStateReader.LEADER_PROP, "true"),
@@ -368,7 +374,8 @@ public class NodePreferenceRulesComparatorTest extends SolrTestCaseJ4 {
             "node2",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node2:8984_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node2:8984_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node2:8984_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "NRT"),
             "collection1",

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/routing/RequestReplicaListTransformerGeneratorTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/routing/RequestReplicaListTransformerGeneratorTest.java
@@ -25,7 +25,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 import org.junit.Test;
 
 @SolrTestCaseJ4.SuppressSSL
@@ -91,7 +91,7 @@ public class RequestReplicaListTransformerGeneratorTest extends SolrTestCaseJ4 {
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node4:8983_solr",
                 ZkStateReader.BASE_URL_PROP,
-                    Utils.getBaseUrlForNodeName("node4:8983_solr", "https"),
+                    URLUtil.getBaseUrlForNodeName("node4:8983_solr", "https"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "TLOG"),
             "c1",
@@ -104,7 +104,7 @@ public class RequestReplicaListTransformerGeneratorTest extends SolrTestCaseJ4 {
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node5:8983_solr",
                 ZkStateReader.BASE_URL_PROP,
-                    Utils.getBaseUrlForNodeName("node5:8983_solr", "https"),
+                    URLUtil.getBaseUrlForNodeName("node5:8983_solr", "https"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "PULL"),
             "c1",
@@ -148,7 +148,8 @@ public class RequestReplicaListTransformerGeneratorTest extends SolrTestCaseJ4 {
             "node1",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node1:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node1:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node1:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "NRT"),
             "c1",
@@ -158,7 +159,8 @@ public class RequestReplicaListTransformerGeneratorTest extends SolrTestCaseJ4 {
             "node2",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node2:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node2:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node2:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "TLOG"),
             "c1",
@@ -168,7 +170,8 @@ public class RequestReplicaListTransformerGeneratorTest extends SolrTestCaseJ4 {
             "node3",
             Map.of(
                 ZkStateReader.NODE_NAME_PROP, "node3:8983_solr",
-                ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName("node3:8983_solr", "http"),
+                ZkStateReader.BASE_URL_PROP,
+                    URLUtil.getBaseUrlForNodeName("node3:8983_solr", "http"),
                 ZkStateReader.CORE_NAME_PROP, "collection1",
                 ZkStateReader.REPLICA_TYPE, "PULL"),
             "c1",

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/routing/ShufflingReplicaListTransformerTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/routing/ShufflingReplicaListTransformerTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import org.apache.solr.SolrTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.cloud.Replica;
-import org.apache.solr.common.util.Utils;
+import org.apache.solr.common.util.URLUtil;
 import org.junit.Test;
 
 @SolrTestCaseJ4.SuppressSSL // not useful / needed for this test
@@ -45,7 +45,7 @@ public class ShufflingReplicaListTransformerTest extends SolrTestCase {
       propMap.put("core", "core" + counter);
       propMap.put("type", "NRT");
       propMap.put("node_name", nodeName);
-      propMap.put("base_url", Utils.getBaseUrlForNodeName(nodeName, "http"));
+      propMap.put("base_url", URLUtil.getBaseUrlForNodeName(nodeName, "http"));
       counter++;
       replicas.add(new Replica(url, propMap, "c1", "s1"));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18386

Removes both `Utils.getBaseUrlForNodeName` overloads — pure delegates to `URLUtil.getBaseUrlForNodeName`, 24 call sites (4 production, 20 test) moved with identical semantics. `Utils.java` now has zero deprecated members.

Where to look: the name collides three ways — the removed `Utils` static, its `URLUtil` replacement, and `ZkStateReader`'s unrelated one-arg *instance* method (~60 call sites, untouched, already delegates to `URLUtil` directly). Census had to key off the exact static signature, not the name. The rename is 5 chars longer, pushing 11 lines from 100 to 102 chars — reflowed by `google-java-format`, matched against pre-existing breaks in the same files.

Guard: `URLUtilTest` pins 4 literal URLs; a planted fault caught before and after the migration, so coverage survived. 9 changed test classes, 52 tests, 0 failures. All gates green.

SOLR-18373 (#4761) and SOLR-18380 (#4762) both touch CloudSolrClient.java -- simulated both merged together, applies cleanly. SOLR-18388 (local, not yet a PR) shares ZkStateReaderTest.java.

AI-assisted (Claude Sonnet 5)

