### PR TITLE
SOLR-18403: fix snapshot-export to actually use the named snapshot

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/SnapshotExportTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/SnapshotExportTool.java
@@ -116,6 +116,7 @@ public class SnapshotExportTool extends ToolBase {
       CollectionAdminRequest.Backup backup =
           new CollectionAdminRequest.Backup(collectionName, snapshotName);
       backup.setCommitName(snapshotName);
+      backup.setIncremental(false);
       backup.setIndexBackupStrategy(CollectionAdminParams.COPY_FILES_STRATEGY);
       backup.setLocation(destPath);
       if (backupRepo != null) {

--- a/solr/core/src/test/org/apache/solr/cli/SnapshotExportToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/SnapshotExportToolTest.java
@@ -24,8 +24,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * SOLR-18403: SnapshotExportTool must export the state of the named snapshot, not the live index
- * at export time.
+ * SOLR-18403: SnapshotExportTool must export the state of the named snapshot, not the live index at
+ * export time.
  */
 public class SnapshotExportToolTest extends SolrCloudTestCase {
 

--- a/solr/core/src/test/org/apache/solr/cli/SnapshotExportToolTest.java
+++ b/solr/core/src/test/org/apache/solr/cli/SnapshotExportToolTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.cli;
+
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * SOLR-18403: SnapshotExportTool must export the state of the named snapshot, not the live index
+ * at export time.
+ */
+public class SnapshotExportToolTest extends SolrCloudTestCase {
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    System.setProperty("solr.security.allow.paths", "*");
+    configureCluster(2).addConfig("conf", configset("cloud-minimal")).configure();
+  }
+
+  @Test
+  public void testExportUsesSnapshotStateNotLiveIndex() throws Exception {
+    CloudSolrClient client = cluster.getSolrClient();
+    String collection = "snapshotexporttest";
+    CollectionAdminRequest.createCollection(collection, "conf", 1, 1).process(client);
+    cluster.waitForActiveCollection(collection, 1, 1);
+
+    // index 5 docs, commit, snapshot at this point
+    for (int i = 0; i < 5; i++) {
+      SolrInputDocument doc = new SolrInputDocument();
+      doc.addField("id", "doc-" + i);
+      client.add(collection, doc);
+    }
+    client.commit(collection);
+
+    String snapshotName = "export-test-snap";
+    new CollectionAdminRequest.CreateSnapshot(collection, snapshotName).process(client);
+
+    // index 5 MORE docs (6-10) and commit -- live index now has 10, snapshot still reflects 5
+    for (int i = 5; i < 10; i++) {
+      SolrInputDocument doc = new SolrInputDocument();
+      doc.addField("id", "doc-" + i);
+      client.add(collection, doc);
+    }
+    client.commit(collection);
+
+    assertEquals(10, client.query(collection, params("q", "*:*")).getResults().getNumFound());
+
+    String backupLocation = createTempDir().toString();
+    SnapshotExportTool tool = new SnapshotExportTool(new DefaultToolRuntime());
+    tool.exportSnapshot(client, collection, snapshotName, backupLocation, null, null);
+
+    String restoredCollection = collection + "_restored";
+    CollectionAdminRequest.Restore restore =
+        CollectionAdminRequest.restoreCollection(restoredCollection, snapshotName)
+            .setLocation(backupLocation);
+    assertEquals(0, restore.process(client).getStatus());
+    cluster.waitForActiveCollection(restoredCollection, 1, 1);
+
+    assertEquals(
+        "export must reflect the snapshot's 5-doc state, not the live index's 10",
+        5,
+        client.query(restoredCollection, params("q", "*:*")).getResults().getNumFound());
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18403

`SnapshotExportTool` built its `Backup` request with `setCommitName(snapshotName)` but never called `setIncremental(false)`. `commitName` is only read by the non-incremental backup path, so it was silently ignored and the export backed up the live index instead of the named snapshot -- no error, no warning.

Verified with a real `MiniSolrCloudCluster` test: indexed 5 docs, snapshotted, indexed 5 more (live index now 10), exported, restored -- got 10 docs before this fix, 5 after. Confirmed the test actually catches the regression (reverted the one-line fix locally, test failed as expected, restored it).

This predates incremental backups entirely -- the `commitName`-based export worked correctly before SOLR-13608 introduced `incremental` defaulting to `true` in 2021. That interaction was never revisited, and SOLR-17180 (2024) carried the bug forward unchanged when porting `snapshotscli.sh` into `bin/solr snapshot-export`.

AI-assisted (Claude Sonnet 5)