### PR TITLE
Review and tidy solr/modules/scripting code

### DIFF
--- a/solr/modules/scripting/src/java/org/apache/solr/scripting/update/ScriptUpdateProcessorFactory.java
+++ b/solr/modules/scripting/src/java/org/apache/solr/scripting/update/ScriptUpdateProcessorFactory.java
@@ -155,7 +155,7 @@ public class ScriptUpdateProcessorFactory extends UpdateRequestProcessorFactory
 
   private List<ScriptFile> scriptFiles;
 
-  /** if non null, this is an override for the engine for all scripts */
+  /** if non-null, this is an override for the engine for all scripts */
   private String engineName = null;
 
   private Object params = null;
@@ -200,7 +200,7 @@ public class ScriptUpdateProcessorFactory extends UpdateRequestProcessorFactory
   @Override
   public UpdateRequestProcessor getInstance(
       SolrQueryRequest req, SolrQueryResponse rsp, UpdateRequestProcessor next) {
-    List<EngineInfo> scriptEngines = null;
+    List<EngineInfo> scriptEngines;
 
     scriptEngines = initEngines(req, rsp);
 
@@ -286,7 +286,7 @@ public class ScriptUpdateProcessorFactory extends UpdateRequestProcessorFactory
             "Engine "
                 + ((null != engineName) ? engineName : ("for script " + scriptFile.getFileName()))
                 + " does not support function invocation (via Invocable): "
-                + engine.getClass().toString()
+                + engine.getClass()
                 + " ("
                 + engine.getFactory().getEngineName()
                 + ")";
@@ -335,7 +335,7 @@ public class ScriptUpdateProcessorFactory extends UpdateRequestProcessorFactory
   }
 
   /**
-   * For error messages - returns null if there are any exceptions of any kind building the string
+   * For error messages - returns null if there are any exceptions registered building the string
    * (or of the list is empty for some unknown reason).
    *
    * @param ext - if true, list of extensions, otherwise a list of engine names
@@ -437,8 +437,8 @@ public class ScriptUpdateProcessorFactory extends UpdateRequestProcessorFactory
       for (EngineInfo engine : engines) {
         try {
           Object result = engine.getEngine().invokeFunction(name, cmd);
-          if (null != result && result instanceof Boolean) {
-            if (!((Boolean) result).booleanValue()) {
+          if (result instanceof Boolean) {
+            if (!(Boolean) result) {
               return false;
             }
           }

--- a/solr/modules/scripting/src/java/org/apache/solr/scripting/xslt/TransformerProvider.java
+++ b/solr/modules/scripting/src/java/org/apache/solr/scripting/xslt/TransformerProvider.java
@@ -57,7 +57,7 @@ class TransformerProvider {
 
   /** singleton */
   private TransformerProvider() {
-    // tell'em: currently, we only cache the last used XSLT transform, and blindly recompile it
+    // currently, we only cache the last used XSLT transform, and blindly recompile it
     // once cacheLifetimeSeconds expires
     log.warn(
         "The TransformerProvider's simplistic XSLT caching mechanism is not appropriate "
@@ -74,7 +74,7 @@ class TransformerProvider {
       SolrQueryRequest request, String xslt, int xsltCacheLifetimeSeconds) throws IOException {
     // not the cleanest way to achieve this
     // no need to synchronize access to context, right?
-    // Nothing else happens with it at the same time
+    // Nothing else happens to it at the same time
     final Map<Object, Object> ctx = request.getContext();
     Transformer result = (Transformer) ctx.get(CONTEXT_TRANSFORMER_KEY);
     if (result == null) {

--- a/solr/modules/scripting/src/java/org/apache/solr/scripting/xslt/XSLTResponseWriter.java
+++ b/solr/modules/scripting/src/java/org/apache/solr/scripting/xslt/XSLTResponseWriter.java
@@ -57,7 +57,7 @@ public class XSLTResponseWriter implements TextQueryResponseWriter {
 
   @Override
   public String getContentType(SolrQueryRequest request, SolrQueryResponse response) {
-    Transformer t = null;
+    Transformer t;
     try {
       t = getTransformer(request);
     } catch (Exception e) {
@@ -66,16 +66,16 @@ public class XSLTResponseWriter implements TextQueryResponseWriter {
     }
 
     String mediaType = t.getOutputProperty("media-type");
-    if (mediaType == null || mediaType.length() == 0) {
+    if (mediaType == null || mediaType.isEmpty()) {
       // This did not happen in my tests, mediaTypeFromXslt is set to "text/xml"
-      // if the XSLT transform does not contain an xsl:output element. Not sure
+      // if the XSLT transform does not contain a xsl:output element. Not sure
       // if this is standard behavior or if it's just my JVM/libraries
       mediaType = DEFAULT_CONTENT_TYPE;
     }
 
     if (!mediaType.contains("charset")) {
       String encoding = t.getOutputProperty("encoding");
-      if (encoding == null || encoding.length() == 0) {
+      if (encoding == null || encoding.isEmpty()) {
         encoding = "UTF-8";
       }
       mediaType = mediaType + "; charset=" + encoding;

--- a/solr/modules/scripting/src/test-files/scripting/solr/collection1/conf/bad-solrconfig-bogus-scriptengine-name.xml
+++ b/solr/modules/scripting/src/test-files/scripting/solr/collection1/conf/bad-solrconfig-bogus-scriptengine-name.xml
@@ -23,7 +23,7 @@
 
   <updateRequestProcessorChain name="force-script-engine" default="true">
     <processor class="org.apache.solr.scripting.update.ScriptUpdateProcessorFactory">
-      <str name="engine">giberish</str>
+      <str name="engine">gibberish</str>
       <str name="script">missleading.extension.updateprocessor.js.txt</str>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />

--- a/solr/modules/scripting/src/test/org/apache/solr/scripting/update/ScriptEngineTest.java
+++ b/solr/modules/scripting/src/test/org/apache/solr/scripting/update/ScriptEngineTest.java
@@ -35,7 +35,7 @@ public class ScriptEngineTest extends SolrTestCase {
   private ScriptEngineManager manager;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     assumeFalse(
         "https://twitter.com/UweSays/status/260487231880433664 / SOLR-4233: OS X bogusly starts AWT!",
         Constants.MAC_OS_X);

--- a/solr/modules/scripting/src/test/org/apache/solr/scripting/update/ScriptUpdateProcessorFactoryTest.java
+++ b/solr/modules/scripting/src/test/org/apache/solr/scripting/update/ScriptUpdateProcessorFactoryTest.java
@@ -74,7 +74,7 @@ public class ScriptUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
     SolrCore core = h.getCore();
     UpdateRequestProcessorChain chained = core.getUpdateProcessingChain("single-script");
     final ScriptUpdateProcessorFactory factory =
-        ((ScriptUpdateProcessorFactory) chained.getProcessors().get(0));
+        ((ScriptUpdateProcessorFactory) chained.getProcessors().getFirst());
     final List<String> functionMessages = new ArrayList<>();
     factory.setScriptEngineCustomizer(
         new ScriptEngineCustomizer() {
@@ -85,8 +85,7 @@ public class ScriptUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
         });
     assertNotNull(chained);
 
-    SolrInputDocument d =
-        processAdd("single-script", doc(f("id", "1"), f("name", " foo "), f("subject", "bar")));
+    processAdd("single-script", doc(f("id", "1"), f("name", " foo "), f("subject", "bar")));
 
     processCommit("run-no-scripts");
 
@@ -111,7 +110,7 @@ public class ScriptUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
 
       UpdateRequestProcessorChain chained = core.getUpdateProcessingChain(chain);
       final ScriptUpdateProcessorFactory factory =
-          ((ScriptUpdateProcessorFactory) chained.getProcessors().get(0));
+          ((ScriptUpdateProcessorFactory) chained.getProcessors().getFirst());
       final List<String> functionMessages = new ArrayList<>();
       ScriptEngineCustomizer customizer =
           new ScriptEngineCustomizer() {
@@ -202,7 +201,7 @@ public class ScriptUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
     assertEquals(chain + " didn't add integer field", 42, d.getFieldValue("script_added_i"));
   }
 
-  public void testPropogatedException() throws Exception {
+  public void testPropagatedException() {
     final String chain = "error-on-add";
     SolrException e =
         expectThrows(
@@ -213,7 +212,7 @@ public class ScriptUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
         0 < e.getMessage().indexOf("no-soup-fo-you"));
   }
 
-  public void testMissingFunctions() throws Exception {
+  public void testMissingFunctions() {
     final String chain = "missing-functions";
     SolrException e =
         expectThrows(
@@ -233,7 +232,7 @@ public class ScriptUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
 
   @SuppressWarnings("removal")
   @SuppressForbidden(reason = "Deprecated for removal in future Java version")
-  public void testScriptSandbox() throws Exception {
+  public void testScriptSandbox() {
     assumeTrue("This test only works with security manager", System.getSecurityManager() != null);
     expectThrows(
         SecurityException.class,

--- a/solr/modules/scripting/src/test/org/apache/solr/scripting/update/TestBadScriptingUpdateProcessorConfig.java
+++ b/solr/modules/scripting/src/test/org/apache/solr/scripting/update/TestBadScriptingUpdateProcessorConfig.java
@@ -29,13 +29,13 @@ public class TestBadScriptingUpdateProcessorConfig extends SolrTestCaseJ4 {
 
   public void testBogusScriptEngine() throws Exception {
     // sanity check
-    Assume.assumeTrue(null == (new ScriptEngineManager()).getEngineByName("giberish"));
+    Assume.assumeTrue(null == (new ScriptEngineManager()).getEngineByName("gibberish"));
 
     assertConfigs(
         "bad-solrconfig-bogus-scriptengine-name.xml",
         "schema.xml",
         getFile("scripting/solr/collection1").getParent().toString(),
-        "giberish");
+        "gibberish");
   }
 
   public void testMissingScriptFile() throws Exception {

--- a/solr/modules/scripting/src/test/org/apache/solr/scripting/xslt/XSLTUpdateRequestHandlerTest.java
+++ b/solr/modules/scripting/src/test/org/apache/solr/scripting/xslt/XSLTUpdateRequestHandlerTest.java
@@ -116,7 +116,7 @@ public class XSLTUpdateRequestHandlerTest extends SolrTestCaseJ4 {
     ContentStreamLoader loader = new XSLTUpdateRequestHandler.XsltXMLLoader().init(null);
     loader.load(req, rsp, new ContentStreamBase.StringStream(xml), p);
 
-    AddUpdateCommand add = p.addCommands.get(0);
+    AddUpdateCommand add = p.addCommands.getFirst();
     assertEquals("12345", add.solrDoc.getField("id").getFirstValue());
     assertEquals("zzz", add.solrDoc.getField("foo_s").getFirstValue());
     req.close();


### PR DESCRIPTION
# Description

Split out from #4743 into smaller, per-module PRs to make review easier. This PR contains only the tidy-up changes to `solr/modules/scripting`.

# Solution

Leverage IntelliJ warnings (redundant null-check removal, unnecessary `throws` removal, `.get(0)` → `.getFirst()`, `giberish` → `gibberish` typo fix kept in sync between the Java test and its `solrconfig.xml` fixture, javadoc/comment fixes). No behavior changes.

# Tests

existing

Relates to #4743