### PR TITLE
SOLR-18332: More 'qt' removal, rd 6

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -1993,6 +1993,11 @@ public class SolrCore implements SolrInfoBean, Closeable {
   /**
    * Get the request handler registered to a given name.
    *
+   * <p>A {@code null} handlerName resolves to the core's default request handler (whichever handler
+   * is aliased to the empty string, normally the one registered at "/select", or "standard" for
+   * legacy configs) rather than returning {@code null}; see {@link
+   * RequestHandlers#initHandlersFromConfig}.
+   *
    * <p>This function is thread safe.
    */
   public SolrRequestHandler getRequestHandler(String handlerName) {

--- a/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
+++ b/solr/core/src/test/org/apache/solr/BasicFunctionalityTest.java
@@ -759,7 +759,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
 
     SolrQueryRequest req = req("q", "id:7777", "fl", "id,title,test_hlt");
     SolrQueryResponse rsp = new SolrQueryResponse();
-    core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
+    core.execute(core.getRequestHandler(null), req, rsp);
 
     DocList dl = ((ResultContext) rsp.getResponse()).getDocList();
     Document d = req.getSearcher().getDocFetcher().doc(dl.iterator().nextDoc());
@@ -786,7 +786,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
     // initial request
     SolrQueryRequest req = req("q", "id:7777", "fl", "id,title");
     SolrQueryResponse rsp = new SolrQueryResponse();
-    core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
+    core.execute(core.getRequestHandler(null), req, rsp);
 
     DocList dl = ((ResultContext) rsp.getResponse()).getDocList();
     DocIterator di = dl.iterator();
@@ -808,7 +808,7 @@ public class BasicFunctionalityTest extends SolrTestCaseJ4 {
     // followup request, different fl
     req = req("q", "id:7777", "fl", "id,test_hlt");
     rsp = new SolrQueryResponse();
-    core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
+    core.execute(core.getRequestHandler(null), req, rsp);
 
     dl = ((ResultContext) rsp.getResponse()).getDocList();
     di = dl.iterator();

--- a/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
+++ b/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
@@ -22,7 +22,6 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
-import org.apache.solr.request.SolrQueryRequestBase;
 import org.apache.solr.util.ErrorLogMuter;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,8 +60,7 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
     assertU("<commit/>");
     assertQ(req("val_s:[a TO z]"), "//*[@numFound='3'] ", "*[count(//doc)=3] ", "//*[@start='0']");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 2, 5, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 2, 5, args));
     assertQ(
         req,
         "//*[@numFound='3'] ",
@@ -70,54 +68,42 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
         "*//doc[1]/str[.='pear'] ",
         "//*[@start='2']");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 3, 5, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 3, 5, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 4, 5, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 4, 5, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 25, 5, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 25, 5, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 0, 1, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 0, 1, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=1] ", "*//doc[1]/str[.='apple']");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 0, 2, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 0, 2, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=2] ", "*//doc[2]/str[.='banana']");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 1, 1, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 1, 1, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=1] ", "*//doc[1]/str[.='banana']");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 3, 1, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 3, 1, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 4, 1, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 4, 1, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 1, 0, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 1, 0, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 0, 0, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 0, 0, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
     args.put("sort", "val_s1 asc");
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 0, 0, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 0, 0, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     args = new HashMap<>();
     args.put("sort", "val_s1 desc");
-    req =
-        new SolrQueryRequestBase(h.getCore(), makeParams("val_s:[a TO z]", "/select", 0, 0, args));
+    req = reqWithPath("/select", makeParams("val_s:[a TO z]", 0, 0, args));
     assertQ(req, "//*[@numFound='3'] ", "*[count(//doc)=0]");
     assertQ(req("val_s:[a TO b]"), "//*[@numFound='1']");
     assertQ(req("val_s:[a TO cat]"), "//*[@numFound='2']");
