### PR TITLE
Review and tidy solr/modules/ltr code

### DIFF
--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/CSVFeatureLogger.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/CSVFeatureLogger.java
@@ -51,7 +51,7 @@ public class CSVFeatureLogger extends FeatureLogger {
       }
     }
 
-    final String features = (sb.length() > 0 ? sb.substring(0, sb.length() - 1) : "");
+    final String features = (!sb.isEmpty() ? sb.substring(0, sb.length() - 1) : "");
 
     return features;
   }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/FeatureLogger.java
@@ -23,7 +23,7 @@ public abstract class FeatureLogger {
   public enum FeatureFormat {
     DENSE,
     SPARSE
-  };
+  }
 
   protected final FeatureFormat featureFormat;
 

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRScoringQuery.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRScoringQuery.java
@@ -232,7 +232,7 @@ public class LTRScoringQuery extends Query implements Accountable {
         extractedFeatureWeights[i++] = fw;
       }
       for (final Feature f : modelFeatures) {
-        // we can lookup by featureid because all features will be extracted
+        // we can look up by featureid because all features will be extracted
         modelFeaturesWeights[j++] = extractedFeatureWeights[f.getIndex()];
       }
     } else {
@@ -248,10 +248,9 @@ public class LTRScoringQuery extends Query implements Accountable {
       IndexSearcher searcher,
       boolean needsScores,
       List<Feature.FeatureWeight> featureWeights,
-      Collection<Feature> features)
-      throws IOException {
+      Collection<Feature> features) {
     final SolrQueryRequest req = getRequest();
-    // since the feature store is a linkedhashmap order is preserved
+    // since the feature store is a linked hashmap order is preserved
     for (final Feature f : features) {
       try {
         Feature.FeatureWeight fw = f.createWeight(searcher, needsScores, req, originalQuery, efi);
@@ -465,7 +464,7 @@ public class LTRScoringQuery extends Query implements Accountable {
     public ModelScorer modelScorer(LeafReaderContext context) throws IOException {
 
       final List<Feature.FeatureWeight.FeatureScorer> featureScorers =
-          new ArrayList<Feature.FeatureWeight.FeatureScorer>(extractedFeatureWeights.length);
+          new ArrayList<>(extractedFeatureWeights.length);
       for (final Feature.FeatureWeight featureWeight : extractedFeatureWeights) {
         final Feature.FeatureWeight.FeatureScorer scorer = featureWeight.featureScorer(context);
         if (scorer != null) {

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRThreadModule.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/LTRThreadModule.java
@@ -155,7 +155,7 @@ public final class LTRThreadModule implements NamedListInitializedPlugin {
     ltrSemaphore.acquire();
   }
 
-  public void releaseLTRSemaphore() throws InterruptedException {
+  public void releaseLTRSemaphore() {
     ltrSemaphore.release();
   }
 

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/Feature.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/Feature.java
@@ -375,7 +375,7 @@ public abstract class Feature extends Query implements Accountable {
       }
 
       // Currently (Q1 2021) we intentionally don't delegate twoPhaseIterator()
-      // because it doesn't always work and we don't yet know why, please see
+      // because it doesn't always work, and we don't yet know why, please see
       // SOLR-15071 for more details.
 
       @Override

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/FieldLengthFeature.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/FieldLengthFeature.java
@@ -82,7 +82,7 @@ public class FieldLengthFeature extends Feature {
   }
 
   /** Decodes the norm value, assuming it is a single byte. */
-  private final float decodeNorm(long norm) {
+  private float decodeNorm(long norm) {
     return NORM_TABLE[(int) (norm & 0xFF)]; // & 0xFF maps negative bytes to
     // positive above 127
   }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/FieldValueFeature.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/FieldValueFeature.java
@@ -127,8 +127,8 @@ public class FieldValueFeature extends Feature {
     }
 
     /**
-     * Override this method in sub classes that wish to use not an absolute time but an interval
-     * such as document age or remaining shelf life relative to a specific date or relative to now.
+     * Override this method in subclasses that wish to use not an absolute time but an interval such
+     * as document age or remaining shelf life relative to a specific date or relative to now.
      *
      * @param val value of the field
      * @return value after transformation
@@ -179,14 +179,12 @@ public class FieldValueFeature extends Feature {
     /** A FeatureScorer that reads the stored value for a field */
     public class FieldValueFeatureScorer extends FeatureScorer {
 
-      private final LeafReaderContext context;
       private final StoredFields storedFields;
 
       public FieldValueFeatureScorer(
           FeatureWeight weight, LeafReaderContext context, DocIdSetIterator itr)
           throws IOException {
         super(weight, itr);
-        this.context = context;
         this.storedFields = (context == null ? null : context.reader().storedFields());
       }
 
@@ -205,7 +203,7 @@ public class FieldValueFeature extends Feature {
           } else {
             final String string = indexableField.stringValue();
             if (string.length() == 1) {
-              // boolean values in the index are encoded with the
+              // boolean values in the index are encoded with
               // a single char contained in TRUE_TOKEN or FALSE_TOKEN
               // (see BoolField)
               if (string.charAt(0) == BoolField.TRUE_TOKEN[0]) {
@@ -217,8 +215,7 @@ public class FieldValueFeature extends Feature {
             }
           }
         } catch (final IOException e) {
-          throw new FeatureException(
-              e.toString() + ": " + "Unable to extract feature for " + name, e);
+          throw new FeatureException(e + ": " + "Unable to extract feature for " + name, e);
         }
         return getDefaultValue();
       }
@@ -320,7 +317,7 @@ public class FieldValueFeature extends Feature {
       private float readSortedDocValues(BytesRef bytesRef) {
         String string = bytesRef.utf8ToString();
         if (string.length() == 1) {
-          // boolean values in the index are encoded with the
+          // boolean values in the index are encoded with
           // a single char contained in TRUE_TOKEN or FALSE_TOKEN
           // (see BoolField)
           if (string.charAt(0) == BoolField.TRUE_TOKEN[0]) {

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/ValueFeature.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/feature/ValueFeature.java
@@ -43,7 +43,7 @@ import org.apache.solr.request.SolrQueryRequest;
  * differently if the search came from a mobile device, or maybe you want to use your external query
  * intent system as a feature. In the rerank request you can pass in rq={... efi.userFromMobile=1},
  * and the above feature will return 1 for all the docs for that request. If required is set to
- * true, the request will return an error since you failed to pass in the efi, otherwise if will
+ * true, the request will return an error since you failed to pass in the efi, otherwise it will
  * just skip the feature and use a default value of 0 instead.
  */
 public class ValueFeature extends Feature {
@@ -64,7 +64,7 @@ public class ValueFeature extends Feature {
     } else if (value instanceof Double) {
       configValue = ((Double) value).floatValue();
     } else if (value instanceof Float) {
-      configValue = ((Float) value).floatValue();
+      configValue = (Float) value;
     } else if (value instanceof Integer) {
       configValue = ((Integer) value).floatValue();
     } else if (value instanceof Long) {

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingQuery.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/interleaving/LTRInterleavingQuery.java
@@ -24,12 +24,12 @@ import org.apache.solr.ltr.search.LTRQuery;
 import org.apache.solr.search.RankQuery;
 
 /**
- * A learning to rank Query with Interleaving, will incapsulate two models, and delegate to it the
+ * A learning to rank Query with Interleaving, will encapsulate two models, and delegate to it the
  * rescoring of the documents.
  */
 public class LTRInterleavingQuery extends LTRQuery {
   private final LTRInterleavingScoringQuery[] rerankingQueries;
-  private final Interleaving interlavingAlgorithm;
+  private final Interleaving interleavingAlgorithm;
 
   public LTRInterleavingQuery(
       Interleaving interleavingAlgorithm,
@@ -37,7 +37,7 @@ public class LTRInterleavingQuery extends LTRQuery {
       int rerankDocs) {
     super(null, rerankDocs, new LTRInterleavingRescorer(interleavingAlgorithm, rerankingQueries));
     this.rerankingQueries = rerankingQueries;
-    this.interlavingAlgorithm = interleavingAlgorithm;
+    this.interleavingAlgorithm = interleavingAlgorithm;
   }
 
   @Override
@@ -79,7 +79,7 @@ public class LTRInterleavingQuery extends LTRQuery {
 
   @Override
   protected Query rewrite(Query rewrittenMainQuery) throws IOException {
-    return new LTRInterleavingQuery(interlavingAlgorithm, rerankingQueries, reRankDocs)
+    return new LTRInterleavingQuery(interleavingAlgorithm, rerankingQueries, reRankDocs)
         .wrap(rewrittenMainQuery);
   }
 }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/LTRScoringModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/LTRScoringModel.java
@@ -201,7 +201,7 @@ public abstract class LTRScoringModel implements Accountable {
     return hashCode;
   }
 
-  private final int calculateHashCode() {
+  private int calculateHashCode() {
     final int prime = 31;
     int result = 1;
     result = (prime * result) + Objects.hashCode(features);

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/LinearModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/LinearModel.java
@@ -151,8 +151,7 @@ public class LinearModel extends LTRScoringModel {
       index++;
     }
 
-    return Explanation.match(
-        finalScore, toString() + " model applied to features, sum of:", details);
+    return Explanation.match(finalScore, this + " model applied to features, sum of:", details);
   }
 
   @Override

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/MultipleAdditiveTreesModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/MultipleAdditiveTreesModel.java
@@ -116,6 +116,10 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
 
   private boolean isNullSameAsZero = true;
 
+  public void setIsNullSameAsZero(boolean nullSameAsZero) {
+    isNullSameAsZero = nullSameAsZero;
+  }
+
   private RegressionTree createRegressionTree(Map<String, Object> map) {
     final RegressionTree rt = new RegressionTree();
     if (map != null) {
@@ -130,10 +134,6 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
       SolrPluginUtils.invokeSetters(rtn, map.entrySet());
     }
     return rtn;
-  }
-
-  public void setIsNullSameAsZero(boolean nullSameAsZero) {
-    isNullSameAsZero = nullSameAsZero;
   }
 
   public class RegressionTreeNode {
@@ -197,7 +197,7 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
         sb.append(value);
       } else {
         sb.append("(feature=").append(feature);
-        sb.append(",threshold=").append(threshold.floatValue() - NODE_SPLIT_SLACK);
+        sb.append(",threshold=").append(threshold - NODE_SPLIT_SLACK);
         if (missing != null) {
           sb.append(",missing=").append(missing);
         }
@@ -231,9 +231,9 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
 
     public float score(float[] featureVector) {
       if (isNullSameAsZero) {
-        return weight.floatValue() * scoreNode(featureVector, root);
+        return weight * scoreNode(featureVector, root);
       } else {
-        return weight.floatValue() * scoreNodeWithNullSupport(featureVector, root);
+        return weight * scoreNodeWithNullSupport(featureVector, root);
       }
     }
 
@@ -500,8 +500,7 @@ public class MultipleAdditiveTreesModel extends LTRScoringModel {
       index++;
     }
 
-    return Explanation.match(
-        finalScore, toString() + " model applied to features, sum of:", details);
+    return Explanation.match(finalScore, this + " model applied to features, sum of:", details);
   }
 
   @Override

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/NeuralNetworkModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/NeuralNetworkModel.java
@@ -112,11 +112,11 @@ public class NeuralNetworkModel extends LTRScoringModel {
   }
 
   public interface Layer {
-    public float[] calculateOutput(float[] inputVec);
+    float[] calculateOutput(float[] inputVec);
 
-    public int validate(int inputDim) throws ModelException;
+    int validate(int inputDim) throws ModelException;
 
-    public String describe();
+    String describe();
   }
 
   public class DefaultLayer implements Layer {
@@ -235,11 +235,11 @@ public class NeuralNetworkModel extends LTRScoringModel {
             "Dimension mismatch in model \""
                 + name
                 + "\". Layer "
-                + Integer.toString(this.layerID)
+                + this.layerID
                 + " has "
-                + Integer.toString(this.numUnits)
+                + this.numUnits
                 + " bias weights but "
-                + Integer.toString(this.matrixRows)
+                + this.matrixRows
                 + " weight matrix rows.");
       }
       if (this.activation == null) {
@@ -247,7 +247,7 @@ public class NeuralNetworkModel extends LTRScoringModel {
             "Invalid activation function (\""
                 + this.activationStr
                 + "\") in layer "
-                + Integer.toString(this.layerID)
+                + this.layerID
                 + " of model \""
                 + name
                 + "\".");
@@ -258,23 +258,23 @@ public class NeuralNetworkModel extends LTRScoringModel {
               "Dimension mismatch in model \""
                   + name
                   + "\". The input has "
-                  + Integer.toString(inputDim)
+                  + inputDim
                   + " features, but the weight matrix for layer 0 has "
-                  + Integer.toString(this.matrixCols)
+                  + this.matrixCols
                   + " columns.");
         } else {
           throw new ModelException(
               "Dimension mismatch in model \""
                   + name
                   + "\". The weight matrix for layer "
-                  + Integer.toString(this.layerID - 1)
+                  + (this.layerID - 1)
                   + " has "
-                  + Integer.toString(inputDim)
+                  + inputDim
                   + " rows, but the "
                   + "weight matrix for layer "
-                  + Integer.toString(this.layerID)
+                  + this.layerID
                   + " has "
-                  + Integer.toString(this.matrixCols)
+                  + this.matrixCols
                   + " columns.");
         }
       }
@@ -285,9 +285,9 @@ public class NeuralNetworkModel extends LTRScoringModel {
     public String describe() {
       final StringBuilder sb = new StringBuilder();
       sb.append("(matrix=")
-          .append(Integer.toString(this.matrixRows))
+          .append(this.matrixRows)
           .append('x')
-          .append(Integer.toString(this.matrixCols))
+          .append(this.matrixCols)
           .append(",activation=")
           .append(this.activationStr)
           .append(")");
@@ -338,7 +338,7 @@ public class NeuralNetworkModel extends LTRScoringModel {
           "The output matrix for model \""
               + name
               + "\" has "
-              + Integer.toString(inputDim)
+              + inputDim
               + " rows, but should only have one.");
     }
   }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/model/WrapperModel.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/model/WrapperModel.java
@@ -165,10 +165,6 @@ public abstract class WrapperModel extends AdapterModel {
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder(getClass().getSimpleName());
-    sb.append("(name=").append(getName());
-    sb.append(",model=(").append(model.toString()).append(")");
-
-    return sb.toString();
+    return getClass().getSimpleName() + "(name=" + getName() + ",model=(" + model.toString() + ")";
   }
 }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/norm/Normalizer.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/norm/Normalizer.java
@@ -35,7 +35,7 @@ public abstract class Normalizer {
 
   public Explanation explain(Explanation explain) {
     final float normalized = normalize(explain.getValue().floatValue());
-    final String explainDesc = "normalized using " + toString();
+    final String explainDesc = "normalized using " + this;
 
     return Explanation.match(normalized, explainDesc, explain);
   }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -486,7 +486,7 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
         float finalScore,
         List<Explanation> featureExplanations) {
       return Explanation.match(
-          finalScore, toString() + " logging model, used only for logging the features");
+          finalScore, this + " logging model, used only for logging the features");
     }
   }
 }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/search/LTRQParserPlugin.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/search/LTRQParserPlugin.java
@@ -99,9 +99,9 @@ public class LTRQParserPlugin extends QParserPlugin
   }
 
   /**
-   * Given a set of local SolrParams, extract all of the efi.key=value params into a map
+   * Given a set of local SolrParams, extract all the efi.key=value params into a map
    *
-   * @param localParams Local request parameters that might conatin efi params
+   * @param localParams Local request parameters that might contain efi params
    * @return Map of efi params, where the key is the name of the efi param, and the value is the
    *     value of the efi param
    */

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/search/LTRQuery.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/search/LTRQuery.java
@@ -26,7 +26,7 @@ import org.apache.solr.search.AbstractReRankQuery;
 import org.apache.solr.search.RankQuery;
 
 /**
- * A learning to rank Query, will incapsulate a learning to rank model, and delegate to it the
+ * A learning to rank Query, will encapsulate a learning to rank model, and delegate to it the
  * rescoring of the documents.
  */
 public class LTRQuery extends AbstractReRankQuery {

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/store/ModelStore.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/store/ModelStore.java
@@ -42,8 +42,7 @@ public class ModelStore {
   }
 
   public List<LTRScoringModel> getModels() {
-    final List<LTRScoringModel> availableModelsValues =
-        new ArrayList<LTRScoringModel>(availableModels.values());
+    final List<LTRScoringModel> availableModelsValues = new ArrayList<>(availableModels.values());
     return Collections.unmodifiableList(availableModelsValues);
   }
 

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedFeatureStore.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedFeatureStore.java
@@ -155,9 +155,7 @@ public class ManagedFeatureStore extends ManagedResource
 
   @Override
   public synchronized void doDeleteChild(BaseSolrResource endpoint, String childId) {
-    if (stores.containsKey(childId)) {
-      stores.remove(childId);
-    }
+    stores.remove(childId);
     storeManagedData(applyUpdatesToManagedData(null));
   }
 

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
@@ -42,7 +42,7 @@ import org.apache.solr.rest.ManagedResourceStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Menaged resource for storing a model */
+/** Managed resource for storing a model */
 public class ManagedModelStore extends ManagedResource
     implements ManagedResource.ChildResourceSupport {
 

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/FeatureLoggerTestUtils.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/FeatureLoggerTestUtils.java
@@ -35,7 +35,7 @@ public class FeatureLoggerTestUtils {
           .append(featureSeparator);
     }
 
-    final String features = (sb.length() > 0 ? sb.substring(0, sb.length() - 1) : "");
+    final String features = (!sb.isEmpty() ? sb.substring(0, sb.length() - 1) : "");
 
     return features;
   }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserExplain.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRQParserExplain.java
@@ -213,30 +213,78 @@ public class TestLTRQParserExplain extends TestRerankBase {
     int[] expectedInterleaved = new int[] {7, 6, 8, 9};
     String[] expectedExplains =
         new String[] {
-          "\n8.0 = LinearModel(name=modelB,"
-              + "featureWeights=[featureB1=2.0,featureB2=4.0,featureAB=8.0]) "
-              + "model applied to features, sum of:\n  "
-              + "0.0 = prod of:\n    2.0 = weight on feature\n    0.0 = SolrFeature [name=featureB1, params={fq=[{!terms f=popularity}5]}]\n  "
-              + "0.0 = prod of:\n    4.0 = weight on feature\n    0.0 = SolrFeature [name=featureB2, params={fq=[{!terms f=title}different]}]\n  "
-              + "8.0 = prod of:\n    8.0 = weight on feature\n    1.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]\n",
-          "\n12.0 = LinearModel(name=modelA,"
-              + "featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) "
-              + "model applied to features, sum of:\n  "
-              + "3.0 = prod of:\n    3.0 = weight on feature\n    1.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]\n  "
-              + "9.0 = prod of:\n    9.0 = weight on feature\n    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]\n  "
-              + "0.0 = prod of:\n    27.0 = weight on feature\n    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]\n",
-          "\n9.0 = LinearModel(name=modelA,"
-              + "featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) "
-              + "model applied to features, sum of:\n  "
-              + "0.0 = prod of:\n    3.0 = weight on feature\n    0.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]\n  "
-              + "9.0 = prod of:\n    9.0 = weight on feature\n    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]\n  "
-              + "0.0 = prod of:\n    27.0 = weight on feature\n    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]\n",
-          "\n2.0 = LinearModel(name=modelB,"
-              + "featureWeights=[featureB1=2.0,featureB2=4.0,featureAB=8.0]) "
-              + "model applied to features, sum of:\n  "
-              + "2.0 = prod of:\n    2.0 = weight on feature\n    1.0 = SolrFeature [name=featureB1, params={fq=[{!terms f=popularity}5]}]\n  "
-              + "0.0 = prod of:\n    4.0 = weight on feature\n    0.0 = SolrFeature [name=featureB2, params={fq=[{!terms f=title}different]}]\n  "
-              + "0.0 = prod of:\n    8.0 = weight on feature\n    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]\n"
+"""
+
+8.0 = LinearModel(name=modelB,\
+featureWeights=[featureB1=2.0,featureB2=4.0,featureAB=8.0]) \
+model applied to features, sum of:
+  \
+0.0 = prod of:
+    2.0 = weight on feature
+    0.0 = SolrFeature [name=featureB1, params={fq=[{!terms f=popularity}5]}]
+  \
+0.0 = prod of:
+    4.0 = weight on feature
+    0.0 = SolrFeature [name=featureB2, params={fq=[{!terms f=title}different]}]
+  \
+8.0 = prod of:
+    8.0 = weight on feature
+    1.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]
+""",
+"""
+
+12.0 = LinearModel(name=modelA,\
+featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) \
+model applied to features, sum of:
+  \
+3.0 = prod of:
+    3.0 = weight on feature
+    1.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]
+  \
+9.0 = prod of:
+    9.0 = weight on feature
+    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]
+  \
+0.0 = prod of:
+    27.0 = weight on feature
+    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]
+""",
+"""
+
+9.0 = LinearModel(name=modelA,\
+featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) \
+model applied to features, sum of:
+  \
+0.0 = prod of:
+    3.0 = weight on feature
+    0.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]
+  \
+9.0 = prod of:
+    9.0 = weight on feature
+    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]
+  \
+0.0 = prod of:
+    27.0 = weight on feature
+    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]
+""",
+"""
+
+2.0 = LinearModel(name=modelB,\
+featureWeights=[featureB1=2.0,featureB2=4.0,featureAB=8.0]) \
+model applied to features, sum of:
+  \
+2.0 = prod of:
+    2.0 = weight on feature
+    1.0 = SolrFeature [name=featureB1, params={fq=[{!terms f=popularity}5]}]
+  \
+0.0 = prod of:
+    4.0 = weight on feature
+    0.0 = SolrFeature [name=featureB2, params={fq=[{!terms f=title}different]}]
+  \
+0.0 = prod of:
+    8.0 = weight on feature
+    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]
+"""
         };
 
     String[] tests = new String[16];
@@ -293,34 +341,84 @@ public class TestLTRQParserExplain extends TestRerankBase {
     int[] expectedInterleaved = new int[] {9, 7, 6, 8};
     String[] expectedExplains =
         new String[] {
-          "\n0.07662583 = weight(title:bloomberg in 3) [SchemaSimilarity], result of:\n  "
-              + "0.07662583 = score(freq=4.0), computed as boost * idf * tf from:\n    "
-              + "0.105360515 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n      4 = n, number of documents containing term\n      4 = N, total number of documents with field\n    "
-              + "0.72727275 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:\n      4.0 = freq, occurrences of term within document\n      "
-              + "1.2 = k1, term saturation parameter\n      "
-              + "0.75 = b, length normalization parameter\n      "
-              + "4.0 = dl, length of field\n      "
-              + "3.0 = avgdl, average length of field\n",
-          "\n36.0 = LinearModel(name=modelA,"
-              + "featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) "
-              + "model applied to features, sum of:\n  "
-              + "0.0 = prod of:\n    3.0 = weight on feature\n    0.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]\n  "
-              + "9.0 = prod of:\n    9.0 = weight on feature\n    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]\n  "
-              + "27.0 = prod of:\n    27.0 = weight on feature\n    1.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]\n",
-          "\n12.0 = LinearModel(name=modelA,"
-              + "featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) "
-              + "model applied to features, sum of:\n  "
-              + "3.0 = prod of:\n    3.0 = weight on feature\n    1.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]\n  "
-              + "9.0 = prod of:\n    9.0 = weight on feature\n    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]\n  "
-              + "0.0 = prod of:\n    27.0 = weight on feature\n    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]\n",
-          "\n0.07525751 = weight(title:bloomberg in 2) [SchemaSimilarity], result of:\n  "
-              + "0.07525751 = score(freq=3.0), computed as boost * idf * tf from:\n    "
-              + "0.105360515 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n      4 = n, number of documents containing term\n      4 = N, total number of documents with field\n    "
-              + "0.71428573 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:\n      3.0 = freq, occurrences of term within document\n      "
-              + "1.2 = k1, term saturation parameter\n      "
-              + "0.75 = b, length normalization parameter\n      "
-              + "3.0 = dl, length of field\n      "
-              + "3.0 = avgdl, average length of field\n"
+"""
+
+0.07662583 = weight(title:bloomberg in 3) [SchemaSimilarity], result of:
+  \
+0.07662583 = score(freq=4.0), computed as boost * idf * tf from:
+    \
+0.105360515 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:
+      4 = n, number of documents containing term
+      4 = N, total number of documents with field
+    \
+0.72727275 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:
+      4.0 = freq, occurrences of term within document
+      \
+1.2 = k1, term saturation parameter
+      \
+0.75 = b, length normalization parameter
+      \
+4.0 = dl, length of field
+      \
+3.0 = avgdl, average length of field
+""",
+"""
+
+36.0 = LinearModel(name=modelA,\
+featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) \
+model applied to features, sum of:
+  \
+0.0 = prod of:
+    3.0 = weight on feature
+    0.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]
+  \
+9.0 = prod of:
+    9.0 = weight on feature
+    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]
+  \
+27.0 = prod of:
+    27.0 = weight on feature
+    1.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]
+""",
+"""
+
+12.0 = LinearModel(name=modelA,\
+featureWeights=[featureA1=3.0,featureA2=9.0,featureAB=27.0]) \
+model applied to features, sum of:
+  \
+3.0 = prod of:
+    3.0 = weight on feature
+    1.0 = SolrFeature [name=featureA1, params={fq=[{!terms f=popularity}1]}]
+  \
+9.0 = prod of:
+    9.0 = weight on feature
+    1.0 = SolrFeature [name=featureA2, params={fq=[{!terms f=description}bloomberg]}]
+  \
+0.0 = prod of:
+    27.0 = weight on feature
+    0.0 = SolrFeature [name=featureAB, params={fq=[{!terms f=popularity}2]}]
+""",
+"""
+
+0.07525751 = weight(title:bloomberg in 2) [SchemaSimilarity], result of:
+  \
+0.07525751 = score(freq=3.0), computed as boost * idf * tf from:
+    \
+0.105360515 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:
+      4 = n, number of documents containing term
+      4 = N, total number of documents with field
+    \
+0.71428573 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:
+      3.0 = freq, occurrences of term within document
+      \
+1.2 = k1, term saturation parameter
+      \
+0.75 = b, length normalization parameter
+      \
+3.0 = dl, length of field
+      \
+3.0 = avgdl, average length of field
+"""
         };
 
     String[] tests = new String[16];

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRReRankingPipeline.java
@@ -66,7 +66,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
   private static List<Feature> makeFieldValueFeatures(int[] featureIds, String field) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      final Map<String, Object> params = new HashMap<String, Object>();
+      final Map<String, Object> params = new HashMap<>();
       params.put("field", field);
       final Feature f =
           Feature.getInstance(
@@ -126,8 +126,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       final List<Feature> features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScore");
       final List<Normalizer> norms =
-          new ArrayList<Normalizer>(
-              Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+          new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
       final List<Feature> allFeatures =
           makeFieldValueFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, "finalScore");
       final LTRScoringModel ltrScoringModel =
@@ -181,8 +180,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
 
       final List<Feature> features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScoreFloat");
       final List<Normalizer> norms =
-          new ArrayList<Normalizer>(
-              Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+          new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
       final List<Feature> allFeatures =
           makeFieldValueFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, "finalScoreFloat");
       final Double featureWeight = 0.1;
@@ -238,8 +236,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
         new SolrQueryRequestBase(h.getCore(), new ModifiableSolrParams())) {
       List<Feature> features = makeFieldValueFeatures(new int[] {0}, "finalScore");
       List<Normalizer> norms =
-          new ArrayList<Normalizer>(
-              Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+          new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
       List<Feature> allFeatures = makeFieldValueFeatures(new int[] {0}, "finalScore");
       MockModel ltrScoringModel = new MockModel("test", features, norms, "test", allFeatures, null);
       LTRScoringQuery query = new LTRScoringQuery(ltrScoringModel);
@@ -255,9 +252,7 @@ public class TestLTRReRankingPipeline extends SolrTestCaseJ4 {
       }
 
       features = makeFieldValueFeatures(new int[] {0, 1, 2}, "finalScore");
-      norms =
-          new ArrayList<Normalizer>(
-              Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+      norms = new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
       allFeatures = makeFieldValueFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, "finalScore");
       ltrScoringModel = new MockModel("test", features, norms, "test", allFeatures, null);
       query = new LTRScoringQuery(ltrScoringModel);

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRScoringQuery.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRScoringQuery.java
@@ -66,7 +66,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
   private static List<Feature> makeFeatures(int[] featureIds) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("value", i);
       final Feature f =
           Feature.getInstance(solrResourceLoader, ValueFeature.class.getName(), "f" + i, params);
@@ -79,7 +79,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
   private static List<Feature> makeFilterFeatures(int[] featureIds) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("value", i);
       final Feature f =
           Feature.getInstance(solrResourceLoader, ValueFeature.class.getName(), "f" + i, params);
@@ -116,8 +116,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
   public void testLTRScoringQueryEquality() throws ModelException {
     final List<Feature> features = makeFeatures(new int[] {0, 1, 2});
     final List<Normalizer> norms =
-        new ArrayList<Normalizer>(
-            Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+        new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
     final List<Feature> allFeatures = makeFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
     final Map<String, Object> modelParams = TestLinearModel.makeFeatureWeights(features);
 
@@ -199,8 +198,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
     List<Feature> features = makeFeatures(new int[] {0, 1, 2});
     final List<Feature> allFeatures = makeFeatures(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
     List<Normalizer> norms =
-        new ArrayList<Normalizer>(
-            Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+        new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
     LTRScoringModel ltrScoringModel =
         TestLinearModel.createLinearModel(
             "test",
@@ -230,9 +228,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
 
     final int[] mixPositions = new int[] {8, 2, 4, 9, 0};
     features = makeFeatures(mixPositions);
-    norms =
-        new ArrayList<Normalizer>(
-            Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+    norms = new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
     ltrScoringModel =
         TestLinearModel.createLinearModel(
             "test",
@@ -254,9 +250,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
         new ModelException("no features declared for model test");
     final int[] noPositions = new int[] {};
     features = makeFeatures(noPositions);
-    norms =
-        new ArrayList<Normalizer>(
-            Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+    norms = new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
     try {
       ltrScoringModel =
           TestLinearModel.createLinearModel(
@@ -292,7 +286,7 @@ public class TestLTRScoringQuery extends SolrTestCase {
           @Override
           protected void validate() throws NormalizerException {}
         };
-    norms = new ArrayList<Normalizer>(Collections.nCopies(features.size(), norm));
+    norms = new ArrayList<>(Collections.nCopies(features.size(), norm));
     final LTRScoringModel normMeta =
         TestLinearModel.createLinearModel(
             "test",

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRWithFacet.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestLTRWithFacet.java
@@ -75,7 +75,7 @@ public class TestLTRWithFacet extends TestRerankBase {
     // Normal term match
     assertJQ(
         "/query" + query.toQueryString(),
-        "" + "/facet_counts/facet_fields/description==" + "['b', 4, 'e', 2, 'c', 1, 'd', 1]");
+        "/facet_counts/facet_fields/description==" + "['b', 4, 'e', 2, 'c', 1, 'd', 1]");
 
     query.add("rq", "{!ltr model=powpularityS-model reRankDocs=4}");
     query.set("debugQuery", "on");
@@ -92,6 +92,6 @@ public class TestLTRWithFacet extends TestRerankBase {
 
     assertJQ(
         "/query" + query.toQueryString(),
-        "" + "/facet_counts/facet_fields/description==" + "['b', 4, 'e', 2, 'c', 1, 'd', 1]");
+        "/facet_counts/facet_fields/description==" + "['b', 4, 'e', 2, 'c', 1, 'd', 1]");
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestParallelWeightCreation.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestParallelWeightCreation.java
@@ -51,14 +51,13 @@ public class TestParallelWeightCreation extends TestRerankBase {
   }
 
   @Test
-  public void testLTRQParserThreadInitialization() throws Exception {
+  public void testLTRQParserThreadInitialization() {
     // setting the value of number of threads to -ve should throw an exception
     String msg1 = null;
     try {
       new LTRThreadModule(1, -1);
     } catch (IllegalArgumentException iae) {
       msg1 = iae.getMessage();
-      ;
     }
     assertEquals("numThreadsPerRequest cannot be less than 1", msg1);
 

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestRerankBase.java
@@ -56,7 +56,6 @@ public class TestRerankBase extends RestTestBase {
 
   public static final String FEATURE_FILE_NAME = "_schema_feature-store.json";
   public static final String MODEL_FILE_NAME = "_schema_model-store.json";
-  public static final String PARENT_ENDPOINT = "/schema/*";
 
   protected static final String COLLECTION = "collection1";
   protected static final String CONF_DIR = COLLECTION + "/conf";
@@ -83,7 +82,7 @@ public class TestRerankBase extends RestTestBase {
     }
   }
 
-  protected static void chooseDefaultFeatureFormat() throws Exception {
+  protected static void chooseDefaultFeatureFormat() {
     switch (random().nextInt(3)) {
       case 0:
         defaultFeatureFormat = null;
@@ -286,14 +285,13 @@ public class TestRerankBase extends RestTestBase {
   }
 
   public static LTRScoringModel createModelFromFiles(String modelFileName, String featureFileName)
-      throws ModelException, Exception {
+      throws Exception {
     return createModelFromFiles(
         modelFileName, featureFileName, FeatureStore.DEFAULT_FEATURE_STORE_NAME);
   }
 
   public static LTRScoringModel createModelFromFiles(
-      String modelFileName, String featureFileName, String featureStoreName)
-      throws ModelException, Exception {
+      String modelFileName, String featureFileName, String featureStoreName) throws Exception {
     URL url = TestRerankBase.class.getResource("/modelExamples/" + modelFileName);
     final String modelJson = Files.readString(Path.of(url.toURI()), StandardCharsets.UTF_8);
     final ManagedModelStore ms = getManagedModelStore();
@@ -311,7 +309,7 @@ public class TestRerankBase extends RestTestBase {
     final ManagedFeatureStore fs = getManagedFeatureStore();
     // fs.getFeatureStore(null).clear();
     fs.doDeleteChild(null, featureStoreName); // is this safe??
-    // based on my need to call this I dont think that
+    // based on my need to call this I don't think that
     // "getNewManagedFeatureStore()"
     // is actually returning a new feature store each time
     fs.applyUpdatesToManagedData(parsedFeatureJson);
@@ -347,7 +345,7 @@ public class TestRerankBase extends RestTestBase {
     final List<Feature> features = new ArrayList<>();
     int pos = 0;
     for (final String name : names) {
-      final Map<String, Object> params = new HashMap<String, Object>();
+      final Map<String, Object> params = new HashMap<>();
       params.put("value", 10);
       final Feature f =
           Feature.getInstance(
@@ -363,7 +361,7 @@ public class TestRerankBase extends RestTestBase {
     return getFeatures(Arrays.asList(names));
   }
 
-  protected static void bulkIndex() throws Exception {
+  protected static void bulkIndex() {
     assertU(
         adoc(
             "title",
@@ -408,10 +406,10 @@ public class TestRerankBase extends RestTestBase {
   }
 
   protected static void doTestParamsToMap(
-      String featureClassName, LinkedHashMap<String, Object> featureParams) throws Exception {
+      String featureClassName, LinkedHashMap<String, Object> featureParams) {
 
     // start with default parameters
-    final LinkedHashMap<String, Object> paramsA = new LinkedHashMap<String, Object>();
+    final LinkedHashMap<String, Object> paramsA = new LinkedHashMap<>();
     final Object defaultValue;
     switch (random().nextInt(6)) {
       case 0:
@@ -421,16 +419,16 @@ public class TestRerankBase extends RestTestBase {
         defaultValue = "1.2";
         break;
       case 2:
-        defaultValue = Double.valueOf(3.4d);
+        defaultValue = 3.4d;
         break;
       case 3:
-        defaultValue = Float.valueOf(0.5f);
+        defaultValue = 0.5f;
         break;
       case 4:
-        defaultValue = Integer.valueOf(67);
+        defaultValue = 67;
         break;
       case 5:
-        defaultValue = Long.valueOf(89);
+        defaultValue = 89L;
         break;
       default:
         defaultValue = null;

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/TestSelectiveWeightCreation.java
@@ -59,7 +59,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
   private static List<Feature> makeFeatures(int[] featureIds) {
     final List<Feature> features = new ArrayList<>();
     for (final int i : featureIds) {
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("value", i);
       final Feature f =
           Feature.getInstance(solrResourceLoader, ValueFeature.class.getName(), "f" + i, params);
@@ -70,7 +70,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
   }
 
   private LTRScoringQuery.ModelWeight performQuery(
-      TopDocs hits, IndexSearcher searcher, int docid, LTRScoringQuery model)
+      TopDocs hits, IndexSearcher searcher, LTRScoringQuery model)
       throws IOException, ModelException {
     final List<LeafReaderContext> leafContexts = searcher.getTopReaderContext().leaves();
     final int n = ReaderUtil.subIndex(hits.scoreDocs[0].doc, leafContexts);
@@ -165,7 +165,6 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
         performQuery(
             hits,
             searcher,
-            hits.scoreDocs[0].doc,
             new LTRScoringQuery(ltrScoringModel1)); // features not requested in response
     LTRScoringQuery.FeatureInfo[] featuresInfo = modelWeight.getAllFeaturesInStore();
 
@@ -190,7 +189,7 @@ public class TestSelectiveWeightCreation extends TestRerankBase {
     LTRScoringQuery ltrQuery2 = new LTRScoringQuery(ltrScoringModel2);
     // features requested in response
     ltrQuery2.setFeatureLogger(new CSVFeatureLogger(FeatureLogger.FeatureFormat.DENSE, true));
-    modelWeight = performQuery(hits, searcher, hits.scoreDocs[0].doc, ltrQuery2);
+    modelWeight = performQuery(hits, searcher, ltrQuery2);
     featuresInfo = modelWeight.getAllFeaturesInStore();
 
     assertEquals(features.size(), modelWeight.getModelFeatureValuesNormalized().length);

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestExternalFeatures.java
@@ -129,7 +129,7 @@ public class TestExternalFeatures extends TestRerankBase {
     query.add("fl", "score,fvalias:[fv store=fstore3 efi.myOcc=2.3]");
     assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/fvalias=='" + docs0fv_csv + "'");
 
-    // Adding efi in transformer + rq should still returns features
+    // Adding efi in transformer + rq should still return features
     query.remove("fl");
     query.add("fl", "score,fvalias:[fv store=fstore3 efi.myOcc=2.3]");
     query.add("rq", "{!ltr reRankDocs=10 model=externalmodel efi.user_query=w3}");

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureExtractionFromMultipleSegments.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestFeatureExtractionFromMultipleSegments.java
@@ -256,9 +256,9 @@ public class TestFeatureExtractionFromMultipleSegments extends TestRerankBase {
     int passCount = 0;
     for (final Map<String, Object> doc : docs) {
       String features = (String) doc.get("fv");
-      assertTrue(features.length() > 0);
+      assertFalse(features.isEmpty());
       ++passCount;
     }
-    assertEquals(passCount, numRows);
+    assertEquals(numRows, passCount);
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestNoMatchSolrFeature.java
@@ -139,7 +139,7 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
             ((Map<String, Object>)
                     ((ArrayList<Object>)
                             ((Map<String, Object>) jsonParse.get("response")).get("docs"))
-                        .get(0))
+                        .getFirst())
                 .get("score");
 
     final String docs0fv_dense_csv =
@@ -221,7 +221,7 @@ public class TestNoMatchSolrFeature extends TestRerankBase {
             ((Map<String, Object>)
                     ((ArrayList<Object>)
                             ((Map<String, Object>) jsonParse.get("response")).get("docs"))
-                        .get(0))
+                        .getFirst())
                 .get("score");
 
     final String docs0fv_dense_csv =

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestUserTermScorerQDF.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestUserTermScorerQDF.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.ltr.feature;
+
+import org.apache.solr.client.solrj.request.SolrQuery;
+import org.apache.solr.ltr.TestRerankBase;
+import org.apache.solr.ltr.model.LinearModel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestUserTermScorerQDF extends TestRerankBase {
+
+  @Before
+  public void before() throws Exception {
+    setuptest(false);
+
+    assertU(adoc("id", "1", "title", "w1", "description", "w1", "popularity", "1"));
+    assertU(
+        adoc(
+            "id",
+            "2",
+            "title",
+            "w2 2asd asdd didid",
+            "description",
+            "w2 2asd asdd didid",
+            "popularity",
+            "2"));
+    assertU(adoc("id", "3", "title", "w3", "description", "w3", "popularity", "3"));
+    assertU(adoc("id", "4", "title", "w4", "description", "w4", "popularity", "4"));
+    assertU(adoc("id", "5", "title", "w5", "description", "w5", "popularity", "5"));
+    assertU(adoc("id", "6", "title", "w1 w2", "description", "w1 w2", "popularity", "6"));
+    assertU(
+        adoc(
+            "id",
+            "7",
+            "title",
+            "w1 w2 w3 w4 w5",
+            "description",
+            "w1 w2 w3 w4 w5 w8",
+            "popularity",
+            "7"));
+    assertU(
+        adoc(
+            "id",
+            "8",
+            "title",
+            "w1 w1 w1 w2 w2 w8",
+            "description",
+            "w1 w1 w1 w2 w2",
+            "popularity",
+            "8"));
+    assertU(commit());
+  }
+
+  @After
+  public void after() throws Exception {
+    aftertest();
+  }
+
+  @Test
+  public void testUserTermScorerQWithDF() throws Exception {
+    // before();
+    loadFeature("matchedTitleDF", SolrFeature.class.getName(), "{\"q\":\"w5\",\"df\":\"title\"}");
+    loadModel(
+        "Term-matchedTitleDF",
+        LinearModel.class.getName(),
+        new String[] {"matchedTitleDF"},
+        "{\"weights\":{\"matchedTitleDF\":1.0}}");
+    final SolrQuery query = new SolrQuery();
+    query.setQuery("title:w1");
+    query.add("fl", "*, score");
+    query.add("rows", "2");
+    query.add("rq", "{!ltr model=Term-matchedTitleDF reRankDocs=4}");
+    query.set("debugQuery", "on");
+
+    assertJQ("/query" + query.toQueryString(), "/response/numFound/==4");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[0]/id=='7'");
+    assertJQ("/query" + query.toQueryString(), "/response/docs/[1]/score==0.0");
+  }
+}

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestValueFeature.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/feature/TestValueFeature.java
@@ -109,7 +109,7 @@ public class TestValueFeature extends TestRerankBase {
   }
 
   @Test
-  public void testValueFeatureExplictlyNotRequiredShouldReturnOkStatusCode() throws Exception {
+  public void testValueFeatureExplicitlyNotRequiredShouldReturnOkStatusCode() throws Exception {
     loadFeature(
         "c7", ValueFeature.class.getName(), "c7", "{\"value\":\"${val7}\",\"required\":false}");
     loadModel(

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestAdapterModel.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestAdapterModel.java
@@ -160,8 +160,7 @@ public class TestAdapterModel extends TestRerankBase {
         int doc,
         float finalScore,
         List<Explanation> featureExplanations) {
-      return Explanation.match(
-          finalScore, toString() + " model, always returns " + Float.toString(answerValue) + ".");
+      return Explanation.match(finalScore, this + " model, always returns " + answerValue + ".");
     }
   }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestLinearModel.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestLinearModel.java
@@ -60,8 +60,8 @@ public class TestLinearModel extends TestRerankBase {
   }
 
   public static Map<String, Object> makeFeatureWeights(List<Feature> features, Number weight) {
-    final Map<String, Object> nameParams = new HashMap<String, Object>();
-    final HashMap<String, Number> modelWeights = new HashMap<String, Number>();
+    final Map<String, Object> nameParams = new HashMap<>();
+    final HashMap<String, Number> modelWeights = new HashMap<>();
     for (final Feature feat : features) {
       modelWeights.put(feat.getName(), weight);
     }
@@ -93,11 +93,10 @@ public class TestLinearModel extends TestRerankBase {
     weights.put("constant1", 1d);
     weights.put("constant5", 1d);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     final List<Feature> features = getFeatures(new String[] {"constant1", "constant5"});
     final List<Normalizer> norms =
-        new ArrayList<Normalizer>(
-            Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
+        new ArrayList<>(Collections.nCopies(features.size(), IdentityNormalizer.INSTANCE));
     params.put("weights", weights);
     final LTRScoringModel ltrScoringModel =
         createLinearModel("test1", features, norms, "test", fstore.getFeatures(), params);

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestMultipleAdditiveTreesModel.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestMultipleAdditiveTreesModel.java
@@ -119,7 +119,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestNoParams() throws Exception {
+  public void multipleAdditiveTreesTestNoParams() {
     final ModelException expectedException =
         new ModelException("no trees declared for model multipleadditivetreesmodel_no_params");
     Exception ex =
@@ -135,7 +135,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestEmptyParams() throws Exception {
+  public void multipleAdditiveTreesTestEmptyParams() {
     final ModelException expectedException =
         new ModelException("no trees declared for model multipleadditivetreesmodel_no_trees");
     Exception ex =
@@ -151,7 +151,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestNoWeight() throws Exception {
+  public void multipleAdditiveTreesTestNoWeight() {
     final ModelException expectedException =
         new ModelException("MultipleAdditiveTreesModel tree doesn't contain a weight");
     Exception ex =
@@ -167,7 +167,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestTreesParamDoesNotContainTree() throws Exception {
+  public void multipleAdditiveTreesTestTreesParamDoesNotContainTree() {
     final ModelException expectedException =
         new ModelException("MultipleAdditiveTreesModel tree doesn't contain a tree");
     Exception ex =
@@ -183,7 +183,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestNoFeaturesSpecified() throws Exception {
+  public void multipleAdditiveTreesTestNoFeaturesSpecified() {
     final ModelException expectedException =
         new ModelException("no features declared for model multipleadditivetreesmodel_no_features");
     Exception ex =
@@ -199,7 +199,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestNoRight() throws Exception {
+  public void multipleAdditiveTreesTestNoRight() {
     final ModelException expectedException =
         new ModelException("MultipleAdditiveTreesModel tree node is missing right");
     Exception ex =
@@ -215,7 +215,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestNoLeft() throws Exception {
+  public void multipleAdditiveTreesTestNoLeft() {
     final ModelException expectedException =
         new ModelException("MultipleAdditiveTreesModel tree node is missing left");
     Exception ex =
@@ -231,7 +231,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestNoThreshold() throws Exception {
+  public void multipleAdditiveTreesTestNoThreshold() {
     final ModelException expectedException =
         new ModelException("MultipleAdditiveTreesModel tree node is missing threshold");
     Exception ex =
@@ -247,7 +247,7 @@ public class TestMultipleAdditiveTreesModel extends TestRerankBase {
   }
 
   @Test
-  public void multipleAdditiveTreesTestMissingTreeFeature() throws Exception {
+  public void multipleAdditiveTreesTestMissingTreeFeature() {
     final ModelException expectedException =
         new ModelException(
             "MultipleAdditiveTreesModel tree node is leaf with left=-100.0 and right=75.0");

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestNeuralNetworkModel.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestNeuralNetworkModel.java
@@ -65,7 +65,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
   protected static Map<String, Object> createLayerParams(
       double[][] matrix, double[] bias, String activation) {
 
-    final ArrayList<ArrayList<Double>> matrixList = new ArrayList<ArrayList<Double>>();
+    final ArrayList<ArrayList<Double>> matrixList = new ArrayList<>();
     for (int row = 0; row < matrix.length; row++) {
       matrixList.add(new ArrayList<Double>());
       for (int col = 0; col < matrix[row].length; col++) {
@@ -140,7 +140,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
 
     final List<Feature> featuresInModel = new ArrayList<>(allFeaturesInStore);
     Collections.shuffle(featuresInModel, random()); // store and model order of features can vary
-    featuresInModel.remove(0); // models need not use all the store's features
+    featuresInModel.removeFirst(); // models need not use all the store's features
     assertEquals(4, featuresInModel.size()); // the test model uses four features
 
     final List<Normalizer> norms =
@@ -251,7 +251,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
   }
 
   @Test
-  public void badActivationTest() throws Exception {
+  public void badActivationTest() {
     final ModelException expectedException =
         new ModelException(
             "Invalid activation function (\"sig\") in layer 0 of model \"neuralnetworkmodel_bad_activation\".");
@@ -267,7 +267,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
   }
 
   @Test
-  public void biasDimensionMismatchTest() throws Exception {
+  public void biasDimensionMismatchTest() {
     final ModelException expectedException =
         new ModelException(
             "Dimension mismatch in model \"neuralnetworkmodel_mismatch_bias\". "
@@ -284,7 +284,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
   }
 
   @Test
-  public void inputDimensionMismatchTest() throws Exception {
+  public void inputDimensionMismatchTest() {
     final ModelException expectedException =
         new ModelException(
             "Dimension mismatch in model \"neuralnetworkmodel_mismatch_input\". The input has "
@@ -301,7 +301,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
   }
 
   @Test
-  public void layerDimensionMismatchTest() throws Exception {
+  public void layerDimensionMismatchTest() {
     final ModelException expectedException =
         new ModelException(
             "Dimension mismatch in model \"neuralnetworkmodel_mismatch_layers\". The weight matrix "
@@ -318,7 +318,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
   }
 
   @Test
-  public void tooManyRowsTest() throws Exception {
+  public void tooManyRowsTest() {
     final ModelException expectedException =
         new ModelException(
             "Dimension mismatch in model \"neuralnetworkmodel_too_many_rows\". "
@@ -343,7 +343,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
 
     final float[] featureValues = {1.2f, 3.4f, 5.6f, 7.8f};
 
-    final List<Explanation> explanations = new ArrayList<Explanation>();
+    final List<Explanation> explanations = new ArrayList<>();
     for (int ii = 0; ii < featureValues.length; ++ii) {
       explanations.add(Explanation.match(featureValues[ii], ""));
     }
@@ -416,7 +416,7 @@ public class TestNeuralNetworkModel extends TestRerankBase {
     float actualScore = model.score(featureValues);
     assertEquals(expectedScore, actualScore, 0.001);
 
-    final List<Explanation> explanations = new ArrayList<Explanation>();
+    final List<Explanation> explanations = new ArrayList<>();
     for (int ii = 0; ii < featureValues.length; ++ii) {
       explanations.add(Explanation.match(featureValues[ii], ""));
     }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestWrapperModel.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/model/TestWrapperModel.java
@@ -59,7 +59,7 @@ public class TestWrapperModel extends TestRerankBase {
   }
 
   @Test
-  public void testValidate() throws Exception {
+  public void testValidate() {
     WrapperModel wrapperModel = new StubWrapperModel("testModel");
     wrapperModel.validate();
 
@@ -124,18 +124,19 @@ public class TestWrapperModel extends TestRerankBase {
   }
 
   @Test
-  public void testMethodOverridesAndDelegation() throws Exception {
+  public void testMethodOverridesAndDelegation() {
     assumeWorkingMockito();
     final int overridableMethodCount = testOverwrittenMethods();
     final int methodCount = testDelegateMethods();
     assertEquals("method count mismatch", overridableMethodCount, methodCount);
   }
 
-  private int testOverwrittenMethods() throws Exception {
+  private int testOverwrittenMethods() {
     int overridableMethodCount = 0;
     for (final Method superClassMethod : LTRScoringModel.class.getDeclaredMethods()) {
       final int modifiers = superClassMethod.getModifiers();
       if (Modifier.isFinal(modifiers)) continue;
+      if (Modifier.isPrivate(modifiers)) continue;
       if (Modifier.isStatic(modifiers)) continue;
 
       ++overridableMethodCount;
@@ -172,7 +173,7 @@ public class TestWrapperModel extends TestRerankBase {
     return overridableMethodCount;
   }
 
-  private int testDelegateMethods() throws Exception {
+  private int testDelegateMethods() {
     int methodCount = 0;
     WrapperModel wrapperModel = Mockito.spy(new StubWrapperModel("testModel"));
 

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestManagedFeatureStore.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestManagedFeatureStore.java
@@ -39,14 +39,14 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
   }
 
   @After
-  public void cleanup() throws Exception {
+  public void cleanup() {
     featureStore = null;
     deleteCore();
   }
 
   private static Map<String, Object> createMap(
       String name, String className, Map<String, Object> params) {
-    final Map<String, Object> map = new HashMap<String, Object>();
+    final Map<String, Object> map = new HashMap<>();
     map.put(ManagedFeatureStore.NAME_KEY, name);
     map.put(ManagedFeatureStore.CLASS_KEY, className);
     if (params != null) {
@@ -86,7 +86,7 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
   public void testFeatureStoreGet() throws FeatureException {
     final FeatureStore fs = featureStore.getFeatureStore("featureStore-testFeature2");
     for (int i = 0; i < 5; i++) {
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("value", i);
       final String name = "c" + i;
 
@@ -107,7 +107,7 @@ public class TestManagedFeatureStore extends SolrTestCaseJ4 {
   public void testMissingFeatureReturnsNull() {
     final FeatureStore fs = featureStore.getFeatureStore("featureStore-testFeature3");
     for (int i = 0; i < 5; i++) {
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("value", i);
       final String name = "testc" + (float) i;
       featureStore.addFeature(

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
@@ -58,7 +58,7 @@ public class TestModelManager extends TestRerankBase {
 
     final ManagedResource res = restManager.getManagedResource(resourceId);
     assertTrue(res instanceof ManagedFeatureStore);
-    assertEquals(res.getResourceId(), resourceId);
+    assertEquals(resourceId, res.getResourceId());
   }
 
   @Test


### PR DESCRIPTION
# Description

Split out from #4743 into smaller, per-module PRs to make review easier. This PR contains the tidy-up changes to `solr/modules/ltr` (production + test code).

# Solution

Leverage IntelliJ warnings (dead field/method removal, `toString()`/`this` interchange, `isEmpty()` idioms, javadoc/comment fixes, `interlavingAlgorithm` → `interleavingAlgorithm` field rename, `TestUserTermScorereQDF` → `TestUserTermScorerQDF` typo-fix rename).

**One non-cosmetic change to flag explicitly:** `TestWrapperModel.java`'s `testOverwrittenMethods()` now skips `private` methods when reflecting over `LTRScoringModel`'s declared methods. Without this, `LTRScoringModel`'s private `calculateHashCode()` was being picked up as "overridable" and the test incorrectly demanded `WrapperModel` declare an override for it. This is a genuine test bug fix, not just tidying — calling it out here so it doesn't get missed in review.

# Tests

existing

Relates to #4743