### PR TITLE
SOLR-17995: Deprecate "core URL" SolrStream constructors

### DIFF
--- a/changelog/unreleased/SOLR-17995-solrstream-coreUrl-removal.yml
+++ b/changelog/unreleased/SOLR-17995-solrstream-coreUrl-removal.yml
@@ -1,0 +1,13 @@
+# See https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc
+
+title: >
+  Deprecated the `SolrStream` constructors that accept a "core URL" (e.g.
+  `SolrStream(String collectionOrCoreUrl, SolrParams params)` and
+  `SolrStream(String collectionOrCoreUrl, String path, SolrParams params)`). Use one of the
+  "base URL" constructors instead, which take the core/collection name as a separate parameter.
+type: deprecated
+authors:
+  - name: Jason Gerlowski
+links:
+  - name: SOLR-17995
+    url: https://issues.apache.org/jira/browse/SOLR-17995

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
@@ -55,6 +55,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.URLUtil;
 
 /**
  * Connects to Zookeeper to pick replicas from a specific collection to send the query to. Under the
@@ -410,7 +411,15 @@ public class CloudSolrStream extends TupleStream implements Expressible {
             getShards(this.solrConnection, this.collection, this.streamContext, mParams);
         if (shards.isEmpty())
           throw new IOException("No shards available from ZooKeeper: " + this.solrConnection);
-        streamOfSolrStream = shards.stream().map(s -> new SolrStream(s, path, mParams));
+        streamOfSolrStream =
+            shards.stream()
+                .map(
+                    s ->
+                        new SolrStream(
+                            URLUtil.extractBaseUrl(s),
+                            URLUtil.extractCoreFromCoreUrl(s),
+                            path,
+                            mParams));
       } else {
         // stream of replicas to reuse the same SolrHttpClient per baseUrl
         // avoids re-parsing data we already have in the replicas

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/DeepRandomStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/DeepRandomStream.java
@@ -50,6 +50,7 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.URLUtil;
 
 /**
  * Connects to Zookeeper to pick replicas from a specific collection to send the query to. Under the
@@ -295,8 +296,9 @@ public class DeepRandomStream extends TupleStream implements Expressible {
         } else {
           useParams = mParams;
         }
-
-        SolrStream solrStream = new SolrStream(shardUrl, useParams);
+        final var baseUrl = URLUtil.extractBaseUrl(shardUrl);
+        final var core = URLUtil.extractCoreFromCoreUrl(shardUrl);
+        SolrStream solrStream = new SolrStream(baseUrl, useParams, core);
         if (streamContext != null) {
           solrStream.setStreamContext(streamContext);
         }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ParallelStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/ParallelStream.java
@@ -36,6 +36,7 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParamete
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.URLUtil;
 
 /**
  * The ParallelStream decorates a TupleStream implementation and pushes it to N workers for parallel
@@ -299,7 +300,12 @@ public class ParallelStream extends CloudSolrStream implements Expressible {
         paramsLoc.set("expr", pushStream.toString());
 
         String url = shardUrls.get(w);
-        SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+        SolrStream solrStream =
+            new SolrStream(
+                URLUtil.extractBaseUrl(url),
+                URLUtil.extractCoreFromCoreUrl(url),
+                "/stream",
+                paramsLoc);
         solrStream.setStreamContext(streamContext);
         solrStreams.add(solrStream);
       }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -89,7 +89,9 @@ public class SolrStream extends TupleStream {
    * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
    *     "/select".
    * @param params query-parameters sent with the streaming request
+   * @deprecated since 10.1. Use base URL constructor instead.
    */