@@ -776,18 +762,18 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
     assertQ(req("id:44"));
     args = new HashMap<>();
     args.put("fl", "fname_s,arr_f  ");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//str[.='Yonik']  ", "//float[.='1.4142135']");
     args = new HashMap<>();
     args.put("fl", "fname_s,score");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//str[.='Yonik']", "//float[@name='score' and . > 0]");
 
     // test addition of score field
 
     args = new HashMap<>();
     args.put("fl", "score,* ");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(
         req,
         "//str[.='Yonik']  ",
@@ -796,7 +782,7 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
         "*[count(//doc/*)>=13]");
     args = new HashMap<>();
     args.put("fl", "*,score ");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(
         req,
         "//str[.='Yonik']  ",
@@ -805,33 +791,33 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
         "*[count(//doc/*)>=13]");
     args = new HashMap<>();
     args.put("fl", "* ");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//str[.='Yonik']  ", "//float[.='1.4142135'] ", "*[count(//doc/*)>=12]");
 
     // test maxScore
 
     args = new HashMap<>();
     args.put("fl", "score ");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//result[@maxScore>0]");
     args = new HashMap<>();
     args.put("fl", "score ");
     args.put("sort", "id desc");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//result[@maxScore>0]");
     args = new HashMap<>();
     args.put("fl", "score ");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//@maxScore = //doc/float[@name='score']");
     args = new HashMap<>();
     args.put("fl", "score ");
     args.put("sort", "id desc");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 10, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 10, args));
     assertQ(req, "//@maxScore = //doc/float[@name='score']");
     args = new HashMap<>();
     args.put("fl", "*,score");
     args.put("sort", "id desc");
-    req = new SolrQueryRequestBase(h.getCore(), makeParams("id:44", "/select", 0, 0, args));
+    req = reqWithPath("/select", makeParams("id:44", 0, 0, args));
     assertQ(req, "//result[@maxScore>0]");
 
     //  test schema field attribute inheritance and overriding
@@ -908,18 +894,16 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
 
   /**
    * Utility method to build SolrParams from individual query components. This is a convenience
-   * method for legacy code that needs to construct params from separate query, qtype, start, limit,
-   * and additional args.
+   * method for legacy code that needs to construct params from separate query, start, limit, and
+   * additional args.
    *
    * @param query the query string (added as "q" param)
-   * @param qtype the query type (added as "qt" param)
    * @param start the start offset (added as "start" param)
    * @param limit the row limit (added as "rows" param)
    * @param args additional parameters as a map
    * @return SolrParams containing all the specified parameters
    */
