### PR TITLE
SOLR-18385: remove CollectionAdminRequest.PROPERTY_PREFIX

### DIFF
--- a/changelog/unreleased/SOLR-18385-remove-collectionadminrequest-property-prefix.yml
+++ b/changelog/unreleased/SOLR-18385-remove-collectionadminrequest-property-prefix.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated CollectionAdminRequest.PROPERTY_PREFIX field, which was only an alias - use CollectionAdminParams.PROPERTY_PREFIX instead.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18385
+    url: https://issues.apache.org/jira/browse/SOLR-18385

--- a/dev-docs/overseer/overseer.adoc
+++ b/dev-docs/overseer/overseer.adoc
@@ -619,7 +619,7 @@ Note that properties `"parent"`, `"shard_parent_zk_session"` and `"shard_parent_
 
 deleteShard() (implementing `CollectionAction.DELETESHARD`) removes a slice (shard) from a collection.
 
-modifyCollection() (implementing `CollectionAction.MODIFYCOLLECTION`) modifies a given collection by setting new values for (or removing) specified properties, ignoring changes to properties that are not considered modifiable (those listed in `CollectionAdminRequest.MODIFIABLE_COLLECTION_PROPERTIES` and those starting with `CollectionAdminRequest.PROPERTY_PREFIX="property."`).
+modifyCollection() (implementing `CollectionAction.MODIFYCOLLECTION`) modifies a given collection by setting new values for (or removing) specified properties, ignoring changes to properties that are not considered modifiable (those listed in `CollectionAdminRequest.MODIFIABLE_COLLECTION_PROPERTIES` and those starting with `CollectionAdminParams.PROPERTY_PREFIX="property."`).
 
 updateSlice() replaces a `Slice` on an existing `DocCollection` or creates a new `DocCollection` with the provided slice.
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/ReindexCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/ReindexCollectionCmd.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.cloud.DistribStateManager;
-import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -98,7 +97,7 @@ public class ReindexCollectionCmd implements CollApiCmds.CollectionApiCommand {
   public static final String TARGET = "target";
   public static final String TARGET_COL_PREFIX = ".rx_";
   public static final String CHK_COL_PREFIX = ".rx_ck_";
-  public static final String REINDEXING_STATE = CollectionAdminRequest.PROPERTY_PREFIX + "rx";
+  public static final String REINDEXING_STATE = CollectionAdminParams.PROPERTY_PREFIX + "rx";
 
   public static final String STATE = "state";
   public static final String PHASE = "phase";

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/CollectionMutator.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/CollectionMutator.java
@@ -39,6 +39,7 @@ import org.apache.solr.common.cloud.Slice.SliceStateProps;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CollectionAdminParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +155,7 @@ public class CollectionMutator {
     }
     // other aux properties are also modifiable
     for (String prop : message.keySet()) {
-      if (prop.startsWith(CollectionAdminRequest.PROPERTY_PREFIX)) {
+      if (prop.startsWith(CollectionAdminParams.PROPERTY_PREFIX)) {
         hasAnyOps = true;
         if (message.get(prop) == null) {
           props.remove(prop);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
@@ -20,6 +20,7 @@ import static org.apache.solr.common.params.CollectionAdminParams.ALIAS;
 import static org.apache.solr.common.params.CollectionAdminParams.COUNT_PROP;
 import static org.apache.solr.common.params.CollectionAdminParams.CREATE_NODE_SET_PARAM;
 import static org.apache.solr.common.params.CollectionAdminParams.CREATE_NODE_SET_SHUFFLE_PARAM;
+import static org.apache.solr.common.params.CollectionAdminParams.PROPERTY_PREFIX;
 import static org.apache.solr.common.params.CollectionAdminParams.ROUTER_PREFIX;
 import static org.apache.solr.common.params.CollectionAdminParams.SKIP_NODE_ASSIGNMENT;
 import static org.apache.solr.common.params.CoreAdminParams.BACKUP_REPOSITORY;
@@ -76,8 +77,6 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
           CollectionAdminParams.READ_ONLY);
 
   protected final CollectionAction action;
-
-  @Deprecated public static String PROPERTY_PREFIX = CollectionAdminParams.PROPERTY_PREFIX;
 
   public CollectionAdminRequest(CollectionAction action) {
     this("/admin/collections", action);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18385

Removes `CollectionAdminRequest.PROPERTY_PREFIX`, a deprecated non-final alias for `CollectionAdminParams.PROPERTY_PREFIX`. 2 call sites (`ReindexCollectionCmd`, `CollectionMutator`) migrated to the canonical constant; a dev-doc reference updated too. 0 remaining references.

7 tests, 0 failures (OverseerModifyCollectionTest, ReindexCollectionTest).

SOLR-18382 (#4760, already open) shares ReindexCollectionCmd.java -- simulated merge first, applies cleanly. SOLR-18370 (local, not yet a PR) also touches CollectionAdminRequest.java -- re-check once it opens a PR.

AI-assisted (Claude Sonnet 5)
