### PR TITLE
Review and tidy solr/modules/gcs-repository code

### DIFF
--- a/solr/modules/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
+++ b/solr/modules/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
@@ -182,9 +182,8 @@ public class GCSBackupRepository extends AbstractBackupRepository {
     if (path.endsWith("/")) {
       return storage.get(bucketName, path, Storage.BlobGetOption.fields()) != null;
     } else {
-      final String filePath = path;
       final String directoryPath = path + "/";
-      return storage.get(bucketName, filePath, Storage.BlobGetOption.fields()) != null
+      return storage.get(bucketName, path, Storage.BlobGetOption.fields()) != null
           || storage.get(bucketName, directoryPath, Storage.BlobGetOption.fields()) != null;
     }
   }
@@ -201,9 +200,7 @@ public class GCSBackupRepository extends AbstractBackupRepository {
 
   @Override
   public String[] listAll(URI path) throws IOException {
-    final String blobName = appendTrailingSeparatorIfNecessary(path.toString());
-
-    final String pathStr = blobName;
+    final String pathStr = appendTrailingSeparatorIfNecessary(path.toString());
     final List<String> result = new ArrayList<>();
     storage
         .list(
@@ -231,10 +228,10 @@ public class GCSBackupRepository extends AbstractBackupRepository {
 
   @Override
   public IndexInput openInput(URI dirPath, String fileName, IOContext ctx) throws IOException {
-    return openInput(dirPath, fileName, ctx, readBufferSizeBytes);
+    return openInput(dirPath, fileName, readBufferSizeBytes);
   }
 
-  private IndexInput openInput(URI dirPath, String fileName, IOContext ctx, int bufferSize) {
+  private IndexInput openInput(URI dirPath, String fileName, int bufferSize) {
     String blobName = resolve(dirPath, fileName).toString();
 
     final BlobId blobId = BlobId.of(bucketName, blobName);
@@ -309,10 +306,9 @@ public class GCSBackupRepository extends AbstractBackupRepository {
   }
 
   protected List<BlobId> allBlobsAtDir(URI path) throws IOException {
-    final String blobName = appendTrailingSeparatorIfNecessary(path.toString());
+    final String pathStr = appendTrailingSeparatorIfNecessary(path.toString());
 
     final List<BlobId> result = new ArrayList<>();
-    final String pathStr = blobName;
     storage
         .list(bucketName, Storage.BlobListOption.prefix(pathStr), Storage.BlobListOption.fields())
         .iterateAll()

--- a/solr/modules/gcs-repository/src/test/org/apache/solr/gcs/GCSIncrementalBackupTest.java
+++ b/solr/modules/gcs-repository/src/test/org/apache/solr/gcs/GCSIncrementalBackupTest.java
@@ -18,13 +18,10 @@
 package org.apache.solr.gcs;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
-import java.lang.invoke.MethodHandles;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.cloud.api.collections.AbstractIncrementalBackupTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @LuceneTestCase.Nightly
 @ThreadLeakLingering(linger = 10)
@@ -32,7 +29,6 @@ import org.slf4j.LoggerFactory;
   "SimpleText"
 }) // Backups do checksum validation against a footer value not present in 'SimpleText'
 public class GCSIncrementalBackupTest extends AbstractIncrementalBackupTest {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   public static final String SOLR_XML =
       "<solr>\n"
           + "\n"
@@ -73,8 +69,6 @@ public class GCSIncrementalBackupTest extends AbstractIncrementalBackupTest {
           + "  \n"
           + "</solr>\n";
 
-  private static String backupLocation;
-
   @BeforeClass
   public static void setupClass() throws Exception {
     // Enable parallel backup/restore for cloud storage tests
@@ -88,7 +82,7 @@ public class GCSIncrementalBackupTest extends AbstractIncrementalBackupTest {
   }
 
   @AfterClass
-  public static void tearDownClass() throws Exception {
+  public static void tearDownClass() {
     LocalStorageGCSBackupRepository.clearStashedStorage();
   }
 

--- a/solr/modules/gcs-repository/src/test/org/apache/solr/gcs/GCSInstallShardTest.java
+++ b/solr/modules/gcs-repository/src/test/org/apache/solr/gcs/GCSInstallShardTest.java
@@ -67,7 +67,7 @@ public class GCSInstallShardTest extends AbstractInstallShardTest {
   }
 
   @AfterClass
-  public static void tearDownClass() throws Exception {
+  public static void tearDownClass() {
     LocalStorageGCSBackupRepository.clearStashedStorage();
   }
 }

--- a/solr/modules/gcs-repository/src/test/org/apache/solr/gcs/LocalStorageGCSBackupRepository.java
+++ b/solr/modules/gcs-repository/src/test/org/apache/solr/gcs/LocalStorageGCSBackupRepository.java
@@ -81,8 +81,8 @@ public class LocalStorageGCSBackupRepository extends GCSBackupRepository {
     }
 
     // FakeStorageRpc isn't thread-safe, which causes flaky test failures when multiple cores
-    // attempt to backup files
-    // simultaneously.  We work around this here by wrapping it in a delegating instance that adds a
+    // attempt to back up files simultaneously.  We work around this here by wrapping it in a
+    // delegating instance that adds a
     // measure of thread safety.
     stashedStorage =
         new ConcurrentDelegatingStorage(LocalStorageHelper.customOptions(false).getService());


### PR DESCRIPTION
# Description

Split out from #4743 into smaller, per-module PRs to make review easier. This PR contains only the tidy-up changes to `solr/modules/gcs-repository`.

# Solution

Leverage IntelliJ warnings (unused fields/params, javadoc/comment fixes). No behavior changes.

# Tests

existing

Relates to #4743