### PR TITLE
SOLR-18343: Require explicit HTTP methods for admin requests

### DIFF
--- a/changelog/unreleased/solr-18343-explicit-admin-methods.yml
+++ b/changelog/unreleased/solr-18343-explicit-admin-methods.yml
@@ -1,0 +1,8 @@
+title: >
+  SolrJ v1 admin requests now use appropriate HTTP verbs -- mostly POST, some GET
+type: changed
+authors:
+  - name: Xinyao Zhang
+links:
+  - name: SOLR-18343
+    url: https://issues.apache.org/jira/browse/SOLR-18343

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -566,9 +566,8 @@ public class HttpSolrCall {
         path = "/{collection}" + path;
       }
     }
-    SolrParams requestParams = solrReq != null ? solrReq.getParams() : getQueryParams();
     String verb =
-        requestParams.get(CoreAdminParams.ACTION, req.getMethod()).toLowerCase(Locale.ROOT);
+        getQueryParams().get(CoreAdminParams.ACTION, req.getMethod()).toLowerCase(Locale.ROOT);
     span.updateName(verb + ":" + path);
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -566,8 +566,9 @@ public class HttpSolrCall {
         path = "/{collection}" + path;
       }
     }
+    SolrParams requestParams = solrReq != null ? solrReq.getParams() : getQueryParams();
     String verb =
-        getQueryParams().get(CoreAdminParams.ACTION, req.getMethod()).toLowerCase(Locale.ROOT);
+        requestParams.get(CoreAdminParams.ACTION, req.getMethod()).toLowerCase(Locale.ROOT);
     span.updateName(verb + ":" + path);
   }
 

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
@@ -195,7 +195,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 8 spans:
-    // 1. api call "name=create:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=CreateCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
@@ -222,7 +222,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("create:/admin/collections", s0.getName());
+    assertEquals("post:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(11, finishedSpans.size());
@@ -248,7 +248,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 6 spans:
-    // 1. api call "name=delete:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=DeleteCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
@@ -263,7 +263,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("delete:/admin/collections", s0.getName());
+    assertEquals("post:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(5, finishedSpans.size());

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
@@ -195,13 +195,13 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 8 spans:
-    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=create:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=CreateCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
     // - this will be the parent span, all following spans will have the same traceId
     //
-    // 3..6 (4 times) name=post:/admin/cores
+    // 3..6 (4 times) name=create:/admin/cores
     // db.instance=testInternalCollectionApiCommands_shard1_replica_n2
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n4
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n1
@@ -222,7 +222,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("post:/admin/collections", s0.getName());
+    assertEquals("create:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(11, finishedSpans.size());
@@ -238,7 +238,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
       ops.put(span.getName(), ops.getOrDefault(span.getName(), 0) + 1);
     }
     var expectedOps =
-        Map.of("CreateCollectionCmd", 1, "post:/admin/cores", 4, "post:/{core}/get", 6);
+        Map.of("CreateCollectionCmd", 1, "create:/admin/cores", 4, "post:/{core}/get", 6);
     assertEquals(expectedOps, ops);
   }
 
@@ -248,13 +248,13 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 6 spans:
-    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=delete:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=DeleteCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
     // - this will be the parent span, all following spans will have the same traceId
     //
-    // 3..6 (4 times) name=post:/admin/cores
+    // 3..6 (4 times) name=unload:/admin/cores
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n1
     // db.instance=testInternalCollectionApiCommands_shard1_replica_n2
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n4
@@ -263,7 +263,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("post:/admin/collections", s0.getName());
+    assertEquals("delete:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(5, finishedSpans.size());
@@ -278,7 +278,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
       assertEquals(span.getTraceId(), parentTraceId);
       ops.put(span.getName(), ops.getOrDefault(span.getName(), 0) + 1);
     }
-    var expectedOps = Map.of("DeleteCollectionCmd", 1, "post:/admin/cores", 4);
+    var expectedOps = Map.of("DeleteCollectionCmd", 1, "unload:/admin/cores", 4);
     assertEquals(expectedOps, ops);
   }
 

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
@@ -195,13 +195,13 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 8 spans:
-    // 1. api call "name=create:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=CreateCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
     // - this will be the parent span, all following spans will have the same traceId
     //
-    // 3..6 (4 times) name=create:/admin/cores
+    // 3..6 (4 times) name=post:/admin/cores
     // db.instance=testInternalCollectionApiCommands_shard1_replica_n2
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n4
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n1
@@ -222,7 +222,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("create:/admin/collections", s0.getName());
+    assertEquals("post:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(11, finishedSpans.size());
@@ -238,7 +238,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
       ops.put(span.getName(), ops.getOrDefault(span.getName(), 0) + 1);
     }
     var expectedOps =
-        Map.of("CreateCollectionCmd", 1, "create:/admin/cores", 4, "post:/{core}/get", 6);
+        Map.of("CreateCollectionCmd", 1, "post:/admin/cores", 4, "post:/{core}/get", 6);
     assertEquals(expectedOps, ops);
   }
 
@@ -248,13 +248,13 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 6 spans:
-    // 1. api call "name=delete:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=DeleteCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
     // - this will be the parent span, all following spans will have the same traceId
     //
-    // 3..6 (4 times) name=unload:/admin/cores
+    // 3..6 (4 times) name=post:/admin/cores
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n1
     // db.instance=testInternalCollectionApiCommands_shard1_replica_n2
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n4
@@ -263,7 +263,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("delete:/admin/collections", s0.getName());
+    assertEquals("post:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(5, finishedSpans.size());
@@ -278,7 +278,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
       assertEquals(span.getTraceId(), parentTraceId);
       ops.put(span.getName(), ops.getOrDefault(span.getName(), 0) + 1);
     }
