### PR TITLE
SOLR-18332: Remove avoidable QT-usage in SolrStream construction

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/admin/DaemonStreamApiTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/DaemonStreamApiTest.java
@@ -69,7 +69,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
     super.setUp();
     cluster = new MiniSolrCloudCluster(1, createTempDir(), JettyConfig.builder().build());
 
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + CHECKPOINT_COLL;
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     cluster.uploadConfigSet(configset("cloud-minimal"), CONF_NAME);
     // create a single shard, single replica collection. This is necessary until SOLR-13245 since
@@ -294,7 +294,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
   private List<Tuple> getTuples(final SolrParams params, String ofInterest) throws IOException {
     // log.info("Tuples from params: {}", params);
-    TupleStream tupleStream = new SolrStream(url, "/stream", params);
+    TupleStream tupleStream = new SolrStream(url, CHECKPOINT_COLL, "/stream", params);
 
     tupleStream.open();
     List<Tuple> tuples = new ArrayList<>();

--- a/solr/core/src/test/org/apache/solr/handler/admin/DaemonStreamApiTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/DaemonStreamApiTest.java
@@ -110,7 +110,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
       createDaemon(DAEMON_DEF.replace("DAEMON_NAME", name), name);
     }
 
-    List<Tuple> tuples = getTuples(params("qt", "/stream", "action", "list"));
+    List<Tuple> tuples = getTuples(params("action", "list"));
     assertEquals("Should have all daemons listed", numDaemons, tuples.size());
 
     for (int idx = 0; idx < numDaemons; ++idx) {
@@ -125,16 +125,14 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
     // We shouldn't be able to open a daemon twice without closing., leads to thread leeks.
     Tuple tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "start", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "start", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Should not open twice without closing",
         tupleOfInterest.getString(DAEMON_OP).contains("There is already an open daemon named"));
 
     // Try stopping and check return.
     tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "stop", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "stop", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Should have been able to stop the daemon",
         tupleOfInterest.getString(DAEMON_OP).contains(daemonOfInterest + " stopped"));
@@ -149,8 +147,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
     // Try starting and check return.
     tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "start", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "start", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Should have been able to start the daemon",
         tupleOfInterest.getString(DAEMON_OP).contains(daemonOfInterest + " started"));
@@ -162,8 +159,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
     // Try killing a daemon, it should be removed from lists.
     tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "kill", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "kill", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Daemon should have been killed",
         tupleOfInterest.getString(DAEMON_OP).contains(daemonOfInterest + " killed"));
@@ -173,24 +169,21 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
     // Should not be able to start a killed daemon
     tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "start", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "start", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Daemon should not be found",
         tupleOfInterest.getString(DAEMON_OP).contains(daemonOfInterest + " not found"));
 
     // Should not be able to sop a killed daemon
     tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "stop", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "stop", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Daemon should not be found",
         tupleOfInterest.getString(DAEMON_OP).contains(daemonOfInterest + " not found"));
 
     // Should not be able to kill a killed daemon
     tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "kill", "id", daemonOfInterest), DAEMON_OP);
+        getTupleOfInterest(params("action", "kill", "id", daemonOfInterest), DAEMON_OP);
     assertTrue(
         "Daemon should not be found",
         tupleOfInterest.getString(DAEMON_OP).contains(daemonOfInterest + " not found"));
@@ -202,7 +195,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
     // Now kill them all so the threads disappear.
     for (String daemon : daemonNames) {
-      getTuples(params("qt", "/stream", "action", "kill", "id", daemon));
+      getTuples(params("action", "kill", "id", daemon));
       checkDaemonKilled(daemon);
     }
   }
@@ -212,7 +205,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
     TimeOut timeout = new TimeOut(10, TimeUnit.SECONDS, TimeSource.NANO_TIME);
 
     while (timeout.hasTimedOut() == false) {
-      Tuple tuple = getTupleOfInterest(params("qt", "/stream", "action", "list"), daemonName);
+      Tuple tuple = getTupleOfInterest(params("action", "list"), daemonName);
       String state = tuple.getString("state");
       if (state.equals("RUNNABLE") || state.equals("WAITING") || state.equals("TIMED_WAITING")) {
         return;
@@ -232,7 +225,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
     TimeOut timeout = new TimeOut(10, TimeUnit.SECONDS, TimeSource.NANO_TIME);
 
     while (timeout.hasTimedOut() == false) {
-      Tuple tuple = getTupleOfInterest(params("qt", "/stream", "action", "list"), daemonOfInterest);
+      Tuple tuple = getTupleOfInterest(params("action", "list"), daemonOfInterest);
       if (tuple.getString("state").equals("TERMINATED")) {
         return;
       }
@@ -245,7 +238,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
     TimeOut timeout = new TimeOut(10, TimeUnit.SECONDS, TimeSource.NANO_TIME);
 
     while (timeout.hasTimedOut() == false) {
-      List<Tuple> tuples = getTuples(params("qt", "/stream", "action", "list"));
+      List<Tuple> tuples = getTuples(params("action", "list"));
       Boolean foundIt = false;
       for (Tuple tuple : tuples) {
         if (tuple.get("id").equals(daemon)) {
@@ -273,24 +266,21 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
   private void checkCmdsNoDaemon(String daemonName) throws IOException {
 
-    List<Tuple> tuples = getTuples(params("qt", "/stream", "action", "list"));
+    List<Tuple> tuples = getTuples(params("action", "list"));
     assertEquals("List should be empty", 0, tuples.size());
 
     Tuple tupleOfInterest =
-        getTupleOfInterest(
-            params("qt", "/stream", "action", "start", "id", daemonName), "DaemonOp");
+        getTupleOfInterest(params("action", "start", "id", daemonName), "DaemonOp");
     assertTrue(
         "Start for daemon should not be found",
         tupleOfInterest.getString("DaemonOp").contains("not found on"));
 
-    tupleOfInterest =
-        getTupleOfInterest(params("qt", "/stream", "action", "stop", "id", daemonName), "DaemonOp");
+    tupleOfInterest = getTupleOfInterest(params("action", "stop", "id", daemonName), "DaemonOp");
     assertTrue(
         "Stop for daemon should not be found",
         tupleOfInterest.getString("DaemonOp").contains("not found on"));
 
-    tupleOfInterest =
-        getTupleOfInterest(params("qt", "/stream", "action", "kill", "id", daemonName), "DaemonOp");
+    tupleOfInterest = getTupleOfInterest(params("action", "kill", "id", daemonName), "DaemonOp");
 
     assertTrue(
         "Kill for daemon should not be found",
@@ -304,7 +294,7 @@ public class DaemonStreamApiTest extends SolrTestCaseJ4 {
 
   private List<Tuple> getTuples(final SolrParams params, String ofInterest) throws IOException {
     // log.info("Tuples from params: {}", params);
-    TupleStream tupleStream = new SolrStream(url, params);
+    TupleStream tupleStream = new SolrStream(url, "/stream", params);
 
     tupleStream.open();
     List<Tuple> tuples = new ArrayList<>();

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/SQLWithAuthzEnabledTest.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/SQLWithAuthzEnabledTest.java
@@ -30,7 +30,6 @@ import org.apache.solr.client.solrj.io.stream.TupleStream;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.security.BasicAuthPlugin;
@@ -108,18 +107,17 @@ public class SQLWithAuthzEnabledTest extends SolrCloudTestCase {
         .commit(cluster.getSolrClient(), collectionName);
 
     ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set(CommonParams.QT, "/sql");
     params.set("stmt", "select id from " + collectionName);
     String baseUrl =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + collectionName;
-    SolrStream solrStream = new SolrStream(baseUrl, params);
+    SolrStream solrStream = new SolrStream(baseUrl, "/sql", params);
     solrStream.setCredentials(SAD_USER, PASS);
 
     // sad user is not authorized to access /sql endpoints
     expectThrows(IOException.class, () -> countTuples(solrStream));
 
     // sql user has access
-    SolrStream solrStream2 = new SolrStream(baseUrl, params);
+    SolrStream solrStream2 = new SolrStream(baseUrl, "/sql", params);
     solrStream2.setCredentials(SQL_USER, PASS);
     assertEquals(8, countTuples(solrStream2));
   }

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/SQLWithAuthzEnabledTest.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/SQLWithAuthzEnabledTest.java
@@ -108,16 +108,15 @@ public class SQLWithAuthzEnabledTest extends SolrCloudTestCase {
 
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("stmt", "select id from " + collectionName);
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + collectionName;
-    SolrStream solrStream = new SolrStream(baseUrl, "/sql", params);
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    SolrStream solrStream = new SolrStream(baseUrl, collectionName, "/sql", params);
     solrStream.setCredentials(SAD_USER, PASS);
 
     // sad user is not authorized to access /sql endpoints
     expectThrows(IOException.class, () -> countTuples(solrStream));
 
     // sql user has access
-    SolrStream solrStream2 = new SolrStream(baseUrl, "/sql", params);
+    SolrStream solrStream2 = new SolrStream(baseUrl, collectionName, "/sql", params);
     solrStream2.setCredentials(SQL_USER, PASS);
     assertEquals(8, countTuples(solrStream2));
   }

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -210,8 +210,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select id, field_i, str_s, field_f, field_d, field_l from collection1 where (text_t='(XXXX)' OR text_t='XXXX') AND text_t='XXXX' order by field_i desc");
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     List<Tuple> tuples = getTuples(sParams, baseUrl);
 
     assertEquals(8, tuples.size());
@@ -471,15 +470,14 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "1", "text_t", "XXXX XXXX", "str_s", "a", "field_i", "7")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params("caseSensitive", "true", "stmt", "select id, FIELD_I from collection1 limit 1");
 
     // caseSensitive is forwarded to Calcite by default, making column names case-sensitive,
     // unlike the default MySQL dialect behavior
-    SolrStream solrStream = new SolrStream(baseUrl, "/sql", sParams);
+    SolrStream solrStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", sParams);
     Tuple tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -549,8 +547,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "witha\"quote")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     // Equals
     SolrParams sParams = params("stmt", "select id from collection1 where id = 1 order by id asc");
@@ -676,8 +673,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "Text_t", "XXXX XXXX", "Str_s", "c", "Field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -784,8 +780,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -990,8 +985,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1188,8 +1182,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     SolrParams sParams =
         params(
             "numWorkers",
@@ -1403,8 +1396,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "9", "text_t", "XXXX XXXY", "str_s", "d", "field_i", "70")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1640,8 +1632,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "9", "a_s", "hello0", "a_i", "14", "a_f", "10")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1838,8 +1829,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "year_i", "2014", "month_i", "4", "day_i", "2", "item_i", "1")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1948,8 +1938,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1958,7 +1947,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select id, str_s from collection1 where text_t='XXXX' order by field_iff desc");
 
-    SolrStream solrStream = new SolrStream(baseUrl, "/sql", sParams);
+    SolrStream solrStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", sParams);
     Tuple tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -1969,7 +1958,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select id, field_iff, str_s from collection1 where text_t='XXXX' order by field_iff desc");
 
-    solrStream = new SolrStream(baseUrl, "/sql", sParams);
+    solrStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -1983,7 +1972,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select str_s, count(*), sum(field_iff), min(field_i), max(field_i), cast(avg(1.0 * field_i) as float) from collection1 where text_t='XXXX' group by str_s having ((sum(field_iff) = 19) AND (min(field_i) = 8))");
 
-    solrStream = new SolrStream(baseUrl, "/sql", sParams);
+    solrStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -1996,7 +1985,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select str_s, count(*), blah(field_i), min(field_i), max(field_i), cast(avg(1.0 * field_i) as float) from collection1 where text_t='XXXX' group by str_s having ((sum(field_i) = 19) AND (min(field_i) = 8))");
 
-    solrStream = new SolrStream(baseUrl, "/sql", sParams);
+    solrStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2010,7 +1999,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select str_s from collection1 where not_a_field LIKE 'foo%'");
 
-    solrStream = new SolrStream(baseUrl, "/sql", sParams);
+    solrStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2031,8 +2020,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "year_i", "2014", "month_i", "4", "day_i", "2", "item_i", "1")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -2145,8 +2133,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "year_i", "2014", "month_i", "4", "day_i", "2", "item_i", "1")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -2259,7 +2246,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
   protected List<Tuple> getTuples(final SolrParams params, String baseUrl) throws IOException {
     List<Tuple> tuples = new ArrayList<>();
-    try (TupleStream tupleStream = new SolrStream(baseUrl, "/sql", params)) {
+    try (TupleStream tupleStream = new SolrStream(baseUrl, COLLECTIONORALIAS, "/sql", params)) {
       tupleStream.open();
       for (; ; ) {
         Tuple t = tupleStream.read();
@@ -2291,14 +2278,13 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams = params("stmt", "select id from collection1 where str_s IN ('a','b','c')");
 
-    String baseUrl =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     List<Tuple> tuples = getTuples(sParams, baseUrl);
     assertEquals(3, tuples.size());
   }
 
   private String sqlUrl() {
-    return cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    return cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
   }
 
   private List<Tuple> expectResults(String sql, final int expectedCount) throws Exception {

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -38,7 +38,6 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SolrParams;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -208,8 +207,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id, field_i, str_s, field_f, field_d, field_l from collection1 where (text_t='(XXXX)' OR text_t='XXXX') AND text_t='XXXX' order by field_i desc");
 
@@ -298,8 +295,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id, field_i, str_s from collection1 where text_t='XXXX' order by id desc");
 
@@ -349,8 +344,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id, field_i, str_s from collection1 where text_t='XXXX' order by field_i desc limit 1");
 
@@ -365,8 +358,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id, field_i, str_s from collection1 where text_t='XXXX' AND id='(1 2 3)' order by field_i desc");
 
@@ -391,8 +382,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id as myId, field_i as myInt, str_s as myString from collection1 where text_t='XXXX' AND id='(1 2 3)' order by myInt desc");
 
@@ -417,8 +406,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id as myId, field_i as myInt, str_s as myString from collection1 where text_t='XXXX' AND id='(1 2 3)' order by field_i desc");
 
@@ -442,12 +429,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assertEquals("a", tuple.get("myString"));
 
     // SOLR-8845 - Test to make sure that 1 = 0 works for things like Spark SQL
-    sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id, field_i, str_s from collection1 where 1 = 0");
+    sParams = params("stmt", "select id, field_i, str_s from collection1 where 1 = 0");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -457,8 +439,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // 'schemaType' is a real Calcite connection property which would crash the request
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "schemaType",
             "someValue",
             "stmt",
@@ -495,17 +475,11 @@ public class TestSQLHandler extends SolrCloudTestCase {
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
 
     SolrParams sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "caseSensitive",
-            "true",
-            "stmt",
-            "select id, FIELD_I from collection1 limit 1");
+        params("caseSensitive", "true", "stmt", "select id, FIELD_I from collection1 limit 1");
 
     // caseSensitive is forwarded to Calcite by default, making column names case-sensitive,
     // unlike the default MySQL dialect behavior
-    SolrStream solrStream = new SolrStream(baseUrl, sParams);
+    SolrStream solrStream = new SolrStream(baseUrl, "/sql", sParams);
     Tuple tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -579,12 +553,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
 
     // Equals
-    SolrParams sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where id = 1 order by id asc");
+    SolrParams sParams = params("stmt", "select id from collection1 where id = 1 order by id asc");
 
     List<Tuple> tuples = getTuples(sParams, baseUrl);
 
@@ -594,12 +563,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assertEquals("1", tuple.get("id"));
 
     // Not Equals <>
-    sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where id <> 1 order by id asc limit 10");
+    sParams = params("stmt", "select id from collection1 where id <> 1 order by id asc limit 10");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -645,12 +609,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // assertEquals(8L, tuple.get("id"));
 
     // Less than
-    sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where id < 2 order by id asc");
+    sParams = params("stmt", "select id from collection1 where id < 2 order by id asc");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -660,12 +619,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assertEquals("1", tuple.get("id"));
 
     // Less than equal
-    sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where id <= 2 order by id asc");
+    sParams = params("stmt", "select id from collection1 where id <= 2 order by id asc");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -677,12 +631,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assertEquals("2", tuple.get("id"));
 
     // Greater than
-    sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where id > 7 order by id asc");
+    sParams = params("stmt", "select id from collection1 where id > 7 order by id asc");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -692,12 +641,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     assertEquals("8", tuple.get("id"));
 
     // Greater than equal
-    sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where id >= 7 order by id asc");
+    sParams = params("stmt", "select id from collection1 where id >= 7 order by id asc");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -737,8 +681,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -793,8 +735,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // TODO get sum(Field_i) as named one
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select Str_s, sum(Field_i) from collection1 where id='(1 8)' group by Str_s having (sum(Field_i) = 7 OR sum(Field_i) = 60) order by sum(Field_i) desc");
 
@@ -812,8 +752,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -851,8 +789,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -892,8 +828,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // reverse the sort
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -930,8 +864,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // reverse the sort
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -968,8 +900,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // test with limit
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -990,12 +920,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test without a sort. Sort should be asc by default.
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
-            "aggregationMode",
-            "facet",
-            "stmt",
-            "select distinct str_s, field_i from collection1");
+            "aggregationMode", "facet", "stmt", "select distinct str_s, field_i from collection1");
 
     tuples = getTuples(sParams, baseUrl);
 
@@ -1033,8 +958,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test with a predicate.
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1072,8 +995,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1109,8 +1030,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // reverse the sort
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1146,8 +1065,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1184,8 +1101,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // test with limit
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1206,8 +1121,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test without a sort. Sort should be asc by default.
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1244,8 +1157,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test with a predicate.
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1281,8 +1192,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -1323,8 +1232,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // reverse the sort
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -1363,8 +1270,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // reverse the sort
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -1403,8 +1308,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // test with limit
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -1427,8 +1330,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test without a sort. Sort should be asc by default.
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -1467,8 +1368,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test with a predicate.
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -1509,8 +1408,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1543,8 +1440,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1575,8 +1470,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1617,8 +1510,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1659,8 +1550,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1681,8 +1570,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1704,8 +1591,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1727,8 +1612,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -1762,8 +1645,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select count(*), sum(a_i), min(a_i), max(a_i), cast(avg(1.0 * a_i) as float), sum(a_f), "
                 + "min(a_f), max(a_f), avg(a_f) from collection1");
@@ -1798,8 +1679,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select count(*) as myCount, sum(a_i) as mySum, min(a_i) as myMin, max(a_i) as myMax, "
                 + "cast(avg(1.0 * a_i) as float) as myAvg, sum(a_f), min(a_f), max(a_f), avg(a_f) from collection1");
@@ -1835,8 +1714,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test without cast on average int field
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select count(*) as myCount, sum(a_i) as mySum, min(a_i) as myMin, max(a_i) as myMax, "
                 + "avg(a_i) as myAvg, sum(a_f), min(a_f), max(a_f), avg(a_f) from collection1");
@@ -1873,8 +1750,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test where clause hits
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select count(*), sum(a_i), min(a_i), max(a_i), cast(avg(1.0 * a_i) as float), sum(a_f), "
                 + "min(a_f), max(a_f), avg(a_f) from collection1 where id = 2");
@@ -1908,8 +1783,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Test zero hits
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select count(*), sum(a_i), min(a_i), max(a_i), cast(avg(1.0 * a_i) as float), sum(a_f), "
                 + "min(a_f), max(a_f), avg(a_f) from collection1 where a_s = 'blah'");
@@ -1943,8 +1816,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // test bunch of where predicates
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select count(*), sum(a_i), min(a_i), max(a_i), cast(avg(1.0 * a_i) as float), sum(a_f), "
                 + "min(a_f), max(a_f), avg(a_f) from collection1 where id = 2 AND a_s='hello0' AND a_i=2 AND a_f=2");
