### PR TITLE
SOLR-18350: Prefer request and searcher schema snapshots

### DIFF
--- a/changelog/unreleased/solr-18350-stable-schema.yml
+++ b/changelog/unreleased/solr-18350-stable-schema.yml
@@ -1,0 +1,8 @@
+title: Keep request processing and searches on a stable schema snapshot when the schema changes concurrently
+type: fixed
+authors:
+  - name: Shrey Narayan
+    nick: NextbrickInc
+links:
+  - name: SOLR-18350
+    url: https://issues.apache.org/jira/browse/SOLR-18350

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -335,7 +335,14 @@ public class SolrCore implements SolrInfoBean, Closeable {
   }
 
   /**
-   * @return the latest snapshot of the schema used by this core instance.
+   * Returns the latest snapshot of the schema used by this core instance.
+   *
+   * <p>Request processing code should normally use {@link SolrQueryRequest#getSchema()} so that the
+   * schema remains stable for the lifetime of the request. Code operating on a {@link
+   * SolrIndexSearcher} should normally use {@link SolrIndexSearcher#getSchema()} so that the schema
+   * matches the searcher.
+   *
+   * @return the latest schema snapshot
    * @see #setLatestSchema
    */
   public IndexSchema getLatestSchema() {

--- a/solr/core/src/java/org/apache/solr/handler/SchemaHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/SchemaHandler.java
@@ -151,42 +151,38 @@ public class SchemaHandler extends RequestHandlerBase
         case "/schema":
           {
             V2ApiUtils.squashIntoSolrResponseWithoutHeader(
-                rsp, new GetSchema(req.getCore(), req.getCore().getLatestSchema()).getSchemaInfo());
+                rsp, new GetSchema(req.getCore(), req.getSchema()).getSchemaInfo());
             break;
           }
         case "/schema/version":
           {
             V2ApiUtils.squashIntoSolrResponseWithoutHeader(
-                rsp,
-                new GetSchema(req.getCore(), req.getCore().getLatestSchema()).getSchemaVersion());
+                rsp, new GetSchema(req.getCore(), req.getSchema()).getSchemaVersion());
             break;
           }
         case "/schema/uniquekey":
           {
             V2ApiUtils.squashIntoSolrResponseWithoutHeader(
-                rsp,
-                new GetSchema(req.getCore(), req.getCore().getLatestSchema()).getSchemaUniqueKey());
+                rsp, new GetSchema(req.getCore(), req.getSchema()).getSchemaUniqueKey());
             break;
           }
         case "/schema/similarity":
           {
             V2ApiUtils.squashIntoSolrResponseWithoutHeader(
-                rsp,
-                new GetSchema(req.getCore(), req.getCore().getLatestSchema())
-                    .getSchemaSimilarity());
+                rsp, new GetSchema(req.getCore(), req.getSchema()).getSchemaSimilarity());
             break;
           }
         case "/schema/name":
           {
             V2ApiUtils.squashIntoSolrResponseWithoutHeader(
-                rsp, new GetSchema(req.getCore(), req.getCore().getLatestSchema()).getSchemaName());
+                rsp, new GetSchema(req.getCore(), req.getSchema()).getSchemaName());
             break;
           }
         case "/schema/zkversion":
           {
             V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                 rsp,
-                new GetSchema(req.getCore(), req.getCore().getLatestSchema())
+                new GetSchema(req.getCore(), req.getSchema())
                     .getSchemaZkVersion(req.getParams().getInt("refreshIfBelowVersion", -1)));
             break;
           }
@@ -208,22 +204,19 @@ public class SchemaHandler extends RequestHandlerBase
                     if (parts.size() > 2) {
                       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                           rsp,
-                          new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
+                          new GetSchemaField(req.getSchema(), req.getParams())
                               .getFieldInfo(parts.get(2)));
                     } else {
                       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                           rsp,
-                          new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
-                              .listSchemaFields());
+                          new GetSchemaField(req.getSchema(), req.getParams()).listSchemaFields());
                     }
                     return;
                   }
                 case "copyfields":
                   {
                     V2ApiUtils.squashIntoSolrResponseWithoutHeader(
-                        rsp,
-                        new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
-                            .listCopyFields());
+                        rsp, new GetSchemaField(req.getSchema(), req.getParams()).listCopyFields());
                     return;
                   }
                 case "dynamicfields":
