### PR TITLE
SOLR-18362: fix SpellCheckCollatorTest compile error from the removal of Token

### DIFF
--- a/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/SpellCheckCollatorTest.java
@@ -765,17 +765,13 @@ public class SpellCheckCollatorTest extends SolrTestCaseJ4 {
     SpellingResult result = new SpellingResult();
 
     // Add tokens with multiple suggestions to generate many possible collations
-    Token token1 = new Token();
-    token1.copyBuffer("test".toCharArray(), 0, 4);
-    token1.setOffset(0, 4);
+    SpellCheckToken token1 = new SpellCheckToken("test", 0, 4);
     result.add(token1, "best", 1);
     result.add(token1, "rest", 2);
     result.add(token1, "nest", 3);
     result.add(token1, "fest", 4);
 
-    Token token2 = new Token();
-    token2.copyBuffer("query".toCharArray(), 0, 5);
-    token2.setOffset(5, 10);
+    SpellCheckToken token2 = new SpellCheckToken("query", 5, 10);
     result.add(token2, "quarry", 1);
     result.add(token2, "quiry", 2);
     result.add(token2, "quary", 3);


### PR DESCRIPTION
`SpellCheckCollatorTest` still constructed the `org.apache.solr.spelling.Token` that #4812 removed, so `main` currently fails to compile its test sources. This replaces the two usages with the equivalent `SpellCheckToken` records.

No behaviour change; test-only follow-up to SOLR-18362.

https://claude.ai/code/session_01JqDbuMinkcDXHNj6gR8jmz
