### PR TITLE
Tracing & audit: HttpSolrCall.getQueryParams

### DIFF
--- a/changelog/unreleased/PR#4870-httpSolrCallGetQueryParams.yml
+++ b/changelog/unreleased/PR#4870-httpSolrCallGetQueryParams.yml
@@ -1,0 +1,10 @@
+title: >
+  Distributed tracing and audit logging now see request parameters sent in a url-encoded POST body,
+  not only those in the URL query string.
+type: changed
+authors:
+  - name: David Smiley
+  - name: Xinyao Zhang
+links:
+  - name: PR#4870
+    url: https://github.com/apache/solr/pull/4870

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -201,8 +201,12 @@ public class HttpSolrCall {
     return core;
   }
 
+  /**
+   * If the request has been created, return its parameters (merges URL and body if applicable);
+   * otherwise, return only the URL query parameters.
+   */
   public SolrParams getQueryParams() {
-    return queryParams;
+    return solrReq != null ? solrReq.getParams() : queryParams;
   }
 
   /** The collection(s) referenced in this request. Populated in {@link #init()}. Not null. */

--- a/solr/modules/opentelemetry/src/test-files/solr/tracing/TestDistributedTracing/testV2Api.json
+++ b/solr/modules/opentelemetry/src/test-files/solr/tracing/TestDistributedTracing/testV2Api.json
@@ -8,7 +8,7 @@
           "db.instance":"collection1",
           "children":[
             {
-              "name":"post:/admin/cores",
+              "name":"reload:/admin/cores",
               "kind":"SERVER",
               "db.instance":"collection1_shard1_replica_nN",
               "db.type":"solr",
@@ -16,7 +16,7 @@
               "http.response.status_code":200,
               "http.url":"http://NORMALIZED/solr/admin/cores"},
             {
-              "name":"post:/admin/cores",
+              "name":"reload:/admin/cores",
               "kind":"SERVER",
               "db.instance":"collection1_shard1_replica_nN",
               "db.type":"solr",
@@ -24,7 +24,7 @@
               "http.response.status_code":200,
               "http.url":"http://NORMALIZED/solr/admin/cores"},
             {
-              "name":"post:/admin/cores",
+              "name":"reload:/admin/cores",
               "kind":"SERVER",
               "db.instance":"collection1_shard2_replica_nN",
               "db.type":"solr",
@@ -32,7 +32,7 @@
               "http.response.status_code":200,
               "http.url":"http://NORMALIZED/solr/admin/cores"},
             {
-              "name":"post:/admin/cores",
+              "name":"reload:/admin/cores",
               "kind":"SERVER",
               "db.instance":"collection1_shard2_replica_nN",
               "db.type":"solr",

--- a/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
+++ b/solr/modules/opentelemetry/src/test/org/apache/solr/opentelemetry/TestDistributedTracing.java
@@ -222,7 +222,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("post:/admin/collections", s0.getName());
+    assertEquals("create:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(11, finishedSpans.size());
@@ -238,7 +238,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
       ops.put(span.getName(), ops.getOrDefault(span.getName(), 0) + 1);
     }
     var expectedOps =
-        Map.of("CreateCollectionCmd", 1, "post:/admin/cores", 4, "post:/{core}/get", 6);
+        Map.of("CreateCollectionCmd", 1, "create:/admin/cores", 4, "post:/{core}/get", 6);
     assertEquals(expectedOps, ops);
   }
 
@@ -248,13 +248,13 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     assertEquals(0, r1.getStatus());
 
     // Expecting 6 spans:
-    // 1. api call "name=post:/admin/collections". db.instance=testInternalCollectionApiCommands
+    // 1. api call "name=delete:/admin/collections". db.instance=testInternalCollectionApiCommands
     // - unique traceId unrelated to the internal trace id generated for the operation
     // 2. internal CollectionApiCommand "name=DeleteCollectionCmd"
     // db.instance=testInternalCollectionApiCommands
     // - this will be the parent span, all following spans will have the same traceId
     //
-    // 3..6 (4 times) name=post:/admin/cores
+    // 3..6 (4 times) name=unload:/admin/cores
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n1
     // db.instance=testInternalCollectionApiCommands_shard1_replica_n2
     // db.instance=testInternalCollectionApiCommands_shard2_replica_n4
@@ -263,7 +263,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
     var finishedSpans = getAndClearSpans(1);
     var s0 = finishedSpans.remove(0);
     assertCollectionName(s0, collection);
-    assertEquals("post:/admin/collections", s0.getName());
+    assertEquals("delete:/admin/collections", s0.getName());
 
     Map<String, Integer> ops = new HashMap<>();
     assertEquals(5, finishedSpans.size());
@@ -278,7 +278,7 @@ public class TestDistributedTracing extends SolrCloudTestCase {
       assertEquals(span.getTraceId(), parentTraceId);
       ops.put(span.getName(), ops.getOrDefault(span.getName(), 0) + 1);
     }
-    var expectedOps = Map.of("DeleteCollectionCmd", 1, "post:/admin/cores", 4);
+    var expectedOps = Map.of("DeleteCollectionCmd", 1, "unload:/admin/cores", 4);
     assertEquals(expectedOps, ops);
   }
 


### PR DESCRIPTION
Improve the fidelity of tracing & audit info by using the body payload parameters if POST url-encoded.

Discovered via SOLR-18343 that switched many SolrJ admin requests to POST.  Tracing tests revealed an undesirable regression of detail.