### PR TITLE
Test fix: flaky doc-order assertions in TextToVectorUpdateProcessorTest

### DIFF
--- a/solr/modules/language-models/src/test/org/apache/solr/languagemodels/update/processor/TextToVectorUpdateProcessorTest.java
+++ b/solr/modules/language-models/src/test/org/apache/solr/languagemodels/update/processor/TextToVectorUpdateProcessorTest.java
@@ -77,6 +77,9 @@ public class TextToVectorUpdateProcessorTest extends TestLanguageModelBase {
     final SolrQuery query = new SolrQuery();
     query.setQuery(solrQuery);
     query.add("fl", "id,vector");
+    // *:* gives every doc the same score, so without an explicit sort the order between
+    // tied docs is arbitrary (depends on segment/merge timing), which made this flaky.
+    query.setSort("id", SolrQuery.ORDER.desc);
     return query;
   }
 
@@ -187,10 +190,10 @@ public class TextToVectorUpdateProcessorTest extends TestLanguageModelBase {
     assertJQ(
         "/query" + query.toQueryString(),
         "/response/numFound==2]",
-        "/response/docs/[0]/id=='98'",
-        "!/response/docs/[0]/vector==", // no vector field for document 98
-        "/response/docs/[1]/id=='99'",
-        "/response/docs/[1]/vector==[1.0, 2.0, 3.0, 4.0]");
+        "/response/docs/[0]/id=='99'",
+        "/response/docs/[0]/vector==[1.0, 2.0, 3.0, 4.0]",
+        "/response/docs/[1]/id=='98'",
+        "!/response/docs/[1]/vector=="); // no vector field for document 98
 
     restTestHarness.delete(TextToVectorModelStore.REST_END_POINT + "/dummy-1");
   }


### PR DESCRIPTION
The test's shared query helper ran `q=*:*` with no sort. Since *:* gives every doc the same score, the order between tied docs 98 and 99 was resolved by internal segment/merge timing rather than anything Solr guarantees -- causing intermittent failures under contended workers.

Add an explicit `sort=id desc` to make ordering deterministic, and swap the expected doc order in
processAtomicUpdate_shouldTriggerTheVectorizationAndFetchTheStoredContent, whose assertions had been keyed to the opposite (accidental) order.

_found & fixed with AI_