### PR TITLE
SOLR-18389: remove deprecated SolrCore.getAdminResponseWriter

### DIFF
--- a/changelog/unreleased/SOLR-18389-remove-solrcore-getadminresponsewriter.yml
+++ b/changelog/unreleased/SOLR-18389-remove-solrcore-getadminresponsewriter.yml
@@ -1,0 +1,8 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+title: Remove the deprecated SolrCore.getAdminResponseWriter method. Use ResponseWritersRegistry.getWriter instead.
+type: removed
+authors:
+  - name: Serhiy Bzhezytskyy
+links:
+  - name: SOLR-18389
+    url: https://issues.apache.org/jira/browse/SOLR-18389

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3056,18 +3056,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
   }
 
   /**
-   * Gets a response writer suitable for node/container-level requests.
-   *
-   * @param writerName the writer name, or null for default
-   * @return the response writer, never null
-   * @deprecated Use {@link ResponseWritersRegistry#getWriter(String)} instead.
-   */
-  @Deprecated
-  public static QueryResponseWriter getAdminResponseWriter(String writerName) {
-    return ResponseWritersRegistry.getWriter(writerName);
-  }
-
-  /**
    * Initializes query response writers. Response writers from {@code ImplicitPlugins.json} may also
    * be configured.
    */


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18389

Removes `SolrCore.getAdminResponseWriter`, a pure delegate to `ResponseWritersRegistry.getWriter`. 0 remaining callers anywhere; no dedicated test existed.

SOLR-18373 (#4761, already open) shares SolrCore.java -- simulated merge first, applies cleanly.

AI-assisted (Claude Sonnet 5)
