### PR TITLE
Drop solrbot-only unreleased changelog entries from 9_11

### DIFF
--- a/changelog/unreleased/PR#3540-update-com-google-guava-guava.yml
+++ b/changelog/unreleased/PR#3540-update-com-google-guava-guava.yml
@@ -1,7 +1,0 @@
-title: Update com.google.guava:guava to v33.6.0-jre
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#3540
-  url: https://github.com/apache/solr/pull/3540

--- a/changelog/unreleased/PR#3723-update-org-mockito-mockito-to-v5-23-0-branch-9x.yml
+++ b/changelog/unreleased/PR#3723-update-org-mockito-mockito-to-v5-23-0-branch-9x.yml
@@ -1,7 +1,0 @@
-title: Update org.mockito:mockito* to v5.23.0 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#3723
-  url: https://github.com/apache/solr/pull/3723

--- a/changelog/unreleased/PR#3785-update-net-java-dev-jna-jna.yml
+++ b/changelog/unreleased/PR#3785-update-net-java-dev-jna-jna.yml
@@ -1,7 +1,0 @@
-title: Update net.java.dev.jna:jna to v5.18.1
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#3785
-  url: https://github.com/apache/solr/pull/3785

--- a/changelog/unreleased/PR#4018-update-commons-cli-commons-cli.yml
+++ b/changelog/unreleased/PR#4018-update-commons-cli-commons-cli.yml
@@ -1,7 +1,0 @@
-title: Update commons-cli:commons-cli to v1.11.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4018
-  url: https://github.com/apache/solr/pull/4018

--- a/changelog/unreleased/PR#4020-update-org-apache-commons-commons-exec.yml
+++ b/changelog/unreleased/PR#4020-update-org-apache-commons-commons-exec.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.commons:commons-exec to v1.6.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4020
-  url: https://github.com/apache/solr/pull/4020

--- a/changelog/unreleased/PR#4021-update-org-apache-commons-commons-lang3.yml
+++ b/changelog/unreleased/PR#4021-update-org-apache-commons-commons-lang3.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.commons:commons-lang3 to v3.20.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4021
-  url: https://github.com/apache/solr/pull/4021

--- a/changelog/unreleased/PR#4024-update-org-glassfish-hk2-osgi-resource-locator.yml
+++ b/changelog/unreleased/PR#4024-update-org-glassfish-hk2-osgi-resource-locator.yml
@@ -1,7 +1,0 @@
-title: Update org.glassfish.hk2:osgi-resource-locator to v1.0.4
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4024
-  url: https://github.com/apache/solr/pull/4024