-    var expectedOps = Map.of("DeleteCollectionCmd", 1, "unload:/admin/cores", 4);
+    var expectedOps = Map.of("DeleteCollectionCmd", 1, "post:/admin/cores", 4);
     assertEquals(expectedOps, ops);
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
@@ -92,7 +92,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
    */
   @Deprecated(since = "11.0")
   public CollectionAdminRequest(CollectionAction action) {
-    this(METHOD.GET, action);
+    this(METHOD.POST, action);
   }
 
   /**
@@ -100,7 +100,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
    */
   @Deprecated(since = "11.0")
   public CollectionAdminRequest(String path, CollectionAction action) {
-    this(METHOD.GET, path, action);
+    this(METHOD.POST, path, action);
   }
 
   @Override
@@ -173,7 +173,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
      */
     @Deprecated(since = "11.0")
     public AsyncCollectionAdminRequest(CollectionAction action) {
-      this(METHOD.GET, action);
+      this(METHOD.POST, action);
     }
 
     @Override
@@ -291,7 +291,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
      */
     @Deprecated(since = "11.0")
     public AsyncCollectionSpecificAdminRequest(CollectionAction action, String collection) {
-      this(METHOD.GET, action, collection);
+      this(METHOD.POST, action, collection);
     }
 
     public String getCollectionName() {
@@ -331,7 +331,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     @Deprecated(since = "11.0")
     public AsyncShardSpecificAdminRequest(
         CollectionAction action, String collection, String shard) {
-      this(METHOD.GET, action, collection, shard);
+      this(METHOD.POST, action, collection, shard);
     }
 
     @Override
@@ -361,7 +361,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
      */
     @Deprecated(since = "11.0")
     public ShardSpecificAdminRequest(CollectionAction action, String collection, String shard) {
-      this(METHOD.GET, action, collection, shard);
+      this(METHOD.POST, action, collection, shard);
     }
 
     @Override
@@ -400,7 +400,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
      */
     @Deprecated(since = "11.0")
     public CollectionAdminRoleRequest(CollectionAction action, String node, String role) {
-      this(METHOD.GET, action, node, role);
+      this(METHOD.POST, action, node, role);
     }
 
     public String getNode() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
@@ -78,13 +78,29 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
 
   protected final CollectionAction action;
 
-  public CollectionAdminRequest(CollectionAction action) {
-    this("/admin/collections", action);
+  public CollectionAdminRequest(METHOD method, CollectionAction action) {
+    this(method, "/admin/collections", action);
   }
 
-  public CollectionAdminRequest(String path, CollectionAction action) {
-    super(METHOD.GET, path, SolrRequestType.ADMIN);
+  public CollectionAdminRequest(METHOD method, String path, CollectionAction action) {
+    super(method, path, SolrRequestType.ADMIN);
     this.action = checkNotNull(CoreAdminParams.ACTION, action);
+  }
+
+  /**
+   * @deprecated Use {@link #CollectionAdminRequest(METHOD, CollectionAction)}.
+   */
+  @Deprecated(since = "11.0")
+  public CollectionAdminRequest(CollectionAction action) {
+    this(METHOD.GET, action);
+  }
+
+  /**
+   * @deprecated Use {@link #CollectionAdminRequest(METHOD, String, CollectionAction)}.
+   */
+  @Deprecated(since = "11.0")
+  public CollectionAdminRequest(String path, CollectionAction action) {
+    this(METHOD.GET, path, action);
   }
 
   @Override
@@ -148,8 +164,16 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String asyncId = null;
     protected boolean waitForFinalState = false;
 
+    public AsyncCollectionAdminRequest(METHOD method, CollectionAction action) {
+      super(method, action);
+    }
+
+    /**
+     * @deprecated Use {@link #AsyncCollectionAdminRequest(METHOD, CollectionAction)}.
+     */
+    @Deprecated(since = "11.0")
     public AsyncCollectionAdminRequest(CollectionAction action) {
-      super(action);
+      this(METHOD.GET, action);
     }
 
     @Override
@@ -255,9 +279,19 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String collection;
     protected Boolean followAliases;
 
-    public AsyncCollectionSpecificAdminRequest(CollectionAction action, String collection) {
-      super(action);
+    public AsyncCollectionSpecificAdminRequest(
+        METHOD method, CollectionAction action, String collection) {
+      super(method, action);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
+    }
+
+    /**
+     * @deprecated Use {@link #AsyncCollectionSpecificAdminRequest(METHOD, CollectionAction,
+     *     String)}.
+     */
+    @Deprecated(since = "11.0")
+    public AsyncCollectionSpecificAdminRequest(CollectionAction action, String collection) {
+      this(METHOD.GET, action, collection);
     }
 
     public String getCollectionName() {
@@ -284,10 +318,20 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String shard;
 
     public AsyncShardSpecificAdminRequest(
-        CollectionAction action, String collection, String shard) {
-      super(action);
+        METHOD method, CollectionAction action, String collection, String shard) {
+      super(method, action);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.shard = checkNotNull(CoreAdminParams.SHARD, shard);
+    }
+
+    /**
+     * @deprecated Use {@link #AsyncShardSpecificAdminRequest(METHOD, CollectionAction, String,
+     *     String)}.
+     */
+    @Deprecated(since = "11.0")
+    public AsyncShardSpecificAdminRequest(
+        CollectionAction action, String collection, String shard) {
+      this(METHOD.GET, action, collection, shard);
     }
 
     @Override
@@ -305,10 +349,19 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String collection;
     protected String shard;
 
-    public ShardSpecificAdminRequest(CollectionAction action, String collection, String shard) {
-      super(action);
+    public ShardSpecificAdminRequest(
+        METHOD method, CollectionAction action, String collection, String shard) {
+      super(method, action);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.shard = checkNotNull(CoreAdminParams.SHARD, shard);
+    }
+
+    /**
+     * @deprecated Use {@link #ShardSpecificAdminRequest(METHOD, CollectionAction, String, String)}.
+     */
+    @Deprecated(since = "11.0")
+    public ShardSpecificAdminRequest(CollectionAction action, String collection, String shard) {
+      this(METHOD.GET, action, collection, shard);
     }
 
     @Override
@@ -334,10 +387,20 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String node;
     protected String role;
 
-    public CollectionAdminRoleRequest(CollectionAction action, String node, String role) {
-      super(action);
+    public CollectionAdminRoleRequest(
+        METHOD method, CollectionAction action, String node, String role) {
+      super(method, action);
       this.role = checkNotNull(CollectionAdminParams.ROLE, role);
       this.node = checkNotNull(CoreAdminParams.NODE, node);
+    }
+
+    /**
+     * @deprecated Use {@link #CollectionAdminRoleRequest(METHOD, CollectionAction, String,
+     *     String)}.
+     */
+    @Deprecated(since = "11.0")
+    public CollectionAdminRoleRequest(CollectionAction action, String node, String role) {
+      this(METHOD.GET, action, node, role);
     }
 
     public String getNode() {
@@ -518,7 +581,10 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
         Integer numShards,
         String shards,
         ReplicaCount numReplicas) {
-      super(CollectionAction.CREATE, SolrIdentifierValidator.validateCollectionName(collection));
+      super(
+          METHOD.POST,
+          CollectionAction.CREATE,
+          SolrIdentifierValidator.validateCollectionName(collection));
       // NOTE: there's very little we can assert about the args because nothing but "collection" is
       // required by the server
       if ((null != shards) && (null != numShards)) {
@@ -710,7 +776,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   public static class Reload extends AsyncCollectionSpecificAdminRequest {
 
     private Reload(String collection) {
-      super(CollectionAction.RELOAD, collection);
+      super(METHOD.POST, CollectionAction.RELOAD, collection);
     }
   }
 
@@ -722,7 +788,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     String target;
 
     public Rename(String collection, String target) {
-      super(CollectionAction.RENAME, collection);
+      super(METHOD.POST, CollectionAction.RENAME, collection);
       this.target = target;
     }
 
@@ -746,7 +812,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
      * @param node The node to be deleted
      */
     public DeleteNode(String node) {
-      super(CollectionAction.DELETENODE);
+      super(METHOD.POST, CollectionAction.DELETENODE);
       this.node = checkNotNull("node", node);
     }
 
@@ -767,7 +833,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
      * @param target node where the new replicas are to be created
      */
     public ReplaceNode(String source, String target) {
-      super(CollectionAction.REPLACENODE);
+      super(METHOD.POST, CollectionAction.REPLACENODE);
       this.sourceNode = checkNotNull(CollectionParams.SOURCE_NODE, source);
       this.targetNode = target;
     }
@@ -801,7 +867,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected int timeout = -1;
 
     public MoveReplica(String collection, String replica, String targetNode) {
-      super(CollectionAction.MOVEREPLICA);
+      super(METHOD.POST, CollectionAction.MOVEREPLICA);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.replica = checkNotNull(CoreAdminParams.REPLICA, replica);
       this.targetNode = checkNotNull(CollectionParams.TARGET_NODE, targetNode);
@@ -809,7 +875,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     }
 
     public MoveReplica(String collection, String shard, String sourceNode, String targetNode) {
-      super(CollectionAction.MOVEREPLICA);
+      super(METHOD.POST, CollectionAction.MOVEREPLICA);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.shard = checkNotNull(CoreAdminParams.SHARD, shard);
       this.sourceNode = checkNotNull(CollectionParams.SOURCE_NODE, sourceNode);
@@ -876,7 +942,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     }
 
     public RebalanceLeaders(String collection) {
-      super(CollectionAction.REBALANCELEADERS);
+      super(METHOD.POST, CollectionAction.REBALANCELEADERS);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
     }
 
@@ -917,7 +983,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     Map<String, Object> collectionParams = new HashMap<>();
 
     private ReindexCollection(String collection) {
-      super(CollectionAction.REINDEXCOLLECTION, collection);
+      super(METHOD.POST, CollectionAction.REINDEXCOLLECTION, collection);
     }
 
     /** Target collection name (null if the same). */
@@ -1010,12 +1076,12 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Float rawSizeSamplingPercent = null;
 
     private ColStatus(String collection) {
-      super(CollectionAction.COLSTATUS);
+      super(METHOD.GET, CollectionAction.COLSTATUS);
       this.collection = collection;
     }
 
     private ColStatus() {
-      super(CollectionAction.COLSTATUS);
+      super(METHOD.GET, CollectionAction.COLSTATUS);
     }
 
     public ColStatus setWithSegments(boolean withSegments) {
@@ -1083,7 +1149,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   public static class Delete extends AsyncCollectionSpecificAdminRequest {
 
     private Delete(String collection) {
-      super(CollectionAction.DELETE, collection);
+      super(METHOD.POST, CollectionAction.DELETE, collection);
     }
   }
 
@@ -1104,7 +1170,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Properties extraProperties;
 
     public Backup(String collection, String name) {
-      super(CollectionAction.BACKUP, collection);
+      super(METHOD.POST, CollectionAction.BACKUP, collection);
       this.name = name;
       this.repositoryName = Optional.empty();
     }
@@ -1250,7 +1316,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Integer backupId;
 
     public Restore(String collection, String backupName) {
-      super(CollectionAction.RESTORE, collection);
+      super(METHOD.POST, CollectionAction.RESTORE, collection);
       this.backupName = backupName;
       this.numReplicas = ReplicaCount.empty();
     }
@@ -1436,7 +1502,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String location;
 
     public InstallShard(String collection, String shard, String location, String backupRepository) {
-      super(CollectionAction.INSTALLSHARDDATA, collection, shard);
+      super(METHOD.POST, CollectionAction.INSTALLSHARDDATA, collection, shard);
 
       this.repositoryName = backupRepository;
       this.location = location;
@@ -1468,7 +1534,10 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected final String commitName;
 
     public CreateSnapshot(String collection, String commitName) {
-      super(CollectionAction.CREATESNAPSHOT, checkNotNull(CoreAdminParams.COLLECTION, collection));
+      super(
+          METHOD.POST,
+          CollectionAction.CREATESNAPSHOT,
+          checkNotNull(CoreAdminParams.COLLECTION, collection));
       this.commitName = checkNotNull(CoreAdminParams.COMMIT_NAME, commitName);
     }
 
@@ -1495,7 +1564,10 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected final String commitName;
 
     public DeleteSnapshot(String collection, String commitName) {
-      super(CollectionAction.DELETESNAPSHOT, checkNotNull(CoreAdminParams.COLLECTION, collection));
+      super(
+          METHOD.POST,
+          CollectionAction.DELETESNAPSHOT,
+          checkNotNull(CoreAdminParams.COLLECTION, collection));
       this.commitName = checkNotNull(CoreAdminParams.COMMIT_NAME, commitName);
     }
 
@@ -1520,7 +1592,10 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   @SuppressWarnings("serial")
   public static class ListSnapshots extends AsyncCollectionSpecificAdminRequest {
     public ListSnapshots(String collection) {
-      super(CollectionAction.LISTSNAPSHOTS, checkNotNull(CoreAdminParams.COLLECTION, collection));
+      super(
+          METHOD.GET,
+          CollectionAction.LISTSNAPSHOTS,
+          checkNotNull(CoreAdminParams.COLLECTION, collection));
     }
 
     @Override
@@ -1567,6 +1642,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
 
     private CreateShard(String collection, String shard) {
       super(
+          METHOD.POST,
           CollectionAction.CREATESHARD,
           collection,
           SolrIdentifierValidator.validateShardName(shard));
@@ -1596,7 +1672,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String sleep;
 
     private MockCollTask(String collection) {
-      super(CollectionAction.MOCK_COLL_TASK);
+      super(METHOD.POST, CollectionAction.MOCK_COLL_TASK);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
     }
 
@@ -1634,7 +1710,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String createNodeSet;
 
     private SplitShard(String collection) {
-      super(CollectionAction.SPLITSHARD);
+      super(METHOD.POST, CollectionAction.SPLITSHARD);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
     }
 
@@ -1758,7 +1834,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private Boolean deleteDataDir;
 
     private DeleteShard(String collection, String shard) {
-      super(CollectionAction.DELETESHARD, collection, shard);
+      super(METHOD.POST, CollectionAction.DELETESHARD, collection, shard);
     }
 
     public Boolean getDeleteInstanceDir() {
@@ -1805,7 +1881,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   // FORCELEADER request
   public static class ForceLeader extends ShardSpecificAdminRequest {
     private ForceLeader(String collection, String shard) {
-      super(CollectionAction.FORCELEADER, collection, shard);
+      super(METHOD.POST, CollectionAction.FORCELEADER, collection, shard);
     }
   }
 
@@ -1838,7 +1914,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String requestId = null;
 
     private RequestStatus(String requestId) {
-      super(CollectionAction.REQUESTSTATUS);
+      super(METHOD.GET, CollectionAction.REQUESTSTATUS);
       this.requestId = checkNotNull("requestId", requestId);
     }
 
@@ -1899,7 +1975,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Boolean flush = null;
 
     private DeleteStatus(String requestId, Boolean flush) {
-      super(CollectionAction.DELETESTATUS);
+      super(METHOD.POST, CollectionAction.DELETESTATUS);
       if (requestId == null && flush == null)
         throw new IllegalArgumentException(
             "Either requestid or flush parameter must be specified.");
@@ -1950,7 +2026,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private Map<String, String> properties = new HashMap<>();
 
     public SetAliasProperty(String aliasName) {
-      super(CollectionAction.ALIASPROP);
+      super(METHOD.POST, CollectionAction.ALIASPROP);
       this.aliasName = SolrIdentifierValidator.validateAliasName(aliasName);
     }
 
@@ -1989,7 +2065,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String aliasedCollections;
 
     private CreateAlias(String aliasName, String aliasedCollections) {
-      super(CollectionAction.CREATEALIAS);
+      super(METHOD.POST, CollectionAction.CREATEALIAS);
       this.aliasName = SolrIdentifierValidator.validateAliasName(aliasName);
       this.aliasedCollections = checkNotNull("aliasedCollections", aliasedCollections);
     }
@@ -2063,7 +2139,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
         String start,
         String interval,
         Create createCollTemplate) {
-      super(CollectionAction.CREATEALIAS);
+      super(METHOD.POST, CollectionAction.CREATEALIAS);
       this.aliasName = aliasName;
       this.start = start;
       this.interval = interval;
@@ -2178,7 +2254,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
 
     public CreateCategoryRoutedAlias(
         String aliasName, String routerField, int maxCardinality, Create createCollTemplate) {
-      super(CollectionAction.CREATEALIAS);
+      super(METHOD.POST, CollectionAction.CREATEALIAS);
       this.aliasName = aliasName;
       this.routerField = routerField;
       this.maxCardinality = maxCardinality;
@@ -2284,7 +2360,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
 
     public DimensionalRoutedAlias(
         String aliasName, Create createCollTemplate, RoutedAliasAdminRequest... dims) {
-      super(CollectionAction.CREATEALIAS);
+      super(METHOD.POST, CollectionAction.CREATEALIAS);
       this.aliasName = aliasName;
       this.createCollTemplate = createCollTemplate;
       this.dims = dims;
@@ -2368,7 +2444,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String aliasName;
 
     private DeleteAlias(String aliasName) {
-      super(CollectionAction.DELETEALIAS);
+      super(METHOD.POST, CollectionAction.DELETEALIAS);
       this.aliasName = checkNotNull("aliasName", aliasName);
     }
 
@@ -2421,7 +2497,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String createNodeSet;
 
     private AddReplica(String collection, String shard, String routeKey, Replica.Type type) {
-      super(CollectionAction.ADDREPLICA);
+      super(METHOD.POST, CollectionAction.ADDREPLICA);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.shard = shard;
       this.routeKey = routeKey;
@@ -2621,19 +2697,19 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private Integer count;
 
     private DeleteReplica(String collection, String shard, String replica) {
-      super(CollectionAction.DELETEREPLICA, collection);
+      super(METHOD.POST, CollectionAction.DELETEREPLICA, collection);
       this.shard = shard;
       this.replica = replica;
     }
 
     private DeleteReplica(String collection, String shard, int count) {
-      super(CollectionAction.DELETEREPLICA, collection);
+      super(METHOD.POST, CollectionAction.DELETEREPLICA, collection);
       this.shard = shard;
       this.count = count;
     }
 
     private DeleteReplica(String collection, int count) {
-      super(CollectionAction.DELETEREPLICA, collection);
+      super(METHOD.POST, CollectionAction.DELETEREPLICA, collection);
       this.count = count;
     }
 
@@ -2720,7 +2796,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private String propertyValue;
 
     private ClusterProp(String propertyName, String propertyValue) {
-      super(CollectionAction.CLUSTERPROP);
+      super(METHOD.POST, CollectionAction.CLUSTERPROP);
       this.propertyName = checkNotNull("propertyName", propertyName);
       this.propertyValue = propertyValue;
     }
@@ -2760,7 +2836,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private String propertyValue;
 
     private CollectionProp(String collection, String propertyName, String propertyValue) {
-      super(CollectionAction.COLLECTIONPROP, collection);
+      super(METHOD.POST, CollectionAction.COLLECTIONPROP, collection);
       this.propertyName = checkNotNull("propertyName", propertyName);
       this.propertyValue = propertyValue;
     }
@@ -2803,7 +2879,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private Properties properties;
 
     private Migrate(String collection, String targetCollection, String splitKey) {
-      super(CollectionAction.MIGRATE);
+      super(METHOD.POST, CollectionAction.MIGRATE);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.targetCollection = checkNotNull("targetCollection", targetCollection);
       this.splitKey = checkNotNull("split.key", splitKey);
@@ -2869,7 +2945,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   // ADDROLE request
   public static class AddRole extends CollectionAdminRoleRequest {
     private AddRole(String node, String role) {
-      super(CollectionAction.ADDROLE, node, role);
+      super(METHOD.POST, CollectionAction.ADDROLE, node, role);
     }
   }
 
@@ -2886,7 +2962,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   // REMOVEROLE request
   public static class RemoveRole extends CollectionAdminRoleRequest {
     private RemoveRole(String node, String role) {
-      super(CollectionAction.REMOVEROLE, node, role);
+      super(METHOD.POST, CollectionAction.REMOVEROLE, node, role);
     }
   }
 
@@ -2899,7 +2975,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   public static class OverseerStatus extends AsyncCollectionAdminRequest {
 
     public OverseerStatus() {
-      super(CollectionAction.OVERSEERSTATUS);
+      super(METHOD.GET, CollectionAction.OVERSEERSTATUS);
     }
   }
 
@@ -2908,7 +2984,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
       extends CollectionAdminRequest<RequestApiDistributedProcessingResponse> {
 
     public RequestApiDistributedProcessing() {
-      super(CollectionAction.DISTRIBUTEDAPIPROCESSING);
+      super(METHOD.GET, CollectionAction.DISTRIBUTEDAPIPROCESSING);
     }
 
     @Override
@@ -2937,7 +3013,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected String routeKey = null;
 
     public ClusterStatus() {
-      super(CollectionAction.CLUSTERSTATUS);
+      super(METHOD.GET, CollectionAction.CLUSTERSTATUS);
     }
 
     public ClusterStatus setCollectionName(String collectionName) {
@@ -2992,7 +3068,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   public static class ListAliases extends CollectionAdminRequest<CollectionAdminResponse> {
 
     public ListAliases() {
-      super(CollectionAction.LISTALIASES);
+      super(METHOD.GET, CollectionAction.LISTALIASES);
     }
 
     @Override
@@ -3012,7 +3088,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
   // LIST request
   public static class List extends CollectionAdminRequest<CollectionAdminResponse> {
     public List() {
-      super(CollectionAction.LIST);
+      super(METHOD.GET, CollectionAction.LIST);
     }
 
     @Override
@@ -3085,7 +3161,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private Boolean purgeUnused;
 
     private DeleteBackup(String backupName) {
-      super(CollectionAction.DELETEBACKUP);
+      super(METHOD.POST, CollectionAction.DELETEBACKUP);
 
       this.name = backupName;
     }
@@ -3188,7 +3264,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     private String repositoryName;
 
     private ListBackup(String backupName) {
-      super(CollectionAction.LISTBACKUP);
+      super(METHOD.GET, CollectionAction.LISTBACKUP);
 
       this.backupName = backupName;
     }
@@ -3250,7 +3326,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
         String replica,
         String propertyName,
         String propertyValue) {
-      super(CollectionAction.ADDREPLICAPROP, collection, shard);
+      super(METHOD.POST, CollectionAction.ADDREPLICAPROP, collection, shard);
       this.replica = checkNotNull(CoreAdminParams.REPLICA, replica);
       this.propertyName = checkNotNull("propertyName", propertyName);
       this.propertyValue = checkNotNull("propertyValue", propertyValue);
@@ -3306,7 +3382,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
 
     private DeleteReplicaProp(
         String collection, String shard, String replica, String propertyName) {
-      super(CollectionAction.DELETEREPLICAPROP, collection, shard);
+      super(METHOD.POST, CollectionAction.DELETEREPLICAPROP, collection, shard);
       this.replica = checkNotNull(CoreAdminParams.REPLICA, replica);
       this.propertyName = checkNotNull("propertyName", propertyName);
     }
@@ -3342,7 +3418,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Boolean shardUnique;
 
     private BalanceShardUnique(String collection, String propertyName) {
-      super(CollectionAction.BALANCESHARDUNIQUE);
+      super(METHOD.POST, CollectionAction.BALANCESHARDUNIQUE);
       this.collection = checkNotNull(CoreAdminParams.COLLECTION, collection);
       this.propertyName = checkNotNull("propertyName", propertyName);
     }
@@ -3390,7 +3466,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse>
     protected Map<String, Object> attributes;
 
     private Modify(String collection, Map<String, Object> attributes) {
-      super(CollectionAction.MODIFYCOLLECTION, collection);
+      super(METHOD.POST, CollectionAction.MODIFYCOLLECTION, collection);
       this.attributes = attributes;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/ConfigSetAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/ConfigSetAdminRequest.java
@@ -50,12 +50,28 @@ public abstract class ConfigSetAdminRequest<
     return this;
   }
 
-  public ConfigSetAdminRequest() {
-    super(METHOD.GET, "/admin/configs", SolrRequestType.ADMIN);
+  public ConfigSetAdminRequest(METHOD method) {
+    this(method, "/admin/configs");
   }
 
+  public ConfigSetAdminRequest(METHOD method, String path) {
+    super(method, path, SolrRequestType.ADMIN);
+  }
+
+  /**
+   * @deprecated Use {@link #ConfigSetAdminRequest(METHOD)}.
+   */
+  @Deprecated(since = "11.0")
+  public ConfigSetAdminRequest() {
+    this(METHOD.GET);
+  }
+
+  /**
+   * @deprecated Use {@link #ConfigSetAdminRequest(METHOD, String)}.
+   */
+  @Deprecated(since = "11.0")
   public ConfigSetAdminRequest(String path) {
-    super(METHOD.GET, path, SolrRequestType.ADMIN);
+    this(METHOD.GET, path);
   }
 
   protected abstract Q getThis();
@@ -77,6 +93,18 @@ public abstract class ConfigSetAdminRequest<
           T extends ConfigSetAdminRequest<T, ConfigSetAdminResponse>>
       extends ConfigSetAdminRequest<T, ConfigSetAdminResponse> {
     protected String configSetName = null;
+
+    protected ConfigSetSpecificAdminRequest(METHOD method) {
+      super(method);
+    }
+
+    /**
+     * @deprecated Use {@link #ConfigSetSpecificAdminRequest(METHOD)}.
+     */
+    @Deprecated(since = "11.0")
+    protected ConfigSetSpecificAdminRequest() {
+      this(METHOD.GET);
+    }
 
     public final T setConfigSetName(String configSetName) {
       this.configSetName = configSetName;
@@ -121,8 +149,8 @@ public abstract class ConfigSetAdminRequest<
     protected Boolean cleanup;
 
     public Upload() {
+      super(METHOD.POST);
       action = ConfigSetAction.UPLOAD;
-      setMethod(SolrRequest.METHOD.POST);
     }
 
     @Override
@@ -255,6 +283,7 @@ public abstract class ConfigSetAdminRequest<
     protected Properties properties;
 
     public Create() {
+      super(METHOD.POST);
       action = ConfigSetAction.CREATE;
     }
 
@@ -300,6 +329,7 @@ public abstract class ConfigSetAdminRequest<
   // DELETE request
   public static class Delete extends ConfigSetSpecificAdminRequest<Delete> {
     public Delete() {
+      super(METHOD.POST);
       action = ConfigSetAction.DELETE;
     }
 
@@ -312,6 +342,7 @@ public abstract class ConfigSetAdminRequest<
   // LIST request
   public static class List extends ConfigSetAdminRequest<List, ConfigSetAdminResponse.List> {
     public List() {
+      super(METHOD.GET);
       action = ConfigSetAction.LIST;
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/ConfigSetAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/ConfigSetAdminRequest.java
@@ -63,7 +63,7 @@ public abstract class ConfigSetAdminRequest<
    */
   @Deprecated(since = "11.0")
   public ConfigSetAdminRequest() {
-    this(METHOD.GET);
+    this(METHOD.POST);
   }
 
   /**
@@ -71,7 +71,7 @@ public abstract class ConfigSetAdminRequest<
    */
   @Deprecated(since = "11.0")
   public ConfigSetAdminRequest(String path) {
-    this(METHOD.GET, path);
+    this(METHOD.POST, path);
   }
 
   protected abstract Q getThis();
@@ -103,7 +103,7 @@ public abstract class ConfigSetAdminRequest<
      */
     @Deprecated(since = "11.0")
     protected ConfigSetSpecificAdminRequest() {
-      this(METHOD.GET);
+      this(METHOD.POST);
     }
 
     public final T setConfigSetName(String configSetName) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CoreAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CoreAdminRequest.java
@@ -62,6 +62,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     private String collectionConfigName;
 
     public Create() {
+      super(METHOD.POST);
       action = CoreAdminAction.CREATE;
     }
 
@@ -233,6 +234,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     protected Boolean onlyIfLeaderActive;
 
     public WaitForState() {
+      super(METHOD.POST);
       action = CoreAdminAction.PREPRECOVERY;
     }
 
@@ -330,6 +332,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
   public static class RequestRecovery extends CoreAdminRequest {
 
     public RequestRecovery() {
+      super(METHOD.POST);
       action = CoreAdminAction.REQUESTRECOVERY;
     }
 
@@ -352,6 +355,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     private String collection;
 
     public RequestSyncShard() {
+      super(METHOD.POST);
       action = CoreAdminAction.REQUESTSYNCSHARD;
     }
 
@@ -391,6 +395,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     protected List<String> srcCores;
 
     public MergeIndexes() {
+      super(METHOD.POST);
       action = CoreAdminAction.MERGEINDEXES;
     }
 
@@ -438,6 +443,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     protected boolean deleteInstanceDir;
 
     public Unload(boolean deleteIndex) {
+      super(METHOD.POST);
       action = CoreAdminAction.UNLOAD;
       this.deleteIndex = deleteIndex;
     }
@@ -480,7 +486,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     private String commitName;
 
     public CreateSnapshot(String commitName) {
-      super();
+      super(METHOD.POST);
       this.action = CoreAdminAction.CREATESNAPSHOT;
       if (commitName == null) {
         throw new NullPointerException("Please specify non null value for commitName parameter.");
@@ -504,7 +510,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
     private String commitName;
 
     public DeleteSnapshot(String commitName) {
-      super();
+      super(METHOD.POST);
       this.action = CoreAdminAction.DELETESNAPSHOT;
 
       if (commitName == null) {
@@ -527,17 +533,33 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
 
   public static class ListSnapshots extends CoreAdminRequest {
     public ListSnapshots() {
-      super();
+      super(METHOD.GET);
       this.action = CoreAdminAction.LISTSNAPSHOTS;
     }
   }
 
-  public CoreAdminRequest() {
-    super(METHOD.GET, "/admin/cores", SolrRequestType.ADMIN);
+  public CoreAdminRequest(METHOD method) {
+    this(method, "/admin/cores");
   }
 
+  public CoreAdminRequest(METHOD method, String path) {
+    super(method, path, SolrRequestType.ADMIN);
+  }
+
+  /**
+   * @deprecated Use {@link #CoreAdminRequest(METHOD)}.
+   */
+  @Deprecated(since = "11.0")
+  public CoreAdminRequest() {
+    this(METHOD.GET);
+  }
+
+  /**
+   * @deprecated Use {@link #CoreAdminRequest(METHOD, String)}.
+   */
+  @Deprecated(since = "11.0")
   public CoreAdminRequest(String path) {
-    super(METHOD.GET, path, SolrRequestType.ADMIN);
+    this(METHOD.GET, path);
   }
 
   public void setCoreName(String coreName) {
@@ -594,7 +616,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
 
   public static CoreAdminResponse reloadCore(String name, SolrClient client)
       throws SolrServerException, IOException {
-    CoreAdminRequest req = new CoreAdminRequest();
+    CoreAdminRequest req = new CoreAdminRequest(METHOD.POST);
     req.setCoreName(name);
     req.setAction(CoreAdminAction.RELOAD);
     return req.process(client);
@@ -626,7 +648,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
    */
   public static CoreAdminResponse renameCore(String coreName, String newName, SolrClient client)
       throws SolrServerException, IOException {
-    CoreAdminRequest req = new CoreAdminRequest();
+    CoreAdminRequest req = new CoreAdminRequest(METHOD.POST);
     req.setCoreName(coreName);
     req.setOtherCoreName(SolrIdentifierValidator.validateCoreName(newName));
     req.setAction(CoreAdminAction.RENAME);
@@ -645,7 +667,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
    */
   public static CoreAdminResponse swapCore(String core1, String core2, SolrClient client)
       throws SolrServerException, IOException {
-    CoreAdminRequest req = new CoreAdminRequest();
+    CoreAdminRequest req = new CoreAdminRequest(METHOD.POST);
     req.setCoreName(core1);
     req.setOtherCoreName(core2);
     req.setAction(CoreAdminAction.SWAP);
@@ -660,7 +682,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
   public static CoreStatusResponse.SingleCoreData getCoreStatus(
       String coreName, boolean getIndexInfo, SolrClient client)
       throws SolrServerException, IOException {
-    CoreAdminRequest req = new CoreAdminRequest();
+    CoreAdminRequest req = new CoreAdminRequest(METHOD.GET);
     req.setAction(CoreAdminAction.STATUS);
     req.setIndexInfoNeeded(getIndexInfo);
     return req.process(client).getCoreStatus(coreName);
@@ -668,7 +690,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
 
   public static CoreAdminResponse getStatus(String name, SolrClient client)
       throws SolrServerException, IOException {
-    CoreAdminRequest req = new CoreAdminRequest();
+    CoreAdminRequest req = new CoreAdminRequest(METHOD.GET);
     req.setCoreName(name);
     req.setAction(CoreAdminAction.STATUS);
     return req.process(client);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CoreAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CoreAdminRequest.java
@@ -551,7 +551,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
    */
   @Deprecated(since = "11.0")
   public CoreAdminRequest() {
-    this(METHOD.GET);
+    this(METHOD.POST);
   }
 
   /**
@@ -559,7 +559,7 @@ public class CoreAdminRequest extends SolrRequest<CoreAdminResponse> {
    */
   @Deprecated(since = "11.0")
   public CoreAdminRequest(String path) {
-    this(METHOD.GET, path);
+    this(METHOD.POST, path);
   }
 
   public void setCoreName(String coreName) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCollectionAdminRequest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCollectionAdminRequest.java
@@ -17,6 +17,7 @@
 package org.apache.solr.client.solrj.request;
 
 import org.apache.solr.SolrTestCase;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.CreateAlias;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.CreateShard;
 import org.apache.solr.common.SolrException;
@@ -24,6 +25,13 @@ import org.junit.Test;
 
 /** Unit tests for {@link CollectionAdminRequest}. */
 public class TestCollectionAdminRequest extends SolrTestCase {
+
+  @Test
+  public void testAdminRequestsChooseExplicitHttpMethods() {
+    assertEquals(
+        METHOD.POST, CollectionAdminRequest.createCollection("collection", null, 1, 1).getMethod());
+    assertEquals(METHOD.GET, new CollectionAdminRequest.List().getMethod());
+  }
 
   @Test
   public void testInvalidCollectionNameRejectedWhenCreatingCollection() {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCollectionAdminRequest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCollectionAdminRequest.java
@@ -20,14 +20,26 @@ import org.apache.solr.SolrTestCase;
 import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.CreateAlias;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.CreateShard;
+import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.params.CollectionParams.CollectionAction;
+import org.apache.solr.common.util.NamedList;
 import org.junit.Test;
 
 /** Unit tests for {@link CollectionAdminRequest}. */
 public class TestCollectionAdminRequest extends SolrTestCase {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testAdminRequestsChooseExplicitHttpMethods() {
+    CollectionAdminRequest<CollectionAdminResponse> legacyRequest =
+        new CollectionAdminRequest<>(CollectionAction.CREATE) {
+          @Override
+          protected CollectionAdminResponse createResponse(NamedList<Object> namedList) {
+            return new CollectionAdminResponse();
+          }
+        };
+    assertEquals(METHOD.POST, legacyRequest.getMethod());
     assertEquals(
         METHOD.POST, CollectionAdminRequest.createCollection("collection", null, 1, 1).getMethod());
     assertEquals(METHOD.GET, new CollectionAdminRequest.List().getMethod());

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestConfigSetAdminRequest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestConfigSetAdminRequest.java
@@ -28,7 +28,9 @@ import org.junit.Test;
 public class TestConfigSetAdminRequest extends SolrTestCaseJ4 {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testAdminRequestsChooseExplicitHttpMethods() {
+    assertEquals(METHOD.POST, new MyConfigSetAdminRequest().getMethod());
     assertEquals(METHOD.POST, new ConfigSetAdminRequest.Create().getMethod());
     assertEquals(METHOD.GET, new ConfigSetAdminRequest.List().getMethod());
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestConfigSetAdminRequest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestConfigSetAdminRequest.java
@@ -18,6 +18,7 @@ package org.apache.solr.client.solrj.request;
 
 import java.nio.file.Path;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.response.ConfigSetAdminResponse;
 import org.apache.solr.common.params.ConfigSetParams;
 import org.apache.solr.common.util.NamedList;
@@ -25,6 +26,12 @@ import org.junit.Test;
 
 /** Basic error checking of ConfigSetAdminRequests. */
 public class TestConfigSetAdminRequest extends SolrTestCaseJ4 {
+
+  @Test
+  public void testAdminRequestsChooseExplicitHttpMethods() {
+    assertEquals(METHOD.POST, new ConfigSetAdminRequest.Create().getMethod());
+    assertEquals(METHOD.GET, new ConfigSetAdminRequest.List().getMethod());
+  }
 
   @Test
   public void testNoAction() {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCoreAdmin.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCoreAdmin.java
@@ -44,7 +44,9 @@ import org.junit.Test;
 public class TestCoreAdmin extends AbstractEmbeddedSolrServerTestCase {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testAdminRequestsChooseExplicitHttpMethods() {
+    assertEquals(METHOD.POST, new CoreAdminRequest().getMethod());
     assertEquals(METHOD.POST, new CoreAdminRequest.Create().getMethod());
     assertEquals(METHOD.GET, new CoreAdminRequest.ListSnapshots().getMethod());
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCoreAdmin.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/request/TestCoreAdmin.java
@@ -44,6 +44,12 @@ import org.junit.Test;
 public class TestCoreAdmin extends AbstractEmbeddedSolrServerTestCase {
 
   @Test
+  public void testAdminRequestsChooseExplicitHttpMethods() {
+    assertEquals(METHOD.POST, new CoreAdminRequest.Create().getMethod());
+    assertEquals(METHOD.GET, new CoreAdminRequest.ListSnapshots().getMethod());
+  }
+
+  @Test
   public void testConfigSet() throws Exception {
 
     SolrClient client = getSolrAdmin();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-18343

# Description

SolrJ's multi-action admin request classes currently default to GET, including requests that modify server state.

# Solution

This adds constructors that require an HTTP method and updates the Collection, Core, and ConfigSet admin requests to choose GET or POST explicitly. The existing GET-defaulting constructors remain available but are deprecated for compatibility.

Read-only requests use GET. Other admin actions use POST.

I used an AI coding assistant to audit the constructor call sites, make the mechanical edits, and run validation. I reviewed the final diff and the method chosen for each action.

# Tests

- `./gradlew tidy`
- Focused SolrJ tests: 21 tests passed
- `:solr:core:ecjLintTest`
- `:solr:solrj:check`

The full `./gradlew check -x test` reached the Antora documentation build, which failed because the local checkout path contains spaces.

# Checklist

- [x] I have reviewed the contribution guidelines.
- [x] I have added the Jira issue ID to the PR title.
- [x] I developed the patch against `main`.
- [x] I added tests for the changes.
- [ ] I have run the complete `./gradlew check`.
- [ ] I added Reference Guide documentation. Not needed for this SolrJ API change.
- [ ] I added a changelog entry. Not added while the Jira issue is unassigned.
