### PR TITLE
SOLR-18149: rename c_state to clusterState in BackupManager

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/backup/BackupManager.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/BackupManager.java
@@ -226,9 +226,9 @@ public class BackupManager {
       // collection will have a new creation date when persisted in zookeeper.
       @SuppressWarnings("unchecked")
       Map<String, Object> stateMap = (Map<String, Object>) Utils.fromJSON(arr, 0, arr.length);
-      ClusterState c_state =
+      ClusterState clusterState =
           ClusterState.createFromCollectionMap(-1, stateMap, Set.of(), Instant.EPOCH, null);
-      return c_state.getCollection(collectionName);
+      return clusterState.getCollection(collectionName);
     }
   }
 


### PR DESCRIPTION
Follow-up to @dsmiley's comment on #4777: https://github.com/apache/solr/pull/4777#discussion_r3847185477 -- `c_state` is a pre-existing name in `BackupManager.readCollectionState`, not something #4777 introduced (it was just migrating that line off the deprecated `createFromJson`, not renaming). Renaming it now since it's a fair complaint on its own.

Pure local-variable rename, no behavior change.

AI-assisted (Claude Sonnet 5)