@@ -1972,8 +1843,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
@@ -1995,8 +1864,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select year_i, month_i, sum(item_i) from collection1 group by year_i, month_i "
                 + "order by year_i desc, month_i desc");
@@ -2022,8 +1889,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select year_i, month_i, day_i, sum(item_i) from collection1 group by year_i, month_i, day_i "
                 + "order by year_i desc, month_i desc, day_i desc");
@@ -2088,14 +1953,12 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
             "select id, str_s from collection1 where text_t='XXXX' order by field_iff desc");
 
-    SolrStream solrStream = new SolrStream(baseUrl, sParams);
+    SolrStream solrStream = new SolrStream(baseUrl, "/sql", sParams);
     Tuple tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2103,12 +1966,10 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "stmt",
             "select id, field_iff, str_s from collection1 where text_t='XXXX' order by field_iff desc");
 
-    solrStream = new SolrStream(baseUrl, sParams);
+    solrStream = new SolrStream(baseUrl, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2117,14 +1978,12 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
             "select str_s, count(*), sum(field_iff), min(field_i), max(field_i), cast(avg(1.0 * field_i) as float) from collection1 where text_t='XXXX' group by str_s having ((sum(field_iff) = 19) AND (min(field_i) = 8))");
 
-    solrStream = new SolrStream(baseUrl, sParams);
+    solrStream = new SolrStream(baseUrl, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2132,14 +1991,12 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
             "select str_s, count(*), blah(field_i), min(field_i), max(field_i), cast(avg(1.0 * field_i) as float) from collection1 where text_t='XXXX' group by str_s having ((sum(field_i) = 19) AND (min(field_i) = 8))");
 
-    solrStream = new SolrStream(baseUrl, sParams);
+    solrStream = new SolrStream(baseUrl, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2148,14 +2005,12 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // verify exception message formatting with wildcard query
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "map_reduce",
             "stmt",
             "select str_s from collection1 where not_a_field LIKE 'foo%'");
 
-    solrStream = new SolrStream(baseUrl, sParams);
+    solrStream = new SolrStream(baseUrl, "/sql", sParams);
     tuple = getTuple(new ExceptionStream(solrStream));
     assertTrue(tuple.EOF);
     assertTrue(tuple.EXCEPTION);
@@ -2181,8 +2036,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -2204,8 +2057,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -2233,8 +2084,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "aggregationMode",
             "facet",
             "stmt",