+  @Deprecated
   public SolrStream(String collectionOrCoreUrl, String path, SolrParams params) {
     this(collectionOrCoreUrl, null, path, params);
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -73,9 +73,9 @@ public class SolrStream extends TupleStream {
    * @param collectionOrCoreUrl URL of the Solr core or collection to query, typically of the form
    *     "http://host:8983/solr/myCore".
    * @param params query-parameters sent with the streaming request
-   * @deprecated since 10.1. Use base URL constructor instead.
+   * @deprecatedUse base URL constructor instead.
    */
-  @Deprecated
+  @Deprecated(since = "10.1")
   public SolrStream(String collectionOrCoreUrl, SolrParams params) {
     this.baseUrl = collectionOrCoreUrl;
     this.params = params;
@@ -89,9 +89,9 @@ public class SolrStream extends TupleStream {
    * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
    *     "/select".
    * @param params query-parameters sent with the streaming request
-   * @deprecated since 10.1. Use base URL constructor instead.
+   * @deprecatedUse base URL constructor instead.
    */
-  @Deprecated
+  @Deprecated(since = "10.1")
   public SolrStream(String collectionOrCoreUrl, String path, SolrParams params) {
     this(collectionOrCoreUrl, null, path, params);
   }

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -69,13 +69,13 @@ public class SolrStream extends TupleStream {
   private transient SolrClientCache clientCache;
   private transient boolean doCloseCache;
 
-  // TODO SOLR-17995 proposes that we should deprecate this constructor in favor of one of the other
-  // constructors that requires users to provide the core as an explicit parameter
   /**
    * @param collectionOrCoreUrl URL of the Solr core or collection to query, typically of the form
    *     "http://host:8983/solr/myCore".
    * @param params query-parameters sent with the streaming request
+   * @deprecated since 10.1. Use base URL constructor instead.
    */
+  @Deprecated
   public SolrStream(String collectionOrCoreUrl, SolrParams params) {
     this.baseUrl = collectionOrCoreUrl;
     this.params = params;

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -73,7 +73,7 @@ public class SolrStream extends TupleStream {
    * @param collectionOrCoreUrl URL of the Solr core or collection to query, typically of the form
    *     "http://host:8983/solr/myCore".
    * @param params query-parameters sent with the streaming request
-   * @deprecatedUse base URL constructor instead.
+   * @deprecated Use base URL constructor instead.
    */
   @Deprecated(since = "10.1")
   public SolrStream(String collectionOrCoreUrl, SolrParams params) {
@@ -89,7 +89,7 @@ public class SolrStream extends TupleStream {
    * @param path the request handler path to query (e.g. "/export"). If not provided, defaults to
    *     "/select".
    * @param params query-parameters sent with the streaming request
-   * @deprecatedUse base URL constructor instead.
+   * @deprecated Use base URL constructor instead.
    */
   @Deprecated(since = "10.1")
   public SolrStream(String collectionOrCoreUrl, String path, SolrParams params) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SqlStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/SqlStream.java
@@ -37,6 +37,7 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParamete
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.URLUtil;
 
 /**
  * @since 7.0.0
@@ -194,7 +195,9 @@ public class SqlStream extends TupleStream implements Expressible {
       Collections.shuffle(shardUrls, new Random());
       String url = shardUrls.get(0);
       ModifiableSolrParams mParams = new ModifiableSolrParams(params);
-      this.tupleStream = new SolrStream(url, "/sql", mParams);
+      this.tupleStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(url), URLUtil.extractCoreFromCoreUrl(url), "/sql", mParams);
       if (streamContext != null) {
         tupleStream.setStreamContext(streamContext);
         if (streamContext.isLocal()) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/TopicStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/TopicStream.java
@@ -420,8 +420,7 @@ public class TopicStream extends CloudSolrStream implements Expressible {
     params.set("rows", 1);
     for (Replica replica : replicas) {
       if (replica.getState() == Replica.State.ACTIVE && liveNodes.contains(replica.getNodeName())) {
-        String coreUrl = replica.getCoreUrl();
-        SolrStream solrStream = new SolrStream(coreUrl, params);
+        SolrStream solrStream = new SolrStream(replica.getBaseUrl(), params, replica.getCoreName());
 
         if (streamContext != null) {
           StreamContext localContext = new StreamContext();
@@ -534,8 +533,7 @@ public class TopicStream extends CloudSolrStream implements Expressible {
       }
 
       Replica rep = shuffler.get(random.nextInt(shuffler.size()));
-      String url = rep.getCoreUrl();
-      SolrStream solrStream = new SolrStream(url, localParams);
+      SolrStream solrStream = new SolrStream(rep.getBaseUrl(), localParams, rep.getCoreName());
       solrStream.setSlice(slice.getName());
       solrStream.setCheckpoint(checkpoint);
       solrStream.setTrace(true);

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
@@ -505,7 +505,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
   public void testDaemonUpdateStream() throws Exception {
     final Replica daemonReplica = getRandomReplica(COLLECTION_X);
-    log.info("Using Daemon @ {}", daemonReplica.getCoreUrl());
+    if (log.isInfoEnabled()) {
+      log.info("Using Daemon @ {}", daemonReplica.getCoreUrl());
+    }
 
     {
       // NOTE: in spite of what is implied by 'terminate=true', this daemon will NEVER terminate on
@@ -567,7 +569,9 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
 
   public void testDaemonUpdateStreamInsufficientCredentials() throws Exception {
     final Replica daemonReplica = getRandomReplica(COLLECTION_X);
-    log.info("Using Daemon @ {}", daemonReplica.getCoreUrl());
+    if (log.isInfoEnabled()) {
+      log.info("Using Daemon @ {}", daemonReplica.getCoreUrl());
+    }
 
     // both of these users have valid credentials and authz read COLLECTION_X, but neither has
     // authz to write to X...

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/CloudAuthStreamTest.java
@@ -351,7 +351,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     { // WRITE_X user should be able to update X via a (dummy) stream from Y...
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_Y,
+              solrUrl,
+              COLLECTION_Y,
               "/stream",
               params(
                   "expr",
@@ -429,10 +430,11 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   public void testIndirectUpdateStreamInsufficientCredentials() throws Exception {
 
     // regardless of how it's routed, WRITE_Y should NOT have authz to stream updates to X...
-    for (String path : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
+    for (String coll : Arrays.asList(COLLECTION_X, COLLECTION_Y)) {
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + path,
+              solrUrl,
+              coll,
               "/stream",
               params(
                   "expr",
@@ -502,8 +504,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   }
 
   public void testDaemonUpdateStream() throws Exception {
-    final String daemonUrl = getRandomCoreUrl(COLLECTION_X);
-    log.info("Using Daemon @ {}", daemonUrl);
+    final Replica daemonReplica = getRandomReplica(COLLECTION_X);
+    log.info("Using Daemon @ {}", daemonReplica.getCoreUrl());
 
     {
       // NOTE: in spite of what is implied by 'terminate=true', this daemon will NEVER terminate on
@@ -513,7 +515,12 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
           "daemon(id=daemonId,runInterval=1000,terminate=true,update("
               + COLLECTION_X
               + ",tuple(id=42,a_i=1,b_i=5)))";
-      final SolrStream solrStream = new SolrStream(daemonUrl, "/stream", params("expr", expr));
+      final SolrStream solrStream =
+          new SolrStream(
+              daemonReplica.getBaseUrl(),
+              daemonReplica.getCoreName(),
+              "/stream",
+              params("expr", expr));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(solrStream);
       assertEquals(1, tuples.size()); // daemon starting status
@@ -524,7 +531,11 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
       final TimeOut timeout = new TimeOut(60, TimeUnit.SECONDS, TimeSource.NANO_TIME);
       while (!timeout.hasTimedOut()) {
         final SolrStream daemonCheck =
-            new SolrStream(daemonUrl, "/stream", params("action", "list"));
+            new SolrStream(
+                daemonReplica.getBaseUrl(),
+                daemonReplica.getCoreName(),
+                "/stream",
+                params("action", "list"));
         daemonCheck.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
         final List<Tuple> tuples = getTuples(daemonCheck);
         assertEquals(1, tuples.size()); // our daemon;
@@ -541,7 +552,11 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     } finally {
       // kill the damon...
       final SolrStream daemonKiller =
-          new SolrStream(daemonUrl, "/stream", params("action", "kill", "id", "daemonId"));
+          new SolrStream(
+              daemonReplica.getBaseUrl(),
+              daemonReplica.getCoreName(),
+              "/stream",
+              params("action", "kill", "id", "daemonId"));
       daemonKiller.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
       final List<Tuple> tuples = getTuples(daemonKiller);
       assertEquals(1, tuples.size()); // daemon death status
@@ -551,8 +566,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   }
 
   public void testDaemonUpdateStreamInsufficientCredentials() throws Exception {
-    final String daemonUrl = getRandomCoreUrl(COLLECTION_X);
-    log.info("Using Daemon @ {}", daemonUrl);
+    final Replica daemonReplica = getRandomReplica(COLLECTION_X);
+    log.info("Using Daemon @ {}", daemonReplica.getCoreUrl());
 
     // both of these users have valid credentials and authz read COLLECTION_X, but neither has
     // authz to write to X...
@@ -568,7 +583,10 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
                 + ",tuple(id=42,a_i=1,b_i=5)))     ";
         final SolrStream solrStream =
             new SolrStream(
-                daemonUrl, "/stream", params("_trace", "start_" + daemonId, "expr", expr));
+                daemonReplica.getBaseUrl(),
+                daemonReplica.getCoreName(),
+                "/stream",
+                params("_trace", "start_" + daemonId, "expr", expr));
         solrStream.setCredentials(user, passwordFor(user));
         final List<Tuple> tuples = getTuples(solrStream);
         assertEquals(1, tuples.size()); // daemon starting status
@@ -580,7 +598,10 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
         while (!timeout.hasTimedOut()) {
           final SolrStream daemonCheck =
               new SolrStream(
-                  daemonUrl, "/stream", params("_trace", "check_" + daemonId, "action", "list"));
+                  daemonReplica.getBaseUrl(),
+                  daemonReplica.getCoreName(),
+                  "/stream",
+                  params("_trace", "check_" + daemonId, "action", "list"));
           daemonCheck.setCredentials(user, passwordFor(user));
           final List<Tuple> tuples = getTuples(daemonCheck);
           assertEquals(1, tuples.size()); // our daemon;
@@ -604,7 +625,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
         // kill the damon...
         final SolrStream daemonKiller =
             new SolrStream(
-                daemonUrl,
+                daemonReplica.getBaseUrl(),
+                daemonReplica.getCoreName(),
                 "/stream",
                 params("_trace", "kill_" + daemonId, "action", "kill", "id", daemonId));
         daemonKiller.setCredentials(user, passwordFor(user));
@@ -765,7 +787,8 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
     { // WRITE_X user should be able to delete X via a (dummy) stream from Y...
       final SolrStream solrStream =
           new SolrStream(
-              solrUrl + "/" + COLLECTION_Y,
+              solrUrl,
+              COLLECTION_Y,
               "/stream",
               params("expr", "delete(" + COLLECTION_X + ",batchSize=1," + "tuple(id=42z))"));
       solrStream.setCredentials(WRITE_X_USER, passwordFor(WRITE_X_USER));
@@ -921,16 +944,15 @@ public class CloudAuthStreamTest extends SolrCloudTestCase {
   }
 
   /** Sigh. DaemonStream requires polling the same core where the stream was executed. */
-  protected static String getRandomCoreUrl(final String collection) {
-    final List<String> replicaUrls =
+  protected static Replica getRandomReplica(final String collection) {
+    final List<Replica> replicas =
         cluster
             .getZkStateReader()
             .getClusterState()
             .getCollectionOrNull(collection)
             .replicaStream()
-            .map(Replica::getCoreUrl)
             .collect(Collectors.toList());
-    Collections.shuffle(replicaUrls, random());
-    return replicaUrls.get(0);
+    Collections.shuffle(replicas, random());
+    return replicas.get(0);
   }
 }

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionTest.java
@@ -59,6 +59,7 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.junit.Assume;
@@ -309,7 +310,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
       solrParams.add("expr", "sort(search(" + COLLECTIONORALIAS + "), by=\"a_i asc\")");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      SolrStream solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -343,7 +349,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "sort(search("
               + COLLECTIONORALIAS
               + ", q=\"*:*\", fl=\"id,a_i\", sort=\"a_i asc\", partitionKeys=\"id\", qt=\"/export\"), by=\"a_i asc\")");
-      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -387,7 +398,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       solrParams.add(
           "expr",
           "sql(" + COLLECTIONORALIAS + ", stmt=\"select id from collection1 order by a_i asc\")");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      SolrStream solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -396,7 +412,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       // Test with using the default collection
       solrParams = new ModifiableSolrParams();
       solrParams.add("expr", "sql(stmt=\"select id from collection1 order by a_i asc\")");
-      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(5, tuples.size());
@@ -519,8 +540,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           .add(id, "1", "a_s", "hello1", "a_i", "1", "a_f", "1")
           .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-      String url =
-          cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
+      String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
       List<Tuple> tuples;
       TupleStream stream;
 
@@ -536,7 +556,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
           "q2",
           "search(" + COLLECTIONORALIAS + ", q=\"id:(1)\", fl=\"id,a_s,a_i,a_f\", sort=${mySort})");
       sParams.set("mySort", "a_f asc");
-      stream = new SolrStream(url, "/stream", sParams);
+      stream = new SolrStream(url, COLLECTIONORALIAS, "/stream", sParams);
       tuples = getTuples(stream);
 
       assertEquals(4, tuples.size());
@@ -544,7 +564,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       // Basic test desc
       sParams.set("mySort", "a_f desc");
-      stream = new SolrStream(url, "/stream", sParams);
+      stream = new SolrStream(url, COLLECTIONORALIAS, "/stream", sParams);
       tuples = getTuples(stream);
 
       assertEquals(4, tuples.size());
@@ -557,7 +577,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
               + COLLECTIONORALIAS
               + ", q=\"id:(1 2)\", fl=\"id,a_s,a_i,a_f\", sort=${mySort})");
       sParams.set("mySort", "\"a_f asc, a_s asc\"");
-      stream = new SolrStream(url, "/stream", sParams);
+      stream = new SolrStream(url, COLLECTIONORALIAS, "/stream", sParams);
       tuples = getTuples(stream);
 
       assertEquals(5, tuples.size());
@@ -1061,7 +1081,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
       solrParams.add("expr", expr);
       solrParams.add("myCollection.shards", buf.toString());
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      SolrStream solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
 
@@ -1091,7 +1116,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       try {
         ModifiableSolrParams solrParamsBad = new ModifiableSolrParams();
         solrParamsBad.add("expr", expr);
-        solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParamsBad);
+        solrStream =
+            new SolrStream(
+                URLUtil.extractBaseUrl(shardUrls.get(0)),
+                URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+                "/stream",
+                solrParamsBad);
         tuples = getTuples(solrStream);
         throw new Exception("Exception should have been thrown above");
       } catch (IOException e) {
@@ -1125,9 +1155,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\", count(*))";
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1154,7 +1183,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     expr = "facet2D(collection1, x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\")";
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1182,7 +1211,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\", sum(cases_i))";
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1210,7 +1239,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"3,1\", avg(cases_i))";
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -1238,7 +1267,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
         "facet2D(collection1, q=\"*:*\", x=\"diseases_s\", y=\"symptoms_s\", dimensions=\"2,2\")";
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -2236,7 +2265,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       solrParams.add(
           "expr",
           "search(\"collection1, collection2\", q=\"*:*\", fl=\"id, a_i\", rows=50, sort=\"a_i asc\")");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      SolrStream solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(10, tuples.size());
@@ -2248,7 +2282,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       solrParams.add(
           "expr",
           "search(\"collection1, collection2\", q=\"*:*\", fl=\"id, a_i\", sort=\"a_i asc\", path=\"/export\")");
-      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(10, tuples.size());
@@ -2258,7 +2297,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       solrParams.add(
           "expr",
           "facet(\"collection1, collection2\", q=\"*:*\", buckets=\"a_s\", bucketSorts=\"count(*) asc\", count(*))");
-      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -2277,7 +2321,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
 
       solrParams = new ModifiableSolrParams();
       solrParams.add("expr", expr);
-      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(1, tuples.size());
@@ -2291,7 +2340,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       solrParams.add(
           "expr",
           "parallel(collection1, sort=\"a_i asc\", workers=2, search(\"collection1, collection2\", q=\"*:*\", fl=\"id, a_i\", sort=\"a_i asc\", path=\"/export\", partitionKeys=\"a_s\"))");
-      solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);
       assertEquals(10, tuples.size());
@@ -2941,9 +2995,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -2956,7 +3009,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2968,7 +3021,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2980,7 +3033,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -2996,7 +3049,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3012,7 +3065,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3038,9 +3091,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3142,9 +3194,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3214,7 +3265,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3268,7 +3319,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3322,7 +3373,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3385,7 +3436,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3563,7 +3614,7 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    solrStream = new SolrStream(url, "/stream", paramsLoc);
+    solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     solrStream.setStreamContext(context);
     tuples = getTuples(solrStream);
@@ -3625,9 +3676,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", cat);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3656,9 +3706,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -3682,9 +3731,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc2 = new ModifiableSolrParams();
     paramsLoc2.set("expr", expr2);
 
-    String url2 =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream2 = new SolrStream(url2, "/stream", paramsLoc2);
+    String url2 = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream2 = new SolrStream(url2, COLLECTIONORALIAS, "/stream", paramsLoc2);
 
     StreamContext context2 = new StreamContext();
     solrStream2.setStreamContext(context2);
@@ -4080,7 +4128,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       ModifiableSolrParams solrParams = new ModifiableSolrParams();
       solrParams.add("expr", significantTerms);
       solrParams.add("myCollection.shards", buf.toString());
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      SolrStream solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       tuples = getTuples(solrStream);
       assertEquals(2, tuples.size());
 
@@ -4097,7 +4150,12 @@ public class StreamExpressionTest extends SolrCloudTestCase {
       try {
         ModifiableSolrParams solrParamsBad = new ModifiableSolrParams();
         solrParamsBad.add("expr", significantTerms);
-        solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParamsBad);
+        solrStream =
+            new SolrStream(
+                URLUtil.extractBaseUrl(shardUrls.get(0)),
+                URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+                "/stream",
+                solrParamsBad);
         tuples = getTuples(solrStream);
         throw new Exception("Exception should have been thrown above");
       } catch (IOException e) {
@@ -4196,10 +4254,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4218,10 +4275,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt.gz\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4240,10 +4296,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel-empty.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4257,10 +4312,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt,topLevel-empty.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4280,10 +4334,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"topLevel1.txt\", maxLines=2)";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4302,10 +4355,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     final String catStream = "cat(\"directory1\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4335,10 +4387,9 @@ public class StreamExpressionTest extends SolrCloudTestCase {
             + "secondLevel2.txt\")";
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", catStream);
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + FILESTREAM_COLLECTION;
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
 
-    SolrStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    SolrStream solrStream = new SolrStream(url, FILESTREAM_COLLECTION, "/stream", paramsLoc);
 
     StreamContext context = new StreamContext();
     solrStream.setStreamContext(context);
@@ -4363,9 +4414,8 @@ public class StreamExpressionTest extends SolrCloudTestCase {
     ModifiableSolrParams paramsLoc = new ModifiableSolrParams();
     paramsLoc.set("expr", expr);
 
-    String url =
-        cluster.getJettySolrRunners().get(0).getBaseUrl().toString() + "/" + COLLECTIONORALIAS;
-    TupleStream solrStream = new SolrStream(url, "/stream", paramsLoc);
+    String url = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    TupleStream solrStream = new SolrStream(url, COLLECTIONORALIAS, "/stream", paramsLoc);
     solrStream.setStreamContext(streamContext);
     getTuples(solrStream);
   }

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamingTest.java
@@ -64,6 +64,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.URLUtil;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.junit.Assume;
 import org.junit.Before;
@@ -2130,7 +2131,12 @@ public class StreamingTest extends SolrCloudTestCase {
           "rollup(search("
               + COLLECTIONORALIAS
               + ",q=\"*:*\",fl=\"a_s,a_i,a_f,b_f\",sort=\"a_s asc\",partitionKeys=\"a_s\", path=\"/export\"),over=\"a_s\",sum(a_i),sum(a_f),min(a_i),min(a_f),max(a_i),max(a_f),avg(a_i),avg(a_f),count(*),missing(b_f))\n");
-      SolrStream solrStream = new SolrStream(shardUrls.get(0), "/stream", solrParams);
+      SolrStream solrStream =
+          new SolrStream(
+              URLUtil.extractBaseUrl(shardUrls.get(0)),
+              URLUtil.extractCoreFromCoreUrl(shardUrls.get(0)),
+              "/stream",
+              solrParams);
       streamContext = new StreamContext();
       solrStream.setStreamContext(streamContext);
       tuples = getTuples(solrStream);


### PR DESCRIPTION
# Description
Due to some recent additions, SolrStream currently has 4 different constructors in order to support taking in either "base" URLs or "core" URLs.  This is a bit ugly.

# Solution

This PR streamlines this by deprecating the "core URL" constructors and switching usages over to using the "base URL" constructors instead.  The "core URLs" aren't removed entirely, though this can be done (on `main` only) in a subsequent PR.

# Tests

Existing tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/solr/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended, not available for branches on forks living under an organisation)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added a [changelog entry](https://github.com/apache/solr/blob/main/dev-docs/changelog.adoc) for my change
