### PR TITLE
Review and tidy solr/modules/sql code

### DIFF
--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/CalciteSolrDriver.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/CalciteSolrDriver.java
@@ -75,8 +75,8 @@ public class CalciteSolrDriver extends Driver {
     Hook.SQL2REL_CONVERTER_CONFIG_BUILDER.addThread(CalciteSolrDriver::subQueryThreshold);
 
     // disable Calcite's simplify (see SOLR-16009) as it erases some query
-    // constructs that are still meaningful to Solr (such as AND'd filters on the same field,
-    // which works for multi-valued fields in Solr but looks like nonsense to Calcite.
+    // constructs that are still meaningful to Solr (such as AND'd filters on the same field),
+    // which works for multivalued fields in Solr but looks like nonsense to Calcite.
     Hook.REL_BUILDER_SIMPLIFY.addThread(CalciteSolrDriver::relBuilderSimplify);
 
     Connection connection = super.connect(url, info);

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrAggregate.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrAggregate.java
@@ -48,7 +48,7 @@ class SolrAggregate extends Aggregate implements SolrRel {
 
   // Returns the Solr agg metric identifier (includes column) for the SQL metric
   static String solrAggMetricId(String metric, String column) {
-    // CountDistinctMetric's getIdentifer returns "countDist" but all others return a lowercased
+    // CountDistinctMetric's getIdentifier returns "countDist" but all others return a lowercased
     // value
     String funcName =
         COUNT_DISTINCT.equals(metric) ? COUNT_DISTINCT : metric.toLowerCase(Locale.ROOT);
@@ -118,7 +118,7 @@ class SolrAggregate extends Aggregate implements SolrRel {
           return new Pair<>(aggregation.getName(), "*");
         }
       case 1:
-        String inName = inNames.get(args.get(0));
+        String inName = inNames.get(args.getFirst());
         String name = implementor.fieldMappings.getOrDefault(inName, inName);
         if (SUPPORTED_AGGREGATIONS.contains(aggregation)) {
           return new Pair<>(aggregation.getName(), name);

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrEnumerator.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrEnumerator.java
@@ -62,7 +62,7 @@ class SolrEnumerator implements Enumerator<Object> {
   @Override
   public Object current() {
     if (fields.size() == 1) {
-      return this.getter(current, fields.get(0));
+      return this.getter(current, fields.getFirst());
     } else {
       // Build an array with all fields in this row
       Object[] row = new Object[fields.size()];

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -271,7 +271,7 @@ class SolrFilter extends Filter implements SolrRel {
         throw new AssertionError("expected 1 operand for " + node);
       }
 
-      final RexNode left = operands.get(0);
+      final RexNode left = operands.getFirst();
       if (left instanceof RexInputRef) {
         String name = fieldNames.get(((RexInputRef) left).getIndex());
         SqlKind kind = node.getKind();
@@ -325,23 +325,23 @@ class SolrFilter extends Filter implements SolrRel {
           }
         }
 
-        String query = "";
+        StringBuilder query = new StringBuilder();
         if (!andStrings.isEmpty()) {
           String andString = String.join(" AND ", andStrings);
-          query += "(" + andString + ")";
+          query.append("(").append(andString).append(")");
         }
         if (!notStrings.isEmpty()) {
           if (!query.isEmpty()) {
-            query += " AND ";
+            query.append(" AND ");
           }
           for (int i = 0; i < notStrings.size(); i++) {
             if (i > 0) {
-              query += " AND ";
+              query.append(" AND ");
             }
-            query += " (*:* -" + notStrings.get(i) + ")";
+            query.append(" (*:* -").append(notStrings.get(i)).append(")");
           }
         }
-        return query.trim();
+        return query.toString().trim();
       } else {
         return String.join(" AND ", andStrings);
       }
@@ -402,7 +402,7 @@ class SolrFilter extends Filter implements SolrRel {
     protected String translateComparison(RexNode node) {
       final SqlKind kind = node.getKind();
       if (kind == SqlKind.NOT) {
-        RexNode negated = ((RexCall) node).getOperands().get(0);
+        RexNode negated = ((RexCall) node).getOperands().getFirst();
         if (negated.isA(SqlKind.AND)) {
           AndClause andClause = translateAndOrBetween(negated, true);
           // if the resulting andClause is a "between" then don't negate it as it's already
@@ -789,7 +789,7 @@ class SolrFilter extends Filter implements SolrRel {
           notBuilder.append(")");
         }
 
-        return "and(" + builder.toString() + "," + notBuilder.toString() + ")";
+        return "and(" + builder + "," + notBuilder + ")";
       } else {
         return builder.toString();
       }

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrSchema.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrSchema.java
@@ -84,10 +84,6 @@ class SolrSchema extends AbstractSchema implements Closeable {
     isClosed = true;
   }
 
-  public boolean isClosed() {
-    return isClosed;
-  }
-
   @Override
   protected Map<String, Table> getTableMap() {
     CloudSolrClient cloudSolrClient = solrClientCache.getCloudSolrClient(solrConnection);
@@ -160,8 +156,8 @@ class SolrSchema extends AbstractSchema implements Closeable {
 
   RelDataType buildRowSchema(String collection) {
     // Temporary type factory, just for the duration of this method. Allowable
-    // because we're creating a proto-type, not a type; before being used, the
-    // proto-type will be copied into a real type factory.
+    // because we're creating a prototype, not a type; before being used, the
+    // prototype will be copied into a real type factory.
     final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     final RelDataTypeFactory.Builder fieldInfo = typeFactory.builder();
 
@@ -201,12 +197,12 @@ class SolrSchema extends AbstractSchema implements Closeable {
 
       RelDataType type;
 
-      // We have to pass multi-valued fields through Calcite as SQL Type ANY
+      // We have to pass multivalued fields through Calcite as SQL Type ANY
       // Array doesn't work for aggregations! Calcite doesn't like GROUP BY on an ARRAY field
-      // but Solr happily computes aggs on a multi-valued field, so we have a paradigm mis-match and
-      // ANY is the best way to retain use of operators on multi-valued fields while still being
+      // but Solr happily computes aggs on a multivalued field, so we have a paradigm mismatch and
+      // ANY is the best way to retain use of operators on multivalued fields while still being
       // able
-      // to GROUP BY and project the multi-valued fields in results
+      // to GROUP BY and project the multivalued fields in results
       EnumSet<FieldFlag> flags = getFieldFlags(luceneFieldInfo);
       if (flags != null && flags.contains(FieldFlag.MULTI_VALUED)) {
         type = typeFactory.createSqlType(SqlTypeName.ANY);

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrTable.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrTable.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.calcite.adapter.java.AbstractQueryableTable;
 import org.apache.calcite.linq4j.AbstractEnumerable;
 import org.apache.calcite.linq4j.Enumerable;
@@ -143,7 +142,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     boolean mapReduce = "map_reduce".equals(properties.getProperty("aggregationMode"));
     boolean negative = Boolean.parseBoolean(negativeQuery);
 
-    String q = null;
+    String q;
 
     if (query == null) {
       q = DEFAULT_QUERY;
@@ -212,22 +211,6 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     };
   }
 
-  private static StreamComparator bucketSortComp(List<Bucket> buckets, Map<String, String> dirs) {
-    FieldComparator[] comps = new FieldComparator[buckets.size()];
-    for (int i = 0; i < buckets.size(); i++) {
-      ComparatorOrder comparatorOrder =
-          ComparatorOrder.fromString(dirs.get(buckets.get(i).toString()));
-      String sortKey = buckets.get(i).toString();
-      comps[i] = new FieldComparator(sortKey, comparatorOrder);
-    }
-
-    if (comps.length == 1) {
-      return comps[0];
-    } else {
-      return new MultipleFieldComparator(comps);
-    }
-  }
-
   private static StreamComparator bucketSortComp(Bucket[] buckets, String dir) {
     FieldComparator[] comps = new FieldComparator[buckets.length];
     for (int i = 0; i < buckets.length; i++) {
@@ -267,8 +250,8 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
 
   private List<Metric> buildMetrics(List<Pair<String, String>> metricPairs, boolean ifEmptyCount) {
     List<Metric> metrics = new ArrayList<>(metricPairs.size());
-    metrics.addAll(metricPairs.stream().map(this::getMetric).collect(Collectors.toList()));
-    if (metrics.size() == 0 && ifEmptyCount) {
+    metrics.addAll(metricPairs.stream().map(this::getMetric).toList());
+    if (metrics.isEmpty() && ifEmptyCount) {
       metrics.add(new CountMetric());
     }
     return metrics;
@@ -376,7 +359,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
   private String getSort(List<Pair<String, String>> orders) {
     StringBuilder buf = new StringBuilder();
     for (Pair<String, String> pair : orders) {
-      if (buf.length() > 0) {
+      if (!buf.isEmpty()) {
         buf.append(",");
       }
       buf.append(pair.getKey()).append(" ").append(pair.getValue());
@@ -385,17 +368,11 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     return buf.toString();
   }
 
-  private String getSingleSort(Pair<String, String> order) {
-    StringBuilder buf = new StringBuilder();
-    buf.append(order.getKey()).append(" ").append(order.getValue());
-    return buf.toString();
-  }
-
   private String getFields(List<Map.Entry<String, Class<?>>> fields) {
     StringBuilder buf = new StringBuilder();
     for (Map.Entry<String, Class<?>> field : fields) {
 
-      if (buf.length() > 0) {
+      if (!buf.isEmpty()) {
         buf.append(",");
       }
 
@@ -409,7 +386,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     StringBuilder buf = new StringBuilder();
     for (String field : fieldSet) {
 
-      if (buf.length() > 0) {
+      if (!buf.isEmpty()) {
         buf.append(",");
       }
 
@@ -437,7 +414,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
   }
 
   private static String getSortDirection(List<Pair<String, String>> orders) {
-    if (orders != null && orders.size() > 0) {
+    if (orders != null && !orders.isEmpty()) {
       for (Pair<String, String> item : orders) {
         return item.getValue();
       }
@@ -533,7 +510,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     Set<String> fieldSet = getFieldSet(metrics, fields);
 
     if (metrics.length == 0) {
-      throw new IOException("Group by queries must include atleast one aggregate function.");
+      throw new IOException("Group by queries must include at least one aggregate function.");
     }
 
     String fl = getFields(fieldSet);
@@ -552,7 +529,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
 
     params.set(SORT, sort);
 
-    TupleStream tupleStream = null;
+    TupleStream tupleStream;
 
     // Always use the /export handler for Group By Queries because it requires exporting full
     // result sets.
@@ -603,7 +580,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
     //      We need to push down the having clause to ensure that LIMIT does not cut off records
     // prior to the having filter.
 
-    if (orders != null && orders.size() > 0) {
+    if (orders != null && !orders.isEmpty()) {
       if (!sortsEqual(buckets, sortDirection, orders)) {
         int lim = (limit == null) ? 100 : Integer.parseInt(limit);
         StreamComparator comp = getComp(orders);
@@ -678,9 +655,9 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
 
     int limit = lim != null ? Integer.parseInt(lim) : 1000;
 
-    FieldComparator[] sorts = null;
+    FieldComparator[] sorts;
 
-    if (orders == null || orders.size() == 0) {
+    if (orders == null || orders.isEmpty()) {
       sorts = new FieldComparator[buckets.length];
       for (int i = 0; i < sorts.length; i++) {
         sorts[i] = new FieldComparator("index", ComparatorOrder.ASCENDING);
@@ -743,11 +720,11 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
 
     String fl = getFields(fields);
 
-    String sort = null;
-    StreamEqualitor ecomp = null;
-    StreamComparator comp = null;
+    String sort;
+    StreamEqualitor ecomp;
+    StreamComparator comp;
 
-    if (orders != null && orders.size() > 0) {
+    if (orders != null && !orders.isEmpty()) {
       StreamComparator[] adjustedSorts = adjustSorts(orders, buckets);
       // Because of the way adjustSorts works we know that each FieldComparator has a single
       // field name. For this reason we can just look at the leftFieldName
@@ -810,7 +787,7 @@ class SolrTable extends AbstractQueryableTable implements TranslatableTable {
 
     params.set(SORT, sort);
 
-    TupleStream tupleStream = null;
+    TupleStream tupleStream;
 
     // Always use the /export handler for Distinct Queries because it requires exporting full
     // result sets.

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAll.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAll.java
@@ -18,9 +18,9 @@
 package org.apache.solr.handler.sql.functions;
 
 /**
- * Operator for filtering on Solr multi-valued fields with 'AND" clause. Example:
+ * Operator for filtering on Solr multivalued fields with "AND" clause. Example:
  * ARRAY_CONTAINS_ALL(field, ('val1', 'val2')) will be transformed to filter query field:("val1" AND
- * "val2")
+ * "val2").
  */
 public class ArrayContainsAll extends ArrayContains {
   private static final String UDF_NAME = "ARRAY_CONTAINS_ALL";

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAny.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAny.java
@@ -18,9 +18,9 @@
 package org.apache.solr.handler.sql.functions;
 
 /**
- * Operator for filtering on Solr multi-valued fields with 'OR" clause. Example:
+ * Operator for filtering on Solr multivalued fields with "OR" clause. Example:
  * ARRAY_CONTAINS_ALL(field, ('val1', 'val2')) will be transformed to filter query field:("val1" OR
- * "val2")
+ * "val2").
  */
 public class ArrayContainsAny extends ArrayContains {
   private static final String UDF_NAME = "ARRAY_CONTAINS_ANY";

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/SQLWithAuthzEnabledTest.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/SQLWithAuthzEnabledTest.java
@@ -108,7 +108,7 @@ public class SQLWithAuthzEnabledTest extends SolrCloudTestCase {
 
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("stmt", "select id from " + collectionName);
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
     SolrStream solrStream = new SolrStream(baseUrl, collectionName, "/sql", params);
     solrStream.setCredentials(SAD_USER, PASS);
 

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -48,7 +48,6 @@ import org.junit.Test;
 public class TestSQLHandler extends SolrCloudTestCase {
 
   private static final String COLLECTIONORALIAS = "collection1";
-  private static final int TIMEOUT = DEFAULT_TIMEOUT;
   private static final String id = "id";
 
   private static boolean useAlias;
@@ -210,83 +209,83 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "stmt",
             "select id, field_i, str_s, field_f, field_d, field_l from collection1 where (text_t='(XXXX)' OR text_t='XXXX') AND text_t='XXXX' order by field_i desc");
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
     List<Tuple> tuples = getTuples(sParams, baseUrl);
 
     assertEquals(8, tuples.size());
     Tuple tuple;
 
-    tuple = tuples.get(0);
-    assertEquals(tuple.getLong("id").longValue(), 8);
-    assertEquals(tuple.getLong("field_i").longValue(), 60);
+    tuple = tuples.getFirst();
+    assertEquals(8, tuple.getLong("id").longValue());
+    assertEquals(60, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 60L);
-    assertEquals(tuple.getDouble("field_f"), 60.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 60.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 60);
+    assertEquals(60L, tuple.getLong("field_i").longValue());
+    assertEquals(60.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(60.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(60, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(1);
-    assertEquals(tuple.getLong("id").longValue(), 7);
-    assertEquals(tuple.getLong("field_i").longValue(), 50);
+    assertEquals(7, tuple.getLong("id").longValue());
+    assertEquals(50, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 50);
-    assertEquals(tuple.getDouble("field_f"), 50.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 50.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 50);
+    assertEquals(50, tuple.getLong("field_i").longValue());
+    assertEquals(50.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(50.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(50, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(2);
-    assertEquals(tuple.getLong("id").longValue(), 6);
-    assertEquals(tuple.getLong("field_i").longValue(), 40);
+    assertEquals(6, tuple.getLong("id").longValue());
+    assertEquals(40, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 40);
-    assertEquals(tuple.getDouble("field_f"), 40.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 40.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 40);
+    assertEquals(40, tuple.getLong("field_i").longValue());
+    assertEquals(40.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(40.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(40, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(3);
-    assertEquals(tuple.getLong("id").longValue(), 5);
-    assertEquals(tuple.getLong("field_i").longValue(), 30);
+    assertEquals(5, tuple.getLong("id").longValue());
+    assertEquals(30, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 30);
-    assertEquals(tuple.getDouble("field_f"), 30.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 30.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 30);
+    assertEquals(30, tuple.getLong("field_i").longValue());
+    assertEquals(30.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(30.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(30, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(4);
-    assertEquals(tuple.getLong("id").longValue(), 3);
-    assertEquals(tuple.getLong("field_i").longValue(), 20);
+    assertEquals(3, tuple.getLong("id").longValue());
+    assertEquals(20, tuple.getLong("field_i").longValue());
     assertEquals("a", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 20);
-    assertEquals(tuple.getDouble("field_f"), 20.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 20.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 20);
+    assertEquals(20, tuple.getLong("field_i").longValue());
+    assertEquals(20.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(20.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(20, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(5);
-    assertEquals(tuple.getLong("id").longValue(), 4);
-    assertEquals(tuple.getLong("field_i").longValue(), 11);
+    assertEquals(4, tuple.getLong("id").longValue());
+    assertEquals(11, tuple.getLong("field_i").longValue());
     assertEquals("b", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 11);
-    assertEquals(tuple.getDouble("field_f"), 11.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 11.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 11);
+    assertEquals(11, tuple.getLong("field_i").longValue());
+    assertEquals(11.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(11.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(11, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(6);
-    assertEquals(tuple.getLong("id").longValue(), 2);
-    assertEquals(tuple.getLong("field_i").longValue(), 8);
+    assertEquals(2, tuple.getLong("id").longValue());
+    assertEquals(8, tuple.getLong("field_i").longValue());
     assertEquals("b", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 8);
-    assertEquals(tuple.getDouble("field_f"), 8.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 8.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 8);
+    assertEquals(8, tuple.getLong("field_i").longValue());
+    assertEquals(8.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(8.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(8, tuple.getLong("field_l").longValue());
 
     tuple = tuples.get(7);
-    assertEquals(tuple.getLong("id").longValue(), 1);
-    assertEquals(tuple.getLong("field_i").longValue(), 7);
+    assertEquals(1, tuple.getLong("id").longValue());
+    assertEquals(7, tuple.getLong("field_i").longValue());
     assertEquals("a", tuple.get("str_s"));
-    assertEquals(tuple.getLong("field_i").longValue(), 7);
-    assertEquals(tuple.getDouble("field_f"), 7.5, 0.0);
-    assertEquals(tuple.getDouble("field_d"), 7.5, 0.0);
-    assertEquals(tuple.getLong("field_l").longValue(), 7);
+    assertEquals(7, tuple.getLong("field_i").longValue());
+    assertEquals(7.5, tuple.getDouble("field_f"), 0.0);
+    assertEquals(7.5, tuple.getDouble("field_d"), 0.0);
+    assertEquals(7, tuple.getLong("field_l").longValue());
 
     // Assert field order
     // assertResponseContains(clients.get(0), sParams,
@@ -301,7 +300,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(8, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(8, tuple.getLong("id").longValue());
     assertEquals(60, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
@@ -350,7 +349,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(8, tuple.getLong("id").longValue());
     assertEquals(60, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
@@ -364,7 +363,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(3, tuple.getLong("id").longValue());
     assertEquals(20, tuple.getLong("field_i").longValue());
     assertEquals("a", tuple.get("str_s"));
@@ -388,7 +387,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(3, tuple.getLong("myId").longValue());
     assertEquals(20, tuple.getLong("myInt").longValue());
     assertEquals("a", tuple.get("myString"));
@@ -412,7 +411,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(3, tuple.getLong("myId").longValue());
     assertEquals(20, tuple.getLong("myInt").longValue());
     assertEquals("a", tuple.get("myString"));
@@ -446,7 +445,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     tuples = getTuples(sParams, baseUrl);
 
     assertEquals(1, tuples.size());
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(8, tuple.getLong("id").longValue());
     assertEquals(60, tuple.getLong("field_i").longValue());
     assertEquals("c", tuple.get("str_s"));
@@ -470,7 +469,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "1", "text_t", "XXXX XXXX", "str_s", "a", "field_i", "7")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params("caseSensitive", "true", "stmt", "select id, FIELD_I from collection1 limit 1");
@@ -547,7 +546,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "witha\"quote")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     // Equals
     SolrParams sParams = params("stmt", "select id from collection1 where id = 1 order by id asc");
@@ -556,7 +555,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    Tuple tuple = tuples.get(0);
+    Tuple tuple = tuples.getFirst();
     assertEquals("1", tuple.get("id"));
 
     // Not Equals <>
@@ -566,7 +565,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(7, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("2", tuple.get("id"));
     tuple = tuples.get(1);
     assertEquals("3", tuple.get("id"));
@@ -590,7 +589,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     //
     // assertEquals(7, tuples.size());
     //
-    // tuple = tuples.get(0);
+    // tuple = tuples.getFirst();
     // assertEquals(2L, tuple.get("id"));
     // tuple = tuples.get(1);
     // assertEquals(3L, tuple.get("id"));
@@ -612,7 +611,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("1", tuple.get("id"));
 
     // Less than equal
@@ -622,7 +621,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("1", tuple.get("id"));
     tuple = tuples.get(1);
     assertEquals("2", tuple.get("id"));
@@ -634,7 +633,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("8", tuple.get("id"));
 
     // Greater than equal
@@ -644,7 +643,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("7", tuple.get("id"));
     tuple = tuples.get(1);
     assertEquals("8", tuple.get("id"));
@@ -673,7 +672,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "Text_t", "XXXX XXXX", "Str_s", "c", "Field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -688,7 +687,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(8, tuple.getLong("id").longValue());
     assertEquals(60, tuple.getLong("Field_i").longValue());
     assertEquals("c", tuple.get("Str_s"));
@@ -738,7 +737,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(tuples.toString(), 2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("Str_s"));
     assertEquals(60, tuple.getDouble("EXPR$1"), 0.0);
 
@@ -757,7 +756,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("Str_s"));
     assertEquals(60, tuple.getDouble("EXPR$1"), 0.0);
 
@@ -780,7 +779,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -796,7 +795,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -832,7 +831,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -868,7 +867,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("myString"));
     assertEquals(60, tuple.getLong("myInt").longValue());
 
@@ -904,7 +903,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -921,7 +920,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -962,7 +961,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -985,7 +984,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -997,7 +996,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     List<Tuple> tuples = getTuples(sParams, baseUrl);
 
     assertEquals(6, tuples.size());
-    Tuple tuple = tuples.get(0);
+    Tuple tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -1033,7 +1032,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -1068,7 +1067,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("myString"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -1104,7 +1103,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -1124,7 +1123,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -1159,7 +1158,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     tuples = getTuples(sParams, baseUrl);
     assertEquals(tuples.toString(), 2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -1182,7 +1181,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
     SolrParams sParams =
         params(
             "numWorkers",
@@ -1198,7 +1197,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -1236,7 +1235,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -1274,7 +1273,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("myString"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -1312,7 +1311,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(60, tuple.getLong("field_i").longValue());
 
@@ -1334,7 +1333,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -1372,7 +1371,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("a", tuple.get("str_s"));
     assertEquals(1, tuple.getLong("field_i").longValue());
 
@@ -1396,7 +1395,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add("id", "9", "text_t", "XXXX XXXY", "str_s", "d", "field_i", "70")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1414,7 +1413,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("b", tuple.get("str_s"));
     assertEquals(2, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(19, tuple.getDouble("EXPR$2"), 0.0); // sum(field_i)
@@ -1444,7 +1443,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     // Only two results because of the limit.
     assertEquals(2, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("b", tuple.get("str_s"));
     assertEquals(2, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(19, tuple.getDouble("EXPR$2"), 0.0); // sum(field_i)
@@ -1476,7 +1475,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(tuples.toString(), 3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("str_s"));
     assertEquals(4, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(180, tuple.getDouble("EXPR$2"), 0.0); // sum(field_i)
@@ -1516,7 +1515,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("c", tuple.get("myString"));
     assertEquals(4, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(180, tuple.getDouble("mySum"), 0.0);
@@ -1552,7 +1551,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("b", tuple.get("str_s"));
     assertEquals(2, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(19, tuple.getDouble("EXPR$2"), 0.0); // sum(field_i)
@@ -1573,7 +1572,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("b", tuple.get("str_s"));
     assertEquals(2, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(19, tuple.getDouble("EXPR$2"), 0.0); // sum(field_i)
@@ -1594,7 +1593,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals("b", tuple.get("str_s"));
     assertEquals(2, tuple.getDouble("EXPR$1"), 0.0); // count(*)
     assertEquals(19, tuple.getDouble("mySum"), 0.0);
@@ -1632,7 +1631,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "9", "a_s", "hello0", "a_i", "14", "a_f", "10")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1646,7 +1645,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     // Test Long and Double Sums
 
-    Tuple tuple = tuples.get(0);
+    Tuple tuple = tuples.getFirst();
 
     Double count = tuple.getDouble("EXPR$0"); // count(*)
     Double sumi = tuple.getDouble("EXPR$1"); // sum(a_i)
@@ -1680,7 +1679,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     // Test Long and Double Sums
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
 
     count = tuple.getDouble("myCount");
     sumi = tuple.getDouble("mySum");
@@ -1715,7 +1714,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     // Test Long and Double Sums
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
 
     count = tuple.getDouble("myCount");
     sumi = tuple.getDouble("mySum");
@@ -1749,7 +1748,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
 
     count = tuple.getDouble("EXPR$0"); // count(*)
     sumi = tuple.getDouble("EXPR$1"); // sum(a_i)
@@ -1782,7 +1781,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(1, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
 
     count = tuple.getDouble("EXPR$0"); // count(*)
     sumi = tuple.getDouble("EXPR$1"); // sum(a_i)
@@ -1829,7 +1828,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "year_i", "2014", "month_i", "4", "day_i", "2", "item_i", "1")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -1844,7 +1843,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(66, tuple.getDouble("EXPR$1"), 0.0); // sum(item_i)
 
@@ -1862,7 +1861,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(11, tuple.getLong("month_i").longValue());
     assertEquals(57, tuple.getDouble("EXPR$2"), 0.0); // sum(item_i)
@@ -1887,7 +1886,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(11, tuple.getLong("month_i").longValue());
     assertEquals(8, tuple.getLong("day_i").longValue());
@@ -1938,7 +1937,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "text_t", "XXXX XXXX", "str_s", "c", "field_i", "60")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -2020,7 +2019,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "year_i", "2014", "month_i", "4", "day_i", "2", "item_i", "1")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -2035,7 +2034,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(66, tuple.getDouble("EXPR$1"), 0.0); // sum(item_i)
 
@@ -2055,7 +2054,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(11, tuple.getLong("month_i").longValue());
     assertEquals(57, tuple.getDouble("EXPR$2"), 0.0); // sum(item_i)
@@ -2082,7 +2081,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(11, tuple.getLong("month_i").longValue());
     assertEquals(8, tuple.getLong("day_i").longValue());
@@ -2133,7 +2132,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .add(id, "8", "year_i", "2014", "month_i", "4", "day_i", "2", "item_i", "1")
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
 
     SolrParams sParams =
         params(
@@ -2150,7 +2149,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     Tuple tuple;
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertTrue(
         tuple.get("year_i")
@@ -2176,7 +2175,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(3, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(11, tuple.getLong("month_i").longValue());
     assertTrue(tuple.get("year_i") instanceof Long);
@@ -2207,7 +2206,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     assertEquals(6, tuples.size());
 
-    tuple = tuples.get(0);
+    tuple = tuples.getFirst();
     assertEquals(2015, tuple.getLong("year_i").longValue());
     assertEquals(11, tuple.getLong("month_i").longValue());
     assertEquals(8, tuple.getLong("day_i").longValue());
@@ -2278,13 +2277,13 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     SolrParams sParams = params("stmt", "select id from collection1 where str_s IN ('a','b','c')");
 
-    String baseUrl = cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    String baseUrl = cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
     List<Tuple> tuples = getTuples(sParams, baseUrl);
     assertEquals(3, tuples.size());
   }
 
   private String sqlUrl() {
-    return cluster.getJettySolrRunners().get(0).getBaseUrl().toString();
+    return cluster.getJettySolrRunners().getFirst().getBaseUrl().toString();
   }
 
   private List<Tuple> expectResults(String sql, final int expectedCount) throws Exception {
@@ -2683,7 +2682,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             + " FROM $ALIAS";
 
     List<Tuple> tuples = expectResults(sql, 1);
-    Tuple stats = tuples.get(0);
+    Tuple stats = tuples.getFirst();
     assertEquals("A", stats.getString("min_stringx"));
     assertEquals("C", stats.getString("max_stringx"));
     assertEquals("aaa", stats.getString("min_textx"));
@@ -2714,7 +2713,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
   private String toStatsSql(List<String> types) {
     StringBuilder sb = new StringBuilder();
     for (String type : types) {
-      if (sb.length() > 0) {
+      if (!sb.isEmpty()) {
         sb.append(", ");
       }
       sb.append(min("t" + type)).append(", ").append(min("p" + type));
@@ -2783,7 +2782,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
       results =
           expectResults(
               "SELECT id FROM $ALIAS ORDER BY id ASC OFFSET " + i + " FETCH NEXT 1 ROW ONLY", 1);
-      String id = results.get(0).getString("id");
+      String id = results.getFirst().getString("id");
       if (id.startsWith("0")) id = id.substring(1);
       assertEquals(i + 1, Integer.parseInt(id));
     }
@@ -2813,7 +2812,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         expectResults(
             "SELECT COUNT(1) AS total_rows, COUNT(distinct str_s) AS distinct_str, MIN(str_s) AS min_str, MAX(str_s) AS max_str FROM $ALIAS",
             1);
-    Tuple firstRow = tuples.get(0);
+    Tuple firstRow = tuples.getFirst();
     assertEquals(maxDocs, firstRow.getLong("total_rows").longValue());
     assertEquals(cardinality, firstRow.getLong("distinct_str").longValue());
 
@@ -2830,7 +2829,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     tuples =
         expectResults(
             "SELECT APPROX_COUNT_DISTINCT(distinct str_s) AS approx_distinct FROM $ALIAS", 1);
-    firstRow = tuples.get(0);
+    firstRow = tuples.getFirst();
     assertEquals(cardinality, firstRow.getLong("approx_distinct").longValue());
 
     tuples =
@@ -2994,13 +2993,13 @@ public class TestSQLHandler extends SolrCloudTestCase {
     if (limit > 0) sql += " LIMIT " + limit;
     List<Tuple> results = expectResults(sql, 1);
     if (expected != null) {
-      assertEquals(expected, results.get(0).get(mvField));
+      assertEquals(expected, results.getFirst().get(mvField));
     } else {
-      assertNull(results.get(0).get(mvField));
+      assertNull(results.getFirst().get(mvField));
     }
 
     if (expected != null) {
-      String crit = "'" + expected.get(0) + "'";
+      String crit = "'" + expected.getFirst() + "'";
       sql = "SELECT " + projection + " FROM $ALIAS WHERE " + mvField + "=" + crit;
       if (limit > 0) sql += " LIMIT " + limit;
       expectResults(sql, expCount);

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandlerNonCloud.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandlerNonCloud.java
@@ -50,7 +50,7 @@ public class TestSQLHandlerNonCloud extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testSQLHandler() throws Exception {
+  public void testSQLHandler() {
     String sql = "select id, field_i, str_s from " + DEFAULT_TEST_COLLECTION_NAME + " limit 10";
     SolrParams sParams = params("stmt", sql);
     String url = solrTestRule.getBaseUrl();


### PR DESCRIPTION
# Description

Split out from #4743 into smaller, per-module PRs to make review easier. This PR contains the tidy-up changes to `solr/modules/sql` (Calcite/JDBC integration).

# Solution

Leverage IntelliJ warnings (`StringBuilder` conversions in `SolrFilter`'s AND/OR translation, `.get(0)` → `.getFirst()`, dead-code removal, javadoc/comment fixes). The `SolrFilter`/`SolrAggregate`/`SolrEnumerator` predicate-translation logic was checked to confirm AND/OR/NOT semantics are unchanged.

**Includes a restored fix:** two `@SuppressWarnings("resource")` annotations on `ParallelStream` declarations in `SolrTable.java` that had been dropped by the original tidy pass. `ParallelStream` is `Closeable`, but ownership transfers to the caller's stream chain rather than being closed locally in this method, so the annotation legitimately suppresses a false-positive resource-leak warning.

# Tests

existing

Relates to #4743