@@ -2301,8 +2150,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -2330,8 +2177,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -2363,8 +2208,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     sParams =
         params(
-            CommonParams.QT,
-            "/sql",
             "numWorkers",
             "2",
             "aggregationMode",
@@ -2416,7 +2259,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
   protected List<Tuple> getTuples(final SolrParams params, String baseUrl) throws IOException {
     List<Tuple> tuples = new ArrayList<>();
-    try (TupleStream tupleStream = new SolrStream(baseUrl, params)) {
+    try (TupleStream tupleStream = new SolrStream(baseUrl, "/sql", params)) {
       tupleStream.open();
       for (; ; ) {
         Tuple t = tupleStream.read();
@@ -2446,12 +2289,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "4", "text_t", "foobaz", "str_s", "d")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    SolrParams sParams =
-        params(
-            CommonParams.QT,
-            "/sql",
-            "stmt",
-            "select id from collection1 where str_s IN ('a','b','c')");
+    SolrParams sParams = params("stmt", "select id from collection1 where str_s IN ('a','b','c')");
 
     String baseUrl =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
@@ -2465,7 +2303,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
   private List<Tuple> expectResults(String sql, final int expectedCount) throws Exception {
     String sqlStmt = sql.replace("$ALIAS", COLLECTIONORALIAS);
-    SolrParams params = params(CommonParams.QT, "/sql", "stmt", sqlStmt);
+    SolrParams params = params("stmt", sqlStmt);
     List<Tuple> tuples = getTuples(params, sqlUrl());
     assertEquals(expectedCount, tuples.size());
     return tuples;

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandlerNonCloud.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandlerNonCloud.java
@@ -24,7 +24,6 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.stream.SolrStream;
 import org.apache.solr.client.solrj.io.stream.TupleStream;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.util.SolrJettyTestRule;
@@ -53,10 +52,10 @@ public class TestSQLHandlerNonCloud extends SolrTestCaseJ4 {
   @Test
   public void testSQLHandler() throws Exception {
     String sql = "select id, field_i, str_s from " + DEFAULT_TEST_COLLECTION_NAME + " limit 10";
-    SolrParams sParams = params(CommonParams.QT, "/sql", "stmt", sql);
+    SolrParams sParams = params("stmt", sql);
     String url = solrTestRule.getBaseUrl() + "/" + DEFAULT_TEST_COLLECTION_NAME;
 
-    SolrStream solrStream = new SolrStream(url, sParams);
+    SolrStream solrStream = new SolrStream(url, "/sql", sParams);
     IOException ex = expectThrows(IOException.class, () -> getTuples(solrStream));
     assertTrue(ex.getMessage().contains(SQLHandler.sqlNonCloudErrorMsg));
   }

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandlerNonCloud.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandlerNonCloud.java
@@ -53,9 +53,9 @@ public class TestSQLHandlerNonCloud extends SolrTestCaseJ4 {
   public void testSQLHandler() throws Exception {
     String sql = "select id, field_i, str_s from " + DEFAULT_TEST_COLLECTION_NAME + " limit 10";
     SolrParams sParams = params("stmt", sql);
-    String url = solrTestRule.getBaseUrl() + "/" + DEFAULT_TEST_COLLECTION_NAME;
+    String url = solrTestRule.getBaseUrl();
 
-    SolrStream solrStream = new SolrStream(url, "/sql", sParams);
+    SolrStream solrStream = new SolrStream(url, DEFAULT_TEST_COLLECTION_NAME, "/sql", sParams);
     IOException ex = expectThrows(IOException.class, () -> getTuples(solrStream));
     assertTrue(ex.getMessage().contains(SQLHandler.sqlNonCloudErrorMsg));
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ParallelStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ParallelStream.java
@@ -297,10 +297,9 @@ public class ParallelStream extends CloudSolrStream implements Expressible {
         paramsLoc.set("workerID", w);
 
         paramsLoc.set("expr", pushStream.toString());
-        paramsLoc.set("qt", "/stream");
 
         String url = shardUrls.get(w);
-        SolrStream solrStream = new SolrStream(url, paramsLoc);
+        SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
         solrStream.setStreamContext(streamContext);
         solrStreams.add(solrStream);
       }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -52,8 +52,9 @@ public class SolrStream extends TupleStream {
   private static final long serialVersionUID = 1;
 
   private String baseUrl;
-  private SolrParams params;
+  private String core;
   private String path;
+  private SolrParams params;
   private int numWorkers;
   private int workerID;
   private boolean trace;
@@ -64,7 +65,6 @@ public class SolrStream extends TupleStream {
   private boolean distrib = true;
   private String user;
   private String password;
-  private String core;
 
   private transient SolrClientCache clientCache;
   private transient boolean doCloseCache;
@@ -72,26 +72,26 @@ public class SolrStream extends TupleStream {
   // TODO SOLR-17995 proposes that we should deprecate this constructor in favor of one of the other
   // constructors that requires users to provide the core as an explicit parameter
   /**
-   * @param baseUrl URL of the Solr core or collection to query, typically of the form
+   * @param collectionOrCoreUrl URL of the Solr core or collection to query, typically of the form
    *     "http://host:8983/solr/myCore".
    * @param params query-parameters sent with the streaming request
    */
-  public SolrStream(String baseUrl, SolrParams params) {
-    this.baseUrl = baseUrl;
+  public SolrStream(String collectionOrCoreUrl, SolrParams params) {
+    this.baseUrl = collectionOrCoreUrl;
     this.params = params;
   }
 
   // TODO SOLR-17995 proposes that we should deprecate this constructor in favor of one of the other
   // constructors that requires users to provide the core as an explicit parameter
   /**
-   * @param baseUrl URL of the Solr core or collection to query, typically of the form
+   * @param collectionOrCoreUrl URL of the Solr core or collection to query, typically of the form
    *     "http://host:8983/solr/myCore".
    * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
    *     "/select".
    * @param params query-parameters sent with the streaming request
    */
-  public SolrStream(String baseUrl, String path, SolrParams params) {
-    this(baseUrl, null, path, params);
+  public SolrStream(String collectionOrCoreUrl, String path, SolrParams params) {
+    this(collectionOrCoreUrl, null, path, params);
   }
 
   /**
@@ -113,8 +113,8 @@ public class SolrStream extends TupleStream {
   public SolrStream(String baseUrl, String core, String path, SolrParams params) {
     this.baseUrl = baseUrl;
     this.core = core;
-    this.params = params;
     this.path = path != null ? path : "/select";
+    this.params = params;
   }
 
   public void setFieldMappings(Map<String, String> fieldMappings) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -53,6 +53,7 @@ public class SolrStream extends TupleStream {
 
   private String baseUrl;
   private SolrParams params;
+  private String path;
   private int numWorkers;
   private int workerID;
   private boolean trace;
@@ -69,7 +70,10 @@ public class SolrStream extends TupleStream {
   private transient boolean doCloseCache;
 
   /**
-   * @param baseUrl Base URL of the stream.
+   * @param baseUrl URL of the Solr instance to query. May be either a Solr node's "base" URL (i.e.
+   *     ending in "/solr", with no collection or core in the path) or a URL that already includes
+   *     the target collection or core name (e.g. "http://host:8983/solr/myCollection"). See {@link
+   *     org.apache.solr.client.solrj.io.SolrClientCache#getHttpSolrClient(String)}.
    * @param params Map&lt;String, String&gt; of parameters
    */
   public SolrStream(String baseUrl, SolrParams params) {
@@ -77,6 +81,26 @@ public class SolrStream extends TupleStream {
     this.params = params;
   }
 
+  /**
+   * @param baseUrl URL of the Solr instance to query. As with {@link #SolrStream(String,
+   *     SolrParams)}, this may be either a bare node "base" URL or one that already includes the
+   *     target collection/core name.
+   * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
+   *     "/select".
+   * @param params Map&lt;String, String&gt; of parameters
+   */
+  public SolrStream(String baseUrl, String path, SolrParams params) {
+    this(baseUrl, params);
+    this.path = path;
+  }
+
+  /**
+   * @param baseUrl the Solr node's "base" URL (i.e. ending in "/solr", with no collection or core
+   *     in the path) — unlike {@link #SolrStream(String, SolrParams)}, this constructor always
+   *     expects the bare node URL, since {@code core} is supplied separately.
+   * @param params Map&lt;String, String&gt; of parameters
+   * @param core the name of the collection or core to query on the node at {@code baseUrl}
+   */
   SolrStream(String baseUrl, SolrParams params, String core) {
     this(baseUrl, params);
     this.core = core;
@@ -273,7 +297,10 @@ public class SolrStream extends TupleStream {
     // performance optimization - remove extra whitespace when streaming
     requestParams = SolrParams.wrapDefaults(requestParams, SolrParams.of("indent", "off"));
 
-    QueryRequest query = new QueryRequest(requestParams, SolrRequest.METHOD.POST);
+    QueryRequest query =
+        path == null
+            ? new QueryRequest(requestParams, SolrRequest.METHOD.POST)
+            : new QueryRequest(path, requestParams, SolrRequest.METHOD.POST);
     String wt = requestParams.get(CommonParams.WT, "json");
     query.setResponseParser(new InputStreamResponseParser(wt));
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -106,14 +106,15 @@ public class SolrStream extends TupleStream {
   /**
    * @param baseUrl the Solr node's "base" URL (i.e. no core or collection in the path
    * @param core the name of the collection or core to query; must be hosted at {@code baseUrl}
-   * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
-   *     "/select".
+   * @param path the request handler path to query (e.g. "/export"). If not provided (i.e. {@code
+   *     null}), the handler is instead resolved from a "qt" param embedded in {@code params}, or
+   *     defaults to "/select" if no such param is present.
    * @param params query-parameters sent with the streaming request
    */
   public SolrStream(String baseUrl, String core, String path, SolrParams params) {
     this.baseUrl = baseUrl;
     this.core = core;
-    this.path = path != null ? path : "/select";
+    this.path = path;
     this.params = params;
   }
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -69,41 +69,52 @@ public class SolrStream extends TupleStream {
   private transient SolrClientCache clientCache;
   private transient boolean doCloseCache;
 
+  // TODO SOLR-17995 proposes that we should deprecate this constructor in favor of one of the other
+  // constructors that requires users to provide the core as an explicit parameter
   /**
-   * @param baseUrl URL of the Solr instance to query. May be either a Solr node's "base" URL (i.e.
-   *     ending in "/solr", with no collection or core in the path) or a URL that already includes
-   *     the target collection or core name (e.g. "http://host:8983/solr/myCollection"). See {@link
-   *     org.apache.solr.client.solrj.io.SolrClientCache#getHttpSolrClient(String)}.
-   * @param params Map&lt;String, String&gt; of parameters
+   * @param baseUrl URL of the Solr core or collection to query, typically of the form
+   *     "http://host:8983/solr/myCore".
+   * @param params query-parameters sent with the streaming request
    */
   public SolrStream(String baseUrl, SolrParams params) {
     this.baseUrl = baseUrl;
     this.params = params;
   }
 
+  // TODO SOLR-17995 proposes that we should deprecate this constructor in favor of one of the other
+  // constructors that requires users to provide the core as an explicit parameter
   /**
-   * @param baseUrl URL of the Solr instance to query. As with {@link #SolrStream(String,
-   *     SolrParams)}, this may be either a bare node "base" URL or one that already includes the
-   *     target collection/core name.
+   * @param baseUrl URL of the Solr core or collection to query, typically of the form
+   *     "http://host:8983/solr/myCore".
    * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
    *     "/select".
-   * @param params Map&lt;String, String&gt; of parameters
+   * @param params query-parameters sent with the streaming request
    */
   public SolrStream(String baseUrl, String path, SolrParams params) {
-    this(baseUrl, params);
-    this.path = path;
+    this(baseUrl, null, path, params);
   }
 
   /**
-   * @param baseUrl the Solr node's "base" URL (i.e. ending in "/solr", with no collection or core
-   *     in the path) — unlike {@link #SolrStream(String, SolrParams)}, this constructor always
-   *     expects the bare node URL, since {@code core} is supplied separately.
-   * @param params Map&lt;String, String&gt; of parameters
-   * @param core the name of the collection or core to query on the node at {@code baseUrl}
+   * @param baseUrl the Solr node's "base" URL (i.e. no core or collection in the path
+   * @param params query-parameters sent with the streaming request
+   * @param core the name of the collection or core to query; must be hosted at {@code baseUrl}
    */
-  SolrStream(String baseUrl, SolrParams params, String core) {
-    this(baseUrl, params);
+  public SolrStream(String baseUrl, SolrParams params, String core) {
+    this(baseUrl, core, null, params);
+  }
+
+  /**
+   * @param baseUrl the Solr node's "base" URL (i.e. no core or collection in the path
+   * @param core the name of the collection or core to query; must be hosted at {@code baseUrl}
+   * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
+   *     "/select".
+   * @param params query-parameters sent with the streaming request
+   */
+  public SolrStream(String baseUrl, String core, String path, SolrParams params) {
+    this.baseUrl = baseUrl;
     this.core = core;
+    this.params = params;
+    this.path = path != null ? path : "/select";
   }
 
   public void setFieldMappings(Map<String, String> fieldMappings) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SqlStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SqlStream.java
@@ -35,7 +35,6 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExplanation;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 
@@ -195,8 +194,7 @@ public class SqlStream extends TupleStream implements Expressible {
       Collections.shuffle(shardUrls, new Random());
       String url = shardUrls.get(0);
       ModifiableSolrParams mParams = new ModifiableSolrParams(params);
-      mParams.add(CommonParams.QT, "/sql");
-      this.tupleStream = new SolrStream(url, mParams);
+      this.tupleStream = new SolrStream(url, "/sql", mParams);
       if (streamContext != null) {
         tupleStream.setStreamContext(streamContext);
         if (streamContext.isLocal()) {

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
@@ -383,8 +383,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_Y,
-              "/stream", // NOTE: Y route
+              solrUrl,
+              COLLECTION_Y, // NOTE: Y route
+              "/stream",
               params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
@@ -405,8 +406,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl,
-              COLLECTION_X,
-              "/stream", // NOTE: X route
+              COLLECTION_X, // NOTE: X route
+              "/stream",
               params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
@@ -469,8 +470,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     // authz to write to X...
     for (String user : Arrays.asList(READ_ONLY_USER, WRITE_Y_USER)) {
       // ... regardless of how the request is routed...
-      for (String path : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
-        final String trace = user + ":" + path;
+      for (String coll : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
+        final String trace = user + ":" + coll;
         final String expr =
             "executor(threads=1,tuple(expr_s=\"update("
                 + COLLECTION_X
@@ -481,9 +482,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                 + "'))\"))";
         final SolrStream solrStream =
             new SolrStream(
-                solrUrl + "/" + path,
-                "/stream",
-                params("_trace", "executor_via_" + trace, "expr", expr));
+                solrUrl, coll, "/stream", params("_trace", "executor_via_" + trace, "expr", expr));
         solrStream.setCredentials(user, passwordFor(user));
 
         // NOTE: Because of the background threads, no failures will to be returned to client...
@@ -791,8 +790,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_Y,
-              "/stream", // NOTE: Y route
+              solrUrl,
+              COLLECTION_Y, // NOTE: Y route
+              "/stream",
               params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
@@ -817,8 +817,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl,
-              COLLECTION_X,
-              "/stream", // NOTE: X route
+              COLLECTION_X, // NOTE: X route
+              "/stream",
               params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
@@ -850,10 +850,11 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     assertEquals(1L, commitAndCountDocsInCollection(COLLECTION_X, WRITE_X_USER));
 
     // regardless of how it's routed, WRITE_Y should NOT have authz to delete from X...
-    for (String path : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
+    for (String coll : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + path,
+              solrUrl,
+              coll,
               "/stream",
               params("expr", "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
       solrStream.setCredentials(WRITE_Y_USER, passwordFor(WRITE_Y_USER));

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
@@ -251,8 +251,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
   public void testEchoStream() throws Exception {
     final SolrStream solrStream =
-        new SolrStream(
-            solrUrl + "/" + COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
+        new SolrStream(solrUrl, COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
     solrStream.setCredentials(READ_ONLY_USER, passwordFor(READ_ONLY_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
@@ -261,8 +260,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
   public void testEchoStreamNoCredentials() {
     final SolrStream solrStream =
-        new SolrStream(
-            solrUrl + "/" + COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
+        new SolrStream(solrUrl, COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
     // NOTE: no credentials
 
     // NOTE: Can't make any assertions about Exception: SOLR-14226
@@ -275,8 +273,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
   public void testEchoStreamInvalidCredentials() {
     final SolrStream solrStream =
-        new SolrStream(
-            solrUrl + "/" + COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
+        new SolrStream(solrUrl, COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
     solrStream.setCredentials(READ_ONLY_USER, "BOGUS_PASSWORD");
 
     // NOTE: Can't make any assertions about Exception: SOLR-14226
@@ -290,7 +287,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public void testSimpleUpdateStream() throws Exception {
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
+            solrUrl,
+            COLLECTION_X,
             "/stream",
             params(
                 "expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
@@ -305,7 +303,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public void testSimpleUpdateStreamInvalidCredentials() throws Exception {
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
+            solrUrl,
+            COLLECTION_X,
             "/stream",
             params(
                 "expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
@@ -328,7 +327,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     for (String user : Arrays.asList(READ_ONLY_USER, WRITE_Y_USER)) {
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_X,
+              solrUrl,
+              COLLECTION_X,
               "/stream",
               params(
                   "expr",
@@ -404,7 +404,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_X,
+              solrUrl,
+              COLLECTION_X,
               "/stream", // NOTE: X route
               params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
@@ -454,7 +455,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
             + COLLECTION_X
             + ", batchSize=5, tuple(id=42,a_i=1,b_i=5))\"))";
     final SolrStream solrStream =
-        new SolrStream(solrUrl + "/" + COLLECTION_X, "/stream", params("expr", expr));
+        new SolrStream(solrUrl, COLLECTION_X, "/stream", params("expr", expr));
     solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(0, tuples.size());
@@ -633,7 +634,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
+            solrUrl,
+            COLLECTION_X,
             "/stream",
             params("expr", "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
     solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
@@ -669,7 +671,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
               + ", q=\"foo_i:[* TO 10]\", rows=100, fl=\"id,foo_i,_version_\", sort=\"foo_i desc\"))";
 
       final SolrStream solrStream =
-          new SolrStream(solrUrl + "/" + COLLECTION_X, "/stream", params("expr", expr));
+          new SolrStream(solrUrl, COLLECTION_X, "/stream", params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
@@ -691,7 +693,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
+            solrUrl,
+            COLLECTION_X,
             "/stream",
             params("expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
     // "WRITE" credentials should be required for 'update(...)'
@@ -721,7 +724,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     for (String user : Arrays.asList(READ_ONLY_USER, WRITE_Y_USER)) {
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_X,
+              solrUrl,
+              COLLECTION_X,
               "/stream",
               params("expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
 
@@ -812,7 +816,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_X,
+              solrUrl,
+              COLLECTION_X,
               "/stream", // NOTE: X route
               params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
@@ -252,10 +252,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public void testEchoStream() throws Exception {
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
-            params(
-                "qt", "/stream",
-                "expr", "echo(hello world)"));
+            solrUrl + "/" + COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
     solrStream.setCredentials(READ_ONLY_USER, passwordFor(READ_ONLY_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
@@ -265,10 +262,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public void testEchoStreamNoCredentials() {
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
-            params(
-                "qt", "/stream",
-                "expr", "echo(hello world)"));
+            solrUrl + "/" + COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
     // NOTE: no credentials
 
     // NOTE: Can't make any assertions about Exception: SOLR-14226
@@ -282,10 +276,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public void testEchoStreamInvalidCredentials() {
     final SolrStream solrStream =
         new SolrStream(
-            solrUrl + "/" + COLLECTION_X,
-            params(
-                "qt", "/stream",
-                "expr", "echo(hello world)"));
+            solrUrl + "/" + COLLECTION_X, "/stream", params("expr", "echo(hello world)"));
     solrStream.setCredentials(READ_ONLY_USER, "BOGUS_PASSWORD");
 
     // NOTE: Can't make any assertions about Exception: SOLR-14226
@@ -300,11 +291,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     final SolrStream solrStream =
         new SolrStream(
             solrUrl + "/" + COLLECTION_X,
+            "/stream",
             params(
-                "qt",
-                "/stream",
-                "expr",
-                "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
+                "expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
     solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
@@ -317,11 +306,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     final SolrStream solrStream =
         new SolrStream(
             solrUrl + "/" + COLLECTION_X,
+            "/stream",
             params(
-                "qt",
-                "/stream",
-                "expr",
-                "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
+                "expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
     // "WRITE" credentials should be required for 'update(...)'
     solrStream.setCredentials(WRITE_X_USER, "BOGUS_PASSWORD");
 
@@ -342,9 +329,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl + "/" + COLLECTION_X,
+              "/stream",
               params(
-                  "qt",
-                  "/stream",
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
 
@@ -366,9 +352,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl + "/" + COLLECTION_Y,
+              "/stream",
               params(
-                  "qt",
-                  "/stream",
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
@@ -398,8 +383,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_Y, // NOTE: Y route
-              params("qt", "/stream", "expr", expr));
+              solrUrl + "/" + COLLECTION_Y,
+              "/stream", // NOTE: Y route
+              params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -418,8 +404,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_X, // NOTE: X route
-              params("qt", "/stream", "expr", expr));
+              solrUrl + "/" + COLLECTION_X,
+              "/stream", // NOTE: X route
+              params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(3, tuples.size());
@@ -444,9 +431,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl + "/" + path,
+              "/stream",
               params(
-                  "qt",
-                  "/stream",
                   "expr",
                   "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42,a_i=1,b_i=5))"));
       solrStream.setCredentials(WRITE_Y_USER, passwordFor(WRITE_Y_USER));
@@ -468,7 +454,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
             + COLLECTION_X
             + ", batchSize=5, tuple(id=42,a_i=1,b_i=5))\"))";
     final SolrStream solrStream =
-        new SolrStream(solrUrl + "/" + COLLECTION_X, params("qt", "/stream", "expr", expr));
+        new SolrStream(solrUrl + "/" + COLLECTION_X, "/stream", params("expr", expr));
     solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(0, tuples.size());
@@ -495,7 +481,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
         final SolrStream solrStream =
             new SolrStream(
                 solrUrl + "/" + path,
-                params("qt", "/stream", "_trace", "executor_via_" + trace, "expr", expr));
+                "/stream",
+                params("_trace", "executor_via_" + trace, "expr", expr));
         solrStream.setCredentials(user, passwordFor(user));
 
         // NOTE: Because of the background threads, no failures will to be returned to client...
@@ -526,8 +513,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
           "daemon(id=daemonId,runInterval=1000,terminate=true,update("
               + COLLECTION_X
               + ",tuple(id=42,a_i=1,b_i=5)))";
-      final SolrStream solrStream =
-          new SolrStream(daemonUrl, params("qt", "/stream", "expr", expr));
+      final SolrStream solrStream = new SolrStream(daemonUrl, "/stream", params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size()); // daemon starting status
@@ -538,11 +524,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final TimeOut timeout = new TimeOut(60, TimeUnit.SECONDS, TimeSource.NANO_TIME);
       while (!timeout.hasTimedOut()) {
         final SolrStream daemonCheck =
-            new SolrStream(
-                daemonUrl,
-                params(
-                    "qt", "/stream",
-                    "action", "list"));
+            new SolrStream(daemonUrl, "/stream", params("action", "list"));
         daemonCheck.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
         final List<Tuple> tuples = getTuples(daemonCheck);
         assertEquals(1, tuples.size()); // our daemon;
@@ -559,12 +541,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     } finally {
       // kill the damon...
       final SolrStream daemonKiller =
-          new SolrStream(
-              daemonUrl,
-              params(
-                  "qt", "/stream",
-                  "action", "kill",
-                  "id", "daemonId"));
+          new SolrStream(daemonUrl, "/stream", params("action", "kill", "id", "daemonId"));
       daemonKiller.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(daemonKiller);
       assertEquals(1, tuples.size()); // daemon death status
@@ -591,7 +568,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                 + ",tuple(id=42,a_i=1,b_i=5)))     ";
         final SolrStream solrStream =
             new SolrStream(
-                daemonUrl, params("qt", "/stream", "_trace", "start_" + daemonId, "expr", expr));
+                daemonUrl, "/stream", params("_trace", "start_" + daemonId, "expr", expr));
         solrStream.setCredentials(user, passwordFor(user));
         final List<Tuple> tuples = getTuples(solrStream);
         assertEquals(1, tuples.size()); // daemon starting status
@@ -603,11 +580,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
         while (!timeout.hasTimedOut()) {
           final SolrStream daemonCheck =
               new SolrStream(
-                  daemonUrl,
-                  params(
-                      "qt", "/stream",
-                      "_trace", "check_" + daemonId,
-                      "action", "list"));
+                  daemonUrl, "/stream", params("_trace", "check_" + daemonId, "action", "list"));
           daemonCheck.setCredentials(user, passwordFor(user));
           final List<Tuple> tuples = getTuples(daemonCheck);
           assertEquals(1, tuples.size()); // our daemon;
@@ -632,15 +605,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
         final SolrStream daemonKiller =
             new SolrStream(
                 daemonUrl,
-                params(
-                    "qt",
-                    "/stream",
-                    "_trace",
-                    "kill_" + daemonId,
-                    "action",
-                    "kill",
-                    "id",
-                    daemonId));
+                "/stream",
+                params("_trace", "kill_" + daemonId, "action", "kill", "id", daemonId));
         daemonKiller.setCredentials(user, passwordFor(user));
         final List<Tuple> tuples = getTuples(daemonKiller);
         assertEquals(1, tuples.size()); // daemon death status
@@ -668,11 +634,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     final SolrStream solrStream =
         new SolrStream(
             solrUrl + "/" + COLLECTION_X,
-            params(
-                "qt",
-                "/stream",
-                "expr",
-                "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
+            "/stream",
+            params("expr", "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
     solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
     final List<Tuple> tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
@@ -706,7 +669,7 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
               + ", q=\"foo_i:[* TO 10]\", rows=100, fl=\"id,foo_i,_version_\", sort=\"foo_i desc\"))";
 
       final SolrStream solrStream =
-          new SolrStream(solrUrl + "/" + COLLECTION_X, params("qt", "/stream", "expr", expr));
+          new SolrStream(solrUrl + "/" + COLLECTION_X, "/stream", params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
@@ -729,11 +692,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     final SolrStream solrStream =
         new SolrStream(
             solrUrl + "/" + COLLECTION_X,
-            params(
-                "qt",
-                "/stream",
-                "expr",
-                "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
+            "/stream",
+            params("expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
     // "WRITE" credentials should be required for 'update(...)'
     solrStream.setCredentials(WRITE_X_USER, "BOGUS_PASSWORD");
 
@@ -762,11 +722,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl + "/" + COLLECTION_X,
-              params(
-                  "qt",
-                  "/stream",
-                  "expr",
-                  "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
+              "/stream",
+              params("expr", "update(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
 
       solrStream.setCredentials(user, passwordFor(user));
 
@@ -806,11 +763,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl + "/" + COLLECTION_Y,
-              params(
-                  "qt",
-                  "/stream",
-                  "expr",
-                  "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42z))"));
+              "/stream",
+              params("expr", "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42z))"));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -833,8 +787,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_Y, // NOTE: Y route
-              params("qt", "/stream", "expr", expr));
+              solrUrl + "/" + COLLECTION_Y,
+              "/stream", // NOTE: Y route
+              params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -857,8 +812,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_X, // NOTE: X route
-              params("qt", "/stream", "expr", expr));
+              solrUrl + "/" + COLLECTION_X,
+              "/stream", // NOTE: X route
+              params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(3, tuples.size());
@@ -893,11 +849,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final SolrStream solrStream =
           new SolrStream(
               solrUrl + "/" + path,
-              params(
-                  "qt",
-                  "/stream",
-                  "expr",
-                  "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
+              "/stream",
+              params("expr", "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42))"));
       solrStream.setCredentials(WRITE_Y_USER, passwordFor(WRITE_Y_USER));
 
       // NOTE: Can't make any assertions about Exception: SOLR-14226

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/MathExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/MathExpressionTest.java
@@ -104,10 +104,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
               + ", q=\"*:*\", fl=\"id, test_t\", sort=\"id desc\"), analyze(test_t, test_t) as test_t)";
       ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
-      String url =
-          cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+      String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-      SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+      SolrStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
       StreamContext context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -138,7 +137,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
 
-      solrStream = new SolrStream(url, "/stream", paramsLoc);
+      solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
       context = new StreamContext();
       solrStream.setStreamContext(context);
       tuples = getTuples(solrStream);
@@ -155,7 +154,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
 
-      solrStream = new SolrStream(url, "/stream", paramsLoc);
+      solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
       context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -190,7 +189,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
 
-      solrStream = new SolrStream(url, "/stream", paramsLoc);
+      solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
       context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -205,7 +204,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
 
-      solrStream = new SolrStream(url, "/stream", paramsLoc);
+      solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
       context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -229,9 +228,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -250,9 +248,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -271,9 +268,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -292,9 +288,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -314,9 +309,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -341,9 +335,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -368,9 +361,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -396,9 +388,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -454,9 +445,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -501,9 +491,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -530,9 +519,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -550,7 +538,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
     assertEquals(5, tuples.size());
@@ -580,9 +568,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -653,9 +640,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -691,9 +677,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -754,9 +739,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -813,9 +797,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -835,9 +818,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -877,9 +859,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1030,9 +1011,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1091,9 +1071,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1166,9 +1145,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1196,9 +1174,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1212,7 +1189,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1226,7 +1203,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1240,7 +1217,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1259,9 +1236,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1288,9 +1264,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "binomialCoefficient(8,3)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1306,9 +1281,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1368,9 +1342,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1399,9 +1372,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "array(1, 2, 3, 300, 2, 500)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1418,7 +1390,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "array(1.122, 2.222, 3.333, 300.1, 2.13, 500.23)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
@@ -1440,9 +1412,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               c=pairSort(a, b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1470,9 +1441,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ones(6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1493,9 +1463,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "natural(6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1516,9 +1485,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "repeat(6.5, 6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1539,9 +1507,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ltrim(array(1,2,3,4,5,6), 2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1560,9 +1527,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "rtrim(array(1,2,3,4,5,6), 2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1581,9 +1547,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "zeros(6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1616,9 +1581,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               i=indexOf(d, \"col3\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1677,15 +1641,14 @@ public class MathExpressionTest extends SolrCloudTestCase {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void testZplot() throws Exception {
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
     String cexpr =
         "let(a=array(1,2,3,4)," + "        b=array(10,11,12,13)," + "        zplot(x=a, y=b))";
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1714,7 +1677,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1743,7 +1706,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1769,7 +1732,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
       cexpr = "zplot(dist=normalDistribution(100, 10))";
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", cexpr);
-      solrStream = new SolrStream(url, "/stream", paramsLoc);
+      solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
       context = new StreamContext();
       solrStream.setStreamContext(context);
       tuples = getTuples(solrStream);
@@ -1797,7 +1760,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1823,7 +1786,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1871,7 +1834,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1921,7 +1884,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1982,9 +1945,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2082,9 +2044,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=matrix(array(1,2,3), array(4,5,6)), b=transpose(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2114,9 +2075,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=unitize(matrix(array(1,2,3), array(4,5,6))), b=unitize(array(4,5,6)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2153,9 +2113,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "c=normalizeSum(array(1,2,3), 100))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2196,9 +2155,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=standardize(matrix(array(1,2,3), array(4,5,6))), b=standardize(array(4,5,6)),  c=zscores(array(4,5,6)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2244,9 +2202,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    f=freqTable(s))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2265,9 +2222,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "addAll(array(1, 2, 3), array(4.5, 5.5, 6.5), array(7,8,9))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2291,9 +2247,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=normalDistribution(500, 20), " + "b=probability(a, 520, 530))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2316,8 +2271,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "tuple(sample=b, ks=ks(a,b), ks2=ks(a, d), ks3=ks(u, t)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     try {
       sampleTest(paramsLoc, url);
     } catch (AssertionError e) {
@@ -2336,7 +2290,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
   }
 
   private void sampleTest(ModifiableSolrParams paramsLoc, String url) throws IOException {
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2366,9 +2320,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "sumDifference(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2382,9 +2335,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "meanDifference(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2402,9 +2354,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "                  recNum() as recNum)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2426,9 +2377,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "having(list(tuple(a=\"Hello World\"), tuple(a=\"Good bye\")), matches(a, \"Hello\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2440,8 +2390,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "having(list(tuple(a=\"Hello World\"), tuple(a=\"Good bye\")), matches(a, \"(?i)good\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2455,9 +2405,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "having(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), notNull(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2471,9 +2420,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "having(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), isNull(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2488,9 +2436,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "select(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), if(notNull(a),a, 0) as out)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2508,9 +2455,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "select(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), if(isNull(a), 0, a) as out)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2527,9 +2473,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true, a=1.88888, b=8888888888.98)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2544,9 +2489,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true, a=array(10, 20, 30), b=log10(a), c=log10(30.5))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2568,9 +2512,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true, a=array(10, 20, 30), b=recip(a), c=recip(30.5))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2594,9 +2537,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=array(10, 20, 30), b=pow(a, 2), c=pow(2, a), d=pow(10, 3), e=pow(a, array(1, 2, 3)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2640,9 +2582,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               e=getAttribute(b, \"docFreqs\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2720,7 +2661,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    e=getAttribute(b, \"docFreqs\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2792,7 +2733,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2863,7 +2804,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    e=getAttribute(b, \"docFreqs\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2917,7 +2858,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    e=getAttribute(b, \"docFreqs\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2941,9 +2882,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               d=getColumnLabels(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2989,9 +2929,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               h=ebeSubtract(f, g))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3044,9 +2983,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               i=matrixMult(b, a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3124,9 +3062,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               k=getRowLabels(h))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3203,9 +3140,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               zplot(clusters=f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3236,9 +3172,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               zplot(clusters=f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3269,9 +3204,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               zplot(clusters=f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3296,9 +3230,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               k=getRowLabels(h))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3384,9 +3317,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               l=getMembershipMatrix(f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3482,9 +3414,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ebeMultiply(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3515,9 +3446,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               i=derivative(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3563,9 +3493,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               h=ebeAdd(f, g))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3614,9 +3543,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               f=getValue(e, \"blah\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3638,9 +3566,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ebeDivide(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3661,9 +3588,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "freqTable(array(2,4,6,8,10,12,12,4,8,8,8,2))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3701,9 +3627,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               b=ifft(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3760,9 +3685,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "cosineSimilarity(array(2,4,6,8),array(1,1,3,4))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3779,9 +3703,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "                by=\"sim desc\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3800,9 +3723,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3835,9 +3757,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3876,9 +3797,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3900,9 +3820,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3922,9 +3841,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=sample(zipFDistribution(10, 1), 50000), b=freqTable(a), c=col(b, count))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3956,9 +3874,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               e=valueAt(c, 1, 0))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3975,9 +3892,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=sample(betaDistribution(1, 5), 50000), b=hist(a, 11), c=col(b, N))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3997,7 +3913,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "let(a=sample(betaDistribution(5, 1), 50000), b=hist(a, 11), c=col(b, N))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4027,9 +3943,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4050,8 +3965,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4069,9 +3984,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "dotProduct(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4085,9 +3999,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true,a=var(array(1,2,3,4,5)),b=stddev(array(2,2,2,2)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4116,14 +4029,14 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String url = null;
     for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
       if (jetty.getNodeName().equals(node)) {
-        url = jetty.getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+        url = jetty.getBaseUrl().toString();
         break;
       }
     }
     if (url == null) {
       fail("unable to find a node with replica");
     }
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4134,7 +4047,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "getCache(\"space1\", \"key1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4145,7 +4058,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "listCache(\"space1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4157,7 +4070,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "listCache()";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4169,7 +4082,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "removeCache(\"space1\", \"key1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4180,7 +4093,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "listCache(\"space1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4198,9 +4111,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4241,9 +4153,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               d=getColumnLabels(c))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4275,9 +4186,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "diff(array(1709.0, 1621.0, 1973.0, 1812.0, 1975.0, 1862.0, 1940.0, 2013.0, 1596.0, 1725.0, 1676.0, 1814.0, 1615.0, 1557.0, 1891.0, 1956.0, 1885.0, 1623.0, 1903.0, 1997.0))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4312,9 +4222,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "diff(array(1709.0, 1621.0, 1973.0, 1812.0, 1975.0, 1862.0, 1940.0, 2013.0, 1596.0, 1725.0, 1676.0, 1814.0, 1615.0, 1557.0, 1891.0, 1956.0, 1885.0, 1623.0, 1903.0, 1997.0), 12)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4338,9 +4247,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "diff(diff(array(1709.0, 1621.0, 1973.0, 1812.0, 1975.0, 1862.0, 1940.0, 2013.0, 1596.0, 1725.0, 1676.0, 1814.0, 1615.0, 1557.0, 1891.0, 1956.0, 1885.0, 1623.0, 1903.0, 1997.0)), 12)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4367,9 +4275,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               predictions=predict(fit, a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4409,9 +4316,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "pairedttest=pairedTtest(a,b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4448,9 +4354,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4473,9 +4378,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4505,9 +4409,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4558,9 +4461,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               g=getAttributes(f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4618,9 +4520,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "f=integral(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4647,9 +4548,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4690,9 +4590,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4743,9 +4642,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4774,9 +4672,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4818,9 +4715,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4872,9 +4768,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4910,9 +4805,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4930,9 +4824,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "anova(array(1,2,3,5,4,6), array(5,2,3,5,4,6), array(1,2,7,5,4,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4954,9 +4847,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, e))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5004,9 +4896,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, e))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5035,8 +4926,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, array(8, 5, 4)))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5056,8 +4947,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, array(8, 5, 4)))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5070,8 +4961,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "let(echo=true, a=sequence(10, 0, 1), " + "c=knnRegress(a, a, 3)," + "d=predict(c, 3))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5085,8 +4976,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "d=predict(c, array(3,4)))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5104,9 +4995,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5124,9 +5014,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5154,9 +5043,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5177,9 +5065,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5202,9 +5089,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5244,9 +5130,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=array(3,2,3), plot(type=scatter, x=a, y=array(5,6,3)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5272,9 +5157,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "movingAvg(array(1,2,3,4,5,6,7), 4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5293,9 +5177,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "movingMAD(array(1,2,3,4,5,6,9.25), 4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5317,9 +5200,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "array(0.10,0.20,0.30,0.10,0.10,0.02,0.05,0.07))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5334,9 +5216,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "movingMedian(array(1,2,6,9,10,12,15), 5)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5354,9 +5235,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "sumSq(array(-3,-2.5, 10))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5371,9 +5251,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(a=constantDistribution(10), b=constantDistribution(20), c=monteCarlo(add(sample(a), sample(b)), 10))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5404,9 +5283,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "                    10))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5440,9 +5318,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5488,9 +5365,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5517,9 +5393,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5554,9 +5429,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5584,9 +5458,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(a=array(1,2,3), b=array(2,4,6), c=array(4, 8, 12), d=transpose(matrix(a, b, c)), f=cov(d))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5630,9 +5503,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               k=getColumnLabels(f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5736,9 +5608,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=precision(array(1.44445, 1, 2.00006), 4), b=precision(1.44445, 4))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5761,9 +5632,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(a=matrix(array(1.3333999, 2.4444445), array(2.333333, 10.10009)), b=precision(a, 4))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5793,9 +5663,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "d=minMaxScale(array(1,2,3,4,5), 0, 100))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5851,9 +5720,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "mean(array(1,2,3,4,5))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5874,9 +5742,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               f=add(abs(a)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5939,9 +5806,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6010,9 +5876,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6070,9 +5935,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6146,9 +6010,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6177,7 +6040,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6206,7 +6069,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6240,9 +6103,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6310,9 +6172,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6346,9 +6207,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6364,7 +6224,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6382,7 +6242,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + ", q=\"*:*\", partitionKeys=miles_i, sort=\"miles_i asc\", fl=\"miles_i\", qt=\"/export\"), convert(miles, kilometers, miles_i) as kilometers))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6398,7 +6258,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + ", q=\"*:*\", sum(miles_i)), convert(miles, kilometers, sum(miles_i)) as kilometers)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/MathExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/MathExpressionTest.java
@@ -104,11 +104,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
               + ", q=\"*:*\", fl=\"id, test_t\", sort=\"id desc\"), analyze(test_t, test_t) as test_t)";
       ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
-      paramsLoc.set("qt", "/stream");
       String url =
           cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
 
-      SolrStream solrStream = new SolrStream(url, paramsLoc);
+      SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
       StreamContext context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -138,9 +137,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
       expr = "analyze(\"hello world\", test_t)";
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
-      paramsLoc.set("qt", "/stream");
 
-      solrStream = new SolrStream(url, paramsLoc);
+      solrStream = new SolrStream(url, "/stream", paramsLoc);
       context = new StreamContext();
       solrStream.setStreamContext(context);
       tuples = getTuples(solrStream);
@@ -156,9 +154,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
               + ", q=\"*:*\", fl=\"id, test_t\", sort=\"id desc\"), analyze(test_t) as test_t)";
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
-      paramsLoc.set("qt", "/stream");
 
-      solrStream = new SolrStream(url, paramsLoc);
+      solrStream = new SolrStream(url, "/stream", paramsLoc);
 
       context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -192,9 +189,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
               + ", q=\"*:*\", fl=\"id\", sort=\"id desc\"), analyze(test_t, test_t) as test_t)";
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
-      paramsLoc.set("qt", "/stream");
 
-      solrStream = new SolrStream(url, paramsLoc);
+      solrStream = new SolrStream(url, "/stream", paramsLoc);
 
       context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -208,9 +204,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
               + ", q=\"*:*\", fl=\"id, test_t\", sort=\"id desc\"), analyze(test_t, test_t) as test1_t)";
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", expr);
-      paramsLoc.set("qt", "/stream");
 
-      solrStream = new SolrStream(url, paramsLoc);
+      solrStream = new SolrStream(url, "/stream", paramsLoc);
 
       context = new StreamContext();
       solrStream.setStreamContext(context);
@@ -233,11 +228,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         " select(list(tuple(field1=\"a\", field2=\"b\"), tuple(field1=\"c\", field2=\"d\")), concat(field1, field2, \"hello\", delim=\"-\") as field3)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -255,11 +249,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         " select(list(tuple(field1=\"abcde\", field2=\"012345\")), trunc(field1, 2) as field3, trunc(field2, 4) as field4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -277,11 +270,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         " select(list(tuple(field1=\"a\", field2=\"C\")), upper(field1) as field3, lower(field2) as field4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -299,11 +291,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         " select(list(tuple(field1=array(\"aaaa\",\"bbbb\",\"cccc\"))), trunc(field1, 3) as field2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -322,11 +313,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         " select(list(tuple(field1=array(\"a\",\"b\",\"c\"), field2=array(\"X\",\"Y\",\"Z\"))), upper(field1) as field3, lower(field2) as field4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -350,11 +340,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String expr = " select(list(tuple(field1=\"a, b, c\")), trim(split(field1, \",\")) as field2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -378,11 +367,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "              c=add(f2))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -407,11 +395,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "              c=add(f2))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -466,11 +453,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -514,11 +500,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -544,11 +529,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String expr = "hist(sequence(100, 0, 1), 10)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -565,9 +549,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     expr = "hist(sequence(100, 0, 1), 5)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
     assertEquals(5, tuples.size());
@@ -596,11 +579,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "              i=projectToBorder(d, matrix(array(99.11076410926444, 109.5441846957560))))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -670,11 +652,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "              g=getSupportPoints(d))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -709,11 +690,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String expr = "cumulativeProbability(normalDistribution(500, 40), 500)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -773,11 +753,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -833,11 +812,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -857,10 +835,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -900,10 +877,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1053,11 +1029,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1115,11 +1090,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1191,11 +1165,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1222,11 +1195,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "percentile(array(1,2,3,4,5,6,7,8,9,10,11), 50)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1239,9 +1211,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "percentile(array(11,10,3,4,5,6,7,8,9,2,1), 50)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1254,9 +1225,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "percentile(array(11,10,3,4,5,6,7,8,9,2,1), 20)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1269,9 +1239,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "percentile(array(11,10,3,4,5,6,7,8,9,2,1), array(20, 50))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1289,11 +1258,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "primes(10, 0)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1320,10 +1288,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "binomialCoefficient(8,3)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1338,11 +1305,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "asc(array(11.5, 12.3, 4, 3, 1, 0))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1401,11 +1367,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1434,10 +1399,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "array(1, 2, 3, 300, 2, 500)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1454,8 +1418,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "array(1.122, 2.222, 3.333, 300.1, 2.13, 500.23)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
     assertEquals(1, tuples.size());
@@ -1477,10 +1440,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               c=pairSort(a, b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1508,10 +1470,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ones(6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1532,10 +1493,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "natural(6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1556,10 +1516,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "repeat(6.5, 6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1580,10 +1539,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ltrim(array(1,2,3,4,5,6), 2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1602,10 +1560,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "rtrim(array(1,2,3,4,5,6), 2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1624,10 +1581,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "zeros(6)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1660,10 +1616,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               i=indexOf(d, \"col3\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1730,8 +1685,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -1760,8 +1714,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1790,8 +1743,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1817,8 +1769,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
       cexpr = "zplot(dist=normalDistribution(100, 10))";
       paramsLoc = new ModifiableSolrParams();
       paramsLoc.set("expr", cexpr);
-      paramsLoc.set("qt", "/stream");
-      solrStream = new SolrStream(url, paramsLoc);
+      solrStream = new SolrStream(url, "/stream", paramsLoc);
       context = new StreamContext();
       solrStream.setStreamContext(context);
       tuples = getTuples(solrStream);
@@ -1846,8 +1797,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1873,8 +1823,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1922,8 +1871,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -1973,8 +1921,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2035,10 +1982,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2136,10 +2082,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=matrix(array(1,2,3), array(4,5,6)), b=transpose(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2169,10 +2114,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=unitize(matrix(array(1,2,3), array(4,5,6))), b=unitize(array(4,5,6)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2209,10 +2153,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "c=normalizeSum(array(1,2,3), 100))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2253,10 +2196,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=standardize(matrix(array(1,2,3), array(4,5,6))), b=standardize(array(4,5,6)),  c=zscores(array(4,5,6)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2302,10 +2244,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    f=freqTable(s))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2324,10 +2265,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "addAll(array(1, 2, 3), array(4.5, 5.5, 6.5), array(7,8,9))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2351,10 +2291,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=normalDistribution(500, 20), " + "b=probability(a, 520, 530))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2377,7 +2316,6 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "tuple(sample=b, ks=ks(a,b), ks2=ks(a, d), ks3=ks(u, t)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
     try {
@@ -2398,7 +2336,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
   }
 
   private void sampleTest(ModifiableSolrParams paramsLoc, String url) throws IOException {
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2428,10 +2366,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "sumDifference(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2445,10 +2382,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "meanDifference(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2466,10 +2402,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "                  recNum() as recNum)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2491,10 +2426,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "having(list(tuple(a=\"Hello World\"), tuple(a=\"Good bye\")), matches(a, \"Hello\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2506,9 +2440,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "having(list(tuple(a=\"Hello World\"), tuple(a=\"Good bye\")), matches(a, \"(?i)good\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2522,10 +2455,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "having(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), notNull(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2539,10 +2471,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "having(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), isNull(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2557,10 +2488,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "select(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), if(notNull(a),a, 0) as out)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2578,10 +2508,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "select(list(tuple(a=add(1, 1)), tuple(b=add(1, 2))), if(isNull(a), 0, a) as out)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2598,10 +2527,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true, a=1.88888, b=8888888888.98)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2616,10 +2544,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true, a=array(10, 20, 30), b=log10(a), c=log10(30.5))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2641,10 +2568,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true, a=array(10, 20, 30), b=recip(a), c=recip(30.5))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2668,10 +2594,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=array(10, 20, 30), b=pow(a, 2), c=pow(2, a), d=pow(10, 3), e=pow(a, array(1, 2, 3)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2715,10 +2640,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               e=getAttribute(b, \"docFreqs\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -2796,8 +2720,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    e=getAttribute(b, \"docFreqs\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2869,8 +2792,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2941,8 +2863,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    e=getAttribute(b, \"docFreqs\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2996,8 +2917,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "    e=getAttribute(b, \"docFreqs\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3021,10 +2941,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               d=getColumnLabels(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3070,10 +2989,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               h=ebeSubtract(f, g))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3126,10 +3044,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               i=matrixMult(b, a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3207,10 +3124,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               k=getRowLabels(h))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3287,10 +3203,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               zplot(clusters=f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3321,10 +3236,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               zplot(clusters=f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3355,10 +3269,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               zplot(clusters=f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3383,10 +3296,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               k=getRowLabels(h))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3472,10 +3384,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               l=getMembershipMatrix(f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3571,10 +3482,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ebeMultiply(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3605,10 +3515,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               i=derivative(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3654,10 +3563,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               h=ebeAdd(f, g))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3706,10 +3614,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               f=getValue(e, \"blah\"))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3731,10 +3638,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "ebeDivide(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3755,10 +3661,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "freqTable(array(2,4,6,8,10,12,12,4,8,8,8,2))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3796,10 +3701,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               b=ifft(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3856,10 +3760,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "cosineSimilarity(array(2,4,6,8),array(1,1,3,4))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3876,10 +3779,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "                by=\"sim desc\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3898,10 +3800,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3934,10 +3835,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -3976,10 +3876,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4001,10 +3900,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4024,10 +3922,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=sample(zipFDistribution(10, 1), 50000), b=freqTable(a), c=col(b, count))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4059,10 +3956,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               e=valueAt(c, 1, 0))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4079,10 +3975,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=sample(betaDistribution(1, 5), 50000), b=hist(a, 11), c=col(b, N))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4102,8 +3997,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "let(a=sample(betaDistribution(5, 1), 50000), b=hist(a, 11), c=col(b, N))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4133,10 +4027,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4157,9 +4050,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4177,10 +4069,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "dotProduct(array(2,4,6,8,10,12),array(1,2,3,4,5,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4194,10 +4085,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(echo=true,a=var(array(1,2,3,4,5)),b=stddev(array(2,2,2,2)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4218,7 +4108,6 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "putCache(\"space1\", \"key1\", dotProduct(array(2,4,6,8,10,12),array(1,2,3,4,5,6)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     // find a node with a replica
     ClusterState clusterState = cluster.getSolrClient().getClusterState();
     String collection = useAlias ? COLLECTIONORALIAS + "_collection" : COLLECTIONORALIAS;
@@ -4234,7 +4123,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     if (url == null) {
       fail("unable to find a node with replica");
     }
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4245,8 +4134,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "getCache(\"space1\", \"key1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4257,8 +4145,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "listCache(\"space1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4270,8 +4157,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "listCache()";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4283,8 +4169,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "removeCache(\"space1\", \"key1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4295,8 +4180,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "listCache(\"space1\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -4314,10 +4198,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4358,10 +4241,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               d=getColumnLabels(c))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4393,10 +4275,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "diff(array(1709.0, 1621.0, 1973.0, 1812.0, 1975.0, 1862.0, 1940.0, 2013.0, 1596.0, 1725.0, 1676.0, 1814.0, 1615.0, 1557.0, 1891.0, 1956.0, 1885.0, 1623.0, 1903.0, 1997.0))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4431,10 +4312,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "diff(array(1709.0, 1621.0, 1973.0, 1812.0, 1975.0, 1862.0, 1940.0, 2013.0, 1596.0, 1725.0, 1676.0, 1814.0, 1615.0, 1557.0, 1891.0, 1956.0, 1885.0, 1623.0, 1903.0, 1997.0), 12)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4458,10 +4338,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "diff(diff(array(1709.0, 1621.0, 1973.0, 1812.0, 1975.0, 1862.0, 1940.0, 2013.0, 1596.0, 1725.0, 1676.0, 1814.0, 1615.0, 1557.0, 1891.0, 1956.0, 1885.0, 1623.0, 1903.0, 1997.0)), 12)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4488,10 +4367,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               predictions=predict(fit, a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4531,10 +4409,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "pairedttest=pairedTtest(a,b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4571,10 +4448,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4597,10 +4473,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4630,10 +4505,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4684,10 +4558,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               g=getAttributes(f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4745,10 +4618,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "f=integral(b))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4775,10 +4647,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4819,10 +4690,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4873,10 +4743,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4905,10 +4774,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -4950,10 +4818,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5005,10 +4872,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5044,10 +4910,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5065,10 +4930,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "anova(array(1,2,3,5,4,6), array(5,2,3,5,4,6), array(1,2,7,5,4,6))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5090,10 +4954,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, e))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5141,10 +5004,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, e))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5173,9 +5035,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, array(8, 5, 4)))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5195,9 +5056,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "g=predict(f, array(8, 5, 4)))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5210,9 +5070,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
     cexpr = "let(echo=true, a=sequence(10, 0, 1), " + "c=knnRegress(a, a, 3)," + "d=predict(c, 3))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5226,9 +5085,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "d=predict(c, array(3,4)))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -5245,11 +5103,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "select(list(tuple(a=20001011:10:11:01), tuple(a=20071011:14:30:20)), dateTime(a, \"yyyyMMdd:kk:mm:ss\") as date)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5266,11 +5123,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "select(list(tuple(a=20001011), tuple(a=20071011)), dateTime(a, \"yyyyMMdd\", \"UTC\") as date, dateTime(a, \"yyyyMMdd\", \"EST\") as date1, dateTime(a, \"yyyyMMdd\") as date2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5297,11 +5153,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String expr = "select(tuple(d=\"1.1\", l=\"5000\"), double(d) as d, long(l) as l)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5321,11 +5176,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "              tuple(doubles=double(b)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -5348,10 +5202,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5391,10 +5244,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "let(a=array(3,2,3), plot(type=scatter, x=a, y=array(5,6,3)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5420,10 +5272,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "movingAvg(array(1,2,3,4,5,6,7), 4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5442,10 +5293,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "movingMAD(array(1,2,3,4,5,6,9.25), 4)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5467,10 +5317,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "array(0.10,0.20,0.30,0.10,0.10,0.02,0.05,0.07))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5485,10 +5334,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "movingMedian(array(1,2,6,9,10,12,15), 5)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5506,10 +5354,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "sumSq(array(-3,-2.5, 10))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5524,10 +5371,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(a=constantDistribution(10), b=constantDistribution(20), c=monteCarlo(add(sample(a), sample(b)), 10))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5558,10 +5404,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "                    10))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5595,10 +5440,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5644,10 +5488,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5674,10 +5517,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5712,10 +5554,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5743,10 +5584,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(a=array(1,2,3), b=array(2,4,6), c=array(4, 8, 12), d=transpose(matrix(a, b, c)), f=cov(d))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5790,10 +5630,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               k=getColumnLabels(f))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5897,10 +5736,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(echo=true, a=precision(array(1.44445, 1, 2.00006), 4), b=precision(1.44445, 4))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5923,10 +5761,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
         "let(a=matrix(array(1.3333999, 2.4444445), array(2.333333, 10.10009)), b=precision(a, 4))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -5956,10 +5793,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "d=minMaxScale(array(1,2,3,4,5), 0, 100))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -6015,10 +5851,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String cexpr = "mean(array(1,2,3,4,5))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -6039,10 +5874,9 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + "               f=add(abs(a)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
     List<Tuple> tuples = getTuples(solrStream);
@@ -6104,11 +5938,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6176,11 +6009,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6237,11 +6069,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6314,11 +6145,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6346,9 +6176,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6376,9 +6205,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6411,11 +6239,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6482,11 +6309,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cexpr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6519,11 +6345,10 @@ public class MathExpressionTest extends SolrCloudTestCase {
     String expr = "select(calc(), convert(miles, kilometers, 10) as kilometers)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -6538,9 +6363,8 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + ", q=\"*:*\", sort=\"miles_i asc\", fl=\"miles_i\"), convert(miles, kilometers, miles_i) as kilometers)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6558,8 +6382,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + ", q=\"*:*\", partitionKeys=miles_i, sort=\"miles_i asc\", fl=\"miles_i\", qt=\"/export\"), convert(miles, kilometers, miles_i) as kilometers))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -6575,8 +6398,7 @@ public class MathExpressionTest extends SolrCloudTestCase {
             + ", q=\"*:*\", sum(miles_i)), convert(miles, kilometers, sum(miles_i)) as kilometers)";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
     context = new StreamContext();
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -3863,9 +3863,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3895,9 +3894,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4423,7 +4421,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     String url = null;
     for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
       if (jetty.getNodeName().equals(node)) {
-        url = jetty.getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+        url = jetty.getBaseUrl().toString();
         break;
       }
     }
@@ -4473,7 +4471,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    SolrStream classifyStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream classifyStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     Map<String, Double> idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(1.0, idToLabel.get("0"), 0.001);
@@ -4485,7 +4483,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     updateRequest.add(id, String.valueOf(3), "text_s", "a b e e f");
     updateRequest.commit(cluster.getSolrClient(), "uknownCollection");
 
-    classifyStream = new SolrStream(url, "/stream", paramsLoc);
+    classifyStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(1.0, idToLabel.get("2"), 0.001);
@@ -4514,7 +4512,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     updateRequest.add(id, String.valueOf(5), "text_s", "a b e e f");
     updateRequest.commit(cluster.getSolrClient(), "uknownCollection");
 
-    classifyStream = new SolrStream(url, "/stream", paramsLoc);
+    classifyStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(0, idToLabel.get("4"), 0.001);
@@ -4532,7 +4530,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
             + "analyzerField=\"tv_text\"))";
 
     paramsLoc.set("expr", expr);
-    classifyStream = new SolrStream(url, "/stream", paramsLoc);
+    classifyStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(0, idToLabel.get("4"), 0.001);
@@ -4561,9 +4559,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4599,9 +4596,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4625,9 +4621,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4665,7 +4660,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     workRequest.commit(cluster.getSolrClient(), "workQueue");
     dataRequest.commit(cluster.getSolrClient(), "mainCorpus");
 
-    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/destination";
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     TupleStream executorStream;
     ModifiableSolrParams paramsLoc;
 
@@ -4694,7 +4689,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         "expr",
         "search(destination, q=\"*:*\", fl=\"id, body_t, field_i\", rows=1000, sort=\"field_i asc\")");
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "destination", "/stream", paramsLoc);
     List<Tuple> tuples = getTuples(solrStream);
     assertEquals(500, tuples.size());
     for (int i = 0; i < 500; i++) {
@@ -4746,7 +4741,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     workRequest.commit(cluster.getSolrClient(), "workQueue1");
     dataRequest.commit(cluster.getSolrClient(), "mainCorpus1");
 
-    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/destination1";
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     TupleStream executorStream;
     ModifiableSolrParams paramsLoc;
 
@@ -4776,7 +4771,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         "expr",
         "search(destination1, q=\"*:*\", fl=\"id, body_t, field_i\", rows=1000, sort=\"field_i asc\")");
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "destination1", "/stream", paramsLoc);
     List<Tuple> tuples = getTuples(solrStream);
     assertEquals(tuples.size(), cnt);
     for (int i = 0; i < cnt; i++) {
@@ -5104,8 +5099,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
   }
 
   public void testDeleteStream() throws Exception {
-    final String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+    final String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
     final SolrClient client = cluster.getSolrClient();
 
     {
@@ -5140,7 +5134,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + COLLECTIONORALIAS
               + ",batchSize=10,   "
               + "              tuple(id=doc_2)))                     ";
-      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
+      final SolrStream stream =
+          new SolrStream(url, COLLECTIONORALIAS, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());
@@ -5168,7 +5163,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + "               tuple(id=doc_17),                         "
               + "               tuple(id=doc_15),                         "
               + "              ) ) )                                      ";
-      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
+      final SolrStream stream =
+          new SolrStream(url, COLLECTIONORALIAS, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(3, tuples.size());
@@ -5207,7 +5203,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + v13_ok
               + "),      "
               + "              ) ) )                                        ";
-      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
+      final SolrStream stream =
+          new SolrStream(url, COLLECTIONORALIAS, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());
@@ -5245,7 +5242,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + v10_bad
               + "),     "
               + "              ) ) )                                        ";
-      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
+      final SolrStream stream =
+          new SolrStream(url, COLLECTIONORALIAS, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());
@@ -5277,7 +5275,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + "                     q=\"deletable_s:yup\",                    "
               + "                     sort=\"id asc\",fl=\"id,_version_\"       "
               + "              ) ) )                                            ";
-      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
+      final SolrStream stream =
+          new SolrStream(url, COLLECTIONORALIAS, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -64,7 +64,6 @@ import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.junit.Assume;
@@ -3575,8 +3574,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
 
       // Lets sleep long enough for daemon updates to run.
       // Lets stop the daemons
-      ModifiableSolrParams sParams =
-          new ModifiableSolrParams(params(CommonParams.QT, "/stream", "action", "list"));
+      ModifiableSolrParams sParams = new ModifiableSolrParams(params("action", "list"));
 
       int workersComplete = 0;
       for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
@@ -3584,7 +3582,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (iterations == 0) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -3614,11 +3612,11 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
 
       // Lets stop the daemons
       sParams = new ModifiableSolrParams();
-      sParams.set(CommonParams.QT, "/stream");
       sParams.set("action", "stop");
       sParams.set("id", "test");
       for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
-        SolrStream solrStream = new SolrStream(jetty.getBaseUrl() + "/collection1", sParams);
+        SolrStream solrStream =
+            new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
         solrStream.setStreamContext(streamContext);
         solrStream.open();
         Tuple tupleResponse = solrStream.read();
@@ -3626,7 +3624,6 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       }
 
       sParams = new ModifiableSolrParams();
-      sParams.set(CommonParams.QT, "/stream");
       sParams.set("action", "list");
 
       workersComplete = 0;
@@ -3634,7 +3631,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         long stopTime = 0;
         INNER:
         while (stopTime == 0) {
-          SolrStream solrStream = new SolrStream(jetty.getBaseUrl() + "/collection1", sParams);
+          SolrStream solrStream =
+              new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -3770,8 +3768,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       List<Tuple> tuples = getTuples(parallelUpdateStream);
       assertEquals(2, tuples.size());
 
-      ModifiableSolrParams sParams =
-          new ModifiableSolrParams(params(CommonParams.QT, "/stream", "action", "list"));
+      ModifiableSolrParams sParams = new ModifiableSolrParams(params("action", "list"));
 
       int workersComplete = 0;
 
@@ -3781,7 +3778,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (true) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -3865,11 +3862,10 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
             + "                        tuple(file=\"file2\", line=\"8,9,\")))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3898,11 +3894,10 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
             + "                        tuple(file=\"file2\", line=\"8\t\t9\")))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4213,8 +4208,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
 
       // Lets sleep long enough for daemon updates to run.
       // Lets stop the daemons
-      ModifiableSolrParams sParams =
-          new ModifiableSolrParams(params(CommonParams.QT, "/stream", "action", "list"));
+      ModifiableSolrParams sParams = new ModifiableSolrParams(params("action", "list"));
 
       int workersComplete = 0;
       for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
@@ -4222,7 +4216,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (iterations == 0) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -4249,11 +4243,11 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
 
       // Lets stop the daemons
       sParams = new ModifiableSolrParams();
-      sParams.set(CommonParams.QT, "/stream");
       sParams.set("action", "stop");
       sParams.set("id", "test");
       for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
-        SolrStream solrStream = new SolrStream(jetty.getBaseUrl() + "/collection1", sParams);
+        SolrStream solrStream =
+            new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
         solrStream.setStreamContext(streamContext);
         solrStream.open();
         Tuple tupleResponse = solrStream.read();
@@ -4261,7 +4255,6 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       }
 
       sParams = new ModifiableSolrParams();
-      sParams.set(CommonParams.QT, "/stream");
       sParams.set("action", "list");
 
       workersComplete = 0;
@@ -4269,7 +4262,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         long stopTime = 0;
         INNER:
         while (stopTime == 0) {
-          SolrStream solrStream = new SolrStream(jetty.getBaseUrl() + "/collection1", sParams);
+          SolrStream solrStream =
+              new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -4479,8 +4473,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
 
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
-    SolrStream classifyStream = new SolrStream(url, paramsLoc);
+    SolrStream classifyStream = new SolrStream(url, "/stream", paramsLoc);
     Map<String, Double> idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(1.0, idToLabel.get("0"), 0.001);
@@ -4492,7 +4485,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     updateRequest.add(id, String.valueOf(3), "text_s", "a b e e f");
     updateRequest.commit(cluster.getSolrClient(), "uknownCollection");
 
-    classifyStream = new SolrStream(url, paramsLoc);
+    classifyStream = new SolrStream(url, "/stream", paramsLoc);
     idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(1.0, idToLabel.get("2"), 0.001);
@@ -4521,7 +4514,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     updateRequest.add(id, String.valueOf(5), "text_s", "a b e e f");
     updateRequest.commit(cluster.getSolrClient(), "uknownCollection");
 
-    classifyStream = new SolrStream(url, paramsLoc);
+    classifyStream = new SolrStream(url, "/stream", paramsLoc);
     idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(0, idToLabel.get("4"), 0.001);
@@ -4539,7 +4532,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
             + "analyzerField=\"tv_text\"))";
 
     paramsLoc.set("expr", expr);
-    classifyStream = new SolrStream(url, paramsLoc);
+    classifyStream = new SolrStream(url, "/stream", paramsLoc);
     idToLabel = getIdToLabel(classifyStream, "probability_d");
     assertEquals(idToLabel.size(), 2);
     assertEquals(0, idToLabel.get("4"), 0.001);
@@ -4567,11 +4560,10 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
             + ", b = add(1,3), c=col(d, test_i), tuple(test = add(1,1), test1=b, results=d, test2=add(c)))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4606,11 +4598,10 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     String cat = "let(a =" + expr + ",get(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4633,11 +4624,10 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     String cat = "let(a =" + expr + ",stream(a))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4703,9 +4693,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     paramsLoc.set(
         "expr",
         "search(destination, q=\"*:*\", fl=\"id, body_t, field_i\", rows=1000, sort=\"field_i asc\")");
-    paramsLoc.set("qt", "/stream");
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     List<Tuple> tuples = getTuples(solrStream);
     assertEquals(500, tuples.size());
     for (int i = 0; i < 500; i++) {
@@ -4786,9 +4775,8 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     paramsLoc.set(
         "expr",
         "search(destination1, q=\"*:*\", fl=\"id, body_t, field_i\", rows=1000, sort=\"field_i asc\")");
-    paramsLoc.set("qt", "/stream");
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     List<Tuple> tuples = getTuples(solrStream);
     assertEquals(tuples.size(), cnt);
     for (int i = 0; i < cnt; i++) {
@@ -5152,7 +5140,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + COLLECTIONORALIAS
               + ",batchSize=10,   "
               + "              tuple(id=doc_2)))                     ";
-      final SolrStream stream = new SolrStream(url, params("qt", "/stream", "expr", expr));
+      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());
@@ -5180,7 +5168,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + "               tuple(id=doc_17),                         "
               + "               tuple(id=doc_15),                         "
               + "              ) ) )                                      ";
-      final SolrStream stream = new SolrStream(url, params("qt", "/stream", "expr", expr));
+      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(3, tuples.size());
@@ -5219,7 +5207,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + v13_ok
               + "),      "
               + "              ) ) )                                        ";
-      final SolrStream stream = new SolrStream(url, params("qt", "/stream", "expr", expr));
+      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());
@@ -5257,7 +5245,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + v10_bad
               + "),     "
               + "              ) ) )                                        ";
-      final SolrStream stream = new SolrStream(url, params("qt", "/stream", "expr", expr));
+      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());
@@ -5289,7 +5277,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
               + "                     q=\"deletable_s:yup\",                    "
               + "                     sort=\"id asc\",fl=\"id,_version_\"       "
               + "              ) ) )                                            ";
-      final SolrStream stream = new SolrStream(url, params("qt", "/stream", "expr", expr));
+      final SolrStream stream = new SolrStream(url, "/stream", params("expr", expr));
 
       final List<Tuple> tuples = getTuples(stream);
       assertEquals(1, tuples.size());

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -3582,7 +3582,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (iterations == 0) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+              new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -3616,7 +3616,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       sParams.set("id", "test");
       for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
         SolrStream solrStream =
-            new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
+            new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
         solrStream.setStreamContext(streamContext);
         solrStream.open();
         Tuple tupleResponse = solrStream.read();
@@ -3632,7 +3632,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (stopTime == 0) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
+              new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -3778,7 +3778,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (true) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+              new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -4216,7 +4216,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (iterations == 0) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+              new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();
@@ -4247,7 +4247,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
       sParams.set("id", "test");
       for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
         SolrStream solrStream =
-            new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
+            new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
         solrStream.setStreamContext(streamContext);
         solrStream.open();
         Tuple tupleResponse = solrStream.read();
@@ -4263,7 +4263,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
         INNER:
         while (stopTime == 0) {
           SolrStream solrStream =
-              new SolrStream(jetty.getBaseUrl() + "/collection1", "/stream", sParams);
+              new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
           solrStream.setStreamContext(streamContext);
           solrStream.open();
           Tuple tupleResponse = solrStream.read();

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
@@ -58,7 +58,6 @@ import org.apache.solr.client.solrj.io.stream.metrics.SumMetric;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
-import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.embedded.JettySolrRunner;
@@ -266,7 +265,6 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr", "search(myCollection, q=*:*, fl=\"id,a_s,a_i,a_f\", sort=\"a_f asc, a_i asc\")");
       solrParams.add("myCollection.shards", buf.toString());
@@ -310,9 +308,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add("expr", "sort(search(" + COLLECTIONORALIAS + "), by=\"a_i asc\")");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -370,11 +367,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr",
           "sql(" + COLLECTIONORALIAS + ", stmt=\"select id from collection1 order by a_i asc\")");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -382,9 +378,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       // Test with using the default collection
       solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add("expr", "sql(stmt=\"select id from collection1 order by a_i asc\")");
-      solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -515,7 +510,6 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       // Basic test
       ModifiableSolrParams sParams = new ModifiableSolrParams();
       sParams.set("expr", "merge(" + "${q1}," + "${q2}," + "on=${mySort})");
-      sParams.set(CommonParams.QT, "/stream");
       sParams.set(
           "q1",
           "search("
@@ -525,7 +519,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "q2",
           "search(" + COLLECTIONORALIAS + ", q=\"id:(1)\", fl=\"id,a_s,a_i,a_f\", sort=${mySort})");
       sParams.set("mySort", "a_f asc");
-      stream = new SolrStream(url, sParams);
+      stream = new SolrStream(url, "/stream", sParams);
       tuples = getTuples(stream);
 
       assertEquals(4, tuples.size());
@@ -533,7 +527,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       // Basic test desc
       sParams.set("mySort", "a_f desc");
-      stream = new SolrStream(url, sParams);
+      stream = new SolrStream(url, "/stream", sParams);
       tuples = getTuples(stream);
 
       assertEquals(4, tuples.size());
@@ -546,7 +540,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
               + COLLECTIONORALIAS
               + ", q=\"id:(1 2)\", fl=\"id,a_s,a_i,a_f\", sort=${mySort})");
       sParams.set("mySort", "\"a_f asc, a_s asc\"");
-      stream = new SolrStream(url, sParams);
+      stream = new SolrStream(url, "/stream", sParams);
       tuples = getTuples(stream);
 
       assertEquals(5, tuples.size());
@@ -751,21 +745,22 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       // Exercise the /stream handler
-      ModifiableSolrParams sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      ModifiableSolrParams sParams = new ModifiableSolrParams(params());
       sParams.add(
           "expr", "random(" + COLLECTIONORALIAS + ", q=\"*:*\", rows=\"1\", fl=\"id, a_i\")");
       JettySolrRunner jetty = cluster.getJettySolrRunner(0);
       SolrStream solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       List<Tuple> tuples4 = getTuples(solrStream);
       assertEquals(1, tuples4.size());
       // Assert no x-axis
       assertNull(tuples4.get(0).get("x"));
 
-      sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      sParams = new ModifiableSolrParams(params());
       sParams.add("expr", "random(" + COLLECTIONORALIAS + ")");
       jetty = cluster.getJettySolrRunner(0);
-      solrStream = new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+      solrStream =
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       tuples4 = getTuples(solrStream);
       assertEquals(500, tuples4.size());
       @SuppressWarnings({"rawtypes"})
@@ -798,7 +793,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     SolrClientCache cache = new SolrClientCache();
     try {
       context.setSolrClientCache(cache);
-      ModifiableSolrParams sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      ModifiableSolrParams sParams = new ModifiableSolrParams(params());
       sParams.add(
           "expr",
           "knnSearch("
@@ -806,49 +801,53 @@ public class StreamExpressionTest extends SolrCloudTestCase {
               + ", id=\"1\", qf=\"a_t\", rows=\"4\", fl=\"id, score\", mintf=\"1\", mindf=\"0\")");
       JettySolrRunner jetty = cluster.getJettySolrRunner(0);
       SolrStream solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       List<Tuple> tuples = getTuples(solrStream);
       assertEquals(3, tuples.size());
       assertOrder(tuples, 2, 3, 4);
 
-      sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      sParams = new ModifiableSolrParams(params());
       sParams.add(
           "expr",
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", k=\"2\", fl=\"id, score\", mintf=\"1\", mindf=\"0\")");
-      solrStream = new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+      solrStream =
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
       assertOrder(tuples, 2, 3);
 
-      sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      sParams = new ModifiableSolrParams(params());
       sParams.add(
           "expr",
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", rows=\"4\", fl=\"id, score\", mintf=\"1\", maxdf=\"0\")");
-      solrStream = new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+      solrStream =
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(0, tuples.size());
 
-      sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      sParams = new ModifiableSolrParams(params());
       sParams.add(
           "expr",
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", rows=\"4\", fl=\"id, score\", mintf=\"1\", maxwl=\"1\")");
-      solrStream = new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+      solrStream =
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(0, tuples.size());
 
-      sParams = new ModifiableSolrParams(params(CommonParams.QT, "/stream"));
+      sParams = new ModifiableSolrParams(params());
       sParams.add(
           "expr",
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", rows=\"2\", fl=\"id, score\", mintf=\"1\", minwl=\"20\")");
-      solrStream = new SolrStream(jetty.getBaseUrl().toString() + "/collection1", sParams);
+      solrStream =
+          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(0, tuples.size());
 
@@ -1048,10 +1047,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add("expr", expr);
       solrParams.add("myCollection.shards", buf.toString());
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
 
@@ -1080,9 +1078,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       try {
         ModifiableSolrParams solrParamsBad = new ModifiableSolrParams();
-        solrParamsBad.add("qt", "/stream");
         solrParamsBad.add("expr", expr);
-        solrStream = new SolrStream(shardUrls.get(0), solrParamsBad);
+        solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParamsBad);
         tuples = getTuples(solrStream);
         throw new Exception("Exception should have been thrown above");
       } catch (IOException e) {
@@ -1115,11 +1112,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     String expr =
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\", count(*))";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1145,9 +1141,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     expr = "facet2D(collection1, x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\")";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1174,9 +1169,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr =
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\", sum(cases_i))";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1203,9 +1197,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr =
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\", avg(cases_i))";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1232,9 +1225,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr =
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"2,2\")";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1294,11 +1286,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "                  sum(cnt), sum(saf)"
             + ")";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1355,11 +1346,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "  over=\"a_s\", std(a_i), std(a_f), count(*)"
             + ")";
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -2233,11 +2223,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr",
           "search(\"collection1, collection2\", q=\"*:*\", fl=\"id, a_i\", rows=50, sort=\"a_i asc\")");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(10, tuples.size());
@@ -2246,22 +2235,20 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       // Test with export handler, different code path.
 
       solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr",
           "search(\"collection1, collection2\", q=\"*:*\", fl=\"id, a_i\", sort=\"a_i asc\", qt=\"/export\")");
-      solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(10, tuples.size());
       assertOrder(tuples, 0, 1, 2, 3, 4, 10, 11, 12, 13, 14);
 
       solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr",
           "facet(\"collection1, collection2\", q=\"*:*\", buckets=\"a_s\", bucketSorts=\"count(*) asc\", count(*))");
-      solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -2279,9 +2266,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
               + "count(*))";
 
       solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add("expr", expr);
-      solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -2292,11 +2278,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       // Test parallel
 
       solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr",
           "parallel(collection1, sort=\"a_i asc\", workers=2, search(\"collection1, collection2\", q=\"*:*\", fl=\"id, a_i\", sort=\"a_i asc\", qt=\"/export\", partitionKeys=\"a_s\"))");
-      solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(10, tuples.size());
@@ -2945,11 +2930,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     String expr = "echo(hello world)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -2961,9 +2945,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr = "echo(\"hello world\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2974,9 +2957,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr = "echo(\"hello, world\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2987,9 +2969,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr = "echo(\"hello, \\\"t\\\" world\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3004,9 +2985,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + ", workers=2, sort=\"echo asc\", echo(\"hello, \\\"t\\\" world\"))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3021,9 +3001,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + " yiuyiuyi yiuyiuuyiu yiyiuyiyiu iyiuyiuyiuiuyiu yiuyiuyi yiuyiy yiuiyiuiuy\")";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3048,11 +3027,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + ", q=\\\"*:*\\\", fl=id, sort=\\\"id desc\\\")\"), echo as expr_s))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3153,11 +3131,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "count(*), sum(price_f), max(price_f), min(price_f), avg(price_f), std(price_f), per(price_f, 50), countDist(id))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3226,9 +3203,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "count(*), sum(price_f), max(price_f), min(price_f), avg(price_f), std(price_f), per(price_f, 50))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3281,9 +3257,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "count(*), sum(price_f), max(price_f), min(price_f), avg(price_f), std(price_f), per(price_f, 50))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3336,9 +3311,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "count(*), sum(price_f), max(price_f), min(price_f), avg(price_f), std(price_f), per(price_f, 50))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3400,9 +3374,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "count(*), sum(price_f), max(price_f), min(price_f), avg(price_f), std(price_f), per(price_f, 50))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3579,9 +3552,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "count(*), sum(price_f), max(price_f), min(price_f), avg(price_f), std(price_f), per(price_f, 50))";
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
-    solrStream = new SolrStream(url, paramsLoc);
+    solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3642,11 +3614,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     String cat = "tuple(results=" + expr + ", sum=add(1,1))";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3674,11 +3645,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3701,11 +3671,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
     ModifiableSolrParams paramsLoc2 = new ModifiableSolrParams();
     paramsLoc2.set("expr", expr2);
-    paramsLoc2.set("qt", "/stream");
 
     String url2 =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream2 = new SolrStream(url2, paramsLoc2);
+    TupleStream solrStream2 = new SolrStream(url2, "/stream", paramsLoc2);
 
     StreamContext context2 = new StreamContext();
     solrStream2.setStreamContext(context2);
@@ -4099,10 +4068,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       }
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add("expr", significantTerms);
       solrParams.add("myCollection.shards", buf.toString());
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
 
@@ -4118,9 +4086,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       try {
         ModifiableSolrParams solrParamsBad = new ModifiableSolrParams();
-        solrParamsBad.add("qt", "/stream");
         solrParamsBad.add("expr", significantTerms);
-        solrStream = new SolrStream(shardUrls.get(0), solrParamsBad);
+        solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParamsBad);
         tuples = getTuples(solrStream);
         throw new Exception("Exception should have been thrown above");
       } catch (IOException e) {
@@ -4219,11 +4186,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4242,11 +4208,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt.gz\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4265,11 +4230,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel-empty.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4283,11 +4247,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt,topLevel-empty.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4307,11 +4270,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt\", maxLines=2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4330,11 +4292,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"directory1\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4364,11 +4325,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "secondLevel2.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    paramsLoc.set("qt", "/stream");
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
 
-    SolrStream solrStream = new SolrStream(url, paramsLoc);
+    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4392,11 +4352,10 @@ public class StreamExpressionTest extends SolrCloudTestCase {
   private void assertSuccess(String expr, StreamContext streamContext) throws IOException {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
-    paramsLoc.set("qt", "/stream");
 
     String url =
         cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, paramsLoc);
+    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
     solrStream.setStreamContext(streamContext);
     getTuples(solrStream);
   }

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
@@ -750,7 +750,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "expr", "random(" + COLLECTIONORALIAS + ", q=\"*:*\", rows=\"1\", fl=\"id, a_i\")");
       JettySolrRunner jetty = cluster.getJettySolrRunner(0);
       SolrStream solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+          new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       List<Tuple> tuples4 = getTuples(solrStream);
       assertEquals(1, tuples4.size());
       // Assert no x-axis
@@ -759,8 +759,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       sParams = new ModifiableSolrParams(params());
       sParams.add("expr", "random(" + COLLECTIONORALIAS + ")");
       jetty = cluster.getJettySolrRunner(0);
-      solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+      solrStream = new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       tuples4 = getTuples(solrStream);
       assertEquals(500, tuples4.size());
       @SuppressWarnings({"rawtypes"})
@@ -801,7 +800,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
               + ", id=\"1\", qf=\"a_t\", rows=\"4\", fl=\"id, score\", mintf=\"1\", mindf=\"0\")");
       JettySolrRunner jetty = cluster.getJettySolrRunner(0);
       SolrStream solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+          new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       List<Tuple> tuples = getTuples(solrStream);
       assertEquals(3, tuples.size());
       assertOrder(tuples, 2, 3, 4);
@@ -812,8 +811,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", k=\"2\", fl=\"id, score\", mintf=\"1\", mindf=\"0\")");
-      solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+      solrStream = new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
       assertOrder(tuples, 2, 3);
@@ -824,8 +822,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", rows=\"4\", fl=\"id, score\", mintf=\"1\", maxdf=\"0\")");
-      solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+      solrStream = new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(0, tuples.size());
 
@@ -835,8 +832,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", rows=\"4\", fl=\"id, score\", mintf=\"1\", maxwl=\"1\")");
-      solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+      solrStream = new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(0, tuples.size());
 
@@ -846,8 +842,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "knnSearch("
               + COLLECTIONORALIAS
               + ", id=\"1\", qf=\"a_t\", rows=\"2\", fl=\"id, score\", mintf=\"1\", minwl=\"20\")");
-      solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/collection1", "/stream", sParams);
+      solrStream = new SolrStream(jetty.getBaseUrl().toString(), "collection1", "/stream", sParams);
       tuples = getTuples(solrStream);
       assertEquals(0, tuples.size());
 

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
@@ -1282,9 +1282,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + ")";
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1342,9 +1341,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + ")";
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
@@ -2038,7 +2038,7 @@ public class StreamingTest extends SolrCloudTestCase {
     int count = 0;
     while (count == 0) {
       SolrStream solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/" + COLLECTIONORALIAS, "/get", sParams1);
+          new SolrStream(jetty.getBaseUrl().toString(), COLLECTIONORALIAS, "/get", sParams1);
       solrStream.setStreamContext(context);
       List<Tuple> tuples = getTuples(solrStream);
       count = tuples.size();

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
@@ -2034,11 +2034,11 @@ public class StreamingTest extends SolrCloudTestCase {
     // Wait for the checkpoint
     JettySolrRunner jetty = cluster.getJettySolrRunners().get(0);
 
-    SolrParams sParams1 = params("qt", "/get", "ids", "50000000", "fl", "id");
+    SolrParams sParams1 = params("ids", "50000000", "fl", "id");
     int count = 0;
     while (count == 0) {
       SolrStream solrStream =
-          new SolrStream(jetty.getBaseUrl().toString() + "/" + COLLECTIONORALIAS, sParams1);
+          new SolrStream(jetty.getBaseUrl().toString() + "/" + COLLECTIONORALIAS, "/get", sParams1);
       solrStream.setStreamContext(context);
       List<Tuple> tuples = getTuples(solrStream);
       count = tuples.size();
@@ -2125,13 +2125,12 @@ public class StreamingTest extends SolrCloudTestCase {
       List<String> shardUrls =
           TupleStream.getShards(solrConnection, COLLECTIONORALIAS, streamContext);
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
-      solrParams.add("qt", "/stream");
       solrParams.add(
           "expr",
           "rollup(search("
               + COLLECTIONORALIAS
               + ",q=\"*:*\",fl=\"a_s,a_i,a_f,b_f\",sort=\"a_s asc\",partitionKeys=\"a_s\", qt=\"/export\"),over=\"a_s\",sum(a_i),sum(a_f),min(a_i),min(a_f),max(a_i),max(a_f),avg(a_i),avg(a_f),count(*),missing(b_f))\n");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), solrParams);
+      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
       streamContext = new StreamContext();
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18332

# Description

SOLR-18332 aims to reduce the usages of "qt" across our codebase.  Its usage complicates our code (by making the path of an HTTP "untrustworthy" for determining what code an API call actually triggers) and complicates security.

One place where "QT" is very commonly used is in Solr's streaming expressions code.  Much of this is attributable to the SolrStream class and its cousins, which send HTTP requests but don't offer any way for callers to specify the HTTP path (without smuggling a "QT" parameter into the SolrParams object they consume).

# Solution

This PR resolves this problem by adding two new constructors to SolrStream that take in an explicit "path" parameter, and then replacing many QT usage sites with usage of the new, path-aware, constructor.

In the process we also shift some of the SolrStream usage away from using string-concatenation and "coreUrls", in favor of explicit (and separate) base URL and core-name parameters.  

# Tests

This code is a refactor and doesn't modify any behavior or introduce any truly "new" code.  So validation consists of existing tests (particular streaming-related ones) continuing to pass.
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
