### PR TITLE
SOLR-18413: Handle deleted MIGRATE routing targets

### DIFF
--- a/changelog/unreleased/fix-dangling-routing-rule-target.yml
+++ b/changelog/unreleased/fix-dangling-routing-rule-target.yml
@@ -1,0 +1,8 @@
+title: Prevent partial writes when a collection referenced by a MIGRATE routing rule has been deleted
+type: fixed
+authors:
+  - name: ZhenyuLi
+    nick: JHSUYU
+links:
+  - name: SOLR-18413
+    url: https://issues.apache.org/jira/browse/SOLR-18413

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -1014,6 +1014,11 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
                     DocCollection targetColl =
                         cstate.getCollectionOrNull(rule.getTargetCollectionName());
                     if (targetColl == null) {
+                      if (log.isInfoEnabled()) {
+                        log.info(
+                            "Removing shard update routing rule because the target collection {} doesn't exist",
+                            rule.getTargetCollectionName());
+                      }
                       removeRoutingRule(myShardId, routeKey);
                       break;
                     }
@@ -1036,6 +1041,7 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
                 }
               }
             } else {
+              log.info("Removing shard update routing rule because it has expired");
               removeRoutingRule(myShardId, routeKey);
             }
           }
@@ -1052,7 +1058,6 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
     }
     try {
       if (ruleExpiryLock.tryLock(10, TimeUnit.MILLISECONDS)) {
-        log.info("Going to remove routing rule");
         try {
           Map<String, Object> map =
               Map.of(

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -1011,7 +1011,12 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
                 int hash = compositeIdRouter.sliceHash(id, doc, null, coll);
                 for (DocRouter.Range range : ranges) {
                   if (range.includes(hash)) {
-                    DocCollection targetColl = cstate.getCollection(rule.getTargetCollectionName());
+                    DocCollection targetColl =
+                        cstate.getCollectionOrNull(rule.getTargetCollectionName());
+                    if (targetColl == null) {
+                      removeRoutingRule(myShardId, routeKey);
+                      break;
+                    }
                     Collection<Slice> activeSlices =
                         targetColl.getRouter().getSearchSlicesSingle(id, null, targetColl);
                     if (activeSlices == null || activeSlices.isEmpty()) {
@@ -1031,52 +1036,55 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
                 }
               }
             } else {
-              ReentrantLock ruleExpiryLock = req.getCore().getRuleExpiryLock();
-              if (!ruleExpiryLock.isLocked()) {
-                try {
-                  if (ruleExpiryLock.tryLock(10, TimeUnit.MILLISECONDS)) {
-                    log.info("Going to expire routing rule");
-                    try {
-                      Map<String, Object> map =
-                          Map.of(
-                              Overseer.QUEUE_OPERATION,
-                              OverseerAction.REMOVEROUTINGRULE.toLower(),
-                              ZkStateReader.COLLECTION_PROP,
-                              collection,
-                              ZkStateReader.SHARD_ID_PROP,
-                              myShardId,
-                              "routeKey",
-                              routeKey + "!");
-                      if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
-                        ZkNodeProps message = new ZkNodeProps(map);
-                        distributedClusterStateUpdater.doSingleStateUpdate(
-                            DistributedClusterStateUpdater.MutatingCommand.SliceRemoveRoutingRule,
-                            message,
-                            zkController.getOverseer().getSolrCloudManager(),
-                            zkController.getOverseer().getZkStateReader());
-                      } else {
-                        zkController.getOverseer().offerStateUpdate(Utils.toJSON(map));
-                      }
-                    } catch (KeeperException e) {
-                      log.warn(
-                          "Exception while removing routing rule for route key: {}", routeKey, e);
-                    } catch (Exception e) {
-                      log.error(
-                          "Exception while removing routing rule for route key: {}", routeKey, e);
-                    } finally {
-                      ruleExpiryLock.unlock();
-                    }
-                  }
-                } catch (InterruptedException e) {
-                  Thread.currentThread().interrupt();
-                }
-              }
+              removeRoutingRule(myShardId, routeKey);
             }
           }
         }
       }
     }
     return nodes;
