### PR TITLE
SOLR-18417: Deprecate v1 PingRequestHandler and related code

### DIFF
--- a/changelog/unreleased/SOLR-18417-deprecate-pingrequesthandler.yml
+++ b/changelog/unreleased/SOLR-18417-deprecate-pingrequesthandler.yml
@@ -1,5 +1,5 @@
 type: deprecated
-title: Deprecate PingRequestHandler (the "/admin/ping" endpoint) in favor of `/api/node/health` (v2) or `/solr/admin/info/health` (v1).
+title: Deprecate PingRequestHandler (the "/admin/ping" endpoint), SolrPing, SolrPingResponse, and SolrClient.ping()/ping(String).
 authors:
   - name: Jason Gerlowski
 links:

--- a/changelog/unreleased/SOLR-18417-deprecate-pingrequesthandler.yml
+++ b/changelog/unreleased/SOLR-18417-deprecate-pingrequesthandler.yml
@@ -1,0 +1,7 @@
+type: deprecated
+title: Deprecate PingRequestHandler (the "/admin/ping" endpoint) in favor of `/api/node/health` (v2) or `/solr/admin/info/health` (v1).
+authors:
+  - name: Jason Gerlowski
+links:
+  - name: SOLR-18417
+    url: https://issues.apache.org/jira/browse/SOLR-18417

--- a/solr/core/src/java/org/apache/solr/handler/PingRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/PingRequestHandler.java
@@ -105,8 +105,12 @@ import org.slf4j.LoggerFactory;
  *       healthcheck file exists ("<code>enabled</code>") or not ("<code>disabled</code>")
  * </ul>
  *
+ * @deprecated This handler is deprecated and will be removed in a future release. For load balancer
+ *     or orchestration health checks, use {@link org.apache.solr.handler.admin.HealthCheckHandler}
+ *     instead. instead.
  * @since solr 1.3
  */
+@Deprecated(since = "10.1")
 public class PingRequestHandler extends RequestHandlerBase implements SolrCoreAware {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/implicit-requesthandlers.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/implicit-requesthandlers.adoc
@@ -83,6 +83,8 @@ This handler must have a collection name in the path to the endpoint.
 Ping:: Health check.
 This handler must have a collection name in the path to the endpoint.
 +
+CAUTION: `PingRequestHandler` is deprecated and will be removed in a future release. Use the `Health` endpoint below instead.
++
 *Documentation*: xref:deployment-guide:ping.adoc[]
 +
 [cols="3*.",frame=none,grid=cols,options="header"]

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/ping.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/ping.adoc
@@ -16,6 +16,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+[WARNING]
+====
+The `/admin/ping` endpoint (`PingRequestHandler`) is deprecated and will be removed in a future release.
+For load balancer or orchestration health checks, use the `solr/admin/info/health` (v1) or `api/node/health` (v2) endpoint, documented in the "Health" section of xref:configuration-guide:implicit-requesthandlers.adoc[], instead.
+====
+
 Choosing Ping under a core name issues a `ping` request to check whether the core is up and responding to requests.
 
 .Ping Option in Core Dropdown

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrClient.java
@@ -895,7 +895,9 @@ public abstract class SolrClient implements Serializable, Closeable {
    *     response from the server
    * @throws IOException If there is a low-level I/O error.
    * @throws SolrServerException if there is an error on the server
+   * @deprecated This method is deprecated and will be removed in a future release.
    */
+  @Deprecated(since = "10.1")
   public SolrPingResponse ping(String collection) throws SolrServerException, IOException {
     return new SolrPing().process(this, collection);
   }
@@ -907,7 +909,9 @@ public abstract class SolrClient implements Serializable, Closeable {
    *     response from the server
    * @throws IOException If there is a low-level I/O error.
    * @throws SolrServerException if there is an error on the server
+   * @deprecated This method is deprecated and will be removed in a future release.
    */
+  @Deprecated(since = "10.1")
   public SolrPingResponse ping() throws SolrServerException, IOException {
     return new SolrPing().process(this, null);
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/SolrPing.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/SolrPing.java
@@ -26,8 +26,11 @@ import org.apache.solr.common.util.NamedList;
  * org.apache.solr.client.solrj.SolrClient}. To use this class, the solrconfig.xml for the relevant
  * core must include the request handler for <code>/admin/ping</code>.
  *
+ * @deprecated <code>PingRequestHandler</code> (the <code>/admin/ping</code> endpoint) is deprecated
+ *     and will be removed in a future release. Use {@link HealthCheckRequest} instead.
  * @since solr 1.3
  */
+@Deprecated(since = "10.1")
 public class SolrPing extends CollectionRequiringSolrRequest<SolrPingResponse> {
 
   /** serialVersionUID. */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/SolrPingResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/SolrPingResponse.java
@@ -17,8 +17,10 @@
 package org.apache.solr.client.solrj.response;
 
 /**
+ * @deprecated This class is deprecated and will be removed in a future release.
  * @since solr 1.3
  */
+@Deprecated(since = "10.1")
 public class SolrPingResponse extends SolrResponseBase {
   // nothing special now...
 }

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
@@ -75,7 +75,13 @@ public interface CommonParams {
   String INDENT = "indent";
 
   // SOLR-4228 start
-  /** handler value for SolrPing */
+  /**
+   * handler value for SolrPing
+   *
+   * @deprecated <code>PingRequestHandler</code> (the <code>/admin/ping</code> endpoint) is
+   *     deprecated and will be removed in a future release.
+   */
+  @Deprecated(since = "10.1")
   String PING_HANDLER = "/admin/ping";
 
   /** "action" parameter for SolrPing */


### PR DESCRIPTION
PingRequestHandler has largely been superseded by HealthcheckHandler (or even SystemInfoHandler) which do healthchecks at the node-level instead and tend to be much more compatible with typical load balancers.

This commit deprecates PingRequestHandler and some related code, including the SolrPing and SolrPingResponse classes in SolrJ, and the `SolrClient.ping()` methods on the SolrClient.

Removal will be handled in a subsequent (main-only) PR.