### PR TITLE
SOLR-504: a missing or blank "pf" must not add an empty/no-op boolean clause to the query

### DIFF
--- a/changelog/unreleased/SOLR-504-dismax-blank-pf-empty-clause.yml
+++ b/changelog/unreleased/SOLR-504-dismax-blank-pf-empty-clause.yml
@@ -1,0 +1,9 @@
+title: >
+  The DisMax query parser no longer adds an empty, no-op boolean clause to the query when the
+  pf parameter is blank or missing.
+type: fixed
+authors:
+  - name: Eric Pugh
+links:
+  - name: SOLR-504
+    url: https://issues.apache.org/jira/browse/SOLR-504

--- a/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/DisMaxQParser.java
@@ -227,7 +227,12 @@ public class DisMaxQParser extends QParser {
      * matched those phrases but do match looser phrases.
      */
     String userPhraseQuery = userQuery.replace("\"", "");
-    return pp.parse("\"" + userPhraseQuery + "\"");
+    Query phrase = pp.parse("\"" + userPhraseQuery + "\"");
+    // blank/missing pf yields an empty BooleanQuery, not null; normalize it
+    if (ExtendedDismaxQParser.isEmpty(phrase)) {
+      return null;
+    }
+    return phrase;
   }
 
   protected Query getUserQuery(

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -3384,7 +3384,7 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
     final String expectedNoPf = "+((subject:hello | title:hello) (subject:world | title:world))";
     final String expectedRealPf = expectedNoPf + " (subject:\"hello world\")";
 
-    for (String defType : Arrays.asList("dismax", "edismax")) {
+    for (String defType : List.of("dismax", "edismax")) {
       try (SolrQueryRequest req = req("qf", "subject title", "defType", defType)) {
         assertEquals(
             defType,

--- a/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
+++ b/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java
@@ -3377,4 +3377,33 @@ public class TestExtendedDismaxParser extends SolrTestCaseJ4 {
         "org.apache.solr.search.SyntaxError: Query Field 'nosuchfield' is not a valid field name",
         exception.getMessage());
   }
+
+  /** SOLR-504: a missing or blank "pf" must not add an empty/no-op boolean clause to the query */
+  @Test
+  public void testPfMissingOrBlankAddsNoEmptyClause() throws Exception {
+    final String expectedNoPf = "+((subject:hello | title:hello) (subject:world | title:world))";
+    final String expectedRealPf = expectedNoPf + " (subject:\"hello world\")";
+
+    for (String defType : Arrays.asList("dismax", "edismax")) {
+      try (SolrQueryRequest req = req("qf", "subject title", "defType", defType)) {
+        assertEquals(
+            defType,
+            expectedNoPf,
+            QParser.getParser("hello world", defType, req).getQuery().toString());
+      }
+      try (SolrQueryRequest req = req("qf", "subject title", "pf", "", "defType", defType)) {
+        assertEquals(
+            defType,
+            expectedNoPf,
+            QParser.getParser("hello world", defType, req).getQuery().toString());
+      }
+      // sanity check: a real pf *does* add a (non-empty) phrase clause
+      try (SolrQueryRequest req = req("qf", "subject title", "pf", "subject", "defType", defType)) {
+        assertEquals(
+            defType,
+            expectedRealPf,
+            QParser.getParser("hello world", defType, req).getQuery().toString());
+      }
+    }
+  }
 }


### PR DESCRIPTION

https://issues.apache.org/jira/browse/SOLR-504



# Description

Fix a long standing bug.

A triple digit SOLR JIRA!

# Solution

Simple check.   I had @hossman review the patch file that I attached to the JIRA, and then tweak it a bit once I opened it up in GitHub.

# Tests

See the test