-  public static SolrParams makeParams(
-      String query, String qtype, int start, int limit, Map<?, ?> args) {
+  public static SolrParams makeParams(String query, int start, int limit, Map<?, ?> args) {
     Map<String, String[]> map = new HashMap<>();
     for (Map.Entry<?, ?> e : args.entrySet()) {
       String k = e.getKey().toString();
@@ -928,7 +912,6 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
       else map.put(k, new String[] {v.toString()});
     }
     if (query != null) map.put(CommonParams.Q, new String[] {query});
-    if (qtype != null) map.put(CommonParams.QT, new String[] {qtype});
     map.put(CommonParams.START, new String[] {Integer.toString(start)});
     map.put(CommonParams.ROWS, new String[] {Integer.toString(limit)});
     return new MultiMapSolrParams(map);

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -430,8 +430,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     try {
       SolrRequestInfo.setRequestInfo(new SolrRequestInfo(request, response));
-      String handlerName = request.getParams().get(CommonParams.QT);
-      h.getCore().execute(h.getCore().getRequestHandler(handlerName), request, response);
+      h.getCore().execute(h.getCore().getRequestHandler(null), request, response);
       JavaBinResponseWriter responseWriter = new JavaBinResponseWriter();
       responseWriter.write(out, request, response);
     } finally {

--- a/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
@@ -595,7 +595,6 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
             assertFullWalkNoDupsElevated(
                 wrapDefaults(
                     params(
-                        "qt", "/elevate",
                         "fl", "id,[elevated]",
                         "forceElevation", "true",
                         "elevateIds", "50,20,80"),
@@ -649,8 +648,6 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
           assertFullWalkNoDupsElevated(
               wrapDefaults(
                   params(
-                      "qt",
-                      "/elevate",
                       "fl",
                       fl + ",[elevated]",
                       // HACK: work around SOLR-15307... same results should match, just not same
@@ -782,6 +779,7 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
     final SentinelIntSet idsElevated = new SentinelIntSet(32, -1);
 
     assertFullWalkNoDups(
+        "/elevate",
         params,
         (doc) -> {
           final int id = Integer.parseInt(doc.get("id").toString());
@@ -883,8 +881,16 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
    */
   public void assertFullWalkNoDups(SolrParams params, Consumer<SolrDocument> consumer)
       throws Exception {
+    assertFullWalkNoDups("/select", params, consumer);
+  }
 
-    final String requestHandler = params.get(CommonParams.QT, "/select");
+  /**
+   * Identical to {@link #assertFullWalkNoDups(SolrParams,Consumer)}, but dispatches the query to
+   * the specified request handler path.
+   */
+  public void assertFullWalkNoDups(
+      String requestHandler, SolrParams params, Consumer<SolrDocument> consumer) throws Exception {
+
     String cursorMark = CURSOR_MARK_START;
     int docsOnThisPage = Integer.MAX_VALUE;
     while (0 < docsOnThisPage) {

--- a/solr/core/src/test/org/apache/solr/cloud/ShardRoutingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ShardRoutingTest.java
@@ -27,6 +27,7 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.ShardParams;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.util.ServletFixtures;
 import org.junit.BeforeClass;
@@ -351,7 +352,7 @@ public class ShardRoutingTest extends AbstractFullDistribZkTestBase {
   }
 
   void doRTG(String ids) throws Exception {
-    doQuery(ids, "qt", "/get", "ids", ids);
+    doQuery(StrUtils.splitSmart(ids, ",", true), "/get", "ids", ids);
   }
 
   // TODO: refactor some of this stuff into the SolrJ client... it should be easier to use

--- a/solr/core/src/test/org/apache/solr/cloud/ShardRoutingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ShardRoutingTest.java
@@ -352,7 +352,9 @@ public class ShardRoutingTest extends AbstractFullDistribZkTestBase {
   }
 
   void doRTG(String ids) throws Exception {
-    doQuery(StrUtils.splitSmart(ids, ",", true), "/get", "ids", ids);
+    final var expectedIds = StrUtils.splitSmart(ids, ",", true);
+    final var request = new QueryRequest("/get", params("ids", ids));
+    doQuery(expectedIds, request);
   }
 
   // TODO: refactor some of this stuff into the SolrJ client... it should be easier to use

--- a/solr/core/src/test/org/apache/solr/cloud/TestTlogReplayVsRecovery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTlogReplayVsRecovery.java
@@ -277,7 +277,7 @@ public class TestTlogReplayVsRecovery extends SolrCloudTestCase {
                     SolrRequest.METHOD.GET,
                     "/get",
                     SolrRequestType.QUERY,
-                    params("qt", "/get", "id", docId, "_trace", clientName, "distrib", "false"))
+                    params("id", docId, "_trace", clientName, "distrib", "false"))
                 .setRequiresCollection(true))
             .process(client, COLLECTION);
 

--- a/solr/core/src/test/org/apache/solr/response/TestJavaBinResponseWriter.java
+++ b/solr/core/src/test/org/apache/solr/response/TestJavaBinResponseWriter.java
@@ -25,7 +25,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ByteUtils;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
@@ -73,7 +72,7 @@ public class TestJavaBinResponseWriter extends SolrTestCaseJ4 {
     assertU(adoc("id", "101", "uuid", s));
     assertU(commit());
     SolrQueryRequestBase req = lrf.makeRequest("q", "*:*");
-    SolrQueryResponse rsp = h.queryAndResponse(req.getParams().get(CommonParams.QT), req);
+    SolrQueryResponse rsp = h.queryAndResponse(null, req);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     h.getCore().getQueryResponseWriter("javabin").write(baos, req, rsp);
     NamedList<?> res;

--- a/solr/core/src/test/org/apache/solr/response/TestJavaBinResponseWriter.java
+++ b/solr/core/src/test/org/apache/solr/response/TestJavaBinResponseWriter.java
@@ -71,8 +71,8 @@ public class TestJavaBinResponseWriter extends SolrTestCaseJ4 {
     String s = UUID.randomUUID().toString().toLowerCase(Locale.ROOT);
     assertU(adoc("id", "101", "uuid", s));
     assertU(commit());
-    SolrQueryRequestBase req = lrf.makeRequest("q", "*:*");
-    SolrQueryResponse rsp = h.queryAndResponse(null, req);
+    SolrQueryRequest req = withPath("/select", lrf.makeRequest("q", "*:*"));
+    SolrQueryResponse rsp = h.queryAndResponse(req);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     h.getCore().getQueryResponseWriter("javabin").write(baos, req, rsp);
     NamedList<?> res;

--- a/solr/core/src/test/org/apache/solr/response/transform/TestSubQueryTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestSubQueryTransformer.java
@@ -29,7 +29,6 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException.ErrorCode;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
@@ -626,8 +625,7 @@ public class TestSubQueryTransformer extends SolrTestCaseJ4 {
     SolrQueryResponse rsp = new SolrQueryResponse();
     SolrRequestInfo.setRequestInfo(new SolrRequestInfo(johnTwoFL, rsp));
 
-    SolrQueryResponse response =
-        h.queryAndResponse(johnTwoFL.getParams().get(CommonParams.QT), johnTwoFL);
+    SolrQueryResponse response = h.queryAndResponse(null, johnTwoFL);
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     johnTwoFL.getResponseWriter().write(bytes, johnTwoFL, response);

--- a/solr/core/src/test/org/apache/solr/response/transform/TestSubQueryTransformer.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestSubQueryTransformer.java
@@ -613,7 +613,7 @@ public class TestSubQueryTransformer extends SolrTestCaseJ4 {
   @SuppressWarnings("unchecked")
   @Test
   public void testJustJohnJavabin() throws Exception {
-    final SolrQueryRequest johnTwoFL = req(johnAndNancyParams);
+    final SolrQueryRequest johnTwoFL = reqWithPath("/select", johnAndNancyParams);
     ModifiableSolrParams params = new ModifiableSolrParams(johnTwoFL.getParams());
     params.set("q", "name_s:john");
     params.set("wt", "javabin");

--- a/solr/core/src/test/org/apache/solr/schema/EnumFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/EnumFieldTest.java
@@ -690,7 +690,7 @@ public class EnumFieldTest extends SolrTestCaseJ4 {
             jsonFacetParam,
             "wt",
             "json")) {
-      SolrQueryResponse rsp = h.queryAndResponse(req.getParams().get(CommonParams.QT), req);
+      SolrQueryResponse rsp = h.queryAndResponse(null, req);
       List<NamedList<?>> buckets =
           (List<NamedList<?>>)
               ((NamedList<?>) ((NamedList<?>) rsp.getValues().get("facets")).get("severity"))

--- a/solr/core/src/test/org/apache/solr/schema/EnumFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/EnumFieldTest.java
@@ -681,7 +681,8 @@ public class EnumFieldTest extends SolrTestCaseJ4 {
         "//*[@name='buckets']/lst[long[@name='count'][.='1']][str[@name='val'][.='High']]");
 
     try (SolrQueryRequest req =
-        req(
+        reqWithPath(
+            "/select",
             "fl",
             "" + FIELD_NAME,
             "q",
@@ -690,7 +691,7 @@ public class EnumFieldTest extends SolrTestCaseJ4 {
             jsonFacetParam,
             "wt",
             "json")) {
-      SolrQueryResponse rsp = h.queryAndResponse(null, req);
+      SolrQueryResponse rsp = h.queryAndResponse(req);
       List<NamedList<?>> buckets =
           (List<NamedList<?>>)
               ((NamedList<?>) ((NamedList<?>) rsp.getValues().get("facets")).get("severity"))

--- a/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
@@ -58,7 +58,7 @@ public class CacheHeaderTest extends CacheHeaderTestBase {
 
   @Test
   public void testCacheVetoException() throws Exception {
-    String url = getSelectUrl("q", "xyz_ignore_exception:solr", "qt", "standard");
+    String url = getSelectUrl("q", "xyz_ignore_exception:solr");
     // We force an exception from Solr. This should emit "no-cache" HTTP headers
     ContentResponse response = getHttpClient().GET(url);
     assertNotEquals(200, response.getStatus());

--- a/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTestBase.java
+++ b/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTestBase.java
@@ -35,7 +35,7 @@ public abstract class CacheHeaderTestBase extends SolrTestCaseJ4 {
     sb.append("/select?");
 
     if (params.length == 0) {
-      sb.append("q=solr&qt=standard");
+      sb.append("q=solr");
     } else {
       for (int i = 0; i < params.length / 2; i++) {
         if (i > 0) sb.append("&");

--- a/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/SolrRequestParserTest.java
@@ -111,7 +111,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
 
   @Test
   public void testStandardParseParamsAndFillStreams() throws Exception {
-    final String getParams = "qt=%C3%BC&dup=foo", postParams = "q=hello&d%75p=bar";
+    final String getParams = "misc=%C3%BC&dup=foo", postParams = "q=hello&d%75p=bar";
     final byte[] postBytes = postParams.getBytes(StandardCharsets.US_ASCII);
 
     // Set up the expected behavior
@@ -137,7 +137,7 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
       SolrParams p = standard.parseParamsAndFillStreams(request, new ArrayList<ContentStream>());
 
       assertEquals("contentType: " + contentType, "hello", p.get("q"));
-      assertEquals("contentType: " + contentType, "\u00FC", p.get("qt"));
+      assertEquals("contentType: " + contentType, "\u00FC", p.get("misc"));
       assertArrayEquals(
           "contentType: " + contentType, new String[] {"foo", "bar"}, p.getParams("dup"));
 
@@ -202,8 +202,8 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
 
   @Test
   public void testStandardParseParamsAndFillStreamsISO88591() throws Exception {
-    final String getParams = "qt=%FC&dup=foo&ie=iso-8859-1&dup=%FC",
-        postParams = "qt2=%FC&q=hello&d%75p=bar";
+    final String getParams = "misc=%FC&dup=foo&ie=iso-8859-1&dup=%FC",
+        postParams = "misc2=%FC&q=hello&d%75p=bar";
     final byte[] postBytes = postParams.getBytes(StandardCharsets.US_ASCII);
     final String contentType = "application/x-www-form-urlencoded; charset=iso-8859-1";
 
@@ -221,8 +221,8 @@ public class SolrRequestParserTest extends SolrTestCaseJ4 {
     SolrParams p = standard.parseParamsAndFillStreams(request, new ArrayList<ContentStream>());
 
     assertEquals("contentType: " + contentType, "hello", p.get("q"));
-    assertEquals("contentType: " + contentType, "\u00FC", p.get("qt"));
-    assertEquals("contentType: " + contentType, "\u00FC", p.get("qt2"));
+    assertEquals("contentType: " + contentType, "\u00FC", p.get("misc"));
+    assertEquals("contentType: " + contentType, "\u00FC", p.get("misc2"));
     assertArrayEquals(
         "contentType: " + contentType, new String[] {"foo", "\u00FC", "bar"}, p.getParams("dup"));
 

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -2180,10 +2180,10 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
     assertEquals(expectedIds, obtainedIds);
   }
 
-  void doQuery(List<String> expectedIds, String path, String... queryParams) throws Exception {
+  void doQuery(Collection<String> expectedIds, QueryRequest request) throws Exception {
     Set<String> expectedIdSet = new HashSet<>(expectedIds);
 
-    QueryResponse rsp = new QueryRequest(path, params(queryParams)).process(cloudClient);
+    QueryResponse rsp = request.process(cloudClient);
     Set<String> obtainedIds = new HashSet<>();
     for (SolrDocument doc : rsp.getResults()) {
       obtainedIds.add((String) doc.get("id"));

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -71,6 +71,7 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.RequestStatusState;
+import org.apache.solr.client.solrj.response.SimpleSolrResponse;
 import org.apache.solr.cloud.ZkController.NotInClusterStateException;
 import org.apache.solr.cloud.api.collections.CollectionHandlingUtils;
 import org.apache.solr.common.SolrDocument;
@@ -1409,10 +1410,10 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
     handle.put("response", UNORDERED); // get?ids=a,b,c requests are unordered
     String ids = "987654";
     for (int i = 0; i < 20; i++) {
-      query("qt", "/get", "id", Integer.toString(i));
-      query("qt", "/get", "ids", Integer.toString(i));
+      query("/get", params("id", Integer.toString(i)));
+      query("/get", params("ids", Integer.toString(i)));
       ids = ids + ',' + Integer.toString(i);
-      query("qt", "/get", "ids", ids);
+      query("/get", params("ids", ids));
     }
     handle.remove("response");
 
@@ -2177,6 +2178,18 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
     }
 
     assertEquals(expectedIds, obtainedIds);
+  }
+
+  void doQuery(List<String> expectedIds, String path, String... queryParams) throws Exception {
+    Set<String> expectedIdSet = new HashSet<>(expectedIds);
+
+    QueryResponse rsp = new QueryRequest(path, params(queryParams)).process(cloudClient);
+    Set<String> obtainedIds = new HashSet<>();
+    for (SolrDocument doc : rsp.getResults()) {
+      obtainedIds.add((String) doc.get("id"));
+    }
+
+    assertEquals(expectedIdSet, obtainedIds);
   }
 
   @Override
@@ -3002,10 +3015,12 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
             .withDefaultCollection(replica.getCoreName())
             .build()) {
       ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set("qt", "/replication");
       params.set(ReplicationHandler.COMMAND, ReplicationHandler.CMD_SHOW_COMMITS);
       try {
-        QueryResponse response = client.query(params);
+        SimpleSolrResponse response =
+            new GenericSolrRequest(METHOD.GET, "/replication", params)
+                .setRequiresCollection(true)
+                .process(client);
         @SuppressWarnings("unchecked")
         List<NamedList<Object>> commits =
             (List<NamedList<Object>>)
@@ -3052,10 +3067,12 @@ public abstract class AbstractFullDistribZkTestBase extends BaseDistributedSearc
             .withDefaultCollection(replica.getCoreName())
             .build()) {
       ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set("qt", "/replication");
       params.set(ReplicationHandler.COMMAND, ReplicationHandler.CMD_DETAILS);
       try {
-        QueryResponse response = client.query(params);
+        SimpleSolrResponse response =
+            new GenericSolrRequest(METHOD.GET, "/replication", params)
+                .setRequiresCollection(true)
+                .process(client);
         builder.append(
             String.format(
                 Locale.ROOT,

--- a/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
@@ -343,6 +343,9 @@ public class TestHarness extends BaseTestHarness {
   /**
    * It is the users responsibility to close the request object when done with it. This method does
    * not set/clear SolrRequestInfo
+   *
+   * @deprecated use {@link #queryAndResponse(SolrQueryRequest)} instead, ensuring that
+   *     SolrQueryRequest has a valid path
    */
   public SolrQueryResponse queryAndResponse(String handler, SolrQueryRequest req) throws Exception {
     try (var mdcSnap = MDCSnapshot.create();
@@ -350,6 +353,23 @@ public class TestHarness extends BaseTestHarness {
       assert null != mdcSnap; // prevent compiler warning of unused var
       SolrQueryResponse rsp = new SolrQueryResponse();
       core.execute(core.getRequestHandler(handler), req, rsp);
+      if (rsp.getException() != null) {
+        throw rsp.getException();
+      }
+      return rsp;
+    }
+  }
+
+  /**
+   * It is the users responsibility to close the request object when done with it. This method does
+   * not set/clear SolrRequestInfo
+   */
+  public SolrQueryResponse queryAndResponse(SolrQueryRequest req) throws Exception {
+    try (var mdcSnap = MDCSnapshot.create();
+        SolrCore core = getCoreInc()) {
+      assert null != mdcSnap; // prevent compiler warning of unused var
+      SolrQueryResponse rsp = new SolrQueryResponse();
+      core.execute(core.getRequestHandler(req.getPath()), req, rsp);
       if (rsp.getException() != null) {
         throw rsp.getException();
       }

--- a/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.util;
 
+import static org.apache.solr.SolrTestCaseJ4.withPath;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -347,17 +349,9 @@ public class TestHarness extends BaseTestHarness {
    * @deprecated use {@link #queryAndResponse(SolrQueryRequest)} instead, ensuring that
    *     SolrQueryRequest has a valid path
    */
+  @Deprecated
   public SolrQueryResponse queryAndResponse(String handler, SolrQueryRequest req) throws Exception {
-    try (var mdcSnap = MDCSnapshot.create();
-        SolrCore core = getCoreInc()) {
-      assert null != mdcSnap; // prevent compiler warning of unused var
-      SolrQueryResponse rsp = new SolrQueryResponse();
-      core.execute(core.getRequestHandler(handler), req, rsp);
-      if (rsp.getException() != null) {
-        throw rsp.getException();
-      }
-      return rsp;
-    }
+    return queryAndResponse(withPath(handler, req));
   }
 
   /**


### PR DESCRIPTION
The 'qt' parameter and several related methods in SolrJ are deprecated.
This deprecation may not stick, but it's still worth minimizing use of this
feature as much as possible.
    
Many tests rely on it unnecessarily; this PR is one in a number of batches
slowly removing these test usages. Unlike previous batches, the removals
in this PR are a bit more of a catch-all.  A number of different patterns are
addressed here.  (They've been broken up into separate commits, for the
purpose of making review easier.)