### PR TITLE
Set 10.x milestone on Renovate PRs for main branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "dependencyDashboard": false,
   "enabledManagers": ["gradle", "github-actions"],
   "labels": ["exempt-stale"],
+  "milestone": 1,
   "includePaths": ["gradle/libs.versions.toml", "versions.*", "build.gradle", ".github/workflows/*"],
   "postUpgradeTasks": {
     "commands": [

--- a/dev-docs/dependency-upgrades.adoc
+++ b/dev-docs/dependency-upgrades.adoc
@@ -71,8 +71,11 @@ it will be re-used and auto updated whenever a newer patch- or minor version get
 churn from frequently-updated dependencies by delaying merge until a few weeks before a new release. One can also
 choose to change to a less frequent schedule or disable the bot, by editing `renovate.json`.
 
+Renovate PRs against `main` are put in the `10.x` milestone, via the `milestone` option which takes the numeric
+milestone id (see https://api.github.com/repos/apache/solr/milestones). Bump it when `main` moves to a new major.
+
 The `branch_9x` branch has its own `renovate.json` that layers on top of (and inherits from) this one, overriding only
-the schedule and the lockfile/license commands. Grouping rules defined here therefore apply to `branch_9x` too.
+the schedule, the milestone and the lockfile/license commands. Grouping rules defined here therefore apply to `branch_9x` too.
 
 Please note that Solr version prior to 10.X use a versions resolution plugin that uses `versions.lock` instead of
 `libs.version.toml`. Therefore, changes cannot be backported via cherry-pick.


### PR DESCRIPTION
Renovate's [`milestone`](https://docs.renovatebot.com/configuration-options/#milestone) option takes a numeric milestone id; `1` is `10.x` in this repo. It is top-level only (not allowed in `packageRules`) and only applies at PR creation, so existing Renovate PRs are unaffected.

Companion PR for `branch_9x` follows, since the 9x Renovate job runs with `useBaseBranchConfig: "merge"` and would otherwise inherit this value.