--- a/changelog/unreleased/PR#4025-update-io-netty-netty-tcnative-to-v2-0-75-final.yml
+++ b/changelog/unreleased/PR#4025-update-io-netty-netty-tcnative-to-v2-0-75-final.yml
@@ -1,7 +1,0 @@
-title: Update io.netty:netty-tcnative* to v2.0.75.Final (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4025
-  url: https://github.com/apache/solr/pull/4025

--- a/changelog/unreleased/PR#4027-update-org-apache-hadoop-thirdparty-hadoop-shaded.yml
+++ b/changelog/unreleased/PR#4027-update-org-apache-hadoop-thirdparty-hadoop-shaded.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.hadoop.thirdparty:hadoop-shaded-guava to v1.5.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4027
-  url: https://github.com/apache/solr/pull/4027

--- a/changelog/unreleased/PR#4030-update-actions-cache-action.yml
+++ b/changelog/unreleased/PR#4030-update-actions-cache-action.yml
@@ -1,7 +1,0 @@
-title: Update actions/cache action to v5
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4030
-  url: https://github.com/apache/solr/pull/4030

--- a/changelog/unreleased/PR#4295-update-com-carrotsearch-randomizedtesting.yml
+++ b/changelog/unreleased/PR#4295-update-com-carrotsearch-randomizedtesting.yml
@@ -1,7 +1,0 @@
-title: Update com.carrotsearch.randomizedtesting:randomizedtesting-runner to v2.8.4
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4295
-  url: https://github.com/apache/solr/pull/4295

--- a/changelog/unreleased/PR#4296-update-org-eclipse-jetty-toolchain-jetty-servlet.yml
+++ b/changelog/unreleased/PR#4296-update-org-eclipse-jetty-toolchain-jetty-servlet.yml
@@ -1,7 +1,0 @@
-title: Update org.eclipse.jetty.toolchain:jetty-servlet-api to v4.0.9
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4296
-  url: https://github.com/apache/solr/pull/4296

--- a/changelog/unreleased/PR#4297-update-org-jctools-jctools-core.yml
+++ b/changelog/unreleased/PR#4297-update-org-jctools-jctools-core.yml
@@ -1,7 +1,0 @@
-title: Update org.jctools:jctools-core to v4.0.6
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4297
-  url: https://github.com/apache/solr/pull/4297

--- a/changelog/unreleased/PR#4298-update-org-apache-kafka-to-v3-9-2-branch-9x.yml
+++ b/changelog/unreleased/PR#4298-update-org-apache-kafka-to-v3-9-2-branch-9x.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.kafka:* to v3.9.2 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4298
-  url: https://github.com/apache/solr/pull/4298

--- a/changelog/unreleased/PR#4299-update-org-apache-logging-log4j-to-v2-25-4-branch.yml
+++ b/changelog/unreleased/PR#4299-update-org-apache-logging-log4j-to-v2-25-4-branch.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.logging.log4j:* to v2.25.4 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4299
-  url: https://github.com/apache/solr/pull/4299

--- a/changelog/unreleased/PR#4300-update-org-apache-zookeeper-to-v3-9-5-branch-9x.yml
+++ b/changelog/unreleased/PR#4300-update-org-apache-zookeeper-to-v3-9-5-branch-9x.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.zookeeper:* to v3.9.5 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4300
-  url: https://github.com/apache/solr/pull/4300

--- a/changelog/unreleased/PR#4301-update-org-codehaus-woodstox-stax2-api.yml
+++ b/changelog/unreleased/PR#4301-update-org-codehaus-woodstox-stax2-api.yml
@@ -1,7 +1,0 @@
-title: Update org.codehaus.woodstox:stax2-api to v4.3.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4301
-  url: https://github.com/apache/solr/pull/4301

--- a/changelog/unreleased/PR#4304-update-plugin-de-undercouch-download-to-v5-7-0.yml
+++ b/changelog/unreleased/PR#4304-update-plugin-de-undercouch-download-to-v5-7-0.yml
@@ -1,7 +1,0 @@
-title: Update plugin de.undercouch.download to v5.7.0 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4304
-  url: https://github.com/apache/solr/pull/4304

--- a/changelog/unreleased/PR#4306-update-actions-upload-artifact-action.yml
+++ b/changelog/unreleased/PR#4306-update-actions-upload-artifact-action.yml
@@ -1,7 +1,0 @@
-title: Update actions/upload-artifact action to v7
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4306
-  url: https://github.com/apache/solr/pull/4306

--- a/changelog/unreleased/PR#4307-update-plugin-net-ltgt-errorprone-to-v5-branch-9x.yml
+++ b/changelog/unreleased/PR#4307-update-plugin-net-ltgt-errorprone-to-v5-branch-9x.yml
@@ -1,7 +1,0 @@
-title: Update plugin net.ltgt.errorprone to v5 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4307
-  url: https://github.com/apache/solr/pull/4307

--- a/changelog/unreleased/PR#4332-update-commons-codec-commons-codec.yml
+++ b/changelog/unreleased/PR#4332-update-commons-codec-commons-codec.yml
@@ -1,7 +1,0 @@
-title: Update commons-codec:commons-codec to v1.22.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4332
-  url: https://github.com/apache/solr/pull/4332

--- a/changelog/unreleased/PR#4390-update-com-github-ben-manes-caffeine-caffeine.yml
+++ b/changelog/unreleased/PR#4390-update-com-github-ben-manes-caffeine-caffeine.yml
@@ -1,7 +1,0 @@
-title: Update com.github.ben-manes.caffeine:caffeine to v3.2.4
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4390
-  url: https://github.com/apache/solr/pull/4390

--- a/changelog/unreleased/PR#4403-update-org-apache-logging-log4j-to-v2-26-0-branch.yml
+++ b/changelog/unreleased/PR#4403-update-org-apache-logging-log4j-to-v2-26-0-branch.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.logging.log4j:* to v2.26.0 (branch_9x)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4403
-  url: https://github.com/apache/solr/pull/4403

--- a/changelog/unreleased/PR#4438-update-org-slf4j-to-v2-0-18-branch-9x.yml
+++ b/changelog/unreleased/PR#4438-update-org-slf4j-to-v2-0-18-branch-9x.yml
@@ -1,7 +1,0 @@
-title: Update org.slf4j:* to v2.0.18
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4438
-  url: https://github.com/apache/solr/pull/4438

--- a/changelog/unreleased/PR#4456-update-org-immutables-value-annotations.yml
+++ b/changelog/unreleased/PR#4456-update-org-immutables-value-annotations.yml
@@ -1,7 +1,0 @@
-title: Update org.immutables:value-annotations to v2.12.2
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4456
-  url: https://github.com/apache/solr/pull/4456

--- a/changelog/unreleased/PR#4470-update-org-apache-tika-to-v3-3-1-branch-9x.yml
+++ b/changelog/unreleased/PR#4470-update-org-apache-tika-to-v3-3-1-branch-9x.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.tika:* to v3.3.1
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4470
-  url: https://github.com/apache/solr/pull/4470

--- a/changelog/unreleased/update-awssdk-2.46.18.yml
+++ b/changelog/unreleased/update-awssdk-2.46.18.yml
@@ -1,7 +1,0 @@
-title: Update software.amazon.awssdk:* to v2.46.18
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4379
-  url: https://github.com/apache/solr/pull/4379

--- a/changelog/unreleased/update-bnd-annotation-7.3.0.yml
+++ b/changelog/unreleased/update-bnd-annotation-7.3.0.yml
@@ -1,7 +1,0 @@
-title: Update biz.aQute.bnd:biz.aQute.bnd.annotation to v7.3.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4360
-  url: https://github.com/apache/solr/pull/4360

--- a/changelog/unreleased/update-bouncycastle-bcpkix-1.84.yml
+++ b/changelog/unreleased/update-bouncycastle-bcpkix-1.84.yml
@@ -1,7 +1,0 @@
-title: Update org.bouncycastle:bcpkix-jdk18on to v1.84
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4382
-  url: https://github.com/apache/solr/pull/4382

--- a/changelog/unreleased/update-bytebuddy-1.18.10.yml
+++ b/changelog/unreleased/update-bytebuddy-1.18.10.yml
@@ -1,7 +1,0 @@
-title: Update net.bytebuddy:* to v1.18.10
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4384
-  url: https://github.com/apache/solr/pull/4384

--- a/changelog/unreleased/update-commons-configuration2-2.15.1.yml
+++ b/changelog/unreleased/update-commons-configuration2-2.15.1.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.commons:commons-configuration2 to v2.15.1
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4439
-  url: https://github.com/apache/solr/pull/4439

--- a/changelog/unreleased/update-commons-io-2.22.0.yml
+++ b/changelog/unreleased/update-commons-io-2.22.0.yml
@@ -1,7 +1,0 @@
-title: Update commons-io:commons-io to v2.22.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4327
-  url: https://github.com/apache/solr/pull/4327

--- a/changelog/unreleased/update-dropwizard-metrics-4.2.39.yml
+++ b/changelog/unreleased/update-dropwizard-metrics-4.2.39.yml
@@ -1,7 +1,0 @@
-title: Update io.dropwizard.metrics:* to v4.2.39
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4480
-  url: https://github.com/apache/solr/pull/4480

--- a/changelog/unreleased/update-google-cloud-bom-0.265.0.yml
+++ b/changelog/unreleased/update-google-cloud-bom-0.265.0.yml
@@ -1,7 +1,0 @@
-title: Update com.google.cloud:google-cloud-bom to v0.265.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#3589
-  url: https://github.com/apache/solr/pull/3589

--- a/changelog/unreleased/update-grpc-1.82.1.yml
+++ b/changelog/unreleased/update-grpc-1.82.1.yml
@@ -1,7 +1,0 @@
-title: Update io.grpc:grpc-* to v1.82.1
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4378
-  url: https://github.com/apache/solr/pull/4378

--- a/changelog/unreleased/update-jackson-bom-2.22.0.yml
+++ b/changelog/unreleased/update-jackson-bom-2.22.0.yml
@@ -1,7 +1,0 @@
-title: Update com.fasterxml.jackson:jackson-bom to v2.22.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4016
-  url: https://github.com/apache/solr/pull/4016

--- a/changelog/unreleased/update-json-path-2.10.0.yml
+++ b/changelog/unreleased/update-json-path-2.10.0.yml
@@ -1,7 +1,0 @@
-title: Update com.jayway.jsonpath:json-path to v2.10.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4017
-  url: https://github.com/apache/solr/pull/4017

--- a/changelog/unreleased/update-kerby-2.1.2.yml
+++ b/changelog/unreleased/update-kerby-2.1.2.yml
@@ -1,7 +1,0 @@
-title: Update org.apache.kerby:* to v2.1.2
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4380
-  url: https://github.com/apache/solr/pull/4380

--- a/changelog/unreleased/update-logchange-plugin-1.19.15.yml
+++ b/changelog/unreleased/update-logchange-plugin-1.19.15.yml
@@ -1,7 +1,0 @@
-title: Update plugin dev.logchange to v1.19.15
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4015
-  url: https://github.com/apache/solr/pull/4015

--- a/changelog/unreleased/update-netty-4.2.15.yml
+++ b/changelog/unreleased/update-netty-4.2.15.yml
@@ -1,7 +1,0 @@
-title: Update io.netty:netty* to v4.2.15.Final
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4398
-  url: https://github.com/apache/solr/pull/4398

--- a/changelog/unreleased/update-opentelemetry-bom-1.63.0.yml
+++ b/changelog/unreleased/update-opentelemetry-bom-1.63.0.yml
@@ -1,7 +1,0 @@
-title: Update io.opentelemetry:opentelemetry-bom to v1.63.0 (and okhttp to v5.4.0)
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#3646
-  url: https://github.com/apache/solr/pull/3646

--- a/changelog/unreleased/update-prometheus-1.8.0.yml
+++ b/changelog/unreleased/update-prometheus-1.8.0.yml
@@ -1,7 +1,0 @@
-title: Update io.prometheus:prometheus* to v1.8.0
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4371
-  url: https://github.com/apache/solr/pull/4371

--- a/changelog/unreleased/update-protobuf-4.35.1.yml
+++ b/changelog/unreleased/update-protobuf-4.35.1.yml
@@ -1,7 +1,0 @@
-title: Update com.google.protobuf:* to v4.35.1
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4460
-  url: https://github.com/apache/solr/pull/4460

--- a/changelog/unreleased/update-randomizedtesting-2.9.1.yml
+++ b/changelog/unreleased/update-randomizedtesting-2.9.1.yml
@@ -1,7 +1,0 @@
-title: Update com.carrotsearch.randomizedtesting:* to v2.9.1
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4494
-  url: https://github.com/apache/solr/pull/4494

--- a/changelog/unreleased/update-testcontainers-2.0.5.yml
+++ b/changelog/unreleased/update-testcontainers-2.0.5.yml
@@ -1,7 +1,0 @@
-title: Update org.testcontainers:testcontainers* to v2.0.5
-type: dependency_update
-authors:
-- name: solrbot
-links:
-- name: PR#4386
-  url: https://github.com/apache/solr/pull/4386


### PR DESCRIPTION
Removes 45 changelog/unreleased/ entries where the author is solrbot (Renovate dependency-update PRs).

Notice the destination branch is `branch_9_11`

Claude-Session: https://claude.ai/code/session_012qvM59KJiPdFjva8BrF8UB