### PR TITLE
SOLR-18388: remove the deprecated ZkStateReader collection-path delegates

### DIFF
--- a/changelog/unreleased/SOLR-18388-remove-zkstatereader-collection-path-delegates.yml
+++ b/changelog/unreleased/SOLR-18388-remove-zkstatereader-collection-path-delegates.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated static ZkStateReader.getCollectionPath and getCollectionPathRoot delegates; use the equivalent methods on DocCollection instead.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18388
+    url: https://issues.apache.org/jira/browse/SOLR-18388

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -264,7 +264,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     assertFalse(ref.isLazilyLoaded());
 
     Stat stat = new Stat();
-    fixture.zkClient.getData(ZkStateReader.getCollectionPath("c1"), null, stat);
+    fixture.zkClient.getData(DocCollection.getCollectionPath("c1"), null, stat);
     assertEquals(Instant.ofEpochMilli(stat.getCtime()), ref.get().getCreationTime());
   }
 
@@ -813,7 +813,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
         "Timeout on waiting for c1 to show up in cluster state",
         () -> reader.getClusterState().getCollectionOrNull(collectionName) != null);
 
-    String collectionPath = ZkStateReader.getCollectionPath(collectionName);
+    String collectionPath = DocCollection.getCollectionPath(collectionName);
 
     // now create the replica, take note that this has to be done after DocCollection creation with
     // empty slice, otherwise the DocCollection ctor would fetch the PRS entries and throw

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateWriterTest.java
@@ -303,7 +303,7 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
         assertNotNull(map.get("c1"));
 
         Stat stat = new Stat();
-        zkClient.getData(ZkStateReader.getCollectionPath("c1"), null, stat);
+        zkClient.getData(DocCollection.getCollectionPath("c1"), null, stat);
         assertEquals(
             Instant.ofEpochMilli(stat.getCtime()),
             clusterState.getCollection("c1").getCreationTime());
@@ -364,7 +364,7 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
         state = reader.getClusterState();
 
         Stat stat = new Stat();
-        zkClient.getData(ZkStateReader.getCollectionPath("c2"), null, stat);
+        zkClient.getData(DocCollection.getCollectionPath("c2"), null, stat);
         assertEquals(
             Instant.ofEpochMilli(stat.getCtime()), state.getCollection("c2").getCreationTime());
 

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1497,16 +1497,6 @@ public class ZkStateReader implements SolrCloseable {
     }
   }
 
-  @Deprecated // see DocCollection
-  public static String getCollectionPathRoot(String coll) {
-    return DocCollection.getCollectionPathRoot(coll);
-  }
-
-  @Deprecated // see DocCollection
-  public static String getCollectionPath(String coll) {
-    return DocCollection.getCollectionPath(coll);
-  }
-
   /**
    * Notify this reader that a local Core is a member of a collection, and so that collection state
    * should be watched.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18388

Removes `ZkStateReader.getCollectionPathRoot`/`getCollectionPath` — one-line delegates to the same-named `DocCollection` methods. A bare-name census is useless here (18 production + 39 test hits, mostly `DocCollection`'s own untouched methods); receiver-qualified, the removed pair had 0 production callers and 4 test ones (`ZkStateReaderTest`, `ZkStateWriterTest`, both already importing `DocCollection`). `getCollectionPathRoot` had 0 references anywhere.

22 tests, 0 failures. Unlike SOLR-18386, the rename is 3 chars shorter, so no reflow.

SOLR-18386 (#4766, already open) shares ZkStateReaderTest.java -- simulated merged first, applies cleanly. SOLR-18370 (local, not yet a PR) also touches ZkStateReader.java -- re-check for conflicts once it opens a PR and either merges.

AI-assisted (Claude Sonnet 5)