+  }
+
+  private void removeRoutingRule(String shardId, String routeKey) {
+    ReentrantLock ruleExpiryLock = req.getCore().getRuleExpiryLock();
+    if (ruleExpiryLock.isLocked()) {
+      return;
+    }
+    try {
+      if (ruleExpiryLock.tryLock(10, TimeUnit.MILLISECONDS)) {
+        log.info("Going to remove routing rule");
+        try {
+          Map<String, Object> map =
+              Map.of(
+                  Overseer.QUEUE_OPERATION,
+                  OverseerAction.REMOVEROUTINGRULE.toLower(),
+                  ZkStateReader.COLLECTION_PROP,
+                  collection,
+                  ZkStateReader.SHARD_ID_PROP,
+                  shardId,
+                  "routeKey",
+                  routeKey + "!");
+          if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
+            ZkNodeProps message = new ZkNodeProps(map);
+            distributedClusterStateUpdater.doSingleStateUpdate(
+                DistributedClusterStateUpdater.MutatingCommand.SliceRemoveRoutingRule,
+                message,
+                zkController.getOverseer().getSolrCloudManager(),
+                zkController.getOverseer().getZkStateReader());
+          } else {
+            zkController.getOverseer().offerStateUpdate(Utils.toJSON(map));
+          }
+        } catch (KeeperException e) {
+          log.warn("Exception while removing routing rule for route key: {}", routeKey, e);
+        } catch (Exception e) {
+          log.error("Exception while removing routing rule for route key: {}", routeKey, e);
+        } finally {
+          ruleExpiryLock.unlock();
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private void doDefensiveChecks(DistribPhase phase, UpdateCommand updateCommand) {

--- a/solr/core/src/test/org/apache/solr/cloud/MigrateRouteKeyTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MigrateRouteKeyTest.java
@@ -101,6 +101,59 @@ public class MigrateRouteKeyTest extends SolrCloudTestCase {
   }
 
   @Test
+  public void updateSucceedsAfterMigrateTargetIsDeleted() throws Exception {
+    String sourceCollection = "deletedMigrateTarget-source";
+    CollectionAdminRequest.createCollection(sourceCollection, "conf", 1, 2)
+        .process(cluster.getSolrClient());
+    String targetCollection = "deletedMigrateTarget-target";
+    CollectionAdminRequest.createCollection(targetCollection, "conf", 1, 1)
+        .process(cluster.getSolrClient());
+
+    cluster.getSolrClient().add(sourceCollection, new SolrInputDocument("id", "a!1"));
+    cluster.getSolrClient().commit(sourceCollection);
+
+    invokeCollectionMigration(
+        CollectionAdminRequest.migrateData(sourceCollection, targetCollection, "a!")
+            .setForwardTimeout(45));
+    waitForState(
+        "Expected to find routing rule for split key a",
+        sourceCollection,
+        c -> {
+          if (c == null) return false;
+          Map<String, RoutingRule> routingRules = c.getSlice("shard1").getRoutingRules();
+          return routingRules != null && routingRules.containsKey("a!");
+        });
+
+    CollectionAdminRequest.deleteCollection(targetCollection).process(cluster.getSolrClient());
+    waitForState("Expected target collection deletion", targetCollection, c -> c == null);
+
+    cluster.getSolrClient().add(sourceCollection, new SolrInputDocument("id", "a!2"));
+    cluster.getSolrClient().commit(sourceCollection);
+
+    DocCollection sourceState = getCollectionState(sourceCollection);
+    assertEquals(2, sourceState.getSlice("shard1").getReplicas().size());
+    for (Replica replica : sourceState.getSlice("shard1")) {
+      try (SolrClient replicaClient = getHttpSolrClient(replica)) {
+        SolrQuery query = new SolrQuery("id:\"a!2\"");
+        query.set("distrib", false);
+        assertEquals(
+            "Document missing from replica " + replica.getName(),
+            1,
+            replicaClient.query(query).getResults().getNumFound());
+      }
+    }
+
+    waitForState(
+        "Expected dangling routing rule removal",
+        sourceCollection,
+        c -> {
+          if (c == null) return false;
+          Map<String, RoutingRule> routingRules = c.getSlice("shard1").getRoutingRules();
+          return routingRules == null || !routingRules.containsKey("a!");
+        });
+  }
+
+  @Test
   public void multipleShardMigrateTest() throws Exception {
 
     String sourceCollection = "sourceCollection";


### PR DESCRIPTION
JIRA: SOLR-18413
# Description

A SolrCloud `MIGRATE` adds a temporary routing rule to the source slice so that matching updates are also forwarded to the target collection.

For example, migrating route key `a!` from `source` to `target` creates state similar to:

```text
source/shard1.routingRules["a!"].targetCollection = "target"
```

The routing rule stores the target collection name as a string. Deleting `target` does not remove routing rules in other collections that refer to it, so the source can retain an unexpired rule whose target is no longer present in `ClusterState`.

A subsequent matching update, such as adding `id=a!2` to `source`, is first applied locally on the source shard leader. `DistributedZkUpdateProcessor.doDistribAdd()` then resolves routing-rule destinations before distributing the update to the source shard replicas:

```java
final List<SolrCmdDistributor.Node> nodesByRoutingRules =
    getNodesByRoutingRules(
        clusterState, coll, cmd.getIndexedIdStr(), cmd.getSolrInputDocument());
...
if (nodes != null) {
  cmdDistrib.distribAdd(...);
}
```

`getNodesByRoutingRules()` previously resolved the target using:

```java
DocCollection targetColl =
    cstate.getCollection(rule.getTargetCollectionName());
```

If the target had been deleted, this threw:

```text
HTTP 400
Could not find collection : target
```

Because the source leader had already applied the update, but the exception occurred before source-replica distribution, the request could leave the shard in this state:

```text
source shard leader:    a!2 exists
source shard replica:   a!2 is missing
client:                 HTTP 400
```

No request was sent to the source replica, so `SolrCmdDistributor` did not record a replica failure and this update did not trigger term demotion or recovery. Queries can then return different results depending on which replica serves them. If leadership subsequently moves to a replica that never received the update, the document is lost.


# Solution

Resolve the routing-rule target with `getCollectionOrNull()`:

```java
DocCollection targetColl =
    cstate.getCollectionOrNull(rule.getTargetCollectionName());
if (targetColl == null) {
  removeRoutingRule(myShardId, routeKey);
  break;
}
```

When the target collection no longer exists, the routing rule is treated as invalid. The existing routing-rule removal logic used for expired rules was extracted into `removeRoutingRule()`. Expired rules and rules with missing targets now share the same cleanup path. The cleanup remains guarded by the core's routing-rule lock.

The behavior for a target collection that exists but has no active slices is unchanged. That condition may be temporary and continues to produce an error rather than permanently removing the routing rule.

# Tests

Added:

- `MigrateRouteKeyTest.updateSucceedsAfterMigrateTargetIsDeleted`

The test uses a real two-node `MiniSolrCloudCluster` and performs this sequence:

1. Creates a `source` collection.
2. Creates a `target` collection.
3. Adds and commits `id=a!1` to the source.
4. Migrates route key `a!` from the source to the target.
5. Confirms that the source shard contains an active routing rule targeting the target collection.
6. Deletes the target collection and waits for it to disappear from `ClusterState`.
7. Adds `id=a!2` to the source and commits.
8. Queries each source replica directly with `distrib=false`.
9. Confirms that both the leader and non-leader replica contain `a!2`.
10. Confirms that the dangling routing rule is removed.

Without the fix, the add in step 7 fails with:

```text
Could not find collection : deletedMigrateTarget-target
```