@@ -231,13 +224,12 @@ public class SchemaHandler extends RequestHandlerBase
                     if (parts.size() > 2) {
                       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                           rsp,
-                          new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
+                          new GetSchemaField(req.getSchema(), req.getParams())
                               .getDynamicFieldInfo(parts.get(2)));
                     } else {
                       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                           rsp,
-                          new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
-                              .listDynamicFields());
+                          new GetSchemaField(req.getSchema(), req.getParams()).listDynamicFields());
                     }
                     return;
                   }
@@ -246,12 +238,12 @@ public class SchemaHandler extends RequestHandlerBase
                     if (parts.size() > 2) {
                       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                           rsp,
-                          new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
+                          new GetSchemaField(req.getSchema(), req.getParams())
                               .getFieldTypeInfo(parts.get(2)));
                     } else {
                       V2ApiUtils.squashIntoSolrResponseWithoutHeader(
                           rsp,
-                          new GetSchemaField(req.getCore().getLatestSchema(), req.getParams())
+                          new GetSchemaField(req.getSchema(), req.getParams())
                               .listSchemaFieldTypes());
                     }
                     return;

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -218,7 +218,7 @@ public class RealTimeGetComponent extends SearchComponent {
     }
 
     final SolrCore core = req.getCore();
-    SchemaField idField = core.getLatestSchema().getUniqueKeyField();
+    SchemaField idField = req.getSchema().getUniqueKeyField();
     FieldType fieldType = idField.getType();
 
     SolrDocumentList docList = new SolrDocumentList();
