### PR TITLE
Do not inherit the main-branch 10.x milestone for branch_9x Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,6 +62,7 @@
     }
   ],
   "schedule": ["before 9am on the first day of the month"],
+  "milestone": null,
   "prConcurrentLimit": 100,
   "prHourlyLimit": 10,
   "branchPrefix": "renovate-9x/",


### PR DESCRIPTION
Companion to #4821. The 9x Renovate job runs with `useBaseBranchConfig: "merge"`, so this overlay inherits `main`'s `renovate.json`, including the new `"milestone": 1` (= `10.x`). Setting it to `null` here keeps 9x PRs unmilestoned.

Set it to `3` instead if we want them in the `9.x` milestone.