### PR TITLE
SolrMessageProcessor: add resilience to NPE from test mocks

### DIFF
--- a/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
+++ b/solr/cross-dc-manager/src/java/org/apache/solr/crossdc/manager/messageprocessor/SolrMessageProcessor.java
@@ -377,9 +377,12 @@ public class SolrMessageProcessor extends MessageProcessor
     boolean connected = false;
     while (!connected) {
       try {
-        // forces a ZK round-trip, throwing if the cluster is unreachable
+        // a probe; throws if the cluster isn't reachable
         clientSupplier.get().getClusterStateProvider().getLiveNodes();
         connected = true;
+      } catch (NullPointerException | ClassCastException e) {
+        // a bug rather than an unreachable cluster; retrying it would loop forever
+        throw e;
       } catch (Exception e) {
         log.error("Unable to connect to solr server. Not consuming.", e);
         uncheckedSleep(5000);


### PR DESCRIPTION
minor improvement to avoid infinite loop in test/CI if we forget to mock a CloudSolrClient, as happened recently.