@@ -275,9 +275,7 @@ public class RealTimeGetComponent extends SearchComponent {
 
                 SolrDocument doc;
                 if (oper == UpdateLog.ADD) {
-                  doc =
-                      toSolrDoc(
-                          (SolrInputDocument) entry.get(entry.size() - 1), core.getLatestSchema());
+                  doc = toSolrDoc((SolrInputDocument) entry.get(entry.size() - 1), req.getSchema());
                   // toSolrDoc filtered copy-field targets already
                   if (transformer != null) {
                     transformer.transform(doc, -1, DocIterationInfo.NONE); // unknown docID
@@ -351,7 +349,7 @@ public class RealTimeGetComponent extends SearchComponent {
         SolrDocumentFetcher docFetcher = searcherInfo.getSearcher().getDocFetcher();
         Document luceneDocument =
             docFetcher.doc(docid, rsp.getReturnFields().getLuceneFieldNames());
-        SolrDocument doc = toSolrDoc(luceneDocument, core.getLatestSchema());
+        SolrDocument doc = toSolrDoc(luceneDocument, searcherInfo.getSearcher().getSchema());
         if (reuseDvIters == null) {
           reuseDvIters = new DocValuesIteratorCache(searcherInfo.getSearcher());
         }
@@ -562,7 +560,7 @@ public class RealTimeGetComponent extends SearchComponent {
     try {
       // now fetch last document from index, and merge partialDoc on top of it
       SolrIndexSearcher searcher = searcherHolder.get();
-      SchemaField idField = core.getLatestSchema().getUniqueKeyField();
+      SchemaField idField = searcher.getSchema().getUniqueKeyField();
       Term idTerm = new Term(idField.getName(), idBytes);
 
       int docid = searcher.getFirstMatch(idTerm);
@@ -784,12 +782,12 @@ public class RealTimeGetComponent extends SearchComponent {
         int docId =
             searcher.getFirstMatch(
                 new Term(
-                    core.getLatestSchema().getUniqueKeyField().getName(),
+                    searcher.getSchema().getUniqueKeyField().getName(),
                     resolveStrategy == Resolution.ROOT_WITH_CHILDREN ? rootIdBytes : idBytes));
         if (docId < 0) return null;
 
         if (resolveStrategy == Resolution.ROOT_WITH_CHILDREN
-            && core.getLatestSchema().isUsableForChildDocs()) {
+            && searcher.getSchema().isUsableForChildDocs()) {
           // check that this doc is in fact a root document as a prevention measure
           if (!hasRootTerm(searcher, rootIdBytes)) {
             throw new SolrException(
@@ -800,7 +798,7 @@ public class RealTimeGetComponent extends SearchComponent {
 
         SolrDocument solrDoc =
             fetchSolrDoc(searcher, docId, makeReturnFields(core, onlyTheseFields, resolveStrategy));
-        sid = toSolrInputDocument(solrDoc, core.getLatestSchema()); // filters copy-field targets
+        sid = toSolrInputDocument(solrDoc, searcher.getSchema()); // filters copy-field targets
         // the assertions above furthermore guarantee the result corresponds to idBytes
       } finally {
         searcherHolder.decref();

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -1318,7 +1318,7 @@ public class SimpleFacets {
       final ParsedParams parsed = parseParams(FacetParams.FACET_INTERVAL, field);
       String[] intervalStrs =
           parsed.required.getFieldParams(parsed.facetValue, FacetParams.FACET_INTERVAL_SET);
-      SchemaField schemaField = searcher.getCore().getLatestSchema().getField(parsed.facetValue);
+      SchemaField schemaField = searcher.getSchema().getField(parsed.facetValue);
       if (parsed.params.getBool(GroupParams.GROUP_FACET, false)) {
         throw new SolrException(
             SolrException.ErrorCode.BAD_REQUEST,

--- a/solr/core/src/java/org/apache/solr/search/PayloadCheckQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/PayloadCheckQParserPlugin.java
@@ -77,7 +77,7 @@ public class PayloadCheckQParserPlugin extends QParserPlugin {
           throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "'payloads' not specified");
         }
 
-        FieldType ft = req.getCore().getLatestSchema().getFieldType(field);
+        FieldType ft = req.getSchema().getFieldType(field);
         Analyzer analyzer = ft.getQueryAnalyzer();
         SpanQuery query = null;
         try {

--- a/solr/core/src/java/org/apache/solr/search/PayloadScoreQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/PayloadScoreQParserPlugin.java
@@ -69,7 +69,7 @@ public class PayloadScoreQParserPlugin extends QParserPlugin {
           throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "query string missing");
         }
 
-        FieldType ft = req.getCore().getLatestSchema().getFieldType(field);
+        FieldType ft = req.getSchema().getFieldType(field);
         Analyzer analyzer = ft.getQueryAnalyzer();
         SpanQuery query;
         try {
@@ -87,7 +87,7 @@ public class PayloadScoreQParserPlugin extends QParserPlugin {
         PayloadFunction payloadFunction = PayloadUtils.getPayloadFunction(func);
         if (payloadFunction == null) throw new SyntaxError("Unknown payload function: " + func);
 
-        PayloadDecoder payloadDecoder = req.getCore().getLatestSchema().getPayloadDecoder(field);
+        PayloadDecoder payloadDecoder = req.getSchema().getPayloadDecoder(field);
         return new PayloadScoreQuery(query, payloadFunction, payloadDecoder, includeSpanScore);
       }
     };

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -870,7 +870,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
                   SolrException.ErrorCode.BAD_REQUEST, "Invalid payload function: " + func);
             }
 
-            IndexSchema schema = fp.getReq().getCore().getLatestSchema();
+            IndexSchema schema = fp.getReq().getSchema();
             PayloadDecoder decoder = schema.getPayloadDecoder(tinfo.field);
 
             if (decoder == null) {

--- a/solr/core/src/java/org/apache/solr/search/vector/KnnQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/vector/KnnQParser.java
@@ -117,7 +117,7 @@ public class KnnQParser extends AbstractVectorQParserBase {
   @Override
   public Query parse() throws SyntaxError {
     final String vectorField = getFieldName();
-    final SchemaField schemaField = req.getCore().getLatestSchema().getField(getFieldName());
+    final SchemaField schemaField = req.getSchema().getField(getFieldName());
     final DenseVectorField denseVectorType = getCheckedFieldType(schemaField);
 
     if (DenseVectorField.FLAT_ALGORITHM.equals(denseVectorType.getKnnAlgorithm())) {

--- a/solr/core/src/java/org/apache/solr/search/vector/VectorSimilarityQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/vector/VectorSimilarityQParser.java
@@ -44,7 +44,7 @@ public class VectorSimilarityQParser extends AbstractVectorQParserBase {
   @Override
   public Query parse() throws SyntaxError {
     final String fieldName = getFieldName();
-    final SchemaField schemaField = req.getCore().getLatestSchema().getField(fieldName);
+    final SchemaField schemaField = req.getSchema().getField(fieldName);
     final DenseVectorField denseVectorType = getCheckedFieldType(schemaField);
 
     if (DenseVectorField.FLAT_ALGORITHM.equals(denseVectorType.getKnnAlgorithm())) {

--- a/solr/core/src/java/org/apache/solr/update/processor/ContentHashVersionProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/ContentHashVersionProcessor.java
@@ -78,7 +78,7 @@ public class ContentHashVersionProcessor extends UpdateRequestProcessor {
     super(next);
     this.core = req.getCore();
 
-    IndexSchema schema = core.getLatestSchema();
+    IndexSchema schema = req.getSchema();
     this.hashField = schema.getField(hashFieldName);
     this.dropSameDocuments = dropSameDocuments;
     this.rsp = rsp;

--- a/solr/core/src/java/org/apache/solr/update/processor/DocBasedVersionConstraintsProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DocBasedVersionConstraintsProcessor.java
@@ -86,7 +86,7 @@ public class DocBasedVersionConstraintsProcessor extends UpdateRequestProcessor 
     this.supportMissingVersionOnOldDocs = supportMissingVersionOnOldDocs;
     this.core = req.getCore();
     this.versionFieldNames = versionFields.toArray(EMPTY_STR_ARR);
-    IndexSchema schema = core.getLatestSchema();
+    IndexSchema schema = req.getSchema();
     userVersionFields = new SchemaField[versionFieldNames.length];
     for (int i = 0; i < versionFieldNames.length; i++) {
       userVersionFields[i] = schema.getField(versionFieldNames[i]);
@@ -469,7 +469,7 @@ public class DocBasedVersionConstraintsProcessor extends UpdateRequestProcessor 
 
       SolrInputDocument newDoc =
           createTombstoneDocument(
-              core.getLatestSchema(),
+              cmd.getReq().getSchema(),
               cmd.getId(),
               versionFieldNames,
               deleteParamValues,
@@ -500,7 +500,7 @@ public class DocBasedVersionConstraintsProcessor extends UpdateRequestProcessor 
 
         SolrInputDocument newDoc =
             createTombstoneDocument(
-                core.getLatestSchema(),
+                cmd.getReq().getSchema(),
                 cmd.getId(),
                 versionFieldNames,
                 deleteParamValues,

--- a/solr/core/src/java/org/apache/solr/update/processor/TolerantUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/TolerantUpdateProcessor.java
@@ -129,7 +129,7 @@ public class TolerantUpdateProcessor extends UpdateRequestProcessor {
     assert !DistribPhase.FROMLEADER.equals(distribPhase);
 
     this.zkController = this.req.getCoreContainer().getZkController();
-    this.uniqueKeyField = this.req.getCore().getLatestSchema().getUniqueKeyField();
+    this.uniqueKeyField = this.req.getSchema().getUniqueKeyField();
     assert null != uniqueKeyField : "Factory didn't enforce uniqueKey field?";
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/ContentHashVersionProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/ContentHashVersionProcessorTest.java
@@ -96,8 +96,8 @@ public class ContentHashVersionProcessorTest extends UpdateProcessorTestBase {
     final IndexSchema indexSchema = mock(IndexSchema.class);
     when(indexSchema.getField("_hash_")).thenReturn(new SchemaField("_hash_", new BinaryField()));
 
-    when(solrCore.getLatestSchema()).thenReturn(indexSchema);
     when(req.getCore()).thenReturn(solrCore);
+    when(req.getSchema()).thenReturn(indexSchema);
     return new ContentHashVersionProcessor(
         ContentHashVersionProcessorFactory.buildFieldMatcher(includedFields),
         ContentHashVersionProcessorFactory.buildFieldMatcher(excludedFields),

--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/search/TextToVectorQParserPlugin.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/search/TextToVectorQParserPlugin.java
@@ -78,8 +78,7 @@ public class TextToVectorQParserPlugin extends QParserPlugin
 
     private void checkVectorEncoding() {
       final VectorEncoding vectorEncoding =
-          getCheckedFieldType(req.getCore().getLatestSchema().getField(getFieldName()))
-              .getVectorEncoding();
+          getCheckedFieldType(req.getSchema().getField(getFieldName())).getVectorEncoding();
 
       if (vectorEncoding != VectorEncoding.FLOAT32) {
         throw new SolrException(

--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/update/processor/factory/DocumentEnrichmentUpdateProcessorFactory.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/update/processor/factory/DocumentEnrichmentUpdateProcessorFactory.java
@@ -185,16 +185,16 @@ public class DocumentEnrichmentUpdateProcessorFactory extends UpdateRequestProce
   @Override
   public UpdateRequestProcessor getInstance(
       SolrQueryRequest req, SolrQueryResponse rsp, UpdateRequestProcessor next) {
-    IndexSchema latestSchema = req.getCore().getLatestSchema();
+    IndexSchema requestSchema = req.getSchema();
 
     for (String fieldName : inputFields) {
-      if (!latestSchema.isDynamicField(fieldName) && !latestSchema.hasExplicitField(fieldName)) {
+      if (!requestSchema.isDynamicField(fieldName) && !requestSchema.hasExplicitField(fieldName)) {
         throw new SolrException(
             SolrException.ErrorCode.SERVER_ERROR, "undefined field: \"" + fieldName + "\"");
       }
     }
 
-    final SchemaField outputFieldSchema = latestSchema.getField(outputField);
+    final SchemaField outputFieldSchema = requestSchema.getField(outputField);
 
     ResponseFormat responseFormat = getJsonSchema(outputFieldSchema);
     boolean multiValued = outputFieldSchema.multiValued();

--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/update/processor/factory/TextToVectorUpdateProcessorFactory.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/update/processor/factory/TextToVectorUpdateProcessorFactory.java
@@ -94,14 +94,14 @@ public class TextToVectorUpdateProcessorFactory extends UpdateRequestProcessorFa
   @Override
   public UpdateRequestProcessor getInstance(
       SolrQueryRequest req, SolrQueryResponse rsp, UpdateRequestProcessor next) {
-    IndexSchema latestSchema = req.getCore().getLatestSchema();
+    IndexSchema requestSchema = req.getSchema();
 
-    if (!latestSchema.isDynamicField(inputField) && !latestSchema.hasExplicitField(inputField)) {
+    if (!requestSchema.isDynamicField(inputField) && !requestSchema.hasExplicitField(inputField)) {
       throw new SolrException(
           SolrException.ErrorCode.SERVER_ERROR, "undefined field: \"" + inputField + "\"");
     }
 
-    final SchemaField outputFieldSchema = latestSchema.getField(outputField);
+    final SchemaField outputFieldSchema = requestSchema.getField(outputField);
     assertIsDenseVectorField(outputFieldSchema);
 
     TextToVectorModelStore modelStore = TextToVectorModelStore.getManagedModelStore(req.getCore());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18350

# Description

`SolrCore#getLatestSchema()` may change during request processing. This patch replaces callers that already have a `SolrQueryRequest` or `SolrIndexSearcher` in scope with the corresponding stable schema accessor.

# Solution

- Use `SolrQueryRequest#getSchema()` for request-scoped schema lookups.
- Use `SolrIndexSearcher#getSchema()` when interpreting data associated with a searcher.
- Document these alternatives on `SolrCore#getLatestSchema()`.
- Leave schema mutation, lifecycle, initialization, managed-resource, and other genuinely live-schema paths unchanged.
- Update the affected Mockito request fixture.

This was patch was developed by contributor.  The resulting changes were reviewed and tested locally by the contributor.

# Tests

- 181 focused Solr core tests passed.
- 88 language-model tests passed.
- `./gradlew tidy` passed.
- Affected-module checks passed.
- `git diff --check` passed.

A whole-repository check was attempted, but the documentation/Antora portion was blocked by a local path-with-spaces environment issue. The affected code-module checks passed.

# Checklist

- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers access to contribute to my PR branch.
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the Reference Guide.
- [ ] I have added a changelog entry for my change.
