### PR TITLE
Only run nightly Docker workflow in apache/solr

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish Docker images
+    # Only run in the canonical repo; forks lack the Docker Hub credentials to publish
+    if: github.repository == 'apache/solr'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
Scheduled runs in forks failed every night at the docker/login-action step with "Username and password required", since DOCKERHUB_USER/DOCKERHUB_TOKEN only exist in apache/solr.
