### PR TITLE
Review and tidy solr/modules/language-models code

### DIFF
--- a/solr/modules/language-models/src/java/org/apache/solr/languagemodels/update/processor/TextToVectorUpdateProcessor.java
+++ b/solr/modules/language-models/src/java/org/apache/solr/languagemodels/update/processor/TextToVectorUpdateProcessor.java
@@ -65,7 +65,7 @@ public class TextToVectorUpdateProcessor extends UpdateRequestProcessor {
       try {
         String textToVectorise = inputFieldContent.getValue().toString();
         float[] vector = textToVector.vectorise(textToVectorise);
-        List<Float> vectorAsList = new ArrayList<Float>(vector.length);
+        List<Float> vectorAsList = new ArrayList<>(vector.length);
         for (float f : vector) {
           vectorAsList.add(f);
         }

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/TestLanguageModelBase.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/TestLanguageModelBase.java
@@ -150,7 +150,7 @@ public class TestLanguageModelBase extends RestTestBase {
     assertJPut(LargeLanguageModelStore.REST_END_POINT, model, "/responseHeader/status==0");
   }
 
-  protected static void prepareIndex() throws Exception {
+  protected static void prepareIndex() {
     List<SolrInputDocument> docsToIndex = prepareDocs();
     for (SolrInputDocument doc : docsToIndex) {
       assertU(adoc(doc));

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/store/rest/TestLargeLanguageModelManager.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/store/rest/TestLargeLanguageModelManager.java
@@ -58,7 +58,7 @@ public class TestLargeLanguageModelManager extends TestLanguageModelBase {
 
     final ManagedResource res = restManager.getManagedResource(resourceId);
     assertTrue(res instanceof LargeLanguageModelStore);
-    assertEquals(res.getResourceId(), resourceId);
+    assertEquals(resourceId, res.getResourceId());
   }
 
   @Test

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/store/rest/TestTextToVectorModelManager.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/store/rest/TestTextToVectorModelManager.java
@@ -58,7 +58,7 @@ public class TestTextToVectorModelManager extends TestLanguageModelBase {
 
     final ManagedResource res = restManager.getManagedResource(resourceId);
     assertTrue(res instanceof TextToVectorModelStore);
-    assertEquals(res.getResourceId(), resourceId);
+    assertEquals(resourceId, res.getResourceId());
   }
 
   @Test

--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/update/processor/factory/DocumentEnrichmentUpdateProcessorFactoryTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/update/processor/factory/DocumentEnrichmentUpdateProcessorFactoryTest.java
@@ -419,8 +419,7 @@ public class DocumentEnrichmentUpdateProcessorFactoryTest extends TestLanguageMo
       String outputFieldName,
       String prompt,
       SolrCore core,
-      String modelName)
-      throws Exception {
+      String modelName) {
 
     LargeLanguageModelStore.getManagedModelStore(core)
         .addModel(new SolrLargeLanguageModel(modelName, null, null));


### PR DESCRIPTION
# Description

Split out from #4743 into smaller, per-module PRs to make review easier. This PR contains only the tidy-up changes to `solr/modules/language-models`.

# Solution

Leverage IntelliJ warnings (`isEmpty()` idioms, JUnit `assertEquals` argument-order fixes, javadoc/comment fixes). No behavior changes.

# Tests

existing

Relates to #4743