### PR TITLE
SOLR-18406: Restart replication after index generation expires

### DIFF
--- a/changelog/unreleased/SOLR-18406-replication-stale-generation.yml
+++ b/changelog/unreleased/SOLR-18406-replication-stale-generation.yml
@@ -1,0 +1,10 @@
+title: >
+  Leader/follower replication now restarts with the latest index generation when the selected
+  generation expires during download, avoiding retries against an unavailable generation.
+type: changed
+authors:
+  - name: ZhenyuLi
+    nick: JHSUYU
+links:
+  - name: SOLR-18406
+    url: https://issues.apache.org/jira/browse/SOLR-18406

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -405,6 +405,18 @@ public class IndexFetcher {
    */
   IndexFetchResult fetchLatestIndex(boolean forceReplication, boolean forceCoreReload)
       throws IOException, InterruptedException {
+    try {
+      return fetchLatestIndexOnce(forceReplication, forceCoreReload);
+    } catch (InvalidIndexGenerationException e) {
+      log.info(
+          "Leader no longer has index generation {}; restarting replication from its latest generation",
+          e.generation);
+      return fetchLatestIndexOnce(forceReplication, forceCoreReload);
+    }
+  }
+
+  private IndexFetchResult fetchLatestIndexOnce(boolean forceReplication, boolean forceCoreReload)
+      throws IOException, InterruptedException {
 
     boolean cleanupDone = false;
     boolean successfulInstall = false;
@@ -556,6 +568,7 @@ public class IndexFetcher {
       log.info("Starting replication process");
       // get the list of files first
       fetchFileList(latestGeneration);
+      assert testWait.getAsBoolean();
       // this can happen if the commit point is deleted before we fetch the file list.
       if (filesToDownload.isEmpty()) {
         return IndexFetchResult.PEER_INDEX_COMMIT_DELETED;
@@ -761,6 +774,8 @@ public class IndexFetcher {
       } catch (ReplicationHandlerException e) {
         log.error("User aborted Replication", e);
         return new IndexFetchResult(IndexFetchResult.FAILED_BY_EXCEPTION_MESSAGE, false, e);
+      } catch (InvalidIndexGenerationException e) {
+        throw e;
       } catch (SolrException e) {
         throw e;
       } catch (InterruptedException e) {
@@ -1593,6 +1608,8 @@ public class IndexFetcher {
       bytesDownloaded = 0;
       try {
         fetch();
+      } catch (InvalidIndexGenerationException e) {
+        throw e;
       } catch (Exception e) {
         if (!aborted) {
           IndexFetcher.log.error("Error fetching file, doing one retry...", e);
@@ -1605,6 +1622,7 @@ public class IndexFetcher {
     }
 
     private void fetch() throws Exception {
+      boolean invalidIndexGeneration = false;
       try {
         while (true) {
           try (FastInputStream fis = getStream()) {
@@ -1617,17 +1635,22 @@ public class IndexFetcher {
             // if there is an error continue. But continue from the point where it got broken
           }
         }
+      } catch (InvalidIndexGenerationException e) {
+        invalidIndexGeneration = true;
+        throw e;
       } finally {
-        cleanup();
-        // if cleanup succeeds, and the file is downloaded fully, then do a fsync.
-        fsyncService.execute(
-            () -> {
-              try {
-                file.sync();
-              } catch (IOException | AlreadyClosedException e) {
-                fsyncException = e;
-              }
-            });
+        cleanup(invalidIndexGeneration);
+        if (!invalidIndexGeneration) {
+          // if cleanup succeeds, and the file is downloaded fully, then do a fsync.
+          fsyncService.execute(
+              () -> {
+                try {
+                  file.sync();
+                } catch (IOException | AlreadyClosedException e) {
+                  fsyncException = e;
+                }
+              });
+        }
       }
     }
 
@@ -1744,7 +1767,7 @@ public class IndexFetcher {
     }
 
     /** cleanup everything */
-    private void cleanup() {
+    private void cleanup(boolean invalidIndexGeneration) {
       try {
         file.close();
       } catch (Exception e) {
@@ -1760,7 +1783,7 @@ public class IndexFetcher {
           log.error("Error deleting file: {}", this.saveAs, e);
         }
         // if the failure is due to a user abort it is returned normally else an exception is thrown
-        if (!aborted)
+        if (!aborted && !invalidIndexGeneration)
           throw new SolrException(
               SolrException.ErrorCode.SERVER_ERROR,
               "Unable to download "
@@ -1806,6 +1829,10 @@ public class IndexFetcher {
         final var responseStatus = (Integer) response.get("responseStatus");
         is = (InputStream) response.get("stream");
 
+        if (responseStatus == ErrorCode.CONFLICT.code) {
+          throw new InvalidIndexGenerationException(indexGen);
+        }
+
         if (responseStatus != 200) {
           final var errorMsg =
               String.format(
@@ -1813,13 +1840,16 @@ public class IndexFetcher {
                   "Unexpected status code [%d] when downloading file [%s].",
                   responseStatus,
                   fileName);
-          closeStreamAndBuildIOE(is, errorMsg, null);
+          throw closeStreamAndBuildIOE(is, errorMsg, null);
         }
 
         if (useInternalCompression) {
           is = new InflaterInputStream(is);
         }
         return new FastInputStream(is);
+      } catch (InvalidIndexGenerationException e) {
+        IOUtils.closeQuietly(is);
+        throw e;
       } catch (Exception e) {
         final var ioe = closeStreamAndBuildIOE(is, "Could not download file '" + fileName + "'", e);
         throw ioe;
@@ -1833,6 +1863,15 @@ public class IndexFetcher {
         return new IOException(exceptionMessage, e);
       }
       return new IOException(exceptionMessage);
+    }
+  }
+
+  private static class InvalidIndexGenerationException extends IOException {
+    private final long generation;
+
+    InvalidIndexGenerationException(long generation) {
+      super("Leader no longer has index generation " + generation);
+      this.generation = generation;
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/api/ReplicationAPIBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/api/ReplicationAPIBase.java
@@ -254,6 +254,7 @@ public abstract class ReplicationAPIBase extends JerseyResource {
 
     protected Long indexGen;
     protected IndexDeletionPolicyWrapper delPolicy;
+    private boolean commitPointSaved;
 
     protected String fileName;
     protected String cfileName;
@@ -342,7 +343,13 @@ public abstract class ReplicationAPIBase extends JerseyResource {
 
       // reserve commit point till write is complete
       if (indexGen != null) {
-        delPolicy.saveCommitPoint(indexGen);
+        try {
+          delPolicy.saveCommitPoint(indexGen);
+          commitPointSaved = true;
+        } catch (IllegalStateException e) {
+          throw new SolrException(
+              SolrException.ErrorCode.CONFLICT, "invalid index generation: " + indexGen, e);
+        }
       }
     }
 
@@ -360,7 +367,7 @@ public abstract class ReplicationAPIBase extends JerseyResource {
       ReplicationHandler replicationHandler =
           (ReplicationHandler) solrCore.getRequestHandler(ReplicationHandler.PATH);
 
-      if (indexGen != null) {
+      if (commitPointSaved) {
         // Reserve the commit point for another 10s for the next file to be to fetched.
         // We need to keep extending the commit reservation between requests so that the replica can
         // fetch all the files correctly.

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -34,6 +34,9 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.lucene.index.DirectoryReader;
@@ -65,7 +68,9 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.core.CachingDirectoryFactory;
 import org.apache.solr.core.CoreContainer;
@@ -1492,6 +1497,63 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
     assertNotNull(resp);
     assertEquals("ERROR", resp.get("status"));
     assertEquals("invalid index generation", resp.get("message"));
+  }
+
+  @Test
+  public void testFollowerRestartsWhenCommitExpiresBeforeFileDownload() throws Exception {
+    invokeReplicationCommand(
+        buildUrl(followerJetty.getLocalPort()) + "/" + DEFAULT_TEST_CORENAME, "disablepoll");
+
+    index(leaderClient, "id", "1", "name", "generation-g");
+    leaderClient.commit();
+    index(leaderClient, "id", "1", "name", "generation-g-plus-one");
+
+    CountDownLatch fileListFetched = new CountDownLatch(1);
+    CountDownLatch continueDownload = new CountDownLatch(1);
+    IndexFetcher.testWait =
+        () -> {
+          fileListFetched.countDown();
+          try {
+            continueDownload.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+          return true;
+        };
+
+    ExecutorService workload =
+        ExecutorUtil.newMDCAwareSingleThreadExecutor(
+            new SolrNamedThreadFactory("staleGenerationWorkload"));
+    try {
+      Future<?> followerFetch =
+          workload.submit(
+              () -> {
+                pullFromTo(leaderJetty, followerJetty);
+                return null;
+              });
+
+      assertTrue(fileListFetched.await(TIMEOUT, TimeUnit.MILLISECONDS));
+
+      long reserveDuration;
+      try (SolrCore core = leaderJetty.getCoreContainer().getCore(DEFAULT_TEST_CORENAME)) {
+        ReplicationHandler handler =
+            (ReplicationHandler) core.getRequestHandler(ReplicationHandler.PATH);
+        reserveDuration = handler.getReserveCommitDuration();
+      }
+      Thread.sleep(reserveDuration + 1000);
+      leaderClient.commit();
+
+      IndexFetcher.testWait = () -> true;
+      continueDownload.countDown();
+      followerFetch.get(TIMEOUT, TimeUnit.MILLISECONDS);
+
+      assertEquals(1, numFound(rQuery(1, "name:generation-g-plus-one", followerClient)));
+    } finally {
+      IndexFetcher.testWait = () -> true;
+      continueDownload.countDown();
+      workload.shutdownNow();
+    }
   }
 
   @Test


### PR DESCRIPTION
SOLR-18406: Restart replication after index generation expires

  # Description

During leader/follower index replication, the follower selects generation G, requests filelist(G), and then downloads its files through separate filecontent requests. Although there is no explicit replication session, G acts as the consistency boundary for the complete replication cycle. The leader pins G while each request is active, but between requests it is protected only by commitReserveDuration—10 seconds by default.

This bounded reservation is intentional: if a follower crashes midway through replication, it must not retain old commits indefinitely. However, the leader cannot distinguish a crashed follower from a live follower delayed by GC, networking, disk I/O, or scheduling. If such a delay exceeds the reservation and a subsequent leader commit deletes G, the follower may return with a filecontent request for a generation that is no longer available.

The earlier `indexversion` → `filelist` handoff already handles this stale-generation
condition. If `G` is deleted after `indexversion` returns it but before `filelist(G)`
begins, `getFileList()` catches the `IllegalStateException`, reports
`"invalid index generation"`, and returns no file list:

```java
try {
  commit = delPol.getAndSaveCommitPoint(generation);
} catch (IllegalStateException ignored) {
  /* handle this below the same way we handle a return value of null... */
}
if (null == commit) {
  // The gen they asked for either doesn't exist or has already been deleted
  reportErrorOnResponse(filesResponse, "invalid index generation", null);
  return filesResponse;
}
```

The follower interprets the missing list as an empty download set and terminates the
current attempt with `PEER_INDEX_COMMIT_DELETED`, without downloading files from `G`.
A later replication attempt can then begin with a new `indexversion` request.

The subsequent filelist → filecontent handoff had no equivalent handling. DirectoryFileStream.initWrite() called saveCommitPoint(G) directly, allowing the same IllegalStateException to escape as HTTP 500. The follower treated it as an ordinary file-transfer failure, retried the file against the same unavailable generation, and then aborted the entire replication cycle, wasting any files already downloaded during that cycle.

This appears to expose a protocol-level gap (correct me if I am wrong): generation G is a session-level consistency boundary—the follower expects to use it for the complete replication cycle—but the leader protects it using request-level reservations. The short reservation is intentional so that a follower that crashes cannot retain old commits indefinitely. However, the leader cannot distinguish a crashed follower from a live follower delayed between
requests, so an active replication can legitimately outlive its reservation. Generation expiration must therefore be treated as an expected protocol event that invalidates the current snapshot and requires renegotiation. Returning a generic HTTP 500 provided no such state transition, causing the follower to retry an irrecoverably stale generation instead of restarting from the leader’s current generation.

  # Solution

  Convert the stale-generation failure in `DirectoryFileStream.initWrite()` into an explicit HTTP 409 conflict with an `invalid index generation` message.

When `IndexFetcher` receives this response, it stops retrying the same file from the already unavailable generation and restarts the complete replication cycle once, beginning with a new `indexversion` request. This allows the follower to fetch the leader's current generation instead of failing the entire replication attempt.

 The change also ensures that a commit point is only reserved and released when it was successfully saved.

  # Tests

  Added
  `TestReplicationHandler.testFollowerRestartsWhenCommitExpiresBeforeFileDownload
  `.

  The test uses real leader and follower Jetty instances and performs this sequence:

  1. The leader commits generation G.
  2. The follower starts an explicit `fetchindex` request.
  3. The follower pauses after receiving `filelist(G)` and before requesting
     `filecontent(G)`.
  4. The commit reservation expires.
  5. The leader commits G+1, allowing G to be deleted.
  6. The follower resumes, detects that G is unavailable, restarts replication, and installs